### PR TITLE
feat(desktop): add manual session status switching via context menu

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -108,11 +108,11 @@ export function Sidebar({
 
   const FILTER_TABS: FilterTab[] = ['ALL', 'IN-PROGRESS', 'REVIEW', 'CC'];
 
-  const filteredSessions = sessions.filter((s, idx) => {
+  const filteredSessions = sessions.filter((s) => {
     if (filter === 'ALL') return true;
-    const status = getStatus(s.key, idx);
+    const status = getStatus(s.key);
     if (filter === 'IN-PROGRESS') return status === 'IN-PROGRESS';
-    if (filter === 'REVIEW') return status === 'REVIEW' || status === 'PENDING'; // REVIEW maps to PENDING in demo
+    if (filter === 'REVIEW') return status === 'REVIEW';
     if (filter === 'CC') return status === 'CC';
     return true;
   });
@@ -187,10 +187,10 @@ export function Sidebar({
           </div>
         ) : (
           <div className="space-y-2">
-            {filteredSessions.slice(0, 20).map((s, idx) => {
+            {filteredSessions.slice(0, 20).map((s) => {
               const isActive = currentSession === s.key;
               const displayName = s.title || formatTimestampKey(s.key);
-              const status = getStatusDisplay(getStatus(s.key, idx));
+              const status = getStatusDisplay(getStatus(s.key));
               return (
                 <ContextMenu
                   key={s.key}

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { cn } from '../lib/utils';
 import { Plus, ListChecks } from 'lucide-react';
 import { MiQiLogo } from './MiQiLogo';
+import { ContextMenu } from './ContextMenu';
+import { useSessionStatus, type SessionStatus } from '../hooks/useSessionStatus';
 import type { SessionInfo } from '../../shared/ipc';
 
 type FilterTab = 'ALL' | 'IN-PROGRESS' | 'REVIEW' | 'CC';
@@ -30,13 +32,6 @@ function relativeTime(iso?: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
-/** Derive status tag from session index (demo heuristic). */
-function statusForIndex(idx: number): { label: string; bg: string; color: string; cardBg: string; cardBorder: string } {
-  if (idx === 0) return { label: 'IN-PROGRESS', bg: 'var(--tag-inprogress-bg)', color: 'var(--tag-inprogress-text)', cardBg: '#fffbe6', cardBorder: '#f0e8c0' };
-  if (idx === 1) return { label: 'COMPLETED', bg: 'var(--tag-completed-bg)', color: 'var(--tag-completed-text)', cardBg: '#f8fcf9', cardBorder: '#d0e8d8' };
-  return { label: 'PENDING', bg: '#f0f0ec', color: '#888', cardBg: '#fafaf9', cardBorder: '#e8e8e0' };
-}
-
 interface SidebarProps {
   currentSession?: string;
   onSessionSelect?: (key: string) => void;
@@ -58,6 +53,8 @@ export function Sidebar({
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_WIDTH);
   const isResizing = useRef(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const { getStatus, getStatusDisplay, setStatus, clearStatus } = useSessionStatus();
 
   // Resize handler
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -111,12 +108,12 @@ export function Sidebar({
 
   const FILTER_TABS: FilterTab[] = ['ALL', 'IN-PROGRESS', 'REVIEW', 'CC'];
 
-  const filteredSessions = sessions.filter((_s, idx) => {
+  const filteredSessions = sessions.filter((s, idx) => {
     if (filter === 'ALL') return true;
-    const status = statusForIndex(idx).label;
+    const status = getStatus(s.key, idx);
     if (filter === 'IN-PROGRESS') return status === 'IN-PROGRESS';
-    if (filter === 'REVIEW') return status === 'PENDING'; // REVIEW maps to PENDING in demo
-    if (filter === 'CC') return status === 'COMPLETED';
+    if (filter === 'REVIEW') return status === 'REVIEW' || status === 'PENDING'; // REVIEW maps to PENDING in demo
+    if (filter === 'CC') return status === 'CC';
     return true;
   });
 
@@ -193,47 +190,81 @@ export function Sidebar({
             {filteredSessions.slice(0, 20).map((s, idx) => {
               const isActive = currentSession === s.key;
               const displayName = s.title || formatTimestampKey(s.key);
-              const status = statusForIndex(idx);
+              const status = getStatusDisplay(getStatus(s.key, idx));
               return (
-                <button
+                <ContextMenu
                   key={s.key}
-                  onClick={() => onSessionSelect?.(s.key)}
-                  className="w-full text-left rounded-xl px-3 py-3 transition-colors"
-                  style={{
-                    background: status.cardBg,
-                    border: `1px solid ${isActive ? status.color : status.cardBorder}`,
-                  }}
+                  items={[
+                    {
+                      label: 'Mark as In Progress',
+                      onSelect: () => setStatus(s.key, 'IN-PROGRESS'),
+                    },
+                    {
+                      label: 'Mark as Pending',
+                      onSelect: () => setStatus(s.key, 'PENDING'),
+                    },
+                    {
+                      label: 'Mark as Review',
+                      onSelect: () => setStatus(s.key, 'REVIEW'),
+                    },
+                    {
+                      label: 'Mark as Completed',
+                      divider: true,
+                      onSelect: () => setStatus(s.key, 'COMPLETED'),
+                    },
+                    {
+                      label: 'Mark as CC',
+                      onSelect: () => setStatus(s.key, 'CC'),
+                    },
+                    {
+                      label: 'Reset to Default',
+                      danger: true,
+                      onSelect: () => clearStatus(s.key),
+                    },
+                  ]}
                 >
-                  {/* Top row: pill status label left · time right */}
-                  <div className="flex items-center justify-between mb-2">
-                    <span
-                      className="text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full"
-                      style={{ background: status.bg, color: status.color }}
+                  {({ onContextMenu }) => (
+                    <button
+                      onClick={() => onSessionSelect?.(s.key)}
+                      onContextMenu={onContextMenu}
+                      className="w-full text-left rounded-xl px-3 py-3 transition-colors"
+                      style={{
+                        background: status.cardBg,
+                        border: `1px solid ${isActive ? status.color : status.cardBorder}`,
+                      }}
                     >
-                      {status.label}
-                    </span>
-                    <span className="text-[10px]" style={{ color: 'var(--text-faint)' }}>
-                      {relativeTime(s.updated_at)}
-                    </span>
-                  </div>
-                  {/* Title — large bold, one line */}
-                  <p
-                    className="text-[13px] font-bold truncate mb-1"
-                    style={{ color: 'var(--text)' }}
-                    title={displayName}
-                  >
-                    {displayName}
-                  </p>
-                  {/* Description — small gray, multi-line */}
-                  <p
-                    className="text-[11px] leading-relaxed"
-                    style={{ color: 'var(--text-muted)' }}
-                  >
-                    {s.message_count != null
-                      ? `${s.message_count} messages`
-                      : 'No description'}
-                  </p>
-                </button>
+                      {/* Top row: pill status label left · time right */}
+                      <div className="flex items-center justify-between mb-2">
+                        <span
+                          className="text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full"
+                          style={{ background: status.bg, color: status.color }}
+                        >
+                          {status.label}
+                        </span>
+                        <span className="text-[10px]" style={{ color: 'var(--text-faint)' }}>
+                          {relativeTime(s.updated_at)}
+                        </span>
+                      </div>
+                      {/* Title — large bold, one line */}
+                      <p
+                        className="text-[13px] font-bold truncate mb-1"
+                        style={{ color: 'var(--text)' }}
+                        title={displayName}
+                      >
+                        {displayName}
+                      </p>
+                      {/* Description — small gray, multi-line */}
+                      <p
+                        className="text-[11px] leading-relaxed"
+                        style={{ color: 'var(--text-muted)' }}
+                      >
+                        {s.message_count != null
+                          ? `${s.message_count} messages`
+                          : 'No description'}
+                      </p>
+                    </button>
+                  )}
+                </ContextMenu>
               );
             })}
           </div>

--- a/apps/desktop/src/renderer/hooks/useSessionStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionStatus.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback } from 'react';
+
+export type SessionStatus = 'IN-PROGRESS' | 'PENDING' | 'REVIEW' | 'COMPLETED' | 'CC';
+
+export interface StatusDisplayInfo {
+  label: string;
+  bg: string;
+  color: string;
+  cardBg: string;
+  cardBorder: string;
+}
+
+const STORAGE_KEY = 'miqi:sessionStatuses';
+
+function loadMap(): Record<string, SessionStatus> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveMap(map: Record<string, SessionStatus>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* localStorage unavailable — silently ignore */
+  }
+}
+
+/** Default status for sessions without a manual override. */
+function fallbackStatus(_idx: number): SessionStatus {
+  return 'PENDING';
+}
+
+export function useSessionStatus() {
+  const [map, setMap] = useState<Record<string, SessionStatus>>(loadMap);
+
+  const getStatus = useCallback(
+    (sessionKey: string, index: number): SessionStatus => {
+      return map[sessionKey] ?? fallbackStatus(index);
+    },
+    [map],
+  );
+
+  const getStatusDisplay = useCallback((status: SessionStatus): StatusDisplayInfo => {
+    switch (status) {
+      case 'IN-PROGRESS':
+        return {
+          label: 'IN-PROGRESS',
+          bg: 'var(--tag-inprogress-bg)',
+          color: 'var(--tag-inprogress-text)',
+          cardBg: '#fffbe6',
+          cardBorder: '#f0e8c0',
+        };
+      case 'REVIEW':
+        return {
+          label: 'REVIEW',
+          bg: 'var(--tag-review-bg)',
+          color: 'var(--tag-review-text)',
+          cardBg: '#fefdf5',
+          cardBorder: '#f0e8c0',
+        };
+      case 'COMPLETED':
+        return {
+          label: 'COMPLETED',
+          bg: 'var(--tag-completed-bg)',
+          color: 'var(--tag-completed-text)',
+          cardBg: '#f8fcf9',
+          cardBorder: '#d0e8d8',
+        };
+      case 'CC':
+        return {
+          label: 'CC',
+          bg: 'var(--tag-cc-bg)',
+          color: 'var(--tag-cc-text)',
+          cardBg: '#f8fcf9',
+          cardBorder: '#d0e8d8',
+        };
+      case 'PENDING':
+      default:
+        return {
+          label: 'PENDING',
+          bg: '#f0f0ec',
+          color: '#888',
+          cardBg: '#fafaf9',
+          cardBorder: '#e8e8e0',
+        };
+    }
+  }, []);
+
+  const setStatus = useCallback((sessionKey: string, status: SessionStatus) => {
+    setMap((prev) => {
+      const next = { ...prev, [sessionKey]: status };
+      saveMap(next);
+      return next;
+    });
+  }, []);
+
+  const clearStatus = useCallback((sessionKey: string) => {
+    setMap((prev) => {
+      const next = { ...prev };
+      delete next[sessionKey];
+      saveMap(next);
+      return next;
+    });
+  }, []);
+
+  return { getStatus, getStatusDisplay, setStatus, clearStatus };
+}

--- a/apps/desktop/src/renderer/hooks/useSessionStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionStatus.ts
@@ -29,17 +29,12 @@ function saveMap(map: Record<string, SessionStatus>): void {
   }
 }
 
-/** Default status for sessions without a manual override. */
-function fallbackStatus(_idx: number): SessionStatus {
-  return 'PENDING';
-}
-
 export function useSessionStatus() {
   const [map, setMap] = useState<Record<string, SessionStatus>>(loadMap);
 
   const getStatus = useCallback(
-    (sessionKey: string, index: number): SessionStatus => {
-      return map[sessionKey] ?? fallbackStatus(index);
+    (sessionKey: string): SessionStatus => {
+      return map[sessionKey] ?? 'PENDING';
     },
     [map],
   );
@@ -75,8 +70,8 @@ export function useSessionStatus() {
           label: 'CC',
           bg: 'var(--tag-cc-bg)',
           color: 'var(--tag-cc-text)',
-          cardBg: '#f8fcf9',
-          cardBorder: '#d0e8d8',
+          cardBg: '#f9f5ff',
+          cardBorder: '#d4c5f0',
         };
       case 'PENDING':
       default:

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -69,6 +69,8 @@
   --tag-completed-text: #2066D0;
   --tag-inprogress-bg: #e0ecff;  /* IN-PROGRESS 标签（浅蓝） */
   --tag-inprogress-text: #2066D0;
+  --tag-cc-bg: rgba(32,102,208,0.12);         /* CC 标签（蓝，同 COMPLETED） */
+  --tag-cc-text: #2066D0;
 
   --radius: 8px;
 }
@@ -204,6 +206,17 @@ code {
 .tag-inprogress {
   background: var(--tag-inprogress-bg);
   color: var(--tag-inprogress-text);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tag-cc {
+  background: var(--tag-cc-bg);
+  color: var(--tag-cc-text);
   font-size: 10px;
   font-weight: 600;
   padding: 2px 6px;

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -69,8 +69,8 @@
   --tag-completed-text: #2066D0;
   --tag-inprogress-bg: #e0ecff;  /* IN-PROGRESS 标签（浅蓝） */
   --tag-inprogress-text: #2066D0;
-  --tag-cc-bg: rgba(32,102,208,0.12);         /* CC 标签（蓝，同 COMPLETED） */
-  --tag-cc-text: #2066D0;
+  --tag-cc-bg: rgba(124,58,237,0.12);          /* CC 标签（紫色） */
+  --tag-cc-text: #7C3AED;
 
   --radius: 8px;
 }


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

为桌面端会话卡片添加右键菜单，支持手动切换会话状态（进行中/待处理/审查中/已完成/抄送/重置）。

## 背景/问题

此前会话状态通过 `statusForIndex` 启发式规则自动推断，用户无法手动标记或修改会话状态，导致状态管理不灵活，无法反映实际工作流中的真实进度。

## 变更内容

- 新增 `useSessionStatus` hook，基于 localStorage 持久化管理会话状态
- 在侧边栏会话卡片上添加右键菜单（ContextMenu），提供 6 种状态选项：IN-PROGRESS / PENDING / REVIEW / COMPLETED / CC / Reset
- 所有会话默认状态为 PENDING，手动设置的状态在页面刷新后保持
- 新增 `.tag-cc` CSS 类和对应 CSS 变量，用于 CC 状态标签样式

## 日志/验证证据

```
✓ 右键菜单正常弹出，6 种状态选项均可点击
✓ 切换状态后侧边栏标签颜色/文字即时更新
✓ localStorage 中状态持久化，刷新页面后状态保持
✓ 重置功能恢复默认 PENDING 状态
✓ CC 状态标签样式正确渲染
```

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/7fd66596-2dd6-4dd5-a3f2-61730b8fb372" />
<img width="343" height="337" alt="image" src="https://github.com/user-attachments/assets/0eab2f79-afab-4a9f-abfc-379702ff6e50" />

## 测试情况

- 本地开发环境手动测试：右键菜单交互、状态切换、localStorage 持久化、页面刷新后状态保持
- 现有 E2E 测试全部通过

🤖 Generated with [Claude Code](https://claude.com/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 每个会话卡片的菜单新增了会话状态控制选项，支持标记为进行中、待处理、审查中、已完成或抄送。
  - 新增重置选项，可将会话恢复为默认状态。
  - 桌面端 UI 新增了 CC 状态标签的样式。

- **Bug 修复**
  - 会话列表和状态标记现在能一致反映已保存的状态变更，包括应用重启后也能正确恢复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
