### PR TITLE
fix(history): handle JSONDecodeError in load_items

### DIFF
--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -244,18 +244,26 @@ class HistoryRuntime:
             (thread_id, self.session_id),
         )
         rows = await cursor.fetchall()
-        return [
-            HistoryItem(
+        results = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload_json"])
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.warning(
+                    "Skipping corrupted payload_json for item %s in thread %s: %s",
+                    row["item_id"], thread_id, exc,
+                )
+                payload = {}
+            results.append(HistoryItem(
                 item_id=row["item_id"],
                 thread_id=row["thread_id"],
                 turn_id=row["turn_id"],
                 role=row["role"],
                 content=row["content"],
-                payload=json.loads(row["payload_json"]),
+                payload=payload,
                 created_at=row["created_at"],
-            )
-            for row in rows
-        ]
+            ))
+        return results
 
     async def load_messages(self, thread_id: str) -> list[dict[str, Any]]:
         """Return provider-compatible message dicts for a thread."""


### PR DESCRIPTION
## 修复内容

`load_items()` 中 `json.loads()` 增加 JSONDecodeError/TypeError 异常处理。

## 问题

`history_runtime.py:254` 中 `json.loads(row["payload_json"])` 无异常保护。数据库中任何一行 payload_json 损坏，整个历史加载崩溃，所有对话历史丢失。

## 修复

```python
try:
    payload = json.loads(row["payload_json"])
except (json.JSONDecodeError, TypeError) as exc:
    logger.warning(...)
    payload = {}
```

损坏的行返回空 dict，不阻断其他正常行加载。

## 影响范围

- `miqi/runtime/history_runtime.py`: +14/-6 行
- 历史消息加载

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)