### PR TITLE
fix(tools): 拒绝空的 web_search/web_fetch 参数

### DIFF
--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -123,7 +123,7 @@ class WebSearchTool(Tool):
     parameters = {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "Search query"},
+            "query": {"type": "string", "description": "Search query", "minLength": 1},
             "count": {
                 "type": "integer",
                 "description": "Results (1-10)",
@@ -229,7 +229,7 @@ class WebFetchTool(Tool):
     parameters = {
         "type": "object",
         "properties": {
-            "url": {"type": "string", "description": "URL to fetch"},
+            "url": {"type": "string", "description": "URL to fetch", "minLength": 1},
             "extractMode": {"type": "string", "enum": ["markdown", "text"], "default": "markdown"},
             "maxChars": {"type": "integer", "minimum": 100},
         },

--- a/tests/execution/test_orchestrator_tool_validation.py
+++ b/tests/execution/test_orchestrator_tool_validation.py
@@ -108,6 +108,24 @@ async def test_web_search_missing_query_returns_validation_error():
 
 
 @pytest.mark.asyncio
+async def test_web_search_empty_query_returns_validation_error():
+    """web_search with empty query should stop before tool execution."""
+    from miqi.agent.tools.web import WebSearchTool
+    tool = WebSearchTool(api_key=None, max_results=3)
+    orch, permission_engine, _hook_runtime = make_orch(tool)
+
+    tool.execute = AsyncMock(return_value="should-not-run")
+
+    ctx = make_ctx(tool_name="web_search", arguments={"query": ""})
+    result_ctx = await orch.execute(ctx)
+
+    assert "Error: Invalid parameters" in result_ctx.result
+    assert "query must be at least 1 chars" in result_ctx.result
+    tool.execute.assert_not_called()
+    permission_engine.check.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_web_search_with_valid_query_proceeds_normally():
     """web_search with query → validation passes, tool executes normally."""
     from miqi.agent.tools.web import WebSearchTool
@@ -142,6 +160,24 @@ async def test_web_fetch_missing_url_returns_validation_error():
 
     assert "Error: Invalid parameters" in result_ctx.result
     assert "missing required url" in result_ctx.result
+    tool.execute.assert_not_called()
+    permission_engine.check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_web_fetch_empty_url_returns_validation_error():
+    """web_fetch with empty url should stop before tool execution."""
+    from miqi.agent.tools.web import WebFetchTool
+    tool = WebFetchTool(max_chars=1000)
+    tool.execute = AsyncMock(return_value="should-not-run")
+
+    orch, permission_engine, _hook_runtime = make_orch(tool)
+
+    ctx = make_ctx(tool_name="web_fetch", arguments={"url": ""})
+    result_ctx = await orch.execute(ctx)
+
+    assert "Error: Invalid parameters" in result_ctx.result
+    assert "url must be at least 1 chars" in result_ctx.result
     tool.execute.assert_not_called()
     permission_engine.check.assert_not_called()
 


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #128：搜索工具缺少配置或模型继续调用空参数时，`web_search("")` / `web_fetch("")` 不应进入工具执行流程。

## 背景/问题

现有工具参数校验只会拦截缺少必填字段，例如：

```json
{}
```

但不会拦截空字符串：

```json
{"url": ""}
```

因此模型在搜索失败后继续发起 `web_fetch("")` 时，空 URL 会进入工具执行，并在实时工具调用里显示为一次看似正常开始/结束的空 URL 调用。

## 变更内容

- 为 `web_search.query` 增加 `minLength: 1`
- 为 `web_fetch.url` 增加 `minLength: 1`
- 增加回归测试，确认：
  - `web_search({"query": ""})` 会在参数校验阶段失败
  - `web_fetch({"url": ""})` 会在参数校验阶段失败
  - 两种情况都不会调用 `tool.execute()`
  - 不会进入权限审批流程

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/execution/test_orchestrator_tool_validation.py -q
```

结果：

```text
2 failed, 9 passed
```

失败原因是空字符串参数会继续进入 `tool.execute()`。

修复后已执行：

```shell
uv run pytest tests/execution/test_orchestrator_tool_validation.py -q
```

结果：

```text
11 passed
```

已执行：

```shell
uv run pytest tests/test_tool_validation.py tests/execution/test_orchestrator_tool_validation.py -q
```

结果：

```text
34 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于工具参数校验层，不涉及 UI 展示改动；原问题中的空 URL 展示由工具执行链路触发，本 PR 通过参数校验阻止 `web_fetch("")` 进入执行。

## 测试情况

- `uv run pytest tests/execution/test_orchestrator_tool_validation.py -q`：11 passed
- `uv run pytest tests/test_tool_validation.py tests/execution/test_orchestrator_tool_validation.py -q`：34 passed
- `git diff --check`：通过

Closes #128