### PR TITLE
fix(turn): save assistant reply before steering continuation

### DIFF
--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -228,12 +228,19 @@ class TurnRunner:
                 # Phase 41: drain steering messages before completing
                 steers = await _drain_steer_messages()
                 if steers:
+                    # Save assistant reply before steering messages
+                    content = response.content or ""
+                    messages = self._context.add_assistant_message(
+                        messages=messages,
+                        content=content,
+                    )
+                    messages_delta.append({"role": "assistant", "content": content})
                     for steer in steers:
-                        content = steer["content"]
-                        messages.append({"role": "user", "content": content})
+                        steer_content = steer["content"]
+                        messages.append({"role": "user", "content": steer_content})
                         delta: dict[str, Any] = {
                             "role": "user",
-                            "content": content,
+                            "content": steer_content,
                         }
                         cid = steer.get("client_user_message_id")
                         if cid is not None:


### PR DESCRIPTION
## 修复内容

steering 触发时先保存 assistant 回复，再追加 steering 消息后 continue。

## 问题

当 steering 消息被 drain 后，代码直接 `continue` 回到循环顶部，assistant 的回复被丢弃，导致对话历史损坏、模型上下文丢失。

## 修复

在 steering 分支的 `continue` 之前，先通过 `_context.add_assistant_message()` 保存 assistant 回复到 messages 和 messages_delta。

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)