### PR TITLE
fix(cron): correct _validate_schedule_for_add import path

### DIFF
--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -840,7 +840,7 @@ def handle_cron_update(req_id: str, params: dict) -> None:
         if kind not in ("at", "every", "cron"):
             _error(req_id, f"Invalid schedule kind: {kind}")
             return
-        from miqi.cron.types import _validate_schedule_for_add
+        from miqi.cron.service import _validate_schedule_for_add
 
         target.schedule.kind = kind
         if kind == "at" and "atMs" in params:

--- a/miqi/runtime/cron_handlers.py
+++ b/miqi/runtime/cron_handlers.py
@@ -189,7 +189,7 @@ async def cron_update_handler(
             raise AppServerError(
                 f"Invalid schedule kind: {kind}", code="INVALID_PARAMS",
             )
-        from miqi.cron.types import _validate_schedule_for_add
+        from miqi.cron.service import _validate_schedule_for_add
 
         target.schedule.kind = kind
         if kind == "at" and "atMs" in params:


### PR DESCRIPTION
## 修复内容

修正 `_validate_schedule_for_add` 的 import 路径。

## 问题

`server.py` 和 `cron_handlers.py` 都从 `miqi.cron.types` 导入 `_validate_schedule_for_add`，但该函数实际位于 `miqi.cron.service`。`types.py` 只包含 dataclass（CronSchedule、CronPayload 等），不含函数。触发任何 cron 定时任务更新操作即 `ImportError`。

## 修复

两个文件各改一行：`miqi.cron.types` → `miqi.cron.service`

| 文件 | 改动 |
|------|------|
| `miqi/bridge/server.py:850` | `from miqi.cron.types` → `from miqi.cron.service` |
| `miqi/runtime/cron_handlers.py:192` | 同上 |

## 验证

```
from miqi.cron.service import _validate_schedule_for_add  # ✅ Import OK
```

## 影响范围

- cron 定时任务的创建/更新/删除操作

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)