### PR TITLE
fix: otel tool span cleanup, fork events, compact param, reasoning complete

### DIFF
--- a/miqi/observability/otel.py
+++ b/miqi/observability/otel.py
@@ -203,6 +203,13 @@ class TelemetrySink:
             span.end()
             self._context.detach(token)
 
+        # Clean up any orphaned child tool spans
+        for tc_id, (tool_span, tool_token) in list(self._tool_spans.items()):
+            tool_span.set_status(self._Status(self._StatusCode.ERROR, "parent turn errored"))
+            tool_span.end()
+            self._context.detach(tool_token)
+        self._tool_spans.clear()
+
 
 # ── Factory ────────────────────────────────────────────────────
 

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -229,6 +229,38 @@ class AgentControl:
             self._agents[agent_id] = agent
             self._thread_agents[fork_thread_id] = agent_id
 
+        if self._store is not None:
+            self._store.add_edge(
+                parent_agent_id=source_agent_id,
+                child_agent_id=agent_id,
+                child_thread_id=fork_thread_id,
+            )
+
+        # Emit spawned event for forked agent
+        await self._events.emit(SubAgentSpawnedEvent(
+            parent_turn_id=source_thread_id,
+            sub_agent_id=agent_id,
+            sub_thread_id=fork_thread_id,
+            agent_type=fork_type,
+            task_label=f"fork from {source_thread_id}",
+        ))
+
+        # Fire sub-agent lifecycle start hook
+        if self._hooks is not None:
+            await self._hooks.run(
+                HookPoint.SUBAGENT_START,
+                LifecycleHookContext(
+                    hook_point=HookPoint.SUBAGENT_START,
+                    data={
+                        "agent_id": agent_id,
+                        "thread_id": fork_thread_id,
+                        "agent_type": fork_type,
+                        "task": f"fork from {source_thread_id}",
+                        "parent_agent_id": source_agent_id,
+                    },
+                ),
+            )
+
         logger.info(
             "Forked thread {} → {} (type: {})",
             source_thread_id, fork_thread_id, fork_type,

--- a/miqi/runtime/context_runtime.py
+++ b/miqi/runtime/context_runtime.py
@@ -231,7 +231,6 @@ class ContextRuntime:
         replacement = await self.compress_messages(
             messages,
             model=model,
-            session_id=thread_id,
         )
         after_tokens = self.estimate_tokens(replacement)
         await history_runtime.replace_messages_with_compaction(

--- a/miqi/runtime/turn_event_adapter.py
+++ b/miqi/runtime/turn_event_adapter.py
@@ -329,6 +329,15 @@ class CodexTurnEventAdapter:
                 self._with_location({"item": agent_message_item(self.turn_id, text)}),
             ))
 
+        # Complete pending reasoning item if needed
+        if self._reasoning_started:
+            self._reasoning_started = False
+            ri = reasoning_item(self.turn_id, "".join(self._reasoning_text_parts))
+            result.append(self._notification(
+                "item/completed",
+                self._with_location({"item": ri}),
+            ))
+
         # Token usage
         if event.token_usage:
             result.append(self._notification(


### PR DESCRIPTION
4 个 P1 修复:

- #65 otel _on_error 清理子 tool span
- #67 fork() 补全 event/hook/graph edge
- #68 compact_thread 移除错误 session_id 参数
- #69 reasoning item/completed on turn end

Closes #65
Closes #67
Closes #68
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forked agents now surface clearer lifecycle events and parent/child relationships, improving visibility into spawned sub-agents.
  * Reasoning updates are now properly marked as complete when a turn finishes.

* **Bug Fixes**
  * Error handling now closes any active child tool spans when a parent turn fails, preventing stray open telemetry records.
  * Thread compaction now uses consistent session handling during compression and related hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->