### PR TITLE
fix(task): emit TurnCompleteEvent on error path

### DIFF
--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -698,6 +698,13 @@ class TaskRunner:
                 recoverable=recoverable,
                 error_kind=error_kind,
             ))
+            await self._events.put(TurnCompleteEvent(
+                turn_id=turn_id,
+                thread_id=thread_id,
+                outcome="error",
+                tools_used=[],
+                token_usage={},
+            ))
         finally:
             self._turn_cancel_events.pop(thread_id, None)
             self._active_turn_ids.pop(thread_id, None)


### PR DESCRIPTION
## 修复内容

错误路径增加 TurnCompleteEvent 发送。

## 问题

`_handle_user_message` 异常处理只发了 ErrorEvent，没有终端 turn event。客户端死等，连接卡死。

## 修复

在 ErrorEvent 之后发送 TurnCompleteEvent(outcome='error')。

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)