### PR TITLE
Revert "fix(agent): correct tool-call message order in sub-agent loop"

### DIFF
--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -490,21 +490,20 @@ class AgentControl:
                             },
                         })
 
-                    # Add assistant message with tool calls (must come BEFORE tool results)
-                    messages.append({
-                        "role": "assistant",
-                        "content": response.content or "",
-                        "tool_calls": tool_call_dicts,
-                    })
-
-                    # Add tool results for each tool call
-                    for tc, result in zip(tool_calls, tool_results):
+                        # Add tool result to messages
                         messages.append({
                             "role": "tool",
                             "tool_call_id": tc.id,
                             "name": tc.name,
                             "content": result or "",
                         })
+
+                    # Add assistant message with tool calls
+                    messages.append({
+                        "role": "assistant",
+                        "content": response.content or "",
+                        "tool_calls": tool_call_dicts,
+                    })
 
                     # Reflect prompt for next iteration
                     messages.append({


### PR DESCRIPTION
Reverts 14790897/MiQi#51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how tool-calling conversation turns are recorded, helping keep assistant and tool messages in the correct order.
  * This should make responses more reliable during multi-tool interactions and reduce cases where conversation history could become inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->