### PR TITLE
fix(runtime): replace deprecated coroutine checks

### DIFF
--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -7,6 +7,7 @@ Frontends should use RuntimeSession.create() + start/stop/submit/next_event.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -488,7 +489,7 @@ class RuntimeSession:
                             thread_id = getattr(submission, "thread_id", None) or "default"
                             orchestrator = getattr(self._runner.services, "orchestrator", None)
                             cancel_fn = getattr(orchestrator, "cancel_approvals_for_thread", None)
-                            if callable(cancel_fn) and asyncio.iscoroutinefunction(cancel_fn):
+                            if callable(cancel_fn) and inspect.iscoroutinefunction(cancel_fn):
                                 await cancel_fn(thread_id, reason="Turn aborted by user.")
                             # Await the cancelled task to guarantee cleanup
                             # (history completion, ledger append, event emission)

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import uuid
 import asyncio
+import inspect
 from typing import Any
 
 from miqi.protocol.commands import (
@@ -141,7 +142,7 @@ class TaskRunner:
             # remain in the pending set.
             orchestrator = getattr(self.services, "orchestrator", None)
             cancel_fn = getattr(orchestrator, "cancel_approvals_for_thread", None)
-            if callable(cancel_fn) and asyncio.iscoroutinefunction(cancel_fn):
+            if callable(cancel_fn) and inspect.iscoroutinefunction(cancel_fn):
                 await cancel_fn(thread_id, reason="Turn aborted by user.")
 
             await self._events.put(ErrorEvent(

--- a/tests/runtime/test_issue_32_coroutinefunction_deprecation.py
+++ b/tests/runtime/test_issue_32_coroutinefunction_deprecation.py
@@ -1,0 +1,16 @@
+"""Regression coverage for issue #32 coroutine function checks."""
+
+from pathlib import Path
+
+
+def test_runtime_uses_inspect_coroutinefunction_not_asyncio_deprecated_api():
+    root = Path(__file__).parent.parent.parent
+    files = [
+        root / "miqi" / "runtime" / "session.py",
+        root / "miqi" / "runtime" / "task_runner.py",
+    ]
+
+    for path in files:
+        source = path.read_text(encoding="utf-8")
+        assert "asyncio.iscoroutinefunction" not in source
+        assert "inspect.iscoroutinefunction" in source

--- a/tests/runtime/test_runtime_task_runner.py
+++ b/tests/runtime/test_runtime_task_runner.py
@@ -1,6 +1,7 @@
 """Tests for TaskRunner (Phase 11.3)."""
 
 import asyncio
+import warnings
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -77,6 +78,24 @@ async def test_task_runner_handles_abort_turn(fake_services):
     event = await asyncio.wait_for(events.get(), timeout=1)
     assert event.__class__.__name__ == "ErrorEvent"
     assert "aborted" in event.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_task_runner_abort_turn_uses_non_deprecated_coroutine_check(fake_services):
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+    called = []
+
+    async def cancel_approvals_for_thread(thread_id: str, reason: str) -> None:
+        called.append((thread_id, reason))
+
+    fake_services.orchestrator.cancel_approvals_for_thread = cancel_approvals_for_thread
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        await runner.handle(AbortTurn(thread_id="cli:default"))
+
+    assert called == [("cli:default", "Turn aborted by user.")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #32：将 runtime abort 路径中的 `asyncio.iscoroutinefunction()` 替换为 `inspect.iscoroutinefunction()`，避免 Python 3.14 下的 `DeprecationWarning`，并兼容未来 Python 3.16 移除该 API。

## 背景/问题

Python 3.14 下执行 abort/cancel approvals 路径会触发：

```text
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

当前代码中有两处：

```python
asyncio.iscoroutinefunction(cancel_fn)
```

分别位于：

- `miqi/runtime/session.py`
- `miqi/runtime/task_runner.py`

如果未来运行到 Python 3.16，该 API 移除后会从 warning 变成运行时错误。

## 变更内容

- `miqi/runtime/session.py`：新增 `import inspect`，使用 `inspect.iscoroutinefunction(cancel_fn)`。
- `miqi/runtime/task_runner.py`：新增 `import inspect`，使用 `inspect.iscoroutinefunction(cancel_fn)`。
- 增加 warning-as-error 回归测试，确认 `AbortTurn` 处理 async `cancel_approvals_for_thread` 时不再触发 `DeprecationWarning`。
- 增加源码审计回归测试，确认 `session.py` 和 `task_runner.py` 不再出现 `asyncio.iscoroutinefunction`，且使用 `inspect.iscoroutinefunction`。

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/runtime/test_runtime_task_runner.py -k "non_deprecated_coroutine_check" -q
```

结果：

```text
1 failed, 27 deselected
```

失败原因：

```text
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

修复前新增源码审计测试可复现失败：

```shell
uv run pytest tests/runtime/test_issue_32_coroutinefunction_deprecation.py -q
```

结果：

```text
1 failed
```

失败原因：`session.py` / `task_runner.py` 仍包含 `asyncio.iscoroutinefunction`。

修复后已执行：

```shell
uv run pytest tests/runtime/test_runtime_task_runner.py -k "non_deprecated_coroutine_check" -q
```

结果：

```text
1 passed, 27 deselected
```

已执行：

```shell
uv run pytest tests/runtime/test_issue_32_coroutinefunction_deprecation.py -q
```

结果：

```text
1 passed
```

已执行：

```shell
uv run pytest tests/runtime/test_runtime_task_runner.py -q
```

结果：

```text
28 passed
```

已执行：

```shell
uv run pytest tests/runtime/test_runtime_session.py -q
```

结果：

```text
12 passed
```

说明：该命令结束时出现一次 Windows pytest 临时目录清理 warning 和既有后台任务输出，但测试结果为通过；随后对 issue 相关 RuntimeSession abort 用例单独使用 warning-as-error 验证。

已执行：

```shell
uv run pytest tests/runtime/test_runtime_task_runner.py::test_task_runner_abort_turn_uses_non_deprecated_coroutine_check -W error::DeprecationWarning -q
```

结果：

```text
1 passed
```

已执行：

```shell
uv run pytest tests/runtime/test_runtime_session.py::test_runtime_session_abort_cancels_active_turn -W error::DeprecationWarning -q
```

结果：

```text
1 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于 Python runtime abort/cancel approvals 路径，不涉及 UI 展示。

## 测试情况

- `uv run pytest tests/runtime/test_runtime_task_runner.py -k "non_deprecated_coroutine_check" -q`：1 passed
- `uv run pytest tests/runtime/test_issue_32_coroutinefunction_deprecation.py -q`：1 passed
- `uv run pytest tests/runtime/test_runtime_task_runner.py -q`：28 passed
- `uv run pytest tests/runtime/test_runtime_session.py -q`：12 passed
- `uv run pytest tests/runtime/test_runtime_task_runner.py::test_task_runner_abort_turn_uses_non_deprecated_coroutine_check -W error::DeprecationWarning -q`：1 passed
- `uv run pytest tests/runtime/test_runtime_session.py::test_runtime_session_abort_cancels_active_turn -W error::DeprecationWarning -q`：1 passed
- `git diff --check`：通过

Closes #32
