### PR TITLE
fix(execution): guard approval detail sanitization depth

### DIFF
--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -53,6 +53,7 @@ _LEGACY_DECISION_MAP = {"allow": "once", "allow_permanent": "always"}
 # Phase 31.4: max lengths for sanitized approval metadata fields
 _MAX_DESCRIPTION_LENGTH = 500
 _MAX_DETAILS_STRING_LENGTH = 2000
+_MAX_DETAILS_DEPTH = 10
 _MAX_COMMAND_LENGTH = 500
 
 # ── Phase 56: arg normalization for provider-agnostic tool calls ───────────
@@ -353,37 +354,61 @@ class ToolOrchestrator:
         return ctx
 
     @staticmethod
-    def _sanitize_details(details: dict[str, Any]) -> dict[str, Any]:
+    def _sanitize_details(
+        details: dict[str, Any],
+        *,
+        _depth: int = 0,
+        _seen: set[int] | None = None,
+    ) -> dict[str, Any]:
         """Return a safe copy of *details* suitable for client emission.
 
         Removes/drops values that are not JSON-serializable or could leak
         internals (Exception objects, futures, process handles, raw secrets).
-        Strings are length-capped.
+        Strings are length-capped. Nested dicts are depth- and cycle-guarded.
         """
         if not isinstance(details, dict):
             return {}
+        if _depth > _MAX_DETAILS_DEPTH:
+            return {"_truncated": "<max_depth_exceeded>"}
+        if _seen is None:
+            _seen = set()
+        details_id = id(details)
+        if details_id in _seen:
+            return {"_truncated": "<cycle>"}
+        _seen.add(details_id)
         safe: dict[str, Any] = {}
-        for key, value in details.items():
-            if not isinstance(key, str):
-                continue
-            # Drop known-unsafe keys
-            if key.lower() in ("exception", "traceback", "secret", "password",
-                               "token", "api_key", "_future", "_process",
-                               "credential", "authorization"):
-                continue
-            if isinstance(value, (bool, int, float, type(None))):
-                safe[key] = value
-            elif isinstance(value, str):
-                safe[key] = value[:_MAX_DETAILS_STRING_LENGTH]
-            elif isinstance(value, (list, tuple)):
-                safe[key] = str(value)[:_MAX_DETAILS_STRING_LENGTH]
-            elif isinstance(value, dict):
-                # Recursively sanitize nested dicts, depth-guarded
-                safe[key] = ToolOrchestrator._sanitize_details(value)
-            else:
-                # Drop non-serializable types (Exception, future, etc.)
-                safe[key] = f"<{type(value).__name__}>"
-        return safe
+        try:
+            for key, value in details.items():
+                if not isinstance(key, str):
+                    continue
+                # Drop known-unsafe keys
+                if key.lower() in ("exception", "traceback", "secret", "password",
+                                   "token", "api_key", "_future", "_process",
+                                   "credential", "authorization"):
+                    continue
+                if isinstance(value, (bool, int, float, type(None))):
+                    safe[key] = value
+                elif isinstance(value, str):
+                    safe[key] = value[:_MAX_DETAILS_STRING_LENGTH]
+                elif isinstance(value, (list, tuple)):
+                    safe[key] = str(value)[:_MAX_DETAILS_STRING_LENGTH]
+                elif isinstance(value, dict):
+                    if id(value) in _seen:
+                        safe[key] = "<cycle>"
+                    elif _depth >= _MAX_DETAILS_DEPTH:
+                        safe[key] = "<max_depth_exceeded>"
+                    else:
+                        safe[key] = ToolOrchestrator._sanitize_details(
+                            value,
+                            _depth=_depth + 1,
+                            _seen=_seen,
+                        )
+                else:
+                    # Drop non-serializable types (Exception, future, etc.)
+                    safe[key] = f"<{type(value).__name__}>"
+            return safe
+        finally:
+            _seen.discard(details_id)
 
     async def _request_approval(
         self,

--- a/tests/execution/test_session_approval_allowlist.py
+++ b/tests/execution/test_session_approval_allowlist.py
@@ -297,3 +297,37 @@ async def test_session_approval_after_permanent_approval():
     assert "exec:echo permanent" in permission_engine.permanent_allowlist
     # Permanent allowlist should NOT have "echo new" (only session-scoped)
     assert "exec:echo new" not in permission_engine.permanent_allowlist
+
+
+def test_sanitize_details_truncates_deeply_nested_dicts():
+    """Deep approval metadata should be truncated instead of overflowing stack."""
+    from miqi.execution.orchestrator import ToolOrchestrator
+
+    details = current = {}
+    for _ in range(1200):
+        child = {}
+        current["child"] = child
+        current = child
+
+    sanitized = ToolOrchestrator._sanitize_details(details)
+
+    current = sanitized
+    for _ in range(20):
+        if current.get("child") == "<max_depth_exceeded>":
+            break
+        current = current["child"]
+    else:
+        pytest.fail("expected deeply nested metadata to be truncated")
+
+
+def test_sanitize_details_handles_self_referential_dicts():
+    """Cyclic approval metadata should not recurse forever."""
+    from miqi.execution.orchestrator import ToolOrchestrator
+
+    details = {"name": "cyclic"}
+    details["self"] = details
+
+    sanitized = ToolOrchestrator._sanitize_details(details)
+
+    assert sanitized["name"] == "cyclic"
+    assert sanitized["self"] == "<cycle>"


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #31：为 `ToolOrchestrator._sanitize_details()` 增加深度限制和循环引用保护，避免极深嵌套或自引用审批 metadata 触发 `RecursionError`，导致工具调用/审批流程崩溃。

## 背景/问题

`_sanitize_details()` 会递归清理嵌套 dict：

```python
elif isinstance(value, dict):
    safe[key] = ToolOrchestrator._sanitize_details(value)
```

但原实现没有 `depth` 参数、没有最大深度限制，也没有循环引用检测。极端输入可以让递归超过 Python 栈限制；自引用 dict 会无限递归。

函数附近注释曾写着 `depth-guarded`，但实际没有实现保护。

## 变更内容

- 新增 `_MAX_DETAILS_DEPTH = 10`。
- `_sanitize_details()` 增加内部 `_depth` / `_seen` 参数：
  - 嵌套超过深度上限时截断为 `"<max_depth_exceeded>"`
  - 遇到循环引用时截断为 `"<cycle>"`
  - 使用 `finally` 从 `_seen` 移除当前 dict id，避免兄弟分支误判
- 保持公开调用方式不变：外部仍调用 `ToolOrchestrator._sanitize_details(details)`。
- 增加回归测试，确认：
  - 1200 层嵌套 dict 不再触发 `RecursionError`
  - 自引用 dict 不再触发 `RecursionError`
  - 常规字段仍保留并被正常清洗

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -k "sanitize_details" -q
```

结果：

```text
2 failed, 10 deselected
```

失败原因：

```text
RecursionError: maximum recursion depth exceeded
```

修复后已执行：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -k "sanitize_details" -q
```

结果：

```text
2 passed, 10 deselected
```

已执行：

```shell
uv run pytest tests/execution/test_session_approval_allowlist.py -q
```

结果：

```text
12 passed
```

已执行：

```shell
uv run pytest tests/execution/test_orchestrator.py tests/execution/test_file_mutation_approval.py -q
```

结果：

```text
28 passed
```

已执行：

```shell
git diff --check
```

结果：通过。

## 截图

不适用。该修复位于审批 metadata 清洗逻辑，不涉及 UI 展示。

## 测试情况

- `uv run pytest tests/execution/test_session_approval_allowlist.py -k "sanitize_details" -q`：2 passed
- `uv run pytest tests/execution/test_session_approval_allowlist.py -q`：12 passed
- `uv run pytest tests/execution/test_orchestrator.py tests/execution/test_file_mutation_approval.py -q`：28 passed
- `git diff --check`：通过

Closes #31
