### PR TITLE
fix(ci): make bwrap job non-blocking for Python Runtime Tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,10 +37,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run portable and subprocess tests
-        run: uv run pytest -q -m "not sandbox"
+        run: uv run pytest -q -m "not sandbox" --tb=short
 
   bwrap:
     runs-on: ubuntu-latest
+    # bwrap requires unprivileged user namespaces which may not be
+    # available in GitHub Actions runners. Don't block PRs on this.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -54,4 +57,4 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run sandbox tests
-        run: uv run pytest -q -m "sandbox and bwrap"
+        run: uv run pytest -q -m "sandbox and bwrap" --suppress-no-test-exit-code

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,9 +41,6 @@ jobs:
 
   bwrap:
     runs-on: ubuntu-latest
-    # bwrap requires unprivileged user namespaces which may not be
-    # available in GitHub Actions runners. Don't block PRs on this.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -56,5 +53,24 @@ jobs:
           sudo apt-get install -y bubblewrap
       - name: Install dependencies
         run: uv sync --all-extras
+      - name: Check bwrap availability
+        id: bwrap-check
+        run: |
+          if bwrap --version && bwrap --ro-bind / / /bin/true; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "bwrap is not usable on this runner; skipping bwrap-only tests."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run sandbox tests
-        run: uv run pytest -q -m "sandbox and bwrap" --suppress-no-test-exit-code
+        if: steps.bwrap-check.outputs.available == 'true'
+        run: |
+          set +e
+          uv run pytest -q -m "sandbox and bwrap"
+          status=$?
+          set -e
+          if [ "$status" -eq 5 ]; then
+            echo "No sandbox+bwrap tests matched; treating as skipped."
+            exit 0
+          fi
+          exit "$status"


### PR DESCRIPTION
## 类型

- [x] 修复

## 变更概述

修复 Python Runtime Tests 中 bwrap job 的门禁逻辑，避免用 job 级 `continue-on-error` 隐藏真实失败。

## 背景/问题

原实现把整个 bwrap job 标记为 `continue-on-error: true`，会把安装失败或真实 sandbox 测试失败都变成非阻塞结果。review 要求不能跳过 CI 错误，只能在 runner 环境确实无法运行 bwrap 时跳过 bwrap-only 测试。

## 变更内容

- 移除 bwrap job 级 `continue-on-error: true`
- 增加 `Check bwrap availability` 步骤，实际运行 `bwrap --ro-bind / / /bin/true` 探测 runner 是否支持 bwrap
- 仅当 bwrap 可用时执行 `sandbox and bwrap` 测试
- 手动处理 pytest exit code 5，将“无匹配测试”视为跳过；其他失败仍返回失败
- 保留普通测试 job 的 `--tb=short` 输出优化

## 日志/验证证据

```
git diff --check
# exit code 0

GitHub Actions / Python Runtime Tests
bwrap: pass
```

## 测试情况

- 已推送到 PR head 分支并触发 GitHub Actions
- `bwrap` job 已通过
- 普通 Python matrix job 继续由 GitHub Actions 验证

Closes #72
