### PR TITLE
fix(bridge): accept thread_id in plan.get handler

### DIFF
--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -1740,7 +1740,7 @@ def handle_agent_get(req_id: str, params: dict) -> None:
 
 def handle_plan_get(req_id: str, params: dict) -> None:
     """Get current plan for a thread."""
-    plan_id = params.get("plan_id", "")
+    plan_id = params.get("plan_id", "") or params.get("thread_id", "")
     tracker = getattr(_state, '_plan_tracker', None)
     if tracker is not None and plan_id:
         plan = tracker.get(plan_id)


### PR DESCRIPTION
## 修复内容

`plan.get` handler 同时接受 `plan_id` 和 `thread_id` 参数。

## 问题

协议 spec（`app-protocol.ts`）和前端 IPC 都发送 `thread_id`，但后端只读 `plan_id`，导致 plan 查找永远返回 `null`，计划功能完全不可用。

## 修复

```diff
- plan_id = params.get("plan_id", "")
+ plan_id = params.get("plan_id", "") or params.get("thread_id", "")
```

兼容双 key，不破坏任何已有调用方。

## 影响范围

- `miqi/bridge/server.py`: 1 行
- Plan/Planning 功能

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)