### PR TITLE
fix(providers): do not retry http 409 conflicts

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -133,8 +133,10 @@ def _classify_by_status_code(exc: BaseException) -> ErrorKind | None:
         return ErrorKind.RATE_LIMIT
     if code in (401, 403):
         return ErrorKind.AUTH
-    if code in (408, 409) or 500 <= code < 600:
+    if code == 408 or 500 <= code < 600:
         return ErrorKind.TRANSIENT
+    if code == 409:
+        return ErrorKind.INVALID_REQUEST
     if code in (400, 404):
         if _is_context_length_error(exc):
             return ErrorKind.CONTEXT_LENGTH
@@ -215,7 +217,7 @@ def classify_error(exc: BaseException) -> ErrorKind:
                 return by_code
             return ErrorKind.INVALID_REQUEST
         if isinstance(exc, conflict_error):
-            return ErrorKind.TRANSIENT
+            return ErrorKind.INVALID_REQUEST
         if isinstance(exc, internal_server_error):
             return ErrorKind.TRANSIENT
         if isinstance(exc, api_status_error):

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -113,6 +113,10 @@ def test_classify_error_invalid_request(status: int) -> None:
     assert classify_error(_StatusError("bad", status_code=status)) == ErrorKind.INVALID_REQUEST
 
 
+def test_classify_error_conflict_409_is_invalid_request() -> None:
+    assert classify_error(_StatusError("conflict", status_code=409)) == ErrorKind.INVALID_REQUEST
+
+
 def test_classify_error_model_not_found() -> None:
     assert classify_error(Exception("NotFoundError: model not found")) == ErrorKind.INVALID_REQUEST
 
@@ -315,6 +319,26 @@ async def test_with_retry_no_retry_on_auth() -> None:
         await with_retry(factory, max_attempts=3, sleep=fake_sleep)
 
     assert len(sleeps) == 0
+
+
+@pytest.mark.asyncio
+async def test_with_retry_no_retry_on_conflict_409() -> None:
+    sleeps: list[float] = []
+    attempts = 0
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    async def factory() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise _StatusError("conflict", status_code=409)
+
+    with pytest.raises(_StatusError):
+        await with_retry(factory, max_attempts=3, sleep=fake_sleep)
+
+    assert attempts == 1
+    assert sleeps == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #27：HTTP 409 Conflict 不应被归类为 `TRANSIENT` 并触发重试，而应作为 `INVALID_REQUEST` 立即返回。

## 背景/问题

现有状态码分类把 409 和 408、5xx 放在一起：

```python
if code in (408, 409) or 500 <= code < 600:
    return ErrorKind.TRANSIENT
```

409 表示请求与目标资源当前状态冲突。对同一个请求直接重试通常不会改变结果，反而会触发无意义的多次请求和指数退避，增加用户等待时间与 API 消耗。

OpenAI SDK 的 `ConflictError` 也同样被归为 `TRANSIENT`，会进入相同的 retry 路径。

## 变更内容

- 将 HTTP 409 从 transient 状态码集合中移除。
- 将 HTTP 409 分类为 `ErrorKind.INVALID_REQUEST`。
- 将 OpenAI SDK `ConflictError` 分类为 `ErrorKind.INVALID_REQUEST`。
- 增加回归测试，确认：
  - `status_code=409` 会被分类为 `INVALID_REQUEST`
  - `with_retry` 遇到 409 时只调用一次 factory
  - 409 不会调用 sleep，也不会进入重试循环

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/test_provider_resilience.py -k "conflict_409" -q
```

结果：

```text
2 failed, 57 deselected
```

失败原因：

```text
409 classified as ErrorKind.TRANSIENT
with_retry attempted 3 times instead of 1
```

修复后已执行：

```shell
uv run pytest tests/test_provider_resilience.py -k "conflict_409" -q
```

结果：

```text
2 passed, 57 deselected
```

已执行：

```shell
uv run pytest tests/test_provider_resilience.py -q
```

结果：

```text
59 passed
```

已执行：

```shell
uv run pytest tests/test_provider_retry.py -q
```

结果：

```text
2 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于 provider resilience 错误分类与重试逻辑，不涉及 UI。

## 测试情况

- `uv run pytest tests/test_provider_resilience.py -k "conflict_409" -q`：2 passed
- `uv run pytest tests/test_provider_resilience.py -q`：59 passed
- `uv run pytest tests/test_provider_retry.py -q`：2 passed
- `git diff --check`：通过

Closes #27
