### PR TITLE
feat(chat): guide provider setup before first chat

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from './components/Sidebar';
 import { StatusBar } from './components/StatusBar';
 import { SetupWizard } from './features/setup/SetupWizard';
 import { ChatConsole } from './features/chat/ChatConsole';
-import { SettingsPage } from './features/settings/SettingsPage';
+import { SettingsPage, type SettingsTab } from './features/settings/SettingsPage';
 import { MCPsPage } from './features/mcps/MCPsPage';
 import { ApprovalProvider } from './contexts/ApprovalContext';
 import { RestartRequiredProvider } from './contexts/RestartRequiredContext';
@@ -56,6 +56,7 @@ function AppShell() {
   const [runtimeReadyKey, setRuntimeReadyKey] = useState(0);
   const [needsSetup, setNeedsSetup] = useState<boolean | null>(null);
   const [canSkipSetup, setCanSkipSetup] = useState(false); // true when re-running wizard from settings
+  const [settingsTab, setSettingsTab] = useState<SettingsTab>('general');
 
   // Persist last active session so the app restores it on next launch
   useEffect(() => {
@@ -225,7 +226,10 @@ function AppShell() {
                   setActiveNav('chat');
                   setSessionRefreshKey((k) => k + 1);
                 }}
-                onNavChange={(id) => setActiveNav(id as NavId)}
+                onNavChange={(id) => {
+                  if (id === 'settings') setSettingsTab('general');
+                  setActiveNav(id as NavId);
+                }}
                 refreshKey={sessionRefreshKey + runtimeReadyKey * 100000}
                 onNewSession={handleNewSession}
               />
@@ -248,6 +252,10 @@ function AppShell() {
                       setSessionRefreshKey((k) => k + 1);
                     }}
                     onChatFinished={() => setSessionRefreshKey((k) => k + 1)}
+                    onOpenProviderSettings={() => {
+                      setSettingsTab('providers');
+                      setActiveNav('settings');
+                    }}
                   />
                 </div>
                 {activeNav === 'workspace' && <WorkspacePage />}
@@ -272,6 +280,7 @@ function AppShell() {
                 )}
                 {activeNav === 'settings' && (
                   <SettingsPage
+                    tab={settingsTab}
                     onReopenSetup={() => {
                       setCanSkipSetup(true);
                       setNeedsSetup(true);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -55,11 +55,28 @@ interface Message {
   attachments?: Attachment[];
   toolHint?: boolean;
   toolCallId?: string;
+  action?: 'open-provider-settings';
+  actionLabel?: string;
   /** When true the message is collapsed by default (user can click to expand) */
   collapsed?: boolean;
   /** Short label shown when collapsed (e.g. "exec" or "write_file → /path/to/file") */
   summary?: string;
   timestamp: number;
+}
+
+function isMissingProviderConfigMessage(message: string) {
+  const normalized = message.toLowerCase();
+  return normalized.includes('no api key configured');
+}
+
+function createProviderConfigMessage(): Message {
+  return {
+    role: 'error',
+    content: '尚未配置模型服务。请先配置 Provider/API Key 后再发送消息。',
+    action: 'open-provider-settings',
+    actionLabel: '配置 Provider',
+    timestamp: Date.now(),
+  };
 }
 
 /* ─── Tracked file from tool hints ───────────────────────────────── */
@@ -337,12 +354,14 @@ export function ChatConsole({
   loadTrigger,
   onNewSession,
   onChatFinished,
+  onOpenProviderSettings,
 }: {
   sessionKey?: string;
   /** Increment to force a session history reload (e.g. after bridge becomes ready) */
   loadTrigger?: number;
   onNewSession?: (newKey: string) => void;
   onChatFinished?: () => void;
+  onOpenProviderSettings?: () => void;
 }) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
@@ -657,6 +676,18 @@ export function ChatConsole({
     const text = input.trim();
     if (!text && attachments.length === 0) return;
 
+    try {
+      const result = await window.miqi.providers.list();
+      const hasConfiguredProvider = result.providers.some((provider) => provider.configured);
+      if (!hasConfiguredProvider) {
+        setMessages((prev) => [...prev, createProviderConfigMessage()]);
+        return;
+      }
+    } catch {
+      // If provider status cannot be read, keep the original send path so the
+      // bridge can surface the underlying runtime error.
+    }
+
     // If a reveal animation is still running from the previous response,
     // cancel it and abort the in-flight request so we can start fresh.
     if (streaming) {
@@ -863,7 +894,9 @@ export function ChatConsole({
       if (animId !== null) cancelAnimationFrame(animId);
       setMessages((prev) => [
         ...prev,
-        { role: 'error', content: data.message, timestamp: Date.now() },
+        isMissingProviderConfigMessage(data.message)
+          ? createProviderConfigMessage()
+          : { role: 'error', content: data.message, timestamp: Date.now() },
       ]);
       setStreaming(false);
       sendCleanup();
@@ -921,7 +954,9 @@ export function ChatConsole({
       if (animId !== null) cancelAnimationFrame(animId);
       const errMsg = sanitizeUiMessage(e?.message ?? String(e ?? 'Unknown error'));
       const detail = `chat.send failed: ${errMsg}`;
-      if (e?.code) {
+      if (isMissingProviderConfigMessage(errMsg)) {
+        setMessages((prev) => [...prev, createProviderConfigMessage()]);
+      } else if (e?.code) {
         setMessages((prev) => [
           ...prev,
           { role: 'error' as const, content: `${detail} (code: ${e.code})`, timestamp: Date.now() },
@@ -1282,6 +1317,7 @@ export function ChatConsole({
                     onCopy={(text) => handleCopy(text, i)}
                     isCopied={copiedIdx === i}
                     onRetry={() => handleRetry(msg)}
+                    onOpenProviderSettings={onOpenProviderSettings}
                   />
                 ))
               )}
@@ -2016,6 +2052,7 @@ function MessageBubble({
   onCopy,
   isCopied,
   onRetry,
+  onOpenProviderSettings,
 }: {
   msg: Message;
   execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
@@ -2023,6 +2060,7 @@ function MessageBubble({
   onCopy: (text: string) => void;
   isCopied: boolean;
   onRetry?: () => void;
+  onOpenProviderSettings?: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -2084,7 +2122,21 @@ function MessageBubble({
             border: '1px solid var(--danger)',
           }}
         >
-          {msg.content}
+          <div className="whitespace-pre-wrap break-words">{msg.content}</div>
+          {msg.action === 'open-provider-settings' && onOpenProviderSettings && (
+            <button
+              type="button"
+              onClick={onOpenProviderSettings}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors"
+              style={{
+                background: 'var(--danger)',
+                color: 'var(--danger-bg)',
+              }}
+            >
+              <Settings size={13} />
+              {msg.actionLabel ?? '配置 Provider'}
+            </button>
+          )}
         </div>
       </div>
     );

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -32,7 +32,7 @@ import { PermissionsPage } from '../permissions/PermissionsPage';
 import { PluginMarket } from '../plugins/PluginMarket';
 import WslStatusPage from '../wsl/WslStatusPage';
 
-type SettingsTab =
+export type SettingsTab =
   | 'general'
   | 'providers'
   | 'channels'


### PR DESCRIPTION
﻿## 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 重构
- [ ] 测试
- [ ] 其他

## 变更概述

为运行时首次聊天缺少模型 Provider 配置的场景增加配置引导，避免用户直接看到底层错误或不知道下一步去哪里配置。

## 背景/问题

#139 简化首次启动后，用户可以只确认 workspace 就进入主界面；但如果用户随后直接发送聊天消息，而本地还没有任何 Provider/API Key 配置，当前体验会直接进入失败路径，缺少明确的下一步操作。

这个 PR 对应 #160 的第一阶段，只处理 `Chat -> Provider` 这一条最小闭环，不把 Web Search、Fetch、Papers 等其他 capability 一起塞进来，避免扩大 issue 边界。

## 产品边界

本 PR 处理的是运行时阻塞型缺配置：

```
用户发送聊天消息
        ↓
检测到没有已配置 Provider
        ↓
在聊天区显示配置引导
        ↓
点击「配置 Provider」
        ↓
跳到 Settings -> Providers
```

未包含：

- Web Search / Brave API Key 引导。
- Web Fetch / Ollama web_fetch 引导。
- Papers / Semantic Scholar 引导。
- 通用 Capability Configuration Framework。
- 聊天内直接弹窗填写 Provider。
- 配置完成后自动重发上一条消息。

这些属于 #160 后续阶段或新的 capability routing issue。

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 发送前检查 `providers.list()` 是否存在已配置 Provider。
  - 没有 Provider 时不发送消息，直接显示“配置 Provider”的错误引导卡片。
  - 对后端返回的 `No API key configured` 错误也转换为同一个配置引导。
  - 错误气泡支持一个操作按钮，用于进入 Provider 设置。
- `apps/desktop/src/renderer/App.tsx`
  - 增加从 Chat 跳转到 Settings -> providers tab 的导航。
  - 普通点击 Settings 时仍默认打开 general tab。
- `apps/desktop/src/renderer/features/settings/SettingsPage.tsx`
  - 导出 `SettingsTab` 类型，供 App 的设置页跳转状态复用。

## 截图/手工验证

已补充真实截图：

- 没有 Provider 时，在 Chat 发送消息出现“配置 Provider”引导卡片。
- 点击按钮后进入 Settings -> Providers。
- 配置 Provider 后再次发送消息不再出现该引导。
<img width="1266" height="853" alt="没有key" src="https://github.com/user-attachments/assets/7f832947-3604-4f61-a29a-3f104f8d12a5" />
<img width="1266" height="853" alt="image" src="https://github.com/user-attachments/assets/ebe89e3e-b660-4515-8244-7bcf5d1cf681" />



## 日志/验证证据

```
$ git diff --check -- apps/desktop/src/renderer/App.tsx apps/desktop/src/renderer/features/chat/ChatConsole.tsx apps/desktop/src/renderer/features/settings/SettingsPage.tsx
# 通过

$ npm.cmd run typecheck:node
> miqi-desktop@0.4.0 typecheck:node
> tsc --noEmit -p tsconfig.node.json
# 通过

$ npm.cmd run typecheck:web
> miqi-desktop@0.4.0 typecheck:web
> tsc --noEmit -p tsconfig.web.json
# 通过

$ npm.cmd run build
> miqi-desktop@0.4.0 build
> electron-vite build
# 通过；仅有既有 Radix/Vite "use client" warning
```

## 测试情况

- 已 rebase 到最新 `origin/develop`。
- 已移除与本 PR 无关的 `action.yml` 噪音 commit。
- 已运行 `git diff --check`，通过。
- 已运行 `npm.cmd run typecheck:node`，通过。
- 已运行 `npm.cmd run typecheck:web`，通过。
- 已运行 `npm.cmd run build`，通过。
- 已自审最终 diff：只包含 Chat Provider 缺配置引导、跳转 Settings providers tab、导出 `SettingsTab` 类型；没有包含 Brave/Search/Papers/Fetch 相关逻辑。

Closes #160


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shortcut from chat errors to open the Provider settings page.
  * Provider-related error messages now include a clear action button to fix missing configuration.

* **Bug Fixes**
  * Improved settings navigation so the correct settings tab opens when coming from chat or the sidebar.
  * When entering Settings, the General tab now opens by default unless Provider settings were specifically requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->