### PR TITLE
fix(execution): persist apply_patch approval keys

### DIFF
--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -618,7 +618,7 @@ class ToolOrchestrator:
                 return None
             return f"exec:{cmd}"
         if tool in (
-            "write_file", "edit_file", "delete_file",
+            "write_file", "edit_file", "delete_file", "apply_patch",
             "docx_write", "pptx_write", "xlsx_write",
         ):
             path = (meta.get("details", {}) or {}).get("path", "")

--- a/tests/execution/test_session_approval_allowlist.py
+++ b/tests/execution/test_session_approval_allowlist.py
@@ -194,6 +194,44 @@ async def test_resolve_approval_always_adds_to_permanent():
 
 
 @pytest.mark.asyncio
+async def test_apply_patch_always_approval_matches_future_permission_check():
+    """always-approved apply_patch calls must use the same key as PermissionEngine."""
+    from miqi.execution.orchestrator import ToolOrchestrator
+    from miqi.execution.permission_engine import PermissionEngine, PermissionVerdict
+
+    permission_engine = PermissionEngine()
+    orchestrator = ToolOrchestrator(
+        permission_engine=permission_engine,
+        sandbox_engine=MagicMock(),
+        hook_runtime=MagicMock(),
+        tool_registry=MagicMock(),
+        event_emitter=MagicMock(),
+        session_id="test-session",
+    )
+
+    approval_id = "turn-1:tool-apply-patch"
+    future = asyncio.get_event_loop().create_future()
+    orchestrator._pending_approvals[approval_id] = future
+    orchestrator._approval_meta[approval_id] = _make_meta(
+        tool_name="apply_patch",
+        command="",
+        details={"path": "/tmp/test.txt", "operation": "apply_patch"},
+    )
+
+    result = orchestrator.resolve_approval(approval_id, "always")
+    assert result.resolved is True
+    assert "apply_patch:/tmp/test.txt" in permission_engine.permanent_allowlist
+
+    ctx = MagicMock()
+    ctx.tool_name = "apply_patch"
+    ctx.arguments = {"path": "/tmp/test.txt"}
+    ctx.permission_profile = None
+
+    decision = await permission_engine.check(ctx)
+    assert decision.verdict == PermissionVerdict.ALLOW
+
+
+@pytest.mark.asyncio
 async def test_resolve_approval_once_does_not_add_to_allowlist():
     """resolve_approval with 'once' does NOT add to any allowlist."""
     from miqi.execution.orchestrator import ToolOrchestrator


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #19：`apply_patch` 选择 `always allow` 后，后续相同路径的 `apply_patch` 调用应命中 permanent allowlist，不再重复弹审批。

## 背景/问题

审批记录侧和权限校验侧的 key 生成逻辑不一致：

```python
# 记录侧：ToolOrchestrator._make_approval_pattern()
if tool in ("write_file", "edit_file", "delete_file",
            "docx_write", "pptx_write", "xlsx_write"):
    return f"{tool}:{path}"
```

记录侧遗漏了 `apply_patch`，导致它落入 description 兜底路径，例如记录成：

```text
Run:
```

但校验侧 `PermissionEngine._make_key()` 已经把 `apply_patch` 作为文件写入工具处理：

```python
if tool in ("write_file", "edit_file", "delete_file", "apply_patch",
            "docx_write", "pptx_write", "xlsx_write"):
    return f"{tool}:{path}"
```

因此永久 allowlist 中的 key 永远匹配不上未来的 `apply_patch:/path` 权限检查。

## 变更内容

- 在 `ToolOrchestrator._make_approval_pattern()` 的文件写入工具列表中补上 `apply_patch`。
- 增加回归测试，确认：
  - `resolve_approval(..., "always")` 会为 `apply_patch` 记录 `apply_patch:<path>`
  - 后续同路径 `PermissionEngine.check()` 返回 `ALLOW`
  - 不再重复进入审批流程

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -k "apply_patch_always" -q
```

结果：

```text
1 failed, 10 deselected
```

失败原因：

```text
Expected "apply_patch:/tmp/test.txt" in permanent_allowlist
Received {"Run:"}
```

修复后已执行：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -k "apply_patch_always" -q
```

结果：

```text
1 passed, 10 deselected
```

已执行：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -q
```

结果：

```text
11 passed
```

已执行：

```shell
uv run pytest tests/runtime/test_approval_handlers.py tests/runtime/test_permission_handlers.py -q
```

结果：

```text
30 passed
```

已执行：

```shell
uv run pytest tests/execution/test_orchestrator_tool_validation.py -q
```

结果：

```text
11 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于审批 allowlist key 生成逻辑，不涉及 UI。

## 测试情况

- `uv run pytest tests/execution/test_session_approval_allowlist.py -k "apply_patch_always" -q`：1 passed
- `uv run pytest tests/execution/test_session_approval_allowlist.py -q`：11 passed
- `uv run pytest tests/runtime/test_approval_handlers.py tests/runtime/test_permission_handlers.py -q`：30 passed
- `uv run pytest tests/execution/test_orchestrator_tool_validation.py -q`：11 passed
- `git diff --check`：通过

Closes #19
