### PR TITLE
fix(desktop): fix bridge test mock and SessionExplorer null safety

### DIFF
--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -185,7 +185,7 @@ function feedLine(proc: ReturnType<typeof createMockProcess>, obj: Record<string
 /** Get the request ID from the last stdin write matching a method. */
 function findRequestId(proc: ReturnType<typeof createMockProcess>, method: string): string | null {
   const write = proc.stdin.write as ReturnType<typeof vi.fn>;
-  for (const call of write.mock.calls) {
+  for (const call of [...write.mock.calls].reverse()) {
     try {
       const r = JSON.parse(call[0] as string);
       if (r.method === method) return r.id;
@@ -572,6 +572,45 @@ describe('BridgeManager lifecycle', () => {
 
     // Wait for timeout
     await expect(sendPromise).rejects.toThrow(/timed out/);
+  }, 10_000);
+
+  it('initializes a running bridge without recursive initialization', async () => {
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge, { clientId: 'initial', serverInfo: { version: '1' } });
+
+    (bridge as any).initialized = false;
+
+    const initPromise = (bridge as any).initializeConnection();
+
+    await new Promise((r) => setTimeout(r, 10));
+    const initId = findRequestId(proc, 'initialize');
+    expect(initId).toBeTruthy();
+
+    feedLine(proc, { id: initId, result: { clientId: 'recursive-test' } });
+    await initPromise;
+
+    expect(bridge.isInitialized()).toBe(true);
+    expect(proc.stdin.write).toHaveBeenCalled();
+  });
+
+  it('cleans up pending request when stdin write fails immediately', async () => {
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge, { clientId: 'write-fail-test', serverInfo: { version: '1' } });
+
+    const err = new Error('write failed');
+    proc.stdin.write = vi.fn((_data: string, cb?: (err?: Error) => void) => {
+      cb?.(err);
+      return false;
+    }) as any;
+
+    await expect(bridge.send('fs/readFile', { path: '/tmp/a' })).rejects.toThrow('write failed');
+    expect((bridge as any).pending.size).toBe(0);
   }, 10_000);
 
   it('keeps chat.send client timeout later than the backend drain timeout', async () => {

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -746,12 +746,26 @@ export class BridgeManager extends EventEmitter {
     onEvent?: (type: string, data: unknown) => void,
     options: SendOptions = {}
   ): Promise<unknown> {
-    const canSend =
-      this.isRunning() ||
-      (options.allowStarting === true && this.process !== null && this.state === 'starting');
-
-    if (!canSend) {
-      throw new Error('Bridge not running');
+    if (options.allowStarting) {
+      if (!this.process || (this.state !== 'starting' && !this.isRunning())) {
+        throw new Error('Bridge not running');
+      }
+    } else if (!this.isInitialized()) {
+      if (this.state === 'stopped' || this.state === 'error') {
+        await this.start();
+      } else if (this.state === 'starting') {
+        for (let i = 0; i < 1400 && this.state === 'starting' && !this.isInitialized(); i++) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        if (!this.isInitialized() && this.state !== 'starting') {
+          throw new Error(this.getStatus().error ?? 'Bridge failed to start');
+        }
+      } else if (this.state === 'running') {
+        await this.initializeConnection();
+      }
+      if (!this.isInitialized()) {
+        throw new Error('Bridge not initialized');
+      }
     }
 
     const id = randomUUID();
@@ -769,44 +783,45 @@ export class BridgeManager extends EventEmitter {
     };
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      let timeout: ReturnType<typeof setTimeout>;
+      const cleanup = () => {
+        clearTimeout(timeout);
         this.pending.delete(id);
         logSlow();
-        reject(new Error(`Request ${method} timed out`));
+      };
+      const rejectWithCleanup = (err: Error) => {
+        cleanup();
+        reject(err);
+      };
+
+      timeout = setTimeout(() => {
+        rejectWithCleanup(new Error(`Request ${method} timed out`));
       }, timeoutMs);
 
       this.pending.set(id, {
         resolve: (value: unknown) => {
-          clearTimeout(timeout);
-          this.pending.delete(id);
-          logSlow();
+          cleanup();
           resolve(value);
         },
         reject: (err: Error) => {
-          clearTimeout(timeout);
-          this.pending.delete(id);
-          logSlow();
-          reject(err);
+          rejectWithCleanup(err);
         },
         onEvent,
       });
 
       const stdin = this.process!.stdin!;
       if (!stdin.writable || stdin.destroyed) {
-        this.pending.delete(id);
-        reject(new Error('Bridge not running'));
+        rejectWithCleanup(new Error('Bridge not running'));
         return;
       }
       try {
         stdin.write(JSON.stringify(request) + '\n', (err) => {
           if (err) {
-            this.pending.delete(id);
-            reject(err);
+            rejectWithCleanup(err);
           }
         });
       } catch (err) {
-        this.pending.delete(id);
-        reject(err instanceof Error ? err : new Error(String(err)));
+        rejectWithCleanup(err instanceof Error ? err : new Error(String(err)));
       }
     });
   }

--- a/apps/desktop/src/renderer/features/sessions/SessionExplorer.tsx
+++ b/apps/desktop/src/renderer/features/sessions/SessionExplorer.tsx
@@ -283,7 +283,7 @@ export function SessionExplorer({
               <div className="text-xs text-[var(--text-faint)] mb-2">
                 Session: {detail.key} • Messages: {detail.messages?.length ?? 0}
               </div>
-              {(detail.messages ?? []).map((msg, i) => {
+              {(detail?.messages ?? []).map((msg, i) => {
                 const role = String(msg.role ?? '');
                 const content = String(msg.content ?? '');
                 const isUser = role === 'user';

--- a/apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts
+++ b/apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts
@@ -5,7 +5,24 @@ async function injectMockAndGoto(
   page: import('@playwright/test').Page,
   opts?: Parameters<typeof buildMockBridgeScript>[0]
 ) {
-  await page.addInitScript({ content: buildMockBridgeScript(opts) });
+  await page.addInitScript({
+    content: buildMockBridgeScript({
+      activeModel: 'deepseek-chat',
+      activeProvider: 'deepseek',
+      providers: [
+        {
+          name: 'deepseek',
+          display_name: 'DeepSeek',
+          env_key: 'DEEPSEEK_API_KEY',
+          provider_type: 'openai',
+          configured: true,
+          configured_model: 'deepseek-chat',
+          verification_status: 'success',
+        },
+      ],
+      ...opts,
+    }),
+  });
   await page.goto('/');
   await page.waitForSelector('#root', { state: 'visible' });
 }


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 bridge 回归：mock child process 补齐 `once()` 等方法，`sendRequest()` 在初始化期间不会递归卡死，发送失败时会清理 pending timeout；同时让 session detail 为空时不崩溃。

## 背景/问题

#38 的失败来自 bridge 测试 mock 不完整，`BridgeManager` 会调用 child process 的 `once()`。后续 review 还指出两个实际风险：初始化握手可能递归进入自身，以及 stdin 写入立即失败时 pending request 的 timeout 没有被清掉。session detail 也存在为空时直接访问 messages 的风险。

## 变更内容

- 为 `bridge.test.ts` 的 spawn mock 提供完整默认进程对象，包括 stdout/stderr、`on()`、`once()`、`removeListener()`、`kill()` 和 `exitCode`。
- `BridgeManager.sendRequest()` 尊重 `allowStarting`，初始化握手不再递归触发自身。
- startup 等待在状态离开 `starting` 后立即退出并抛出实际启动错误，不再固定等满轮询窗口。
- stdin 不可写、write callback error、同步 write throw 都走统一 cleanup，删除 pending 并清 timeout。
- session detail 为空时使用 `detail?.messages ?? []`。
- 稳定 `issue-172` smoke：同一 turn 内连续 final 的测试不再因为监听器清理时序而误红。

## 日志/验证证据

```
npm.cmd test -- src/main/bridge.test.ts
19 passed

npm.cmd run build
PASS

npx.cmd playwright test --config=playwright.config.ts --project=smoke
23 passed

git diff --check -- apps/desktop/src/main/bridge.ts apps/desktop/src/main/bridge.test.ts apps/desktop/src/renderer/features/sessions/SessionExplorer.tsx apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts
PASS
```

## 截图

![not-applicable](https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000000)

## 测试情况

- `npm.cmd test -- src/main/bridge.test.ts`：19 passed
- `npm.cmd run build`：通过
- `npx.cmd playwright test --config=playwright.config.ts --project=smoke`：23 passed
- `git diff --check -- apps/desktop/src/main/bridge.ts apps/desktop/src/main/bridge.test.ts apps/desktop/src/renderer/features/sessions/SessionExplorer.tsx apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts`：通过

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bridge startup handling so requests wait for initialization to finish instead of failing early.
  * Fixed request cleanup when a send operation fails, helping avoid stuck or stale requests.
  * Prevented a crash in the session message view when session details are unavailable.
  * Improved message selection so the most recent matching request is used when multiple writes occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->