### PR TITLE
fix(agent): correct tool-call message order in sub-agent loop

### DIFF
--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -490,20 +490,21 @@ class AgentControl:
                             },
                         })
 
-                        # Add tool result to messages
+                    # Add assistant message with tool calls (must come BEFORE tool results)
+                    messages.append({
+                        "role": "assistant",
+                        "content": response.content or "",
+                        "tool_calls": tool_call_dicts,
+                    })
+
+                    # Add tool results for each tool call
+                    for tc, result in zip(tool_calls, tool_results):
                         messages.append({
                             "role": "tool",
                             "tool_call_id": tc.id,
                             "name": tc.name,
                             "content": result or "",
                         })
-
-                    # Add assistant message with tool calls
-                    messages.append({
-                        "role": "assistant",
-                        "content": response.content or "",
-                        "tool_calls": tool_call_dicts,
-                    })
 
                     # Reflect prompt for next iteration
                     messages.append({


### PR DESCRIPTION
## 修复内容

修正子 Agent tool-call 循环中的消息顺序：assistant (含 tool_calls) 必须在 tool result 之前。

## 问题

`agent_control.py` 中 tool result 消息先于 assistant（含 tool_calls）消息被 append 到消息列表，违反 LLM API 要求的消息顺序。导致子 Agent 工具调用循环异常。

## 修复

调整消息 append 顺序，并改为循环遍历 tool_calls 和 tool_results 逐个添加 tool result（原代码每个 tool_call 的 result 在下一个 tool_call 的 assistant 之前，更严格对齐 API 规范）。

## 影响范围

- `miqi/runtime/agent_control.py`: +9/-8 行
- 子 Agent 工具调用功能

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)