### PR TITLE
fix(runtime): isolate subagent end hook failures

### DIFF
--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -593,17 +593,23 @@ class AgentControl:
         finally:
             # Phase 51.3: fire sub-agent lifecycle end hook on every completion path.
             if self._hooks is not None:
-                await self._hooks.run(
-                    HookPoint.SUBAGENT_END,
-                    LifecycleHookContext(
-                        hook_point=HookPoint.SUBAGENT_END,
-                        data={
-                            "agent_id": agent.agent_id,
-                            "thread_id": agent.thread_id,
-                            "status": agent.state.current.value,
-                        },
-                    ),
-                )
+                try:
+                    await self._hooks.run(
+                        HookPoint.SUBAGENT_END,
+                        LifecycleHookContext(
+                            hook_point=HookPoint.SUBAGENT_END,
+                            data={
+                                "agent_id": agent.agent_id,
+                                "thread_id": agent.thread_id,
+                                "status": agent.state.current.value,
+                            },
+                        ),
+                    )
+                except Exception:
+                    logger.exception(
+                        "SUBAGENT_END hook failed for agent {}",
+                        agent.agent_id,
+                    )
 
     @staticmethod
     def _format_tool_hint(name: str, args: dict) -> str:

--- a/tests/runtime/test_agent_control.py
+++ b/tests/runtime/test_agent_control.py
@@ -333,6 +333,89 @@ async def test_sub_agent_result_persisted(
 
 
 @pytest.mark.asyncio
+async def test_subagent_end_hook_error_does_not_fail_successful_agent(
+    tmp_path,
+    event_emitter,
+    fake_provider,
+    fake_tool_registry,
+):
+    from miqi.runtime.agent_registry import AgentRegistry
+    from miqi.execution.hook_runtime import HookPoint
+
+    hooks = MagicMock()
+
+    async def run_hook(point, ctx):
+        if point == HookPoint.SUBAGENT_END:
+            raise RuntimeError("hook exploded")
+
+    hooks.run = AsyncMock(side_effect=run_hook)
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=event_emitter,
+        workspace=tmp_path,
+        provider=None,
+        tool_registry=fake_tool_registry,
+        orchestrator="placeholder",
+        hooks=hooks,
+    )
+    agent = await control.spawn("code-agent", "task", label="hook-success")
+    control._provider = fake_provider
+    fake_provider.response_sequence = [
+        _FakeResponse(content="Task complete.", tool_calls=[]),
+    ]
+
+    await control._run_agent(agent, "task")
+
+    assert agent.state.current == AgentStatus.COMPLETED
+    assert agent.result == "Task complete."
+    assert agent.error is None
+
+
+@pytest.mark.asyncio
+async def test_subagent_end_hook_error_does_not_mask_agent_error(
+    tmp_path,
+    event_emitter,
+    fake_provider,
+    fake_tool_registry,
+):
+    from miqi.runtime.agent_registry import AgentRegistry
+    from miqi.execution.hook_runtime import HookPoint
+
+    hooks = MagicMock()
+
+    async def run_hook(point, ctx):
+        if point == HookPoint.SUBAGENT_END:
+            raise RuntimeError("hook exploded")
+
+    hooks.run = AsyncMock(side_effect=run_hook)
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=event_emitter,
+        workspace=tmp_path,
+        provider=None,
+        tool_registry=fake_tool_registry,
+        orchestrator=None,
+        hooks=hooks,
+    )
+    agent = await control.spawn("code-agent", "task", label="hook-failure")
+    control._provider = fake_provider
+    fake_provider.response_sequence = [
+        _FakeResponse(
+            tool_calls=[_FakeToolCall("read_file", {"path": "/tmp/x"}, "tc-1")],
+        ),
+    ]
+
+    await control._run_agent(agent, "task")
+
+    assert agent.state.current == AgentStatus.ERROR
+    assert agent.error is not None
+    assert "ToolOrchestrator must be configured" in agent.error
+    assert "hook exploded" not in agent.error
+
+
+@pytest.mark.asyncio
 async def test_get_agent_detail_unknown_raises(tmp_path, event_emitter):
     """get_agent_detail should raise KeyError for unknown agent IDs."""
     from miqi.runtime.agent_control import AgentControl


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #83：`SUBAGENT_END` lifecycle hook 抛异常时，不应覆盖 sub-agent 已完成的成功结果，也不应掩盖 sub-agent 原本的失败原因。

## 背景/问题

`AgentControl._run_agent()` 在 `finally` 中触发 `SUBAGENT_END` hook。此前这段 hook 调用没有隔离异常：如果 end hook 自身抛错，异常会从 `finally` 继续传播，导致成功执行的 sub-agent 变成失败，或把原始执行错误替换成 hook 错误。

## 变更内容

- 为 `SUBAGENT_END` hook 调用增加异常隔离
- hook 失败时记录 exception 日志
- 保留 sub-agent 原始状态、结果和错误信息
- 增加回归测试覆盖：
  - 成功 sub-agent 的 end hook 抛错时，agent 仍为 completed
  - 失败 sub-agent 的 end hook 抛错时，原始错误不会被 hook 错误覆盖

## 日志/验证证据

修复前新增回归测试可复现失败：

```shell
uv run pytest tests/runtime/test_agent_control.py -k "subagent_end_hook_error" -q
```

结果：

```text
2 failed
```

失败原因是 `RuntimeError: hook exploded` 从 `SUBAGENT_END` hook 传播出来，覆盖了 sub-agent 的正常完成/原始失败路径。

修复后已执行：

```shell
uv run pytest tests/runtime/test_agent_control.py -k "subagent_end_hook_error" -q
```

结果：

```text
2 passed, 20 deselected
```

已执行：

```shell
uv run pytest tests/runtime/test_agent_control.py -q
```

结果：

```text
22 passed
```

已执行：

```shell
uv run pytest tests/runtime/test_hook_lifecycle_firing.py -q
```

结果：

```text
8 passed
```

已执行：

```shell
git diff --check
```

结果：通过。仅有 Windows 工作区行尾提示，无 whitespace error。

## 截图

不适用。该修复位于 runtime hook 调用链路，不涉及 UI 展示改动。

## 测试情况

- `uv run pytest tests/runtime/test_agent_control.py -k "subagent_end_hook_error" -q`：2 passed, 20 deselected
- `uv run pytest tests/runtime/test_agent_control.py -q`：22 passed
- `uv run pytest tests/runtime/test_hook_lifecycle_firing.py -q`：8 passed
- `git diff --check`：通过

Closes #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent completion handling so end-of-run hook failures no longer interrupt cleanup or final status updates.
  * Preserved successful results and existing error states even if a lifecycle hook throws an exception.
  * Added coverage to ensure hook-related errors are logged without replacing the underlying agent outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->