### PR TITLE
fix(runtime): filter internal events from chat progress stream

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -608,10 +608,14 @@ class BridgeRuntimeLoop:
             from dataclasses import asdict, is_dataclass
 
             from miqi.protocol.events import (
+                AgentMessageDeltaEvent,
                 AgentMessageEvent,
+                AgentReasoningEvent,
+                ApprovalResolvedEvent,
                 ErrorEvent,
                 TurnAbortedEvent,
                 TurnCompleteEvent,
+                TurnStartedEvent,
             )
 
             while True:
@@ -655,6 +659,16 @@ class BridgeRuntimeLoop:
                             "status": "completed",
                         })
                     break
+
+                # Internal runtime events that should never appear in
+                # the chat message stream.  See Issue #35.
+                if isinstance(event, (
+                    AgentMessageDeltaEvent,   # streaming delta; final content via AgentMessageEvent
+                    AgentReasoningEvent,       # model reasoning; no user-visible rendering target yet
+                    TurnStartedEvent,          # turn lifecycle; not chat content
+                    ApprovalResolvedEvent,     # approval lifecycle; not chat content
+                )):
+                    continue
 
                 # Forward all other events as progress
                 event_name = event.__class__.__name__


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

在 Bridge 事件翻译层（`_drain_chat_events`）过滤 4 类内部 Runtime Event，阻止其以裸 `[EventName]` 格式进入聊天消息流，解决聊天窗口被大量无用信息污染的问题。

## 背景 / 问题

发起对话后，聊天窗口出现大量 `[AgentMessageDeltaEvent]`、`[AgentReasoningEvent]`、`[TurnStartedEvent]`、`[ApprovalResolvedEvent]` 等内部事件名称，严重污染用户界面。

**根因：** `miqi/bridge/loop.py` 的 `_drain_chat_events()` 方法只显式处理了 4 种终端事件（`AgentMessageEvent`、`TurnAbortedEvent`、`ErrorEvent`、`TurnCompleteEvent`），其余所有 Runtime Event 通过 catch-all 以裸 `[EventName]` 格式转发给前端。前端 `extractProgressMessage()` 无法识别，兜底渲染为 `[EventName]`。

## 变更内容

**文件：** `miqi/bridge/loop.py`

**修改规模：** `+10 / -0`

在 catch-all 之前，对 4 类已证实会泄露到聊天窗口的内部事件进行显式过滤：

```python
if isinstance(event, (
    AgentMessageDeltaEvent,   # streaming 增量，最终内容由 AgentMessageEvent 携带
    AgentReasoningEvent,       # 模型推理内容，Desktop 当前无 reasoning 面板
    TurnStartedEvent,          # turn 生命周期事件，非聊天内容
    ApprovalResolvedEvent,     # 审批生命周期事件，非聊天内容
)):
    continue
```

`ToolCallBeginEvent`、`ExecCommandBeginEvent`、`WarningEvent` 等工具调用相关事件不受影响，继续正常转发。

**为什么在 Bridge 修：** Bridge 的职责是 Runtime Event → Frontend Event 翻译层。内部事件不应跨越此边界到达任何前端。在 Bridge 层过滤是源头修复。

## 日志 / 验证证据

### 修复前

见 Issue #35 原始截图 — 聊天区域被 `[AgentMessageDeltaEvent]`、`[AgentReasoningEvent]`、`[TurnStartedEvent]`、`[ApprovalResolvedEvent]` 等内部事件淹没。

### 修复后（dir 命令）

<img width="1266" height="853" alt="修复后-dir命令" src="https://github.com/user-attachments/assets/863d2552-b72a-4703-83e0-61a1398139a8" />

### 修复后（文件搜索）

<img width="1266" height="853" alt="修复后-文件搜索" src="https://github.com/user-attachments/assets/f627d09d-2728-4fec-a62c-fd0898802ce8" />

### 验证清单

| 验证项 | dir 命令 | 文件搜索 |
|--------|:---:|:---:|
| `[AgentMessageDeltaEvent]` 不再出现 | ✅ | ✅ |
| `[AgentReasoningEvent]` 不再出现 | ✅ | ✅ |
| `[TurnStartedEvent]` 不再出现 | ✅ | ✅ |
| `[ApprovalResolvedEvent]` 不再出现 | ✅ | ✅ |
| 工具调用信息正常显示 | ✅ | ✅ |
| Agent 最终回复正常显示 | ✅ | ✅ |

## 测试情况

```
tests/bridge/test_bridge_loop.py — 13 passed
tests/test_event_emitter.py — 6 passed
```

## 关联 Issue

Closes #35
