### PR TITLE
fix(providers): parse HTTP-date Retry-After header per RFC 7231 (Closes #25)

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -4,6 +4,8 @@ import asyncio
 import random
 import re
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from enum import Enum
 from typing import TypeVar
 
@@ -330,7 +332,14 @@ def retry_after_seconds(exc: BaseException) -> float | None:
 
 
 def _parse_retry_after_seconds(value: str) -> float | None:
-    """Parse a Retry-After value expressed in seconds."""
+    """Parse a Retry-After value expressed in seconds or as an HTTP-date.
+
+    RFC 7231 §7.1.1.1 allows Retry-After to be either an integer number of
+    seconds ("120") or an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"). The
+    date form is an absolute timestamp; the returned delay is the remaining
+    seconds until that moment, clamped to 0 (a date already in the past must
+    never produce a negative backoff).
+    """
     value = value.strip()
     if not value:
         return None
@@ -341,7 +350,20 @@ def _parse_retry_after_seconds(value: str) -> float | None:
     try:
         return float(value)
     except ValueError:
+        pass
+
+    # HTTP-date form (RFC 7231 §7.1.1.1). parsedate_to_datetime returns a
+    # naive datetime for dates without tz info; assume GMT per the spec.
+    try:
+        parsed_date = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
         return None
+    if parsed_date is None:
+        return None
+    if parsed_date.tzinfo is None:
+        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
+    delay = (parsed_date - datetime.now(timezone.utc)).total_seconds()
+    return max(0.0, delay)
 
 
 def compute_backoff(

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -154,6 +154,55 @@ def test_retry_after_seconds_ms_attribute() -> None:
     assert retry_after_seconds(SimpleNamespace(retry_after_ms=2500)) == 2.5
 
 
+# ── Issue #25: Retry-After HTTP-date format (RFC 7231 §7.1.1.1) ────────────
+
+
+def test_retry_after_seconds_http_date_header() -> None:
+    """A future HTTP-date Retry-After must yield a positive delay in seconds."""
+    import datetime as _dt
+
+    future = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=30)
+    http_date = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    response = SimpleNamespace(headers=_FakeHeaders({"Retry-After": http_date}))
+    exc = SimpleNamespace(response=response)
+    parsed = retry_after_seconds(exc)
+    assert parsed is not None
+    # Allow scheduling jitter; the server asked for ~30s, not 0.
+    assert 25.0 <= parsed <= 35.0
+
+
+def test_parse_retry_after_seconds_http_date_future() -> None:
+    from miqi.providers.resilience import _parse_retry_after_seconds
+
+    # Fixed RFC 7231 example. As an absolute timestamp it is in the past, so the
+    # remaining delay must clamp to 0 (never a negative backoff).
+    assert _parse_retry_after_seconds("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0
+
+
+def test_parse_retry_after_seconds_http_date_relative() -> None:
+    """Parsing is monotonic: a later target date yields a strictly larger delay."""
+    import datetime as _dt
+
+    from miqi.providers.resilience import _parse_retry_after_seconds
+
+    soon = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=10)
+    later = soon + _dt.timedelta(seconds=20)
+    parse_soon = _parse_retry_after_seconds(soon.strftime("%a, %d %b %Y %H:%M:%S GMT"))
+    parse_later = _parse_retry_after_seconds(later.strftime("%a, %d %b %Y %H:%M:%S GMT"))
+    assert parse_soon is not None and parse_later is not None
+    assert parse_later > parse_soon
+
+
+def test_parse_retry_after_seconds_seconds_still_preferred() -> None:
+    """Plain seconds must keep working unchanged after the HTTP-date addition."""
+    from miqi.providers.resilience import _parse_retry_after_seconds
+
+    assert _parse_retry_after_seconds("120") == 120.0
+    assert _parse_retry_after_seconds("120.5") == 120.5
+    assert _parse_retry_after_seconds("") is None
+    assert _parse_retry_after_seconds("not a date") is None
+
+
 # ---------------------------------------------------------------------------
 # compute_backoff
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 Issue #25：`Retry-After` 响应头使用 RFC 7231 规定的 HTTP-date 格式（如 `Wed, 21 Oct 2015 07:28:00 GMT`）时，`_parse_retry_after_seconds` 无法解析、返回 None，回退到指数退避，退避时长可能远短于服务端要求，导致连续 429。

## 背景/问题

**根因：** `miqi/providers/resilience.py` 的 `_parse_retry_after_seconds`

```python
# 修复前：只解析秒数
def _parse_retry_after_seconds(value: str) -> float | None:
    """Parse a Retry-After value expressed in seconds."""
    value = value.strip()
    if not value:
        return None
    try:
        return float(int(value))      # 只处理 "120"
    except ValueError:
        pass
    try:
        return float(value)           # 只处理 "120.5"
    except ValueError:
        return None                   # "Wed, 21 Oct 2015 07:28:00 GMT" → None
```

RFC 7231 §7.1.1.1 规定 Retry-After 既可以是秒数，也可以是 HTTP-date 绝对时间戳。原实现只处理秒数形式，HTTP-date 形式落入最后的 `except ValueError: return None`，`retry_after_seconds` 回退返回 None，`compute_backoff` 改用指数退避——可能远短于服务端要求的等待时间。

## 变更内容

**文件：** `miqi/providers/resilience.py`（+23 / -1）

在秒数解析（int / float）都失败后，新增 HTTP-date 解析分支：用标准库 `email.utils.parsedate_to_datetime` 解析绝对时间戳，返回 `max(0, target - now)` 秒数。

```python
# 修复后：秒数优先，HTTP-date 兜底
def _parse_retry_after_seconds(value: str) -> float | None:
    """Parse a Retry-After value expressed in seconds or as an HTTP-date.

    RFC 7231 §7.1.1.1 allows Retry-After to be either an integer number of
    seconds ("120") or an HTTP-date ("Wed, 21 Oct 2015 07:28:00 GMT"). The
    date form is an absolute timestamp; the returned delay is the remaining
    seconds until that moment, clamped to 0 (a date already in the past must
    never produce a negative backoff).
    """
    value = value.strip()
    if not value:
        return None
    try:
        return float(int(value))
    except ValueError:
        pass
    try:
        return float(value)
    except ValueError:
        pass

    # HTTP-date form (RFC 7231 §7.1.1.1). parsedate_to_datetime returns a
    # naive datetime for dates without tz info; assume GMT per the spec.
    try:
        parsed_date = parsedate_to_datetime(value)
    except (TypeError, ValueError):
        return None
    if parsed_date is None:
        return None
    if parsed_date.tzinfo is None:
        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
    delay = (parsed_date - datetime.now(timezone.utc)).total_seconds()
    return max(0.0, delay)
```

设计要点：
- 秒数解析路径完全不变（int/float 优先尝试），纯增量、零回归风险。
- HTTP-date 仅在两条秒数解析都失败后才尝试，绝不会让原本能解析为秒数的输入走日期路径。
- 过去的时间戳 clamp 到 `0.0`，绝不返回负 backoff。
- 无 tz 的日期按 RFC 假定为 GMT。
- 非日期、非秒数的垃圾输入仍返回 None（保留原行为）。

回归测试 `tests/test_provider_resilience.py`（新增 4 个用例，+49）：
- `test_retry_after_seconds_http_date_header`：未来 HTTP-date 经 header 路径应返回正秒数（≈30s）。
- `test_parse_retry_after_seconds_http_date_future`：RFC 7231 示例日期（过去时间）应 clamp 到 0.0。
- `test_parse_retry_after_seconds_http_date_relative`：更晚的日期 → 更大的延迟（单调性）。
- `test_parse_retry_after_seconds_seconds_still_preferred`：纯秒数 / 浮点 / 空 / 垃圾输入行为不变（护航测试）。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/test_provider_resilience.py -k "http_date or seconds_still"
  FAILED tests/test_provider_resilience.py::test_retry_after_seconds_http_date_header
    assert parsed is not None  →  None
  FAILED tests/test_provider_resilience.py::test_parse_retry_after_seconds_http_date_future
    assert _parse_retry_after_seconds("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0  →  None == 0.0
  FAILED tests/test_provider_resilience.py::test_parse_retry_after_seconds_http_date_relative
    assert parse_soon is not None  →  None
  3 failed, 1 passed

【应用修复】uv run python -m pytest tests/test_provider_resilience.py -k "http_date or seconds_still"
  4 passed (0.90s)

【全套回归】uv run python -m pytest tests/test_provider_resilience.py tests/test_provider_retry.py
  52 passed (1.28s)   （50 原有 + 2 retry，无回归）
```

边界验证（手动）：
```
_parse_retry_after_seconds("Wed, 21 Oct 2015 07:28:00 GMT")  →  0.0   (过去日期 clamp)
_parse_retry_after_seconds("120")                            →  120.0 (秒数不变)
_parse_retry_after_seconds("120.5")                          →  120.5 (浮点不变)
_parse_retry_after_seconds("not a date")                     →  None  (垃圾不变)
_parse_retry_after_seconds(<ISO datetime str>)               →  None  (ISO 非法日期，安全 None)
```

## 测试情况

- `uv run python -m pytest tests/test_provider_resilience.py` — 50 passed
- `uv run python -m pytest tests/test_provider_resilience.py tests/test_provider_retry.py` — 52 passed
- `uv run python -c "import miqi.providers.resilience"` — 导入无错误

## 关联 Issue

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Retry-After` values so both numeric delays and HTTP-date formats are supported.
  * Backdated or expired timestamps now safely resolve to a zero-second wait instead of a negative delay.

* **Tests**
  * Added coverage for HTTP-date parsing, past and future timestamps, and existing numeric/decimal delay behavior.
  * Verified invalid or empty values continue to be ignored gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->