### PR TITLE
fix(bridge): reject pending on error and add setTimeout error boundary

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -320,6 +320,11 @@ export class BridgeManager extends EventEmitter {
         this.state = 'error'
         this.process = null
         this.emitState()
+        // Reject all pending requests so callers don't hang
+        for (const [id, entry] of this.pending) {
+          entry.reject(new Error(`Bridge process error: ${err.message}`))
+        }
+        this.pending.clear()
       })
 
       // ── Ready handshake ────────────────────────────────────────────
@@ -557,8 +562,10 @@ export class BridgeManager extends EventEmitter {
     this.addLog(`[Hot Reload] Detected change in: ${filename}`)
 
     // Schedule restart after a short delay to allow multiple files to change
-    setTimeout(async () => {
-      await this.restart()
+    setTimeout(() => {
+      this.restart().catch(err => {
+        this.addLog(`[Hot Reload] Restart error: ${err}`)
+      })
     }, 500)
   }
 


### PR DESCRIPTION
## #70: error handler rejects pending

process.on('error') 现在 reject 所有 pending 请求，防止调用方永久 hang。

## #71: setTimeout async error boundary

setTimeout 回调改为 .catch() 模式，避免 unhandled rejection。

Closes #70
Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)