### PR TITLE
fix(skills): reject trailing separators in plugin names (Closes #88)

### DIFF
--- a/miqi/skills/plugin_manager.py
+++ b/miqi/skills/plugin_manager.py
@@ -28,7 +28,7 @@ from miqi.execution.hook_runtime import (
 
 # ── shared plugin-name validator ──────────────────────────────────────────
 
-_PLUGIN_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$")
+_PLUGIN_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$")
 
 
 def validate_plugin_name(name: str) -> None:

--- a/tests/skills/test_plugin_manager.py
+++ b/tests/skills/test_plugin_manager.py
@@ -433,3 +433,42 @@ def test_install_plugin_registers_under_requested_name_only(tmp_path, monkeypatc
     assert pm.get_plugin("my-plugin") is plugin
     # Registration key equals manifest name.
     assert "my-plugin" in pm._plugins
+
+
+# ---------------------------------------------------------------------------
+# Issue #88: plugin name must not end with a separator (- _ .)
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.mark.parametrize("name", [
+    "my-plugin-",      # trailing dash
+    "my.plugin.",      # trailing dot
+    "my_plugin_",      # trailing underscore
+    "a---",            # all separators after first char
+    "ab-",             # length 3, trailing dash
+])
+def test_validate_plugin_name_rejects_trailing_separator(name):
+    """A plugin name ending in a separator is invalid (filesystem/URL safety)."""
+    from miqi.skills.plugin_manager import validate_plugin_name
+
+    with pytest.raises(ValueError):
+        validate_plugin_name(name)
+
+
+@pytest.mark.parametrize("name", [
+    "my-plugin",       # normal
+    "hello_world",     # underscore in middle
+    "test.tool",       # dot in middle
+    "a",               # single char (length 1, no trailing sep)
+    "ab",              # length 2, both alphanumeric
+    "MyPlugin",
+    "x" * 64,          # max length, alphanumeric
+])
+def test_validate_plugin_name_accepts_valid_names(name):
+    """Valid names — including single char and alnum-only max-length — pass."""
+    from miqi.skills.plugin_manager import validate_plugin_name
+
+    # Should not raise.
+    validate_plugin_name(name)


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 Issue #88：插件名正则允许以连字符 `-`、点号 `.`、下划线 `_` 结尾（如 `my-plugin-`、`my.plugin.`）。尾部特殊符在 Windows 上会被自动修剪/引发目录名问题，并在路径拼接、URL 构造中产生非预期行为。

## 背景/问题

**根因：** `miqi/skills/plugin_manager.py` 的 `_PLUGIN_NAME_RE`

```python
# 修复前：末字符可为 - _ .
_PLUGIN_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$")
#                                       首字符字母数字 ✓   末字符任意 ✗
```

只约束了首字符必须是字母数字，末字符可以是任意允许字符（含 `-`/`.`/`_`）。已有的 `..` 连续点号检查（L41）只防中间双点，没防首尾特殊符。

```
"my-plugin-"  → 尾 -  ✗ 合法
"my.plugin."  → 尾 .  ✗ 合法
"a---"        → 全 -  ✗ 合法
```

## 变更内容

**文件：** `miqi/skills/plugin_manager.py`（+1 / -1）

```python
# 修复后：首尾都必须字母数字
_PLUGIN_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?$")
```

设计要点：
- 首字符 `[a-zA-Z0-9]`，可选组 `([a-zA-Z0-9_.-]{0,62}[a-zA-Z0-9])?` 要求若存在则**以字母数字结尾**。
- 单字符名（如 `"a"`）仍合法：可选组不匹配，首字符即整体。
- 长度上限不变：首 1 +（中间 ≤62 + 尾 1）= 最多 64 字符，与原 `{0,63}`（首+63=64）一致。`"x"*64` 合法、`"a"*65` 拒绝。
- 尾部 `-`/`.`/`_` 全部被拒。
- `..` 连续点号检查保留，行为不变。

回归测试 `tests/skills/test_plugin_manager.py`（新增 2 组参数化用例，+39）：
- `test_validate_plugin_name_rejects_trailing_separator`：`my-plugin-` / `my.plugin.` / `my_plugin_` / `a---` / `ab-` → ValueError。
- `test_validate_plugin_name_accepts_valid_names`：`my-plugin` / `hello_world` / `test.tool` / `a`（单字符） / `ab` / `MyPlugin` / `x*64`（最大长度）→ 通过。

注：文件内既有的 `test_invalid_plugin_names_rejected` 使用自带的旧正则副本、且其 invalid 列表未含尾部场景，故不受本修复影响，仍通过。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/skills/test_plugin_manager.py -k "validate_plugin_name"
  FAILED ...[my-plugin-]    Failed: DID NOT RAISE ValueError
  FAILED ...[my.plugin.]    Failed: DID NOT RAISE ValueError
  FAILED ...[my_plugin_]    Failed: DID NOT RAISE ValueError
  FAILED ...[a---]          Failed: DID NOT RAISE ValueError
  FAILED ...[ab-]           Failed: DID NOT RAISE ValueError
  5 failed, 7 passed

【应用修复】uv run python -m pytest tests/skills/test_plugin_manager.py
  24 passed (0.19s)   （12 原有 + 12 新增参数化，无回归）
```

## 测试情况

- `uv run python -m pytest tests/skills/test_plugin_manager.py` — 24 passed
- `uv run python -c "from miqi.skills.plugin_manager import validate_plugin_name"` — 导入无错误

## 关联 Issue

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
