### PR TITLE
fix(provider): gate stream_options to direct OpenAI only

### DIFF
--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -365,8 +365,12 @@ class OpenAIProvider(LLMProvider):
             "max_tokens": max_tokens,
             "temperature": temperature,
             "stream": True,
-            "stream_options": {"include_usage": True},
         }
+        # stream_options with include_usage is OpenAI-specific — gateways
+        # (OpenRouter, etc.) and compatible providers (DeepSeek, Moonshot)
+        # reject it with 400.
+        if self._gateway is None:
+            kwargs["stream_options"] = {"include_usage": True}
 
         self._apply_model_overrides(resolved, kwargs)
 


### PR DESCRIPTION
## 修复内容

`stream_options` 仅在直连 OpenAI（非 gateway）时发送。

## 问题

`openai_provider.py` 无条件发送 `stream_options: {include_usage: true}`，该参数是 OpenAI 专有。所有非 OpenAI 厂商（DeepSeek、Moonshot、DashScope 等十多个）和 Gateway（OpenRouter）收到后返回 400，流式对话完全不可用。

## 修复

```diff
- "stream_options": {"include_usage": True},
+ # Only for direct OpenAI (no gateway)
+ if self._gateway is None:
+     kwargs["stream_options"] = {"include_usage": True}
```

`self._gateway` 在 `__init__` 中已通过 `find_gateway()` 判定，`None` 表示直连 OpenAI。

## 影响范围

- `miqi/providers/openai_provider.py`: +5/-1 行
- 所有非 OpenAI 厂商的流式对话

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)