### PR TITLE
fix(bridge): prevent chat.send timeout race

### DIFF
--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -507,4 +507,36 @@ describe('BridgeManager lifecycle', () => {
     // Wait for timeout
     await expect(sendPromise).rejects.toThrow(/timed out/);
   }, 10_000);
+
+  it('keeps chat.send client timeout later than the backend drain timeout', async () => {
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge, { clientId: 'default-timeout-test', serverInfo: { version: '1' } });
+
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const sendPromise = bridge.send('chat.send', { message: 'test' }, (() => {}) as any);
+      sendPromise.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        }
+      );
+
+      await vi.advanceTimersByTimeAsync(300_001);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await expect(sendPromise).rejects.toThrow(/Request chat\.send timed out/);
+    } finally {
+      vi.useRealTimers();
+      proc.stdout.destroy();
+      proc.stderr.destroy();
+    }
+  }, 10_000);
 });

--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { PassThrough } from 'stream';
-import { buildInitializeParams, normalizeBridgeMessage } from './bridge';
+import {
+  buildInitializeParams,
+  CHAT_BACKEND_DRAIN_TIMEOUT_MS,
+  CHAT_SEND_TIMEOUT_MS,
+  normalizeBridgeMessage,
+} from './bridge';
 
 // ============================================================
 // Pure-function tests (unchanged)
@@ -528,10 +533,12 @@ describe('BridgeManager lifecycle', () => {
         }
       );
 
-      await vi.advanceTimersByTimeAsync(300_001);
+      await vi.advanceTimersByTimeAsync(CHAT_BACKEND_DRAIN_TIMEOUT_MS + 1);
       expect(settled).toBe(false);
 
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(
+        CHAT_SEND_TIMEOUT_MS - CHAT_BACKEND_DRAIN_TIMEOUT_MS - 1
+      );
       await expect(sendPromise).rejects.toThrow(/Request chat\.send timed out/);
     } finally {
       vi.useRealTimers();

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -58,6 +58,8 @@ export interface InitializeParams {
 
 /** Terminal event types that resolve/reject a streaming pending entry. */
 const TERMINAL_EVENT_TYPES = new Set(['final', 'error', 'aborted']);
+const CHAT_BACKEND_DRAIN_TIMEOUT_MS = 300_000;
+const CHAT_SEND_TIMEOUT_MS = CHAT_BACKEND_DRAIN_TIMEOUT_MS + 60_000;
 
 export function normalizeBridgeMessage(resp: BridgeResponse): NormalizedBridgeMessage {
   const requestId =
@@ -649,7 +651,7 @@ export class BridgeManager extends EventEmitter {
 
     const id = randomUUID();
     const request: BridgeRequest = { id, method, params };
-    const timeoutMs = options.timeoutMs ?? (method === 'chat.send' ? 300_000 : 30_000);
+    const timeoutMs = options.timeoutMs ?? (method === 'chat.send' ? CHAT_SEND_TIMEOUT_MS : 30_000);
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -58,8 +58,9 @@ export interface InitializeParams {
 
 /** Terminal event types that resolve/reject a streaming pending entry. */
 const TERMINAL_EVENT_TYPES = new Set(['final', 'error', 'aborted']);
-const CHAT_BACKEND_DRAIN_TIMEOUT_MS = 300_000;
-const CHAT_SEND_TIMEOUT_MS = CHAT_BACKEND_DRAIN_TIMEOUT_MS + 60_000;
+// Keep in sync with `runtime.next_event(timeout=300)` in `miqi/bridge/loop.py`.
+export const CHAT_BACKEND_DRAIN_TIMEOUT_MS = 300_000;
+export const CHAT_SEND_TIMEOUT_MS = CHAT_BACKEND_DRAIN_TIMEOUT_MS + 60_000;
 
 export function normalizeBridgeMessage(resp: BridgeResponse): NormalizedBridgeMessage {
   const requestId =

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -628,6 +628,8 @@ class BridgeRuntimeLoop:
             )
 
             while True:
+                # Keep in sync with CHAT_BACKEND_DRAIN_TIMEOUT_MS in
+                # apps/desktop/src/main/bridge.ts.
                 event = await runtime.next_event(timeout=300)
                 if event is None:
                     # Timeout — no response from agent

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -594,14 +594,21 @@ class BridgeRuntimeLoop:
             )
 
         async def _emit_terminal(event_type: str, data: Any) -> bool:
-            """Emit a terminal event, preventing duplicates."""
+            """Send a terminal event for this chat request.
+
+            Terminal chat events settle the Electron pending request, so they
+            must not depend on session fanout. Fanout can legitimately skip
+            delivery when a client is unsubscribed or a sink is missing; the
+            current request still needs a deterministic terminal response.
+            """
             if request_id in self._terminal_sent:
                 return False
             self._terminal_sent.add(request_id)
-            await app_server.emit_event(
-                session_id, event_type, data,
-                request_id=request_id,
-            )
+            self._send({
+                "id": request_id,
+                "type": event_type,
+                "data": data,
+            })
             return True
 
         try:

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -369,6 +369,39 @@ async def test_drain_chat_events_converts_tool_begin_to_tool_hint_progress():
 
 
 @pytest.mark.asyncio
+async def test_drain_chat_events_sends_backend_timeout_error_directly():
+    from miqi.bridge.loop import BridgeRuntimeLoop
+
+    class DroppingAppServer:
+        async def emit_event(self, session_id, event_type, data, request_id=None):
+            return None
+
+    class TimeoutRuntime:
+        async def next_event(self, timeout=None):
+            return None
+
+    capturer = _CaptureSend()
+    loop = BridgeRuntimeLoop(send_func=capturer.send)
+    loop._app_server = DroppingAppServer()
+
+    await loop._drain_chat_events(
+        request_id="req-timeout",
+        runtime=TimeoutRuntime(),
+        thread_id="thread-timeout",
+        session_id="session-timeout",
+        client_id="client-timeout",
+    )
+
+    assert capturer.messages[0] == {
+        "id": "req-timeout",
+        "type": "error",
+        "data": {
+            "message": "Turn timed out after 300s",
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_phase41_turn_handlers_registered_on_bridge_app_server():
     from miqi.bridge.loop import BridgeRuntimeLoop
 


### PR DESCRIPTION
﻿## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 #119：用户对话或工具调用过程中偶发 `Request chat.send timed out`，导致聊天中断的问题。

## 背景/问题

用户在 MiQi Desktop 中对话，尤其是让 AI 搜索或调用工具时，界面或命令行可能出现：

```text
chat.send failed: Error invoking remote method 'chat:send': Error: Request chat.send timed out
```

修复前现象：

- `chat.send` 客户端默认 timeout 为 300s
- Python bridge 的 `_drain_chat_events()` 同样使用 `runtime.next_event(timeout=300)`
- 两边超时时间相同，可能出现 Electron IPC 客户端先超时，用户看到的是 `Request chat.send timed out`
- terminal event 通过 AppServer session fanout 转发，如果 fanout 跳过或 sink 丢失，当前 request 可能收不到 `final/error/aborted`

根因是 `chat.send` 的客户端等待超时和后端 drain 超时边界重叠，并且 terminal event 依赖 session fanout。当前 request 需要确定收到 terminal response，否则前端会一直等待到 IPC 超时。

## 变更内容

- `apps/desktop/src/main/bridge.ts`
  - 增加 `CHAT_BACKEND_DRAIN_TIMEOUT_MS = 300_000`
  - 增加 `CHAT_SEND_TIMEOUT_MS = CHAT_BACKEND_DRAIN_TIMEOUT_MS + 60_000`
  - 将 `chat.send` 客户端默认 timeout 调整为 360s，确保后端 300s timeout event 有机会先返回

- `miqi/bridge/loop.py`
  - `_drain_chat_events()` 的 terminal event（`final/error/aborted`）直接发送给当前 request
  - 不再依赖 AppServer session fanout 传递 terminal event
  - 保留 `_terminal_sent` 去重，避免重复 terminal event

- `apps/desktop/src/main/bridge.test.ts`
  - 增加 #119 回归测试，确认 `chat.send` 客户端 timeout 晚于后端 drain timeout

- `tests/bridge/test_bridge_loop.py`
  - 增加 #119 回归测试，确认后端 timeout error 会直接发送给当前 request

## 日志/验证证据

修复前：

```text
chat.send failed: Error invoking remote method 'chat:send': Error: Request chat.send timed out
```

修复后截图：

<img width="1264" height="821" alt="119" src="https://github.com/user-attachments/assets/971d44f9-eee3-4756-a7c5-a29cc67a81cd" />

定位结论：

```text
Electron bridge chat.send timeout: 300s
Python bridge _drain_chat_events next_event timeout: 300s

两者边界重叠时，前端可能先抛 Request chat.send timed out。
同时 terminal event 依赖 session fanout，存在当前 request 收不到 terminal 的风险。
```

本 PR 修复后：

```text
Backend drain timeout: 300s
Desktop chat.send client timeout: 360s

后端会先发出 terminal error：Turn timed out after 300s。
terminal event 直接写回当前 request，避免被 session fanout 跳过。
```

## 测试情况

已执行：

```shell
uv run pytest tests/bridge/test_bridge_loop.py -q
```

结果：

```text
15 passed
```

已执行：

```shell
npm run test -- src/main/bridge.test.ts
```

结果：

```text
Test Files  1 passed (1)
Tests       17 passed (17)
```

已执行：

```shell
git diff --check
```

结果：

```text
passed
```

已执行：

```shell
npm run build
```

结果：

```text
passed
```

补充说明：

```text
npm run typecheck:node 当前仍有既有无关错误，不属于本次 #119 改动范围：

src/main/ipc/index.ts:753
```

本次 PR 未修改 UI、配置、WSL 诊断、#109 相关逻辑，也未改变 chat.send 等待完整回答的既有契约。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat requests now allow extra time before timing out, reducing premature failures during long-running sends.
  * Final chat error responses are delivered more reliably, even when event fanout is unavailable.
  * Added coverage to confirm timeout behavior and ensure chat send requests fail with the expected timeout error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->