### PR TITLE
fix(providers): repair malformed stream tool-call args with json_repair (Closes #24)

### DIFF
--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -189,6 +189,29 @@ class OpenAIProvider(LLMProvider):
         """Return True for retryable transient errors."""
         return resilience.classify_error(error) == ErrorKind.TRANSIENT
 
+    def _parse_tool_call_arguments(self, tool_name: str, args: Any) -> dict[str, Any]:
+        """Parse tool-call arguments with json_repair fallback."""
+        if not isinstance(args, str):
+            return args if isinstance(args, dict) else {}
+
+        if not args:
+            return {}
+
+        repaired = json_repair.loads(args)
+        try:
+            parsed = json.loads(args)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning(
+                "json_repair fixed malformed tool args for '{}': {}",
+                tool_name,
+                args[:200],
+            )
+            parsed = repaired
+
+        if isinstance(parsed, dict):
+            return parsed
+        return repaired if isinstance(repaired, dict) else {}
+
     # ------------------------------------------------------------------
     # Main interface
     # ------------------------------------------------------------------
@@ -248,27 +271,13 @@ class OpenAIProvider(LLMProvider):
         tool_calls: list[ToolCallRequest] = []
         if hasattr(message, "tool_calls") and message.tool_calls:
             for tc in message.tool_calls:
-                args = tc.function.arguments
-                if isinstance(args, str):
-                    repaired = json_repair.loads(args)
-                    try:
-                        original = json.loads(args)
-                    except (json.JSONDecodeError, ValueError):
-                        logger.warning(
-                            "json_repair fixed malformed tool args for '{}': {}",
-                            tc.function.name,
-                            args[:200],
-                        )
-                        original = None
-                    args = repaired if original is None else original
-
-                if not isinstance(args, dict):
-                    args = {}
-
                 tool_calls.append(ToolCallRequest(
                     id=tc.id,
                     name=tc.function.name,
-                    arguments=args,
+                    arguments=self._parse_tool_call_arguments(
+                        tc.function.name,
+                        tc.function.arguments,
+                    ),
                 ))
 
         if not tool_calls and isinstance(message.content, str):
@@ -490,26 +499,13 @@ class OpenAIProvider(LLMProvider):
         parsed_tool_calls: list[ToolCallRequest] = []
         for idx in sorted(tool_call_accum.keys()):
             acc = tool_call_accum[idx]
-            raw_args = acc["function"]["arguments"]
-            # Issue #24: parity with the non-stream path — repair malformed
-            # JSON with json_repair and warn, instead of silently falling
-            # back to {}.
-            repaired = json_repair.loads(raw_args) if raw_args else {}
-            try:
-                args = json.loads(raw_args)
-            except (json.JSONDecodeError, ValueError):
-                logger.warning(
-                    "json_repair fixed malformed tool args for '{}': {}",
-                    acc["function"]["name"],
-                    str(raw_args)[:200],
-                )
-                args = repaired
-            if not isinstance(args, dict):
-                args = repaired if isinstance(repaired, dict) else {}
             parsed_tool_calls.append(ToolCallRequest(
                 id=acc["id"],
                 name=acc["function"]["name"],
-                arguments=args,
+                arguments=self._parse_tool_call_arguments(
+                    acc["function"]["name"],
+                    acc["function"]["arguments"],
+                ),
             ))
 
         yield LLMStreamEvent(

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -490,12 +490,22 @@ class OpenAIProvider(LLMProvider):
         parsed_tool_calls: list[ToolCallRequest] = []
         for idx in sorted(tool_call_accum.keys()):
             acc = tool_call_accum[idx]
+            raw_args = acc["function"]["arguments"]
+            # Issue #24: parity with the non-stream path — repair malformed
+            # JSON with json_repair and warn, instead of silently falling
+            # back to {}.
+            repaired = json_repair.loads(raw_args) if raw_args else {}
             try:
-                args = json.loads(acc["function"]["arguments"])
+                args = json.loads(raw_args)
             except (json.JSONDecodeError, ValueError):
-                args = {}
+                logger.warning(
+                    "json_repair fixed malformed tool args for '{}': {}",
+                    acc["function"]["name"],
+                    str(raw_args)[:200],
+                )
+                args = repaired
             if not isinstance(args, dict):
-                args = {}
+                args = repaired if isinstance(repaired, dict) else {}
             parsed_tool_calls.append(ToolCallRequest(
                 id=acc["id"],
                 name=acc["function"]["name"],

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -164,9 +164,9 @@ class _FakeFunction:
 class _FakeToolCall:
     """Simulates an OpenAI streaming tool-call delta with an index."""
 
-    def __init__(self, index=0, id="call_1", name="", arguments=""):
+    def __init__(self, index=0, call_id="call_1", name="", arguments=""):
         self.index = index
-        self.id = id
+        self.id = call_id
         self.type = "function"
         self.function = _FakeFunction(name=name, arguments=arguments)
 
@@ -175,7 +175,7 @@ async def _stream_with_tool_args(provider, arguments_str: str) -> list[LLMStream
     """Stream a single tool call whose accumulated arguments = arguments_str."""
     chunks = [
         [_FakeChoice(_FakeDelta(tool_calls=[_FakeToolCall(
-            index=0, id="call_1", name="web_search", arguments=arguments_str,
+            index=0, call_id="call_1", name="web_search", arguments=arguments_str,
         )]))],
         [_FakeChoice(_FakeDelta(), finish_reason="tool_calls")],
     ]
@@ -220,6 +220,18 @@ async def test_stream_valid_tool_args_unchanged():
 
     completed = events[-1]
     assert completed.response.tool_calls[0].arguments == {"query": "今日要闻"}
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_tool_args_resolves_to_empty_dict():
+    """Empty streamed tool-call args remain an empty dict."""
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    provider = OpenAIProvider(api_key="sk-test")
+    events = await _stream_with_tool_args(provider, "")
+
+    completed = events[-1]
+    assert completed.response.tool_calls[0].arguments == {}
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -148,3 +148,101 @@ async def test_openai_streaming_emits_reasoning_deltas():
     # Final content should still be in the completed response
     assert events[-1].response is not None
     assert events[-1].response.content == "answer"
+
+
+# ── Issue #24: stream tool-call args need json_repair fallback ────────────
+
+
+class _FakeFunction:
+    """Simulates an OpenAI streaming tool-call function delta."""
+
+    def __init__(self, name="", arguments=""):
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeToolCall:
+    """Simulates an OpenAI streaming tool-call delta with an index."""
+
+    def __init__(self, index=0, id="call_1", name="", arguments=""):
+        self.index = index
+        self.id = id
+        self.type = "function"
+        self.function = _FakeFunction(name=name, arguments=arguments)
+
+
+async def _stream_with_tool_args(provider, arguments_str: str) -> list[LLMStreamEvent]:
+    """Stream a single tool call whose accumulated arguments = arguments_str."""
+    chunks = [
+        [_FakeChoice(_FakeDelta(tool_calls=[_FakeToolCall(
+            index=0, id="call_1", name="web_search", arguments=arguments_str,
+        )]))],
+        [_FakeChoice(_FakeDelta(), finish_reason="tool_calls")],
+    ]
+
+    async def _fake_create(**kw):
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+    return await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "search the news"}],
+        model="gpt-4o",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_malformed_tool_args_repaired_not_dropped():
+    """Issue #24: slightly malformed tool-call args must be repaired by
+    json_repair (matching the non-stream path), not silently fall back to {}."""
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    provider = OpenAIProvider(api_key="sk-test")
+    # Single-quoted JSON: json.loads fails, json_repair recovers the real args.
+    events = await _stream_with_tool_args(provider, "{'query': '今日要闻'}")
+
+    completed = events[-1]
+    assert completed.kind == "completed"
+    assert completed.response is not None
+    assert len(completed.response.tool_calls) == 1
+    args = completed.response.tool_calls[0].arguments
+    # Must recover the real query, not silently become {}.
+    assert args == {"query": "今日要闻"}, f"json_repair should recover args, got {args!r}"
+
+
+@pytest.mark.asyncio
+async def test_stream_valid_tool_args_unchanged():
+    """Valid tool-call args parse as before (regression guard)."""
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    provider = OpenAIProvider(api_key="sk-test")
+    events = await _stream_with_tool_args(provider, '{"query": "今日要闻"}')
+
+    completed = events[-1]
+    assert completed.response.tool_calls[0].arguments == {"query": "今日要闻"}
+
+
+@pytest.mark.asyncio
+async def test_stream_malformed_tool_args_logs_warning():
+    """Issue #24: malformed args must also log a warning (parity with non-stream)."""
+    from loguru import logger as loguru_logger
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    messages: list[str] = []
+
+    def _sink(message):
+        messages.append(str(message.record["message"]))
+
+    # loguru uses its own sinks (not stdlib logging), so capture via a test
+    # sink instead of pytest's caplog.
+    handler_id = loguru_logger.add(_sink, level="WARNING")
+    try:
+        provider = OpenAIProvider(api_key="sk-test")
+        await _stream_with_tool_args(provider, "{'query': '今日要闻'}")
+    finally:
+        loguru_logger.remove(handler_id)
+
+    assert any("malformed tool args" in m for m in messages), (
+        f"expected a malformed-tool-args warning, got: {messages}"
+    )


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 #24：`stream_chat` 解析累积的 tool-call 参数时只用 `json.loads()`，失败静默回退 `{}`，与非流式路径用 `json_repair.loads()` 修复畸形 JSON 并记录 warning 的行为不一致。轻微畸形的参数 JSON 导致工具以空参数静默执行。

## 背景/问题

**根因：** `miqi/providers/openai_provider.py` 中流式路径 `stream_chat`

```python
# 修复前：仅 json.loads，失败静默 {}
try:
    args = json.loads(acc["function"]["arguments"])
except (json.JSONDecodeError, ValueError):
    args = {}
```

非流式路径（同文件 `_parse_response` L251-263）已有完整兜底：`json_repair.loads` 先修，`json.loads` 验证，失败记 warning 并用 repaired 兜底。流式路径未对齐此行为。

## 变更内容

**文件：** `miqi/providers/openai_provider.py`（+13 / -3）

将流式 tool-call 参数解析对齐非流式先例：

```python
# 修复后：json_repair 兜底 + warning，与非流式一致
raw_args = acc["function"]["arguments"]
repaired = json_repair.loads(raw_args) if raw_args else {}
try:
    args = json.loads(raw_args)
except (json.JSONDecodeError, ValueError):
    logger.warning(
        "json_repair fixed malformed tool args for '{}': {}",
        acc["function"]["name"],
        str(raw_args)[:200],
    )
    args = repaired
if not isinstance(args, dict):
    args = repaired if isinstance(repaired, dict) else {}
```

- `json_repair` 已在文件顶部导入（非流式路径在用）。
- warning 文案与非流式 `json_repair fixed malformed tool args for ...` 一致。
- 空 arguments（`""`）依旧得到 `{}`，行为不变。
- 合法 JSON 仍走 `json.loads` 原路径，不触发 warning。

回归测试 `tests/providers/test_openai_streaming.py`（新增 3 用例 +98）：
- `test_stream_malformed_tool_args_repaired_not_dropped`：单引号畸形 JSON（`{'query': '今日要闻'}`，`json.loads` 必失败、`json_repair` 可修）→ 修出真实 `{"query": "今日要闻"}`，不再回退 `{}`。
- `test_stream_valid_tool_args_unchanged`：合法 JSON → 行为不变（护航）。
- `test_stream_malformed_tool_args_logs_warning`：畸形 → 记录 `malformed tool args` warning（与非流式 parity）。用 loguru 测试 sink 捕获（loguru 不经 stdlib logging，故用原生 sink 而非 caplog）。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/providers/test_openai_streaming.py -k tool_args
  FAILED test_stream_malformed_tool_args_repaired_not_dropped — got {} not {'query': '今日要闻'}
  FAILED test_stream_malformed_tool_args_logs_warning — no warning logged
  2 failed, 1 passed

【应用修复】uv run python -m pytest tests/providers/test_openai_streaming.py -k tool_args
  3 passed (1.26s)

【全套回归】uv run python -m pytest tests/providers/ tests/test_provider_resilience.py tests/test_tool_call_fallback.py
  55 passed (4.21s)
```

修复后实际日志（畸形输入触发）：
```
WARNING | miqi.providers.openai_provider:stream_chat:501 - json_repair fixed malformed tool args for 'web_search': {'query': '今日要闻'}
```

## 测试情况

- `uv run python -m pytest tests/providers/test_openai_streaming.py` — 6 passed
- `uv run python -m pytest tests/providers/ tests/test_provider_resilience.py tests/test_tool_call_fallback.py` — 55 passed

## 关联 Issue

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed tool-call arguments so slightly malformed JSON can be recovered instead of being dropped or replaced with an empty object.
  * Added a warning when tool-call argument parsing fails, making issues easier to spot while still continuing with repaired data.

* **Tests**
  * Added coverage for valid, malformed, and warning-emitting tool-call argument streams to verify the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->