### PR TITLE
fix: show live tool calls in chat

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -711,6 +711,17 @@ export function ChatConsole({
       fullContent = data.content;
       finalDone = true;
       setCurrentReqId(null);
+      if (data.tool_calls?.length) {
+        const toolMessages = sessionMsgsToUi([
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: data.tool_calls,
+            timestamp: new Date().toISOString(),
+          },
+        ]);
+        setMessages((prev) => [...prev, ...toolMessages]);
+      }
       // Do NOT push an empty assistant bubble here — revealNext creates the
       // bubble lazily once the first chunk is available, so we never flash a
       // blank message box. Handle the empty-reply case (no text at all)

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -680,6 +680,7 @@ export interface ChatProgress {
 export interface ChatFinal {
   content: string;
   aborted?: boolean;
+  tool_calls?: unknown[];
 }
 
 export interface ChatError {

--- a/miqi/bridge/event_emitter.py
+++ b/miqi/bridge/event_emitter.py
@@ -67,6 +67,7 @@ class EventEmitter:
                     "turn_id": event.turn_id,
                     "content": event.content,
                     "finish_reason": event.finish_reason,
+                    "tool_calls": event.tool_calls,
                 })
 
             case "agent_reasoning":

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -633,6 +633,7 @@ class BridgeRuntimeLoop:
                     await _emit_terminal("final", {
                         "content": event.content,
                         "aborted": False,
+                        "tool_calls": event.tool_calls,
                     })
                     # Do NOT break — consume the TurnCompleteEvent that
                     # follows so the next drain task starts with a clean queue.

--- a/miqi/protocol/events.py
+++ b/miqi/protocol/events.py
@@ -97,6 +97,7 @@ class AgentMessageEvent:
     turn_id: str
     content: str
     finish_reason: str = "stop"
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
 
 
 # ── Tool Call Events ────────────────────────────────────────

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -660,10 +660,16 @@ class TaskRunner:
                     },
                 )
 
+            tool_calls: list[dict[str, Any]] = []
+            for message in result.messages_delta:
+                if message.get("role") == "assistant":
+                    tool_calls.extend(message.get("tool_calls") or [])
+
             await self._events.put(AgentMessageEvent(
                 turn_id=turn_id,
                 content=result.final_content or "",
                 finish_reason="stop",
+                tool_calls=tool_calls,
             ))
             await self._events.put(TurnCompleteEvent(
                 turn_id=turn_id,

--- a/tests/protocol/test_events.py
+++ b/tests/protocol/test_events.py
@@ -110,13 +110,20 @@ def test_agent_reasoning_event():
 def test_agent_message_event():
     from miqi.protocol.events import AgentMessageEvent
 
+    tool_calls = [{
+        "id": "call_001",
+        "type": "function",
+        "function": {"name": "web_search", "arguments": '{"query":"MiQi"}'},
+    }]
     event = AgentMessageEvent(
         turn_id="turn_001",
         content="Here is the result.",
         finish_reason="stop",
+        tool_calls=tool_calls,
     )
     assert event.type == "agent_message"
     assert event.finish_reason == "stop"
+    assert event.tool_calls == tool_calls
 
 
 # ── Task 1.4: Tool call events ─────────────────────────────

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -53,6 +53,9 @@ def fake_services(fake_config, fake_provider):
     services.turn_runner.run = AsyncMock()
     run_result = MagicMock()
     run_result.final_content = "hi there"
+    run_result.messages_delta = [{"role": "assistant", "content": "hi there"}]
+    run_result.tools_used = []
+    run_result.token_usage = {}
     services.turn_runner.run.return_value = run_result
     # Phase 17: explicitly None to avoid MagicMock auto-creation
     services.history_runtime = None

--- a/tests/runtime/test_runtime_task_runner.py
+++ b/tests/runtime/test_runtime_task_runner.py
@@ -32,6 +32,37 @@ async def test_task_runner_routes_user_message_to_turn_runner(fake_services):
 
 
 @pytest.mark.asyncio
+async def test_task_runner_forwards_tool_calls_on_final_agent_message(fake_services):
+    """Realtime final events must carry assistant tool_calls for #106."""
+    from miqi.protocol.events import AgentMessageEvent
+
+    tool_calls = [{
+        "id": "tc-search",
+        "type": "function",
+        "function": {"name": "web_search", "arguments": '{"query":"MiQi"}'},
+    }]
+    fake_services.turn_runner.run.return_value.final_content = "found it"
+    fake_services.turn_runner.run.return_value.messages_delta = [
+        {"role": "assistant", "content": None, "tool_calls": tool_calls},
+        {"role": "tool", "tool_call_id": "tc-search", "content": "result"},
+        {"role": "assistant", "content": "found it"},
+    ]
+    fake_services.turn_runner.run.return_value.tools_used = ["web_search"]
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(content="search", thread_id="cli:default"))
+
+    while True:
+        event = await asyncio.wait_for(events.get(), timeout=1)
+        if isinstance(event, AgentMessageEvent):
+            assert event.content == "found it"
+            assert event.tool_calls == tool_calls
+            break
+
+
+@pytest.mark.asyncio
 async def test_task_runner_handles_abort_turn(fake_services):
     """AbortTurn signals cancellation event and emits ErrorEvent (Phase 14 follow-up).
 


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 #106：工具调用消息在实时聊天中不显示，只有切换会话或重新加载后才显示的问题。

## 背景/问题

用户让 AI 搜索或调用工具时，工具调用实际已经发生，历史持久化里也保存了 `tool_calls`。

修复前现象：

- 实时聊天中看不到 `1 tool calls`
- 切到其它聊天再切回来后，才能看到 `1 tool calls`
- 说明 reload 路径正常，实时事件路径缺少工具调用数据

根因是实时 `AgentMessageEvent` / bridge `final` payload 只携带 assistant 文本，没有携带 assistant 消息里的 `tool_calls`。前端实时 `onFinal` 因此无法像 reload 路径一样渲染折叠工具调用消息。

## 变更内容

- `miqi/protocol/events.py`
  - 给 `AgentMessageEvent` 增加 `tool_calls` 字段

- `miqi/runtime/task_runner.py`
  - 从本轮 `TurnResult.messages_delta` 的 assistant 消息中收集 `tool_calls`
  - 将 `tool_calls` 放入最终 `AgentMessageEvent`

- `miqi/bridge/loop.py`
  - bridge 的实时 `final` 事件 payload 转发 `tool_calls`

- `miqi/bridge/event_emitter.py`
  - legacy `chat:final` 路径同步转发 `tool_calls`

- `apps/desktop/src/shared/ipc.ts`
  - `ChatFinal` 类型增加可选 `tool_calls`

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 实时 `onFinal` 收到 `tool_calls` 后，复用已有 `sessionMsgsToUi()` 渲染折叠工具调用消息
  - 让实时路径和 reload 路径显示一致

- `tests/protocol/test_events.py`
  - 覆盖 `AgentMessageEvent.tool_calls`

- `tests/runtime/test_runtime_task_runner.py`
  - 增加 #106 回归测试，确认实时 final agent message 会携带 tool calls

## 日志/验证证据

修复前：

```text
实时聊天中：
U
A
Thinking...

切换到其它聊天再切回来后：
1 tool calls
  web_search(...)
  web_fetch(...)
```

修复后截图：

<img width="1899" height="1233" alt="tool" src="https://github.com/user-attachments/assets/5da370d1-8b4e-4359-b92b-f59ae981acee" />

修复后实时聊天中可以直接看到工具调用消息：

```text
web_search("今日要闻 2026年7月3日")
web_search (0ms)
web_fetch("")
web_fetch("")
web_fetch (0ms)
web_fetch (0ms)
```

定位结论：

```text
Provider -> TurnRunner -> messages_delta -> TaskRunner -> history -> reload
链路中 tool_calls 均存在。

实时路径：
AgentMessageEvent / bridge final payload 未携带 tool_calls，
因此前端 onFinal 无法立即渲染工具调用消息。
```

本 PR 修复后：

```text
TaskRunner 会将 messages_delta 中的 assistant tool_calls 放入 AgentMessageEvent。
bridge final payload 会继续转发 tool_calls。
ChatConsole.onFinal 收到 tool_calls 后，实时渲染折叠工具调用消息。
```

## 测试情况

已执行：

```shell
uv run pytest tests/protocol/test_events.py tests/runtime/test_runtime_task_runner.py tests/runtime/test_runtime_client.py tests/runtime/test_ledger_serialization.py tests/runtime/test_turn_event_adapter.py tests/runtime/test_task_runner_history_integration.py tests/runtime/test_turn_runner.py -q
```

结果：

```text
86 passed
```

已执行：

```shell
npm test
```

结果：

```text
Test Files  6 passed (6)
Tests       79 passed (79)
```

已执行：

```shell
git diff --check
```

结果：

```text
passed
```

补充说明：

```text
npm run typecheck 当前仍有既有无关错误，不属于本次 #106 改动范围：

src/main/ipc/index.ts:753
src/renderer/features/wsl/WslStatusPage.tsx:329
src/renderer/features/chat/ChatConsole.tsx:459
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool-call details are now included in final chat messages and shown in the conversation view.
  * Final assistant responses can now surface structured tool-call entries alongside message content.

* **Bug Fixes**
  * Fixed an issue where tool-call information could be lost before the final chat message was displayed.
  * Improved consistency so final response data now includes tool-call payloads end-to-end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->