### PR TITLE
fix(bridge): add missing _get_session_manager() helper function

### DIFF
--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -368,6 +368,13 @@ def handle_sessions_delete(req_id: str, params: dict) -> None:
     _result(req_id, {"deleted": deleted})
 
 
+def _get_session_manager():
+    """Get a SessionManager instance for the current workspace."""
+    config = _state.load_config()
+    from miqi.session.manager import SessionManager
+    return SessionManager(config.workspace_path)
+
+
 def handle_sessions_archive(req_id: str, params: dict) -> None:
     """Archive a session — hide it from the default session list."""
     session_key = params.get("session_key", "")


### PR DESCRIPTION
## 修复内容

添加缺失的 `_get_session_manager()` 函数。

## 问题

5 个 session handler（archive、unarchive、list_archived、get_tracked_files、clear_tracked_files）调用了 `_get_session_manager()`，但该函数未定义，触发 `NameError`。

## 修复

在同一文件中添加了 `_get_session_manager()` helper，使用与 `handle_sessions_delete` 相同的模式：`_state.load_config()` → `SessionManager(config.workspace_path)`。

## 影响范围

- `miqi/bridge/server.py`：+7 行（仅新增函数定义）

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)