### PR TITLE
fix(runtime): sanitize history items before persistence

### DIFF
--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -471,17 +471,24 @@ def _sanitize_payload(payload: dict[str, Any]) -> str:
         len(payload_json),
         MAX_HISTORY_PAYLOAD_JSON_CHARS,
     )
-    # Reserve ~80 chars for the JSON wrapper keys so the final stored
-    # string never exceeds the configured limit.
+    # Build truncated payload with iterative shrinking to account for
+    # JSON escaping expansion in the preview string.
     preview_limit = max(0, MAX_HISTORY_PAYLOAD_JSON_CHARS - 80)
-    return json.dumps(
-        {
-            "truncated": True,
-            "original_size_chars": len(payload_json),
-            "preview": _truncate_text(payload_json, preview_limit),
-        },
-        ensure_ascii=False,
-    )
+    preview = _truncate_text(payload_json, preview_limit)
+    while True:
+        final_json = json.dumps(
+            {
+                "truncated": True,
+                "original_size_chars": len(payload_json),
+                "preview": preview,
+            },
+            ensure_ascii=False,
+        )
+        if len(final_json) <= MAX_HISTORY_PAYLOAD_JSON_CHARS or preview_limit == 0:
+            return final_json
+        excess = len(final_json) - MAX_HISTORY_PAYLOAD_JSON_CHARS
+        preview_limit = max(0, preview_limit - max(1, excess))
+        preview = _truncate_text(payload_json, preview_limit)
 
 
 def _truncate_text(value: str, limit: int) -> str:

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -238,7 +238,7 @@ class HistoryRuntime:
         db = self._conn
         role = _validate_role(item.role)
         content = _sanitize_content(item.content)
-        payload = _sanitize_payload(item.payload)
+        payload_json = _sanitize_payload(item.payload)
         await db.execute(
             """INSERT INTO runtime_history_items
                (item_id, thread_id, session_id, turn_id, role, content,
@@ -251,7 +251,7 @@ class HistoryRuntime:
                 item.turn_id,
                 role,
                 content,
-                json.dumps(payload),
+                payload_json,
                 item.created_at,
             ),
         )
@@ -455,21 +455,33 @@ def _sanitize_content(content: str) -> str:
     return _truncate_text(content, MAX_HISTORY_CONTENT_CHARS)
 
 
-def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+def _sanitize_payload(payload: dict[str, Any]) -> str:
+    """Sanitize and JSON-serialize payload for storage.
+
+    Returns the final JSON string (not dict) so the caller avoids
+    a second serialization pass.  Enforces MAX_HISTORY_PAYLOAD_JSON_CHARS
+    against the *stored* string, including the truncation-marker framing.
+    """
     safe_payload = _json_safe(payload)
-    payload_json = json.dumps(safe_payload)
+    payload_json = json.dumps(safe_payload, ensure_ascii=False)
     if len(payload_json) <= MAX_HISTORY_PAYLOAD_JSON_CHARS:
-        return safe_payload
+        return payload_json
     logger.warning(
         "Truncating history payload from {} to {} chars",
         len(payload_json),
         MAX_HISTORY_PAYLOAD_JSON_CHARS,
     )
-    return {
-        "truncated": True,
-        "original_size_chars": len(payload_json),
-        "preview": _truncate_text(payload_json, MAX_HISTORY_PAYLOAD_JSON_CHARS),
-    }
+    # Reserve ~80 chars for the JSON wrapper keys so the final stored
+    # string never exceeds the configured limit.
+    preview_limit = max(0, MAX_HISTORY_PAYLOAD_JSON_CHARS - 80)
+    return json.dumps(
+        {
+            "truncated": True,
+            "original_size_chars": len(payload_json),
+            "preview": _truncate_text(payload_json, preview_limit),
+        },
+        ensure_ascii=False,
+    )
 
 
 def _truncate_text(value: str, limit: int) -> str:

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -26,6 +26,19 @@ import aiosqlite
 from loguru import logger
 
 
+VALID_HISTORY_ROLES = frozenset({
+    "system",
+    "user",
+    "assistant",
+    "tool",
+    "developer",
+    "unknown",
+})
+MAX_HISTORY_CONTENT_CHARS = 1_000_000
+MAX_HISTORY_PAYLOAD_JSON_CHARS = 1_000_000
+_TRUNCATED_SUFFIX = "<truncated>"
+
+
 @dataclass(frozen=True)
 class HistoryItem:
     """A single message or event in thread history."""
@@ -223,6 +236,9 @@ class HistoryRuntime:
 
     async def append_item(self, item: HistoryItem) -> None:
         db = self._conn
+        role = _validate_role(item.role)
+        content = _sanitize_content(item.content)
+        payload = _sanitize_payload(item.payload)
         await db.execute(
             """INSERT INTO runtime_history_items
                (item_id, thread_id, session_id, turn_id, role, content,
@@ -233,9 +249,9 @@ class HistoryRuntime:
                 item.thread_id,
                 self.session_id,
                 item.turn_id,
-                item.role,
-                item.content,
-                json.dumps(item.payload),
+                role,
+                content,
+                json.dumps(payload),
                 item.created_at,
             ),
         )
@@ -420,3 +436,57 @@ class HistoryRuntime:
         except Exception:
             await db.execute("ROLLBACK")
             raise
+
+
+def _validate_role(role: str) -> str:
+    if role not in VALID_HISTORY_ROLES:
+        raise ValueError(f"Invalid history role: {role!r}")
+    return role
+
+
+def _sanitize_content(content: str) -> str:
+    if len(content) <= MAX_HISTORY_CONTENT_CHARS:
+        return content
+    logger.warning(
+        "Truncating history content from {} to {} chars",
+        len(content),
+        MAX_HISTORY_CONTENT_CHARS,
+    )
+    return _truncate_text(content, MAX_HISTORY_CONTENT_CHARS)
+
+
+def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    safe_payload = _json_safe(payload)
+    payload_json = json.dumps(safe_payload)
+    if len(payload_json) <= MAX_HISTORY_PAYLOAD_JSON_CHARS:
+        return safe_payload
+    logger.warning(
+        "Truncating history payload from {} to {} chars",
+        len(payload_json),
+        MAX_HISTORY_PAYLOAD_JSON_CHARS,
+    )
+    return {
+        "truncated": True,
+        "original_size_chars": len(payload_json),
+        "preview": _truncate_text(payload_json, MAX_HISTORY_PAYLOAD_JSON_CHARS),
+    }
+
+
+def _truncate_text(value: str, limit: int) -> str:
+    if limit <= len(_TRUNCATED_SUFFIX):
+        return _TRUNCATED_SUFFIX[:limit]
+    return value[: limit - len(_TRUNCATED_SUFFIX)] + _TRUNCATED_SUFFIX
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    if hasattr(value, "value"):
+        return _json_safe(value.value)
+    return repr(value)

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from miqi.runtime import history_runtime
 from miqi.runtime.history_runtime import HistoryRuntime, HistoryItem
 
 
@@ -95,6 +96,72 @@ async def test_history_runtime_load_messages_formats_for_provider(tmp_path):
     assert messages[0] == {"role": "user", "content": "hello"}
     assert messages[1] == {"role": "assistant", "content": "hi there"}
     await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_append_item_rejects_invalid_role(tmp_path):
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        with pytest.raises(ValueError, match="Invalid history role"):
+            await runtime.append_item(HistoryItem(
+                item_id="bad-role",
+                thread_id="thread-1",
+                turn_id="turn-1",
+                role="admin",
+                content="should not persist",
+            ))
+
+        items = await runtime.load_items("thread-1")
+        assert items == []
+    finally:
+        await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_append_item_truncates_large_content_and_payload(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        history_runtime,
+        "MAX_HISTORY_CONTENT_CHARS",
+        32,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        history_runtime,
+        "MAX_HISTORY_PAYLOAD_JSON_CHARS",
+        64,
+        raising=False,
+    )
+
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        await runtime.append_item(HistoryItem(
+            item_id="large-item",
+            thread_id="thread-1",
+            turn_id="turn-1",
+            role="tool",
+            content="x" * 128,
+            payload={"result": "y" * 256},
+        ))
+
+        items = await runtime.load_items("thread-1")
+        assert len(items) == 1
+        item = items[0]
+        assert len(item.content) <= history_runtime.MAX_HISTORY_CONTENT_CHARS
+        assert item.content.endswith("<truncated>")
+        assert item.payload["truncated"] is True
+        assert item.payload["original_size_chars"] > (
+            history_runtime.MAX_HISTORY_PAYLOAD_JSON_CHARS
+        )
+        assert len(item.payload["preview"]) <= (
+            history_runtime.MAX_HISTORY_PAYLOAD_JSON_CHARS
+        )
+    finally:
+        await runtime.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #86：`HistoryRuntime.append_item()` 写入 SQLite 前会校验 history role，并对过大的 `content` / `payload` 做截断，避免异常大的工具结果完整写入 runtime history 数据库。

## 背景/问题

此前 `append_item()` 直接把 role、content 和 payload JSON 写入 `runtime_history_items`。这会让非法 role 进入历史库，也会让大型工具结果完整落库，导致 runtime history 数据异常或数据库膨胀。

## 变更内容

- 新增 history role 白名单校验。
- `append_item()` 写库前统一清洗 content 和 payload。
- 超大 content 截断并记录 warning。
- payload 先转为 JSON-safe 结构，再按大小上限截断为摘要。
- 补充回归测试覆盖非法 role 和超大 content/payload。

## 日志/验证证据

```
uv run pytest tests/runtime/test_history_runtime.py -k "invalid_role or truncates_large" -q
# 2 passed
uv run pytest tests/runtime/test_history_runtime.py -q
# 10 passed
uv run pytest tests/runtime/test_history_runtime.py tests/runtime/test_task_runner_history_integration.py tests/runtime/test_thread_export_import.py tests/runtime/test_thread_stored_handlers.py -q
# 51 passed
git diff --check
# passed
```

## 截图

不适用。该修复位于 runtime history 持久化层，未改变可视展示。

## 测试情况

- `uv run pytest tests/runtime/test_history_runtime.py -q`：10 passed
- `uv run pytest tests/runtime/test_history_runtime.py tests/runtime/test_task_runner_history_integration.py tests/runtime/test_thread_export_import.py tests/runtime/test_thread_stored_handlers.py -q`：51 passed
- `git diff --check`：通过

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * History entries now validate roles before saving.
  * Message content is safely truncated and marked with a clear truncated suffix.
  * Payload data is converted to JSON-safe form, deterministically size-limited, and truncated with preview details when too large.
  * Prevents malformed or oversized history data from being persisted.
* **Tests**
  * Added async tests covering invalid roles and content/payload truncation using configurable limits.
  * Verifies the runtime is closed after history operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->