### PR TITLE
fix(bridge): reject pending requests and reset state on restart

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -569,6 +569,10 @@ export class BridgeManager extends EventEmitter {
 
     this.addLog('[Hot Reload] Restarting bridge due to code changes...')
 
+    // Reject all pending requests so callers don't hang forever
+    for (const [id, entry] of this.pending) {
+      entry.reject(new Error('Bridge restarted — request cancelled'))
+    }
     this.pending.clear()
 
     // Stop current process
@@ -576,6 +580,10 @@ export class BridgeManager extends EventEmitter {
       this.process.stdin?.end()
       this.process.kill('SIGTERM')
     }
+
+    // Reset state so start() can proceed
+    this.state = 'stopped'
+    this.process = null
 
     // Wait briefly for process to exit
     await new Promise((resolve) => setTimeout(resolve, 500))


### PR DESCRIPTION
## 修复内容

热重载 restart() 两处修复：
1. 拒绝所有 pending 请求再清空（而非直接丢弃）
2. 重置 state 为 stopped 再调 start()（而非保持 running）

## 问题

- #47: pending.clear() 直接丢弃，调用方永久 hang
- #48: start() 在 state=running/starting 时提前 return，restart 后 start 静默失败

## 修复

- pending 遍历 reject 后再 clear
- state 设为 stopped，process 设为 null，再调 start()

## 影响范围

- apps/desktop/src/main/bridge.ts: +8 行
- Python 热重载稳定性

Closes #47
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)