### PR TITLE
fix(desktop): 显式解析 WSL uptime 分隔符

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -750,7 +750,7 @@ for m in ("pydantic", "httpx", "loguru"):
 
     if (uptimeSec === 0) {
       const upRaw = runInWsl('cat /proc/uptime');
-      if (upRaw.stdout) uptimeSec = parseFloat(upRaw.stdout.split()[0]) || 0;
+      if (upRaw.stdout) uptimeSec = parseFloat(upRaw.stdout.trim().split(/\s+/)[0]) || 0;
     }
 
     // --- CPU usage: two /proc/stat samples with 0.5s delay ---


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [ ] 测试
- [ ] 其他

## 变更概述

修复 #131：`apps/desktop/src/main/ipc/index.ts` 中 WSL uptime fallback 解析调用了无参数 `String.split()`，导致桌面端 Node TypeScript 类型检查失败。

## 背景/问题

`String.prototype.split` 在 TypeScript 标准库中需要显式传入分隔符。原代码：

```ts
upRaw.stdout.split()[0]
```

会触发：

```text
src/main/ipc/index.ts(753,61): error TS2554: Expected 1-2 arguments, but got 0.
```

## 变更内容

- 将 `/proc/uptime` fallback 解析改为显式按空白字符拆分：

```ts
upRaw.stdout.trim().split(/\s+/)[0]
```

这与 `/proc/uptime` 的格式一致，也避免 TypeScript 编译错误。

## 日志/验证证据

修复前已复现：

```shell
npm.cmd run typecheck:node
```

结果：

```text
src/main/ipc/index.ts(753,61): error TS2554: Expected 1-2 arguments, but got 0.
```

修复后已执行：

```shell
npm.cmd run typecheck:node
```

结果：通过。

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该问题是命令行 TypeScript 类型检查失败，没有 UI 展示问题；验证证据见上方 `typecheck:node` 日志。

## 测试情况

- `npm.cmd run typecheck:node`：通过
- `git diff --check`：通过

Closes #131