### PR TITLE
fix(session): 修复新建对话后左侧列表不显示的问题

### DIFF
--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -155,6 +155,7 @@ async def sessions_get_handler(
     sm = _get_session_manager()
     try:
         session = sm.get_or_create(session_key, client_id=client_id)
+        sm.save(session)  # 立即持久化到磁盘，确保新会话可被 sidebar 列出 (fix #34)
         return {
             "result": {
                 "key": session.key,


### PR DESCRIPTION
## 问题

Closes #34

点击"+"创建对话后，左侧对话列表没有出现对应的会话。

## 根因

在 `sessions_get_handler` 中调用 `SessionManager.get_or_create()` 创建会话时，会话仅存在于内存中，没有写入磁盘文件 `conversation.jsonl`。随后 Sidebar 调用 `sessions.list()` 时只扫描磁盘文件，导致新建的会话无法被发现。

### 调用链

1. 用户点击 "+" → `handleNewSession()` 生成 sessionKey
2. ChatConsole 挂载 → 调用 `sessions.get()` → `sessions_get_handler` → `get_or_create()` → **仅内存创建，未落盘**
3. Sidebar 刷新 → `sessions.list()` → 扫描磁盘 → **找不到新会话** ❌

## 修复

在 `sessions_get_handler` 中，`get_or_create()` 后立即调用 `sm.save(session)` 将会话持久化到磁盘。`save()` 是幂等的——对已有会话且无新消息的情况，实际为空操作。

## 测试

- `tests/runtime/test_session_handlers.py` — 9/9 ✅
- `tests/session/test_ownership.py` — 42/42 ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)