### PR TITLE
fix(runtime): replace hardcoded model='default' with provider default

### DIFF
--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -378,7 +378,7 @@ class TurnRunner:
             agent_metadata=metadata,
             thread_id=job.thread_id,
             workspace=getattr(self._provider, "workspace", Path(".")),
-            model="default",
+            model=self._provider.get_default_model(),
             provider=self._provider,
             temperature=0.1,
             max_tokens=8192,


### PR DESCRIPTION
## 修复内容

将 `run_agent_job()` 中硬编码的 `model="default"` 替换为 `self._provider.get_default_model()`。

## 问题

`turn_runner.py:381` 中 `model="default"` 不是有效模型名，导致所有子 Agent 任务（`agent.spawn`）请求失败。`"default"` 字面量不会被任何 LLM provider 识别。

## 修复

```diff
- model="default",
+ model=self._provider.get_default_model(),
```

`get_default_model()` 是 `LLMProvider` 基类的抽象方法（`base.py:156`），所有 provider 均已实现。

## 影响范围

- `miqi/runtime/turn_runner.py`: 1 行
- 子 Agent 创建（agent.spawn）功能

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)