### PR TITLE
fix(runtime): show tool-created files in task assets

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -613,6 +613,8 @@ class BridgeRuntimeLoop:
                 AgentReasoningEvent,
                 ApprovalResolvedEvent,
                 ErrorEvent,
+                ToolCallBeginEvent,
+                ToolCallEndEvent,
                 TurnAbortedEvent,
                 TurnCompleteEvent,
                 TurnStartedEvent,
@@ -679,6 +681,18 @@ class BridgeRuntimeLoop:
 
                 if event_name == "ApprovalRequestedEvent":
                     await _emit("approval_request", payload)
+                elif isinstance(event, ToolCallBeginEvent):
+                    await _emit("progress", {
+                        "text": event.tool_display or event.tool_name,
+                        "tool_hint": True,
+                        "tool_call_id": event.tool_call_id,
+                    })
+                elif isinstance(event, ToolCallEndEvent):
+                    await _emit("progress", {
+                        "text": f"{event.tool_name} ({event.duration_ms}ms)",
+                        "tool_hint": True,
+                        "tool_call_id": event.tool_call_id,
+                    })
                 else:
                     await _emit("progress", {
                         "event": event_name,

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -160,6 +160,11 @@ class ToolExecutionContext:
     permission_decision: PermissionDecision | None = None
     sandbox_selection: SandboxSelection | None = None
     result: str | None = None
+    # Phase 104: structured execution outcome so callers don't have to infer
+    # success/failure from the result string. ``None`` means the orchestrator
+    # has not yet classified the outcome (e.g. legacy/short-circuit paths or
+    # test fakes); callers should fall back to result-string heuristics.
+    status: OrchestrationResult | None = None
     duration_ms: int = 0
     retry_count: int = 0
 
@@ -224,6 +229,7 @@ class ToolOrchestrator:
                     reason=f"Blocked by hook: {outcome.reason}",
                 )
                 ctx.result = f"Permission denied: {outcome.reason}"
+                ctx.status = OrchestrationResult.DENIED_BY_POLICY
                 ctx.duration_ms = int((time.monotonic() - start) * 1000)
                 return ctx
             if outcome.action == "modify" and outcome.patch:
@@ -247,6 +253,7 @@ class ToolOrchestrator:
                 tool = self.tools.get(ctx.tool_name)
                 if tool is None:
                     ctx.result = f"Error: Unknown tool '{ctx.tool_name}'"
+                    ctx.status = OrchestrationResult.TOOL_ERROR
                     ctx.permission_decision = PermissionDecision(
                         verdict=PermissionVerdict.DENY,
                         reason=f"Unknown tool: {ctx.tool_name}",
@@ -261,6 +268,7 @@ class ToolOrchestrator:
                         + "; ".join(schema_errors)
                         + "\n\n[Analyze the error above and try a different approach.]"
                     )
+                    ctx.status = OrchestrationResult.TOOL_ERROR
                     ctx.permission_decision = PermissionDecision(
                         verdict=PermissionVerdict.DENY,
                         reason=f"Invalid parameters: {'; '.join(schema_errors)}",
@@ -274,6 +282,7 @@ class ToolOrchestrator:
 
             if decision.verdict == PermissionVerdict.DENY:
                 ctx.result = f"Permission denied: {decision.reason}"
+                ctx.status = OrchestrationResult.DENIED_BY_POLICY
                 return ctx
 
             if decision.verdict == PermissionVerdict.APPROVAL_REQUIRED:
@@ -286,10 +295,12 @@ class ToolOrchestrator:
                         reason=f"Blocked by hook: {pr_outcome.reason}",
                     )
                     ctx.result = f"Permission denied: {pr_outcome.reason}"
+                    ctx.status = OrchestrationResult.DENIED_BY_POLICY
                     return ctx
                 decision = await self._request_approval(ctx, decision)
                 if decision.verdict != PermissionVerdict.ALLOW:
                     ctx.result = f"User denied: {decision.reason or 'no reason given'}"
+                    ctx.status = OrchestrationResult.DENIED_BY_USER
                     return ctx
 
             # 3. Try execution with retry-escalation
@@ -303,6 +314,9 @@ class ToolOrchestrator:
 
                     # 3b. Execute inside sandbox
                     ctx.result = await self._execute_in_sandbox(ctx, sandbox_sel)
+                    # _execute_in_sandbox flags its own errors; otherwise success.
+                    if ctx.status is None:
+                        ctx.status = OrchestrationResult.SUCCESS
                     break  # success
 
                 except SandboxDeniedError:
@@ -314,10 +328,12 @@ class ToolOrchestrator:
                     )
                     if ctx.retry_count > self.MAX_RETRIES:
                         ctx.result = "Error: sandbox denied after max retries"
+                        ctx.status = OrchestrationResult.SANDBOX_FAILED
                         return ctx
 
                 except asyncio.TimeoutError:
                     ctx.result = f"Error: tool '{ctx.tool_name}' timed out"
+                    ctx.status = OrchestrationResult.TIMEOUT
                     return ctx
 
             # 4. Post-tool-use hooks
@@ -325,9 +341,11 @@ class ToolOrchestrator:
 
         except asyncio.CancelledError:
             ctx.result = "Tool execution cancelled"
+            ctx.status = OrchestrationResult.CANCELLED
         except Exception as e:
             logger.exception("Tool orchestrator error for {}", ctx.tool_name)
             ctx.result = f"Error executing {ctx.tool_name}: tool execution failed"
+            ctx.status = OrchestrationResult.TOOL_ERROR
 
         finally:
             ctx.duration_ms = int((time.monotonic() - start) * 1000)
@@ -747,6 +765,7 @@ class ToolOrchestrator:
         """Execute the tool inside the selected sandbox."""
         tool = self.tools.get(ctx.tool_name)
         if tool is None:
+            ctx.status = OrchestrationResult.TOOL_ERROR
             return f"Error: Unknown tool '{ctx.tool_name}'"
 
         # Inject sandbox context into tool.
@@ -811,6 +830,7 @@ class ToolOrchestrator:
             result = f"Error executing {ctx.tool_name}: {safe_msg}"
             if ctx.turn_id:
                 result += f"\n[Hint: Use 'exec' to inspect the environment or try a different approach.]"
+            ctx.status = OrchestrationResult.TOOL_ERROR
         else:
             dt_ms = int((time.monotonic() - t0) * 1000)
             logger.debug(

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -445,7 +445,10 @@ class AgentControl:
                         ))
 
                         # Route through ToolOrchestrator (sole execution path — no fallback)
-                        from miqi.execution.orchestrator import ToolExecutionContext
+                        from miqi.execution.orchestrator import (
+                            OrchestrationResult,
+                            ToolExecutionContext,
+                        )
                         ctx = ToolExecutionContext(
                             tool_name=tc.name,
                             tool_call_id=tc.id,
@@ -460,10 +463,7 @@ class AgentControl:
                         )
                         ctx = await self._orchestrator.execute(ctx)
                         result = ctx.result or ""
-                        success = not (
-                            isinstance(result, str)
-                            and result.startswith("Error")
-                        )
+                        success = ctx.status == OrchestrationResult.SUCCESS
                         duration = ctx.duration_ms
 
                         # Emit tool end event

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -333,7 +333,12 @@ class TaskRunner:
 
             ctx = await tool_runtime.execute_one(turn, call)
             if cmd.standalone:
-                outcome = "success" if not str(ctx.result or "").startswith("Error:") else "error"
+                from miqi.execution.orchestrator import OrchestrationResult
+                outcome = (
+                    "success"
+                    if ctx.status == OrchestrationResult.SUCCESS
+                    else "error"
+                )
                 if ledger is not None:
                     await ledger.append_item(
                         thread_id=thread_id,

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -19,6 +19,7 @@ from miqi.execution.hook_runtime import (
     HookRuntime,
     LifecycleHookContext,
 )
+from miqi.execution.orchestrator import OrchestrationResult
 
 
 @dataclass
@@ -299,7 +300,7 @@ class TurnRunner:
                     turn_id=turn.turn_id,
                     tool_call_id=tc.id,
                     tool_name=tc.name,
-                    success=not result_text.startswith("Error"),
+                    success=ctx.status == OrchestrationResult.SUCCESS,
                     output_preview=result_text[:200],
                     output_size=len(result_text),
                     duration_ms=getattr(ctx, "duration_ms", 0),

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -279,8 +279,31 @@ class TurnRunner:
                         },
                     )
 
+            from miqi.protocol.events import ToolCallBeginEvent, ToolCallEndEvent
+
+            for tc in response.tool_calls:
+                await self._events.emit(ToolCallBeginEvent(
+                    turn_id=turn.turn_id,
+                    tool_call_id=tc.id,
+                    tool_name=tc.name,
+                    tool_display=self._format_tool_hint(tc.name, tc.arguments),
+                    arguments=tc.arguments,
+                ))
+
             # Execute tool calls concurrently through ToolRuntime
             contexts = await self._tools.execute_many(turn, response.tool_calls)
+
+            for tc, ctx in zip(response.tool_calls, contexts):
+                result_text = ctx.result or ""
+                await self._events.emit(ToolCallEndEvent(
+                    turn_id=turn.turn_id,
+                    tool_call_id=tc.id,
+                    tool_name=tc.name,
+                    success=not result_text.startswith("Error"),
+                    output_preview=result_text[:200],
+                    output_size=len(result_text),
+                    duration_ms=getattr(ctx, "duration_ms", 0),
+                ))
 
             # Phase 24: record tool call completions in ledger
             if self._ledger is not None:
@@ -405,3 +428,13 @@ class TurnRunner:
             system_prompt=metadata.system_prompt,
             tools=tools,
         )
+
+    @staticmethod
+    def _format_tool_hint(name: str, args: dict) -> str:
+        """Format a tool call as a concise display hint."""
+        val = next(iter(args.values()), "") if args else ""
+        if not isinstance(val, str):
+            return name
+        if len(val) > 50:
+            return f'{name}("{val[:50]}...")'
+        return f'{name}("{val}")'

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -306,6 +306,69 @@ async def test_shutdown_cancels_pending_tasks():
 
 
 @pytest.mark.asyncio
+async def test_drain_chat_events_converts_tool_begin_to_tool_hint_progress():
+    from miqi.bridge.loop import BridgeRuntimeLoop
+    from miqi.protocol.events import ToolCallBeginEvent, TurnCompleteEvent
+
+    class FakeAppServer:
+        def __init__(self):
+            self.events = []
+
+        async def emit_event(self, session_id, event_type, data, request_id=None):
+            self.events.append({
+                "session_id": session_id,
+                "event_type": event_type,
+                "data": data,
+                "request_id": request_id,
+            })
+
+    class FakeRuntime:
+        def __init__(self):
+            self.events = [
+                ToolCallBeginEvent(
+                    turn_id="turn-asset",
+                    tool_call_id="tc-asset",
+                    tool_name="write_file",
+                    tool_display='write_file("/tmp/asset.txt")',
+                    arguments={"path": "/tmp/asset.txt"},
+                ),
+                TurnCompleteEvent(
+                    turn_id="turn-asset",
+                    thread_id="thread-asset",
+                    outcome="success",
+                    tools_used=["write_file"],
+                    token_usage={},
+                ),
+            ]
+
+        async def next_event(self, timeout=None):
+            return self.events.pop(0)
+
+    loop = BridgeRuntimeLoop(send_func=_CaptureSend().send)
+    loop._app_server = FakeAppServer()
+
+    await loop._drain_chat_events(
+        request_id="req-asset",
+        runtime=FakeRuntime(),
+        thread_id="thread-asset",
+        session_id="session-asset",
+        client_id="client-asset",
+    )
+
+    progress = loop._app_server.events[0]
+    assert progress == {
+        "session_id": "session-asset",
+        "event_type": "progress",
+        "data": {
+            "text": 'write_file("/tmp/asset.txt")',
+            "tool_hint": True,
+            "tool_call_id": "tc-asset",
+        },
+        "request_id": "req-asset",
+    }
+
+
+@pytest.mark.asyncio
 async def test_phase41_turn_handlers_registered_on_bridge_app_server():
     from miqi.bridge.loop import BridgeRuntimeLoop
 

--- a/tests/execution/test_tool_result_status.py
+++ b/tests/execution/test_tool_result_status.py
@@ -1,0 +1,232 @@
+"""Regression tests for structured tool success/failure classification.
+
+Issue #104 / PR #108 review: ``success`` must not be inferred from whether the
+tool result text starts with ``"Error"``. The orchestrator sets a structured
+``ctx.status`` (:class:`OrchestrationResult`) on every exit path, and callers
+classify success as ``ctx.status == OrchestrationResult.SUCCESS`` — no text
+guessing. This catches failure paths whose result text does NOT start with
+``"Error"``: ``Permission denied:`` (hook block + DENY), ``User denied:``
+(approval rejected), and ``Tool execution cancelled`` (cancellation), which
+the old ``not result.startswith("Error")`` check wrongly reported as success.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.execution.hook_runtime import (
+    HookPoint,
+    HookRegistration,
+    HookRuntime,
+    HookOutcome,
+)
+from miqi.execution.orchestrator import (
+    OrchestrationResult,
+    ToolExecutionContext,
+    ToolOrchestrator,
+)
+from miqi.execution.permission_engine import (
+    PermissionDecision,
+    PermissionVerdict,
+)
+
+
+def _make_ctx(**kwargs) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        tool_name=kwargs.get("tool_name", "write_file"),
+        tool_call_id=kwargs.get("tool_call_id", "call_001"),
+        arguments=kwargs.get("arguments", {"path": "/tmp/x", "content": "x"}),
+        turn_id=kwargs.get("turn_id", "turn_001"),
+        thread_id=kwargs.get("thread_id", "thread_abc"),
+        agent_type=kwargs.get("agent_type", "main"),
+    )
+
+
+def _build_orch(permission_engine, sandbox_engine, hook_runtime, tool_registry):
+    ev = MagicMock()
+    ev.emit = AsyncMock()
+    return ToolOrchestrator(
+        permission_engine=permission_engine,
+        sandbox_engine=sandbox_engine,
+        hook_runtime=hook_runtime,
+        tool_registry=tool_registry,
+        event_emitter=ev,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_tool_use_block_sets_denied_by_policy():
+    """PRE_TOOL_USE 'block': result is 'Permission denied: ...' which does NOT
+    start with 'Error' — the old startswith('Error') check reported success."""
+    hr = HookRuntime()
+
+    async def veto(ctx):
+        return HookOutcome.block("policy violation")
+
+    hr.register(HookRegistration(HookPoint.PRE_TOOL_USE, "*", veto, priority=10))
+
+    pe = MagicMock()
+    pe.check = AsyncMock()
+    se = MagicMock()
+    se.select = AsyncMock()
+    tr = MagicMock()
+    orch = _build_orch(pe, se, hr, tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result.startswith("Permission denied:")
+    assert result_ctx.status is OrchestrationResult.DENIED_BY_POLICY
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_permission_deny_sets_denied_by_policy():
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.DENY, reason="not on allowlist"
+    ))
+    se = MagicMock()
+    se.select = AsyncMock()
+    tr = MagicMock()
+    orch = _build_orch(pe, se, HookRuntime(), tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result.startswith("Permission denied:")
+    assert result_ctx.status is OrchestrationResult.DENIED_BY_POLICY
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_user_denied_approval_sets_denied_by_user():
+    """'User denied: ...' does not start with 'Error' — old check reported
+    success. Structured status classifies it correctly as failure."""
+    hr = HookRuntime()
+
+    async def _request_approval(ctx, decision):
+        return PermissionDecision(
+            verdict=PermissionVerdict.DENY, reason="user said no"
+        )
+
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.APPROVAL_REQUIRED, reason="needs approval"
+    ))
+    se = MagicMock()
+    se.select = AsyncMock()
+    tr = MagicMock()
+    orch = _build_orch(pe, se, hr, tr)
+    orch._request_approval = _request_approval
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result.startswith("User denied:")
+    assert result_ctx.status is OrchestrationResult.DENIED_BY_USER
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_cancellation_sets_cancelled():
+    """'Tool execution cancelled' does not start with 'Error' — old check
+    reported success."""
+    hr = HookRuntime()
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.ALLOW
+    ))
+    se = MagicMock()
+
+    async def _select(ctx, attempt):
+        raise asyncio.CancelledError()
+
+    se.select = AsyncMock(side_effect=_select)
+    tr = MagicMock()
+    orch = _build_orch(pe, se, hr, tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result == "Tool execution cancelled"
+    assert result_ctx.status is OrchestrationResult.CANCELLED
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_sandbox_max_retries_sets_sandbox_failed():
+    hr = HookRuntime()
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.ALLOW
+    ))
+    se = MagicMock()
+
+    async def _select(ctx, attempt):
+        from miqi.execution.sandbox_policy import SandboxDeniedError
+        raise SandboxDeniedError("no sandbox available")
+
+    se.select = AsyncMock(side_effect=_select)
+    tr = MagicMock()
+    orch = _build_orch(pe, se, hr, tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result.startswith("Error: sandbox denied")
+    assert result_ctx.status is OrchestrationResult.SANDBOX_FAILED
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_exception_sets_tool_error():
+    hr = HookRuntime()
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.ALLOW
+    ))
+    se = MagicMock()
+
+    async def _select(ctx, attempt):
+        sel = MagicMock()
+        sel.sandbox_type = MagicMock()
+        return sel
+
+    se.select = AsyncMock(side_effect=_select)
+    tr = MagicMock()
+    tool_mock = MagicMock()
+    tool_mock.execute = AsyncMock(side_effect=ValueError("disk full"))
+    tool_mock.validate_params.return_value = []
+    tr.get.return_value = tool_mock
+    orch = _build_orch(pe, se, hr, tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result.startswith("Error executing")
+    assert result_ctx.status is OrchestrationResult.TOOL_ERROR
+    assert result_ctx.status != OrchestrationResult.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_successful_execution_sets_success():
+    hr = HookRuntime()
+    pe = MagicMock()
+    pe.check = AsyncMock(return_value=PermissionDecision(
+        verdict=PermissionVerdict.ALLOW
+    ))
+    se = MagicMock()
+
+    async def _select(ctx, attempt):
+        sel = MagicMock()
+        sel.sandbox_type = MagicMock()
+        return sel
+
+    se.select = AsyncMock(side_effect=_select)
+    tr = MagicMock()
+    tool_mock = MagicMock()
+    tool_mock.execute = AsyncMock(return_value="wrote /tmp/x")
+    tool_mock.validate_params.return_value = []
+    tr.get.return_value = tool_mock
+    orch = _build_orch(pe, se, hr, tr)
+
+    result_ctx = await orch.execute(_make_ctx())
+
+    assert result_ctx.result == "wrote /tmp/x"
+    assert result_ctx.status is OrchestrationResult.SUCCESS

--- a/tests/runtime/test_turn_runner.py
+++ b/tests/runtime/test_turn_runner.py
@@ -153,6 +153,78 @@ async def test_turn_runner_handles_tool_calls(turn_runner, fake_turn_context, fa
 
 
 @pytest.mark.asyncio
+async def test_turn_runner_emits_tool_call_lifecycle_events(
+    turn_runner, fake_turn_context, fake_tool_runtime
+):
+    from miqi.protocol.events import ToolCallBeginEvent, ToolCallEndEvent
+    from miqi.providers.base import LLMStreamEvent
+
+    runner, provider = turn_runner
+    emitted = []
+    runner._events.emit.side_effect = lambda event: emitted.append(event)
+
+    tc = _FakeToolCall("write_file", {"path": "/tmp/asset.txt"}, "tc-write")
+    tc.arguments_json = '{"path": "/tmp/asset.txt"}'
+
+    async def _execute_many(turn, calls):
+        emitted.append("execute_many")
+
+        class _Ctx:
+            tool_call_id = "tc-write"
+            result = "created"
+            duration_ms = 12
+
+        return [_Ctx()]
+
+    fake_tool_runtime.execute_many.side_effect = _execute_many
+
+    call_count = 0
+
+    async def _stream_side_effect(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            yield LLMStreamEvent(
+                kind="completed",
+                response=_FakeResponse(tool_calls=[tc]),
+            )
+        else:
+            yield LLMStreamEvent(
+                kind="completed",
+                response=_FakeResponse(content="done after tools"),
+            )
+
+    provider.stream_chat = _stream_side_effect
+
+    result = await runner.run(
+        turn=fake_turn_context,
+        user_content="create a file",
+        system_prompt="sys",
+        tools=[{"type": "function", "function": {"name": "write_file", "parameters": {}}}],
+    )
+
+    assert result.final_content == "done after tools"
+    assert [type(event).__name__ if event != "execute_many" else event for event in emitted] == [
+        "ToolCallBeginEvent",
+        "execute_many",
+        "ToolCallEndEvent",
+    ]
+    begin = emitted[0]
+    end = emitted[2]
+    assert isinstance(begin, ToolCallBeginEvent)
+    assert begin.tool_name == "write_file"
+    assert begin.tool_call_id == "tc-write"
+    assert begin.arguments == {"path": "/tmp/asset.txt"}
+    assert begin.tool_display == 'write_file("/tmp/asset.txt")'
+    assert isinstance(end, ToolCallEndEvent)
+    assert end.tool_name == "write_file"
+    assert end.success is True
+    assert end.output_preview == "created"
+    assert end.output_size == len("created")
+    assert end.duration_ms == 12
+
+
+@pytest.mark.asyncio
 async def test_turn_runner_exhausts_iterations(turn_runner, fake_turn_context):
     from miqi.providers.base import LLMStreamEvent
 

--- a/tests/runtime/test_turn_runner.py
+++ b/tests/runtime/test_turn_runner.py
@@ -52,6 +52,9 @@ def fake_tool_runtime():
         def __init__(self, tc):
             self.tool_call_id = tc.id
             self.result = f"result-for-{tc.name}"
+            # Mirror real orchestrator output: a successful tool call.
+            from miqi.execution.orchestrator import OrchestrationResult
+            self.status = OrchestrationResult.SUCCESS
 
     async def _fake_execute_many(turn, calls):
         return [_Ctx(c) for c in calls]
@@ -173,6 +176,9 @@ async def test_turn_runner_emits_tool_call_lifecycle_events(
             tool_call_id = "tc-write"
             result = "created"
             duration_ms = 12
+            # Mirror real orchestrator output: write_file succeeded.
+            from miqi.execution.orchestrator import OrchestrationResult
+            status = OrchestrationResult.SUCCESS
 
         return [_Ctx()]
 

--- a/tests/runtime/test_user_shell_command_task_runner.py
+++ b/tests/runtime/test_user_shell_command_task_runner.py
@@ -19,11 +19,13 @@ class _FakeToolRuntime:
 
     async def execute_one(self, turn, tool_call):
         self.calls.append((turn, tool_call))
+        from miqi.execution.orchestrator import OrchestrationResult
         return SimpleNamespace(
             result="hello\n",
             duration_ms=12,
             tool_name="exec",
             tool_call_id=tool_call.id,
+            status=OrchestrationResult.SUCCESS,
         )
 
 


### PR DESCRIPTION
## 类型
🐛 Bug 修复

## 变更概述
Closes #104。续 PR #108 的 review 修复（owner 指出 `success=not result_text.startswith("Error")` 过于简单）。

修复 Desktop 中 AI 创建或使用文件后，右侧 Task Assets 面板未显示文件的问题；并按 review 意见把工具成功/失败判定从字符串推断改为结构化状态。

## 背景/问题
Issue #104 现象：AI 可以正常创建/修改文件，文件已生成，但右侧 Task Assets 面板始终显示 No files yet。

定位到两个断点：
1. `TurnRunner` 调用 `ToolRuntime.execute_many()` 时未发送 `ToolCallBeginEvent` / `ToolCallEndEvent`，RuntimeSession 缺少工具生命周期事件。
2. `BridgeRuntimeLoop` 将运行时事件转发为普通 progress 数据，而前端 Task Assets 仅解析带 `tool_hint` 和 `text` 字段的 progress payload，无法识别工具创建/操作的文件。

## 变更内容
### miqi/runtime/turn_runner.py
- 工具执行前发送 `ToolCallBeginEvent`，执行后发送 `ToolCallEndEvent`
- 生成统一工具显示文本，如 `write_file("/tmp/test.txt")`

### miqi/bridge/loop.py
- 新增对 `ToolCallBeginEvent` / `ToolCallEndEvent` 的处理，转换为前端可识别的 progress payload（`text` + `tool_hint: true` + `tool_call_id`），复用现有 `parseToolHint()` / `trackFile()`，前端无需修改

### review 修复（本次提交 82a3e05）
owner @14790897 指出 `success=not result_text.startswith("Error")` 太简单 —— `Permission denied:` / `User denied:` / `Tool execution cancelled` 等失败结果不以 "Error" 开头，会被误判为成功。按 CodeRabbit 建议改为结构化状态：
- `ToolExecutionContext` 新增 `status: OrchestrationResult | None` 字段
- orchestrator 在每个出口显式设置状态（`DENIED_BY_POLICY` / `DENIED_BY_USER` / `SANDBOX_FAILED` / `TIMEOUT` / `CANCELLED` / `TOOL_ERROR` / `SUCCESS`）
- `turn_runner` / `agent_control` / `task_runner` 改为 `ctx.status == OrchestrationResult.SUCCESS`，不再文本猜测
- 新增 `tests/execution/test_tool_result_status.py` 覆盖此前会被误判为成功的失败路径

## Tests
- 新增 Runtime / Bridge 回归测试 + 结构化状态回归测试
- `uv run python -m pytest tests/runtime/test_turn_runner.py tests/bridge/test_bridge_loop.py tests/execution/test_tool_result_status.py -q` → 全部通过
- `python -m py_compile` + `git diff --check` 通过

## 兼容性/风险
- 仅补充缺失的工具生命周期事件，不改变工具执行逻辑
- Bridge 仅新增两个事件处理，其余运行时事件保持原有行为
- 前端无需修改，复用现有 `parseToolHint()` / `trackFile()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer tool-call lifecycle updates during chats, including begin/end progress events with tool details and timing.
  * Tool execution now reports a structured outcome status, improving how results are classified.
* **Bug Fixes**
  * Improved success/error detection for tool runs and shell commands by using execution status instead of parsing output text.
  * Better handling of failures, denials, cancellations, timeouts, and sandbox issues.
* **Tests**
  * Added regression coverage for tool outcome classification and tool-call event ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->