### PR TITLE
fix(runtime): stop leaking raw exception into AppServerError message (Closes #120)

### DIFF
--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -173,7 +173,7 @@ async def sessions_get_handler(
             raise AppServerError(exc.args[0], code=exc.code) from exc
     except Exception as exc:
         logger.warning("Failed to load session %s: %s", session_key, exc)
-        raise AppServerError(f"Failed to get session: {exc}", code="INTERNAL") from exc
+        raise AppServerError("Failed to get session", code="INTERNAL") from exc
 
     if runtime is not None:
         return {


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 #120：develop 上 `test_phase35_no_raw_str_exc_in_runtime_handlers` 失败。`miqi/runtime/session_handlers.py` 的 `sessions_get_handler` 把原始异常 `{exc}` 拼进了对外 `AppServerError` 错误消息，违反 phase35 审计（要求 runtime handler 记录完整异常、对外返回固定安全文案）。

## 背景/问题

**根因：** `miqi/runtime/session_handlers.py:176`

```python
# 修复前：裸 {exc} 透出到对外错误消息
except Exception as exc:
    logger.warning("Failed to load session %s: %s", session_key, exc)
    raise AppServerError(f"Failed to get session: {exc}", code="INTERNAL") from exc
```

phase35 审计（`tests/bridge/test_phase35_control_plane_audit.py`）禁止 `AppServerError(str(exc))` 与 `AppServerError(f"...{exc}...")`，要求「log full exc with logger, return a fixed safe message」。该行是 runtime 目录内唯一违规点。

## 变更内容

**文件：** `miqi/runtime/session_handlers.py`（+1 / -1）

去掉对外消息里的 `{exc}`，返回固定文案。完整异常仍由上一行已有的 `logger.warning("Failed to load session %s: %s", session_key, exc)` 记录，符合审计注释的约定。

```python
# 修复后：固定文案，exc 仅进日志
except Exception as exc:
    logger.warning("Failed to load session %s: %s", session_key, exc)
    raise AppServerError("Failed to get session", code="INTERNAL") from exc
```

修法遵循本文件既有固定文案风格（如 L37 / `app_server.py` L692 的 `"Bridge state not available"`）。本文件其它 `AppServerError(exc.args[0], code=exc.code)` 是已知业务异常（受控 `.args[0]` 与 `.code`），不在审计禁止范围，未改动。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/bridge/test_phase35_control_plane_audit.py::test_phase35_no_raw_str_exc_in_runtime_handlers
  FAILED — Found 1 unsanitized error message(s) in runtime handlers:
    - session_handlers.py:176: f-string with {exc}: raise AppServerError(f"Failed to get session: {exc}", code="INTERNAL") from exc

【应用修复】uv run python -m pytest tests/bridge/test_phase35_control_plane_audit.py::test_phase35_no_raw_str_exc_in_runtime_handlers
  PASSED (0.27s)
```

## 测试情况

- `uv run python -m pytest tests/bridge/test_phase35_control_plane_audit.py` — 14 passed
- `uv run python -m pytest tests/bridge/ tests/runtime/ --deselect tests/runtime/test_phase66_generated_types_audit.py::test_generated_typescript_contract_is_up_to_date` — 1324 passed, 4 skipped
  （deselect 的 `test_generated_typescript_contract_is_up_to_date` 是 #121 跟踪的 develop 预存红，与本 PR 无关，未触碰）

## 关联 Issue

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
