### PR TITLE
fix(providers): treat network 'not found' as transient, not invalid (Closes #26)

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -160,8 +160,17 @@ def _classify_transient_by_message(exc: BaseException) -> bool:
         "bad gateway",
         "service unavailable",
         "overloaded",
+        # Issue #26: DNS / connectivity "not found" phrasing is transient, not
+        # a 404-style invalid request.
+        "host not found",
+        "server not found",
+        "name resolution",
     )
-    return any(s in message for s in signals)
+    if any(s in message for s in signals):
+        return True
+    # "connection ... not found" with arbitrary words/separators in between,
+    # e.g. "Connection to server not found", "_connection not found_".
+    return bool(re.search(r"connection.{0,40}not found", message))
 
 
 def classify_error(exc: BaseException) -> ErrorKind:

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -121,6 +121,30 @@ def test_classify_error_unknown_fatal() -> None:
     assert classify_error(Exception("something weird")) == ErrorKind.FATAL
 
 
+# ── Issue #26: transient network errors must not be caught by "not found" ─
+
+
+@pytest.mark.parametrize("message", [
+    "Connection to server not found",
+    "host not found",
+    "_connection not found_ while dialing upstream",
+    "Temporary failure in name resolution: host not found",
+])
+def test_classify_error_network_not_found_is_transient(message: str) -> None:
+    """A DNS/connection 'not found' is transient and retryable, not invalid."""
+    assert classify_error(Exception(message)) == ErrorKind.TRANSIENT
+
+
+@pytest.mark.parametrize("message", [
+    "NotFoundError: model not found",
+    "model not found: gpt-x",
+    "The model was not found",
+])
+def test_classify_error_resource_not_found_still_invalid(message: str) -> None:
+    """A 404-style resource 'not found' stays invalid (non-retryable)."""
+    assert classify_error(Exception(message)) == ErrorKind.INVALID_REQUEST
+
+
 # ---------------------------------------------------------------------------
 # is_retryable
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 Issue #26：`_classify_by_message` 用 `"not found" in message` 子串匹配判定 INVALID_REQUEST（不可重试），过于宽泛。`"Connection to server not found"`、`"host not found"` 等 DNS/连接错误被误判为不可重试，本可通过重试恢复的请求直接失败。

## 背景/问题

**根因：** `miqi/providers/resilience.py` 的 `_classify_by_message`

```python
# 修复前："not found" 子串匹配过宽
if "not found" in message or "bad request" in message or "invalid request" in message:
    return ErrorKind.INVALID_REQUEST  # 不可重试
# "Connection to server not found" → INVALID_REQUEST ❌
```

`classify_error` 的回退顺序为：SDK 类型 → 状态码 → **transient 关键词** → `_classify_by_message`。瞬态网络错误（DNS/连接）通常没有 HTTP 状态码，落到 transient 关键词词表 `_classify_transient_by_message`；但该词表只有 `connection reset`/`timeout`/`502` 等，**不含** "not found" 类短语，于是穿透到 `_classify_by_message`，命中 `"not found"` 被误判为 INVALID_REQUEST。

## 变更内容

**文件：** `miqi/providers/resilience.py`（+9 / -1）

在 `_classify_transient_by_message` 的 transient 信号表补充 DNS/连接性 "not found" 短语，并加正则匹配变长 `connection ... not found`：

```python
# 修复后：网络性 "not found" 在 transient 步骤命中，不到 INVALID_REQUEST
signals = (
    ...,
    # Issue #26: DNS / connectivity "not found" phrasing is transient, not
    # a 404-style invalid request.
    "host not found",
    "server not found",
    "name resolution",
)
if any(s in message for s in signals):
    return True
# "connection ... not found" with arbitrary words/separators in between,
# e.g. "Connection to server not found", "_connection not found_".
return bool(re.search(r"connection.{0,40}not found", message))
```

设计要点：
- 分类顺序未变：transient 步骤在 `_classify_by_message` 之前。网络性 "not found" 现在在 transient 步骤命中 TRANSIENT，根本不会到 INVALID_REQUEST 判定。
- 404-style 资源缺失（`"model not found"`、`"NotFoundError: ..."`）不含网络性短语，仍走原路径判 INVALID_REQUEST，**行为不变**。
- 正则 `connection.{0,40}not found` 容忍中间任意词/分隔（`Connection to server not found`、`_connection not found_`），{0,40} 限制跨度避免误匹配远距离 "not found"。
- `_classify_by_message` 本身未改，"bad request"/"invalid request" 分支不受影响。

回归测试 `tests/test_provider_resilience.py`（新增 2 组参数化用例，+24）：
- `test_classify_error_network_not_found_is_transient`：4 条网络性 "not found" 消息 → TRANSIENT。
- `test_classify_error_resource_not_found_still_invalid`：3 条资源性 "not found" → 仍 INVALID_REQUEST（护航，防过度修复）。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/test_provider_resilience.py -k "network_not_found or resource_not_found"
  FAILED ...Connection to server not found        → INVALID_REQUEST (应 TRANSIENT)
  FAILED ...host not found                        → INVALID_REQUEST (应 TRANSIENT)
  FAILED ..._connection not found_ ...            → INVALID_REQUEST (应 TRANSIENT)
  3 failed, 4 passed

【应用修复】uv run python -m pytest tests/test_provider_resilience.py -k "network_not_found or resource_not_found"
  7 passed (0.93s)

【全套回归】uv run python -m pytest tests/test_provider_resilience.py tests/test_provider_retry.py
  55 passed (1.31s)   （含原有 model-not-found / transient-keywords 用例，无回归）
```

## 测试情况

- `uv run python -m pytest tests/test_provider_resilience.py` — 53 passed
- `uv run python -m pytest tests/test_provider_resilience.py tests/test_provider_retry.py` — 55 passed
- `uv run python -c "import miqi.providers.resilience"` — 导入无错误

## 关联 Issue

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification so more DNS and connectivity “not found” messages are treated as retryable transient errors.
  * Kept genuine resource/model “not found” responses classified as invalid requests.

* **Tests**
  * Added coverage for both transient network-style “not found” cases and non-retryable resource “not found” cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->