### PR TITLE
fix(execution): timeout hung hook callbacks

### DIFF
--- a/miqi/execution/hook_runtime.py
+++ b/miqi/execution/hook_runtime.py
@@ -6,6 +6,7 @@ They run synchronously in the tool execution context.
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
 from dataclasses import dataclass, field
 from enum import Enum
@@ -102,10 +103,11 @@ class HookRegistration:
 class HookRuntime:
     """Manages and executes hooks."""
 
-    def __init__(self):
+    def __init__(self, hook_timeout: float = 30.0):
         self._hooks: dict[HookPoint, list[HookRegistration]] = {
             p: [] for p in HookPoint
         }
+        self.hook_timeout = hook_timeout
 
     def register(self, reg: HookRegistration) -> None:
         self._hooks[reg.hook_point].append(reg)
@@ -138,7 +140,16 @@ class HookRuntime:
             if not fnmatch.fnmatch(ctx.tool_name, reg.tool_pattern):
                 continue
             try:
-                outcome = await reg.callback(ctx)
+                outcome = await asyncio.wait_for(
+                    reg.callback(ctx),
+                    timeout=self.hook_timeout,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Hook {} timed out after {}s for {}",
+                    reg.tool_pattern, self.hook_timeout, ctx.tool_name
+                )
+                continue
             except Exception:
                 logger.exception(
                     "Hook {} failed for {}", reg.tool_pattern, ctx.tool_name

--- a/tests/execution/test_hook_runtime.py
+++ b/tests/execution/test_hook_runtime.py
@@ -1,5 +1,7 @@
 """Tests for miqi.execution.hook_runtime."""
 
+import asyncio
+
 import pytest
 from miqi.execution.hook_runtime import (
     HookRuntime,
@@ -106,6 +108,37 @@ async def test_hook_error_does_not_crash():
     # Should not raise
     await runtime.run(HookPoint.PRE_TOOL_USE, FakeContext("exec"))
     assert calls == ["good"]  # good hook still runs after bad hook fails
+
+
+@pytest.mark.asyncio
+async def test_hook_timeout_skips_hung_callback_and_continues():
+    runtime = HookRuntime(hook_timeout=0.01)
+    calls = []
+
+    async def hung_hook(ctx):
+        await asyncio.Event().wait()
+
+    async def good_hook(ctx):
+        calls.append("good")
+
+    runtime.register(HookRegistration(
+        hook_point=HookPoint.PRE_TOOL_USE,
+        tool_pattern="*",
+        callback=hung_hook,
+        priority=100,
+    ))
+    runtime.register(HookRegistration(
+        hook_point=HookPoint.PRE_TOOL_USE,
+        tool_pattern="*",
+        callback=good_hook,
+        priority=200,
+    ))
+
+    await asyncio.wait_for(
+        runtime.run(HookPoint.PRE_TOOL_USE, FakeContext("exec")),
+        timeout=0.2,
+    )
+    assert calls == ["good"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #28：插件 hook 回调挂起时，不应永久阻塞整个执行管道。`HookRuntime` 现在会为每个 hook callback 应用默认 30 秒超时，超时后记录 warning 并继续执行后续 hook。

## 背景/问题

现有 hook 执行逻辑直接等待插件 callback：

```python
outcome = await reg.callback(ctx)
```

如果某个插件 hook 内部等待一个永远不会完成的异步操作，例如无超时网络请求、死等 `asyncio.Event`、或其他挂起任务，`run_with_outcome()` 会一直卡住。后续 hook 不会执行，工具执行管道也无法继续，用户侧表现为 Agent 永久停在“执行中”。

## 变更内容

- 为 `HookRuntime` 增加可配置的 `hook_timeout` 参数，默认 `30.0` 秒。
- 使用 `asyncio.wait_for()` 包裹每个 hook callback。
- hook 超时后记录 warning，并跳过该 hook 继续扫描后续 hook。
- 保持原有异常处理语义：普通异常仍记录 exception 并继续，不影响后续 hook。
- 增加回归测试，确认：
  - 一个永远挂起的 hook 会被超时跳过
  - 后续匹配 hook 仍会执行
  - `run()` 不会被挂起 hook 永久阻塞

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/execution/test_hook_runtime.py -k "timeout_skips" -q
```

结果：

```text
1 failed, 8 deselected
```

失败原因：

```text
TimeoutError
```

即 `runtime.run()` 被挂起 hook 阻塞，外层 0.2 秒复现保护超时。

修复后已执行：

```shell
uv run pytest tests/execution/test_hook_runtime.py -k "timeout_skips" -q
```

结果：

```text
1 passed, 8 deselected
```

已执行：

```shell
uv run pytest tests/execution/test_hook_runtime.py -q
```

结果：

```text
9 passed
```

已执行：

```shell
uv run pytest tests/execution/test_hook_outcomes.py tests/runtime/test_hook_lifecycle_firing.py tests/skills/test_plugin_hooks.py -q
```

结果：

```text
17 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于 hook runtime 执行层，不涉及 UI 展示。

## 测试情况

- `uv run pytest tests/execution/test_hook_runtime.py -k "timeout_skips" -q`：1 passed
- `uv run pytest tests/execution/test_hook_runtime.py -q`：9 passed
- `uv run pytest tests/execution/test_hook_outcomes.py tests/runtime/test_hook_lifecycle_firing.py tests/skills/test_plugin_hooks.py -q`：17 passed
- `git diff --check`：通过

Closes #28
