### PR TITLE
fix(runtime): default missing role in compaction instead of KeyError (Closes #85)

### DIFF
--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -357,7 +357,7 @@ class HistoryRuntime:
                         thread_id,
                         self.session_id,
                         turn_id,
-                        msg["role"],
+                        msg.get("role", "unknown"),
                         msg.get("content") or "",
                         json.dumps(
                             {

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -177,3 +177,40 @@ async def test_history_delete_turn_messages(tmp_path):
         assert [m["content"] for m in messages] == ["one"]
     finally:
         await runtime.close()
+
+
+# ── Issue #85: compaction must not crash on a message missing 'role' ──────
+
+
+@pytest.mark.asyncio
+async def test_replace_messages_with_compaction_skips_missing_role(tmp_path):
+    """A replacement message missing the 'role' key must not crash compaction.
+
+    Without the fix, msg["role"] raises KeyError, the compaction transaction
+    rolls back, and the user sees no compaction effect at all. The same loop
+    already used msg.get("content") — role should be accessed the same way.
+    """
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    await runtime.append_message(thread_id="t1", turn_id="a", role="user", content="old")
+
+    # A replacement batch where one message is missing 'role' (e.g. legacy /
+    # abnormally-written data). The other message is well-formed.
+    await runtime.replace_messages_with_compaction(
+        "t1",
+        "compact-1",
+        [
+            {"content": "no role here"},          # missing role
+            {"role": "system", "content": "[summary]"},
+        ],
+    )
+    try:
+        messages = await runtime.load_messages("t1")
+        # Compaction completes: the well-formed message survives; the missing-role
+        # one gets a default role rather than crashing the whole transaction.
+        assert {"role": "system", "content": "[summary]"} in messages
+        assert len(messages) == 2
+        roles = [m["role"] for m in messages]
+        assert "unknown" in roles, f"missing-role msg should default to 'unknown', got {roles}"
+    finally:
+        await runtime.close()


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复 #85：上下文压缩 `replace_messages_with_compaction` 对 `role` 用直接索引 `msg["role"]`，缺 role 字段的历史消息（旧版本数据/异常写入）会触发 `KeyError`，整个压缩事务回滚，用户看不到任何压缩效果，对话持续膨胀直到超出模型限制。同一循环内 `content` 却用安全的 `msg.get("content")` —— 两处访问方式不一致。

## 背景/问题

**根因：** `miqi/runtime/history_runtime.py` 的 `replace_messages_with_compaction`

```python
# 修复前：role 直接索引，content 却 .get —— 不一致
msg["role"],
msg.get("content") or "",
```

## 变更内容

**文件：** `miqi/runtime/history_runtime.py`（+1 / -1）

```python
# 修复后：统一 .get，缺 role 降级为 'unknown'
msg.get("role", "unknown"),
msg.get("content") or "",
```

- 对齐同循环 `content` 的 `.get` 风格。
- 缺 role 的消息降级为可见标记 `"unknown"`（`role` 列 NOT NULL，空串是脏数据；`"unknown"` 是显式异常标记，便于后续排查），压缩不再崩、事务不再回滚。
- 不改变压缩后消息数量与顺序，其余正常消息照常压缩。

回归测试 `tests/runtime/test_history_runtime.py`（新增 1 用例 +37）：
- `test_replace_messages_with_compaction_skips_missing_role`：replacement 批次含一条缺 role 的消息 + 一条正常消息 → 压缩完成；正常消息存活；缺 role 的那条得到 `"unknown"`，且事务未回滚（修复前在此处 KeyError）。

## 日志/验证证据

```
测试驱动调试（RED -> GREEN）：

【回退修复】uv run python -m pytest tests/runtime/test_history_runtime.py::test_replace_messages_with_compaction_skips_missing_role
  FAILED — KeyError: 'role' (compaction transaction rolled back)

【应用修复】uv run python -m pytest tests/runtime/test_history_runtime.py
  8 passed (0.56s)
```

## 测试情况

- `uv run python -m pytest tests/runtime/test_history_runtime.py` — 8 passed

## 关联 Issue

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
