### PR TITLE
fix(runtime): preserve history compaction message order

### DIFF
--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -37,6 +37,7 @@ VALID_HISTORY_ROLES = frozenset({
 MAX_HISTORY_CONTENT_CHARS = 1_000_000
 MAX_HISTORY_PAYLOAD_JSON_CHARS = 1_000_000
 _TRUNCATED_SUFFIX = "<truncated>"
+_HISTORY_CREATED_AT_STEP = 1e-6
 
 
 @dataclass(frozen=True)
@@ -81,6 +82,7 @@ class HistoryRuntime:
         self.db_path = db_path
         self.session_id = session_id
         self._db: aiosqlite.Connection | None = None
+        self._last_history_created_at = 0.0
 
     # ── lifecycle ──────────────────────────────────────────────────────
 
@@ -252,7 +254,7 @@ class HistoryRuntime:
                 role,
                 content,
                 payload_json,
-                item.created_at,
+                self._next_history_created_at(item.created_at),
             ),
         )
         await db.commit()
@@ -410,7 +412,7 @@ class HistoryRuntime:
                                 },
                             },
                         ),
-                        time.time(),
+                        self._next_history_created_at(time.time()),
                     ),
                 )
             # Record the compaction with full audit metadata
@@ -436,6 +438,13 @@ class HistoryRuntime:
         except Exception:
             await db.execute("ROLLBACK")
             raise
+
+    def _next_history_created_at(self, preferred: float | None = None) -> float:
+        created_at = time.time() if preferred is None else preferred
+        if created_at <= self._last_history_created_at:
+            created_at = self._last_history_created_at + _HISTORY_CREATED_AT_STEP
+        self._last_history_created_at = created_at
+        return created_at
 
 
 def _validate_role(role: str) -> str:

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -1,5 +1,7 @@
 """Tests for HistoryRuntime — persistent turn and message history."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from miqi.runtime import history_runtime
@@ -222,6 +224,42 @@ async def test_compaction_record_stores_audit_metadata(tmp_path):
     assert row["tokens_saved"] == 50
     assert json.loads(row["replacement_json"]) == [{"role": "system", "content": "[summary]"}]
     await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_compaction_replacement_order_does_not_fall_back_to_item_id(
+    tmp_path,
+    monkeypatch,
+):
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        await runtime.append_message(
+            thread_id="t1", turn_id="a", role="user", content="old"
+        )
+
+        uuids = iter(["compaction-id", "b-system", "a-user"])
+        monkeypatch.setattr(
+            history_runtime,
+            "time",
+            SimpleNamespace(time=lambda: 1000.0),
+        )
+        monkeypatch.setattr(history_runtime.uuid, "uuid4", lambda: next(uuids))
+
+        await runtime.replace_messages_with_compaction(
+            "t1",
+            "compact-1",
+            [
+                {"role": "system", "content": "[summary]"},
+                {"role": "user", "content": "recent message"},
+            ],
+        )
+
+        messages = await runtime.load_messages("t1")
+        assert [message["role"] for message in messages] == ["system", "user"]
+        assert messages[0]["content"] == "[summary]"
+    finally:
+        await runtime.close()
 
 
 # ── Phase 36: history deletion for rollback ──────────────────────────────


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 #156：history compaction replacement messages 在相同 `created_at` 下不应退化为按随机 `item_id` 排序，导致 `system summary` 和后续 `user` message 顺序被打乱。

## 背景/问题

`HistoryRuntime.load_items()` 通过 `ORDER BY created_at ASC, item_id ASC` 恢复 history item 顺序。`replace_messages_with_compaction()` 快速插入多条 replacement messages 时，这些消息可能拿到相同或不可区分的 `created_at`，尤其 Windows CI 上更容易触发。此时排序会落到随机 item_id 字典序，可能把 `system summary` 和后续 `user recent` 读成相反顺序。

## 变更内容

- 为 `HistoryRuntime` 增加内部 `_next_history_created_at()`。
- 写入 `runtime_history_items` 时，如果传入时间戳不大于上一条 history item，则按 `_HISTORY_CREATED_AT_STEP` 单调递增。
- 普通 `append_item()` 和 compaction replacement 写入都使用该单调时间戳分配。
- 增加确定性回归测试，固定时间和 item_id 顺序，断言 `load_messages()` 保持 replacement list 原始顺序。

## 日志/验证证据

```
uv run pytest tests/runtime/test_history_runtime.py::test_compaction_replacement_order_does_not_fall_back_to_item_id -q
# 修复前：1 failed
# 修复后：1 passed
uv run pytest tests/runtime/test_history_runtime.py -q
# 9 passed
uv run pytest tests/runtime/test_task_runner_history_integration.py -q
# 7 passed
uv run pytest tests/runtime/test_thread_export_import.py tests/runtime/test_thread_stored_handlers.py -q
# 34 passed
git diff --check
# passed
```

## 截图

不适用。该修复位于 runtime history 持久化排序逻辑，未改变可视展示。

## 测试情况

- `uv run pytest tests/runtime/test_history_runtime.py::test_compaction_replacement_order_does_not_fall_back_to_item_id -q`：1 passed
- `uv run pytest tests/runtime/test_history_runtime.py -q`：9 passed
- `uv run pytest tests/runtime/test_task_runner_history_integration.py -q`：7 passed
- `uv run pytest tests/runtime/test_thread_export_import.py tests/runtime/test_thread_stored_handlers.py -q`：34 passed
- `git diff --check`：通过

Closes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the correct order of persisted history messages, including messages added during compaction.
  * Ensured history timestamps remain strictly increasing for reliable chronological display.

* **Tests**
  * Added coverage verifying replacement messages retain their intended order and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->