### PR TITLE
feat(documents): 新增 Workspace Office 文档工具

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   Copy,
   Check,
+  CheckCircle,
   Paperclip,
   X,
   FileText,
@@ -72,6 +73,8 @@ interface TrackedFile {
   truncated?: boolean;
 }
 
+const OFFICE_FILE_RE = /\.(docx|xlsx|pptx)$/i;
+
 /** Extract file path + operation from a tool-hint progress text.
  *  Nanobot tool hints look like:
  *    "Read: /abs/path/to/file.ts"
@@ -92,6 +95,9 @@ function parseToolHint(
     [/^(?:Delete|Deleting(?:\s+file)?)[:\s]+(.+?)(?:\s*….*)?$/i, 'delete'],
     // nanobot / miqi style: write_file("path"), read_file("path"), edit_file("path")
     [/(?:write|edit|delete|read)_file\s*\(\s*["'](.+?)["']\s*\)/i, 'write'],
+    // Office creation tools create files in the workspace.
+    [/(?:create_docx|create_xlsx|create_pptx|docx_write|xlsx_write|pptx_write)\s*\(\s*["'](.+?)["']\s*\)/i, 'write'],
+    [/(?:edit_docx|append_xlsx)\s*\(\s*["'](.+?)["']\s*\)/i, 'edit'],
     // Generic fallback: any mention of a path-like string after a colon
     [/(?:file|path)[:\s]+([^\s,]+\.[a-zA-Z]{1,6})/i, 'read'],
   ];
@@ -114,6 +120,7 @@ function parseToolHint(
         else if (re.source.includes('edit')) inferredOp = 'edit';
         else if (re.source.includes('delete')) inferredOp = 'delete';
         else if (re.source.includes('read')) inferredOp = 'read';
+        else if (re.source.includes('create_') || re.source.includes('_write')) inferredOp = 'write';
         return { path: raw, op: inferredOp, truncated };
       }
     }
@@ -501,7 +508,9 @@ export function ChatConsole({
       const content = `${statusIcon} Subagent "${label}" ${data.status === 'ok' ? 'completed' : 'failed'}:\n\n${data.result}`;
       setMessages((prev) => [...prev, { role: 'subagent', content, timestamp: Date.now() }]);
     });
-    return unsub;
+    return () => {
+      unsub();
+    };
   }, []);
 
   const cleanupListeners = useCallback(() => {
@@ -866,6 +875,14 @@ export function ChatConsole({
   };
 
   const handlePreview = useCallback(async (path: string) => {
+    if (OFFICE_FILE_RE.test(path)) {
+      setPreviewFile({
+        path,
+        content:
+          'Office document created. Text preview is not available for .docx/.xlsx/.pptx files; open it from the workspace or Task Assets file entry.',
+      });
+      return;
+    }
     try {
       const result = await window.miqi.files.read(path);
       setPreviewFile({ path, content: result.content });
@@ -1822,6 +1839,7 @@ function TrackedFileCard({
   };
   const OpIcon = file.op === 'read' ? BookOpen : file.op === 'delete' ? X : Pencil;
   const displayPath = file.path.replace(/\\/g, '/');
+  const isOfficeFile = OFFICE_FILE_RE.test(file.path);
 
   return (
     <div
@@ -1851,6 +1869,17 @@ function TrackedFileCard({
             >
               {file.op.toUpperCase()}
             </span>
+            {isOfficeFile && (
+              <span
+                className="text-[9px] px-1.5 py-0.5 rounded font-semibold shrink-0"
+                style={{
+                  background: 'var(--surface-muted)',
+                  color: 'var(--text-faint)',
+                }}
+              >
+                OFFICE
+              </span>
+            )}
           </div>
         </div>
       </div>
@@ -1871,12 +1900,14 @@ function TrackedFileCard({
           {onDiff && (file.op === 'write' || file.op === 'edit') && (
             <button
               onClick={onDiff}
+              disabled={isOfficeFile}
               className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-[11px] transition-colors"
               style={{
                 border: '1px solid var(--border)',
-                color: 'var(--warning)',
+                color: isOfficeFile ? 'var(--text-faint)' : 'var(--warning)',
+                opacity: isOfficeFile ? 0.55 : 1,
               }}
-              title="Compare diff"
+              title={isOfficeFile ? 'Diff is not available for Office binary files' : 'Compare diff'}
             >
               <GitCompare size={10} />
               Diff
@@ -1889,6 +1920,7 @@ function TrackedFileCard({
               border: '1px solid var(--border)',
               color: 'var(--text-muted)',
             }}
+            title={isOfficeFile ? 'Office binary preview is not available' : 'Preview file'}
           >
             <Eye size={10} />
             Preview
@@ -1927,7 +1959,13 @@ function MessageBubble({
         style={{ color: msg.toolHint ? 'var(--info)' : 'var(--text-muted)' }}
         onClick={msg.collapsed ? () => setExpanded((v) => !v) : undefined}
       >
-        {msg.toolHint ? <Wrench size={12} /> : <Loader2 size={12} className="animate-spin" />}
+        {msg.toolHint ? (
+          <Wrench size={12} />
+        ) : isLast ? (
+          <Loader2 size={12} className="animate-spin" />
+        ) : (
+          <CheckCircle size={12} />
+        )}
         {msg.collapsed &&
           (isCollapsed ? (
             <ChevronRight size={10} className="shrink-0" style={{ color: 'var(--text-faint)' }} />

--- a/apps/desktop/src/renderer/features/chat/progressUtils.ts
+++ b/apps/desktop/src/renderer/features/chat/progressUtils.ts
@@ -20,14 +20,24 @@ export interface ProgressPayload {
 export function extractProgressMessage(
   payload: ProgressPayload
 ): { message: string; role: 'progress' | 'error' | 'warning' } | null {
+  const eventName = payload.event ?? '';
+
   // 1) Direct text is the happy path
   if (payload.text && payload.text.trim()) {
+    if (/^ExecCommand(?:Begin|End)Event$/.test(payload.text.trim())) {
+      return null;
+    }
     return { message: payload.text, role: 'progress' };
   }
 
   // 2) Structured runtime events (ErrorEvent, WarningEvent, etc.)
-  const eventName = payload.event ?? '';
   const data = payload.data ?? {};
+
+  // Exec lifecycle events are internal plumbing. Rendering them as progress
+  // rows makes completed commands look like they are still spinning.
+  if (/^ExecCommand(?:Begin|End)Event$/.test(eventName)) {
+    return null;
+  }
 
   if (eventName.toLowerCase().includes('error') || data.error_kind) {
     const msg =

--- a/miqi/agent/tools/base.py
+++ b/miqi/agent/tools/base.py
@@ -75,6 +75,23 @@ class Tool(ABC):
             return [f"{label} should be {t}"]
 
         errors = []
+        if "anyOf" in schema:
+            option_errors = []
+            for option in schema["anyOf"]:
+                option_schema = {
+                    **option,
+                    "type": option.get("type", schema.get("type", "object")),
+                }
+                branch_errors = self._validate(val, option_schema, path)
+                if not branch_errors:
+                    break
+                option_errors.append("; ".join(branch_errors))
+            else:
+                errors.append(
+                    f"{label} must match one of anyOf schemas: "
+                    + " | ".join(option_errors)
+                )
+
         if "enum" in schema and val not in schema["enum"]:
             errors.append(f"{label} must be one of {schema['enum']}")
         if t in ("integer", "number"):

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -454,6 +454,13 @@ class WriteFileTool(Tool):
         }
 
     async def execute(self, path: str, content: str, **kwargs: Any) -> str:
+        office_suffixes = {".docx", ".xlsx", ".pptx"}
+        if Path(path).suffix.lower() in office_suffixes:
+            return (
+                "Error: write_file cannot create Office binary files. "
+                "Use create_docx, create_xlsx, or create_pptx instead."
+            )
+
         sandbox = _get_active_sandbox(self._sandbox_manager)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox

--- a/miqi/agent/tools/registry.py
+++ b/miqi/agent/tools/registry.py
@@ -68,6 +68,11 @@ _PATH_SCOPED_TOOLS: frozenset[str] = frozenset({
     "write_file",
     "edit_file",
     "read_file",
+    "create_docx",
+    "create_pptx",
+    "create_xlsx",
+    "edit_docx",
+    "append_xlsx",
     "memory",  # writes to workspace/memory/MEMORY.md or USER.md
     "task_begin",  # writes to workspace/traces/
     "task_end",    # writes to workspace/traces/

--- a/miqi/documents/docx_tool.py
+++ b/miqi/documents/docx_tool.py
@@ -3,9 +3,340 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Any
 
 from miqi.agent.tools.base import Tool
+
+
+_MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+
+_CHINESE_STYLE_PRESETS: dict[str, dict[str, dict[str, Any]]] = {
+    "chinese_document": {
+        "title_style": {
+            "font_name": "黑体",
+            "east_asia_font": "黑体",
+            "font_size_pt": 16,
+            "bold": True,
+            "alignment": "center",
+        },
+        "body_style": {
+            "font_name": "宋体",
+            "east_asia_font": "宋体",
+            "font_size_pt": 12,
+            "line_spacing": 1.5,
+        },
+    },
+    "chinese_essay": {
+        "title_style": {
+            "font_name": "黑体",
+            "east_asia_font": "黑体",
+            "font_size_pt": 16,
+            "bold": True,
+            "alignment": "center",
+        },
+        "body_style": {
+            "font_name": "宋体",
+            "east_asia_font": "宋体",
+            "font_size_pt": 12,
+            "line_spacing": 1.5,
+        },
+    },
+}
+
+_CHINESE_SIZE_TO_PT = {
+    "初号": 42,
+    "小初": 36,
+    "一号": 26,
+    "小一": 24,
+    "二号": 22,
+    "小二": 18,
+    "三号": 16,
+    "小三": 15,
+    "四号": 14,
+    "小四": 12,
+    "五号": 10.5,
+    "小五": 9,
+}
+
+
+def _raw_output_path(kwargs: dict[str, Any]) -> str:
+    return str(
+        kwargs.get("filename")
+        or kwargs.get("file_path")
+        or kwargs.get("path")
+        or ""
+    )
+
+
+def _ensure_suffix(path: Path, suffix: str) -> Path:
+    if not path.name or path.name in {".", ".."}:
+        raise ValueError("output filename is required")
+    if path.suffix.lower() == suffix:
+        return path
+    return path.with_suffix(suffix)
+
+
+def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | None) -> None:
+    effective_dir = allowed_dir or workspace
+    if effective_dir is None:
+        return
+    try:
+        path.resolve().relative_to(effective_dir.resolve())
+    except ValueError:
+        raise PermissionError(
+            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
+        )
+
+
+def _add_docx_content(doc: Any, content: Any) -> int:
+    """Add supported structured content to a python-docx document."""
+    blocks = content if isinstance(content, list) else [{"type": "paragraph", "text": str(content)}]
+    count = 0
+    for block in blocks:
+        if not isinstance(block, dict):
+            doc.add_paragraph(str(block))
+            count += 1
+            continue
+        block_type = str(block.get("type", "paragraph")).lower()
+        if block_type == "heading":
+            doc.add_heading(str(block.get("text", "")), level=int(block.get("level", 1)))
+            count += 1
+        elif block_type == "table":
+            rows = block.get("rows", [])
+            if not rows:
+                continue
+            table = doc.add_table(rows=len(rows), cols=max(len(row) for row in rows))
+            table.style = str(block.get("style", "Table Grid"))
+            for row_idx, row in enumerate(rows):
+                for col_idx, value in enumerate(row):
+                    table.cell(row_idx, col_idx).text = "" if value is None else str(value)
+            count += 1
+        elif block_type == "image":
+            image_path = block.get("path")
+            if image_path:
+                doc.add_picture(str(image_path))
+                count += 1
+        else:
+            doc.add_paragraph(str(block.get("text", "")))
+            count += 1
+    return count
+
+
+def _add_markdown_like_text(doc: Any, text: Any) -> int:
+    count = 0
+    for line in str(text).split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        heading = _MARKDOWN_HEADING_RE.match(line)
+        if heading:
+            doc.add_heading(heading.group(2), level=len(heading.group(1)))
+        else:
+            doc.add_paragraph(line)
+        count += 1
+    return count
+
+
+def _set_east_asia_font(run: Any, font_name: str) -> None:
+    from docx.oxml.ns import qn
+
+    r_pr = run._element.get_or_add_rPr()
+    r_fonts = r_pr.rFonts
+    if r_fonts is None:
+        r_fonts = r_pr._add_rFonts()
+    r_fonts.set(qn("w:eastAsia"), font_name)
+
+
+def _alignment_from_value(value: Any) -> Any:
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    return {
+        "center": WD_ALIGN_PARAGRAPH.CENTER,
+        "centered": WD_ALIGN_PARAGRAPH.CENTER,
+        "centre": WD_ALIGN_PARAGRAPH.CENTER,
+        "居中": WD_ALIGN_PARAGRAPH.CENTER,
+        "left": WD_ALIGN_PARAGRAPH.LEFT,
+        "左对齐": WD_ALIGN_PARAGRAPH.LEFT,
+        "right": WD_ALIGN_PARAGRAPH.RIGHT,
+        "右对齐": WD_ALIGN_PARAGRAPH.RIGHT,
+        "justify": WD_ALIGN_PARAGRAPH.JUSTIFY,
+        "justified": WD_ALIGN_PARAGRAPH.JUSTIFY,
+        "两端对齐": WD_ALIGN_PARAGRAPH.JUSTIFY,
+    }.get(normalized)
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if value is None or isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in {"true", "1", "yes", "y", "bold", "加粗"}:
+        return True
+    if normalized in {"false", "0", "no", "n", "normal", "不加粗"}:
+        return False
+    return None
+
+
+def _size_to_pt(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    text = str(value).strip()
+    if text in _CHINESE_SIZE_TO_PT:
+        return float(_CHINESE_SIZE_TO_PT[text])
+    try:
+        return float(text.replace("pt", "").strip())
+    except ValueError:
+        return None
+
+
+def _merge_style(*styles: dict[str, Any] | None) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for style in styles:
+        if isinstance(style, dict):
+            merged.update({k: v for k, v in style.items() if v is not None})
+    return merged
+
+
+def _instruction_clause(instructions: str, label: str) -> str:
+    start = instructions.find(label)
+    if start < 0:
+        return ""
+    other_labels = ["标题", "正文"]
+    end = len(instructions)
+    for other in other_labels:
+        if other == label:
+            continue
+        other_pos = instructions.find(other, start + len(label))
+        if other_pos >= 0:
+            end = min(end, other_pos)
+    return instructions[start:end]
+
+
+def _size_in_clause(clause: str) -> float | None:
+    # Match longer names first so 小四 is not treated as 四号, etc.
+    for chinese_size in sorted(_CHINESE_SIZE_TO_PT, key=len, reverse=True):
+        if chinese_size in clause:
+            return float(_CHINESE_SIZE_TO_PT[chinese_size])
+    return None
+
+
+def _style_from_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    preset_name = str(kwargs.get("style_preset") or "").strip()
+    preset = _CHINESE_STYLE_PRESETS.get(preset_name, {})
+    title_style = _merge_style(preset.get("title_style"), kwargs.get("title_style"))
+    body_style = _merge_style(preset.get("body_style"), kwargs.get("body_style"))
+
+    flat_title = {
+        "font_name": kwargs.get("title_font_name") or kwargs.get("title_font"),
+        "east_asia_font": kwargs.get("title_east_asia_font"),
+        "font_size_pt": kwargs.get("title_font_size_pt") or kwargs.get("title_size_pt"),
+        "bold": kwargs.get("title_bold"),
+        "alignment": kwargs.get("title_alignment"),
+    }
+    flat_body = {
+        "font_name": kwargs.get("body_font_name") or kwargs.get("body_font"),
+        "east_asia_font": kwargs.get("body_east_asia_font"),
+        "font_size_pt": kwargs.get("body_font_size_pt") or kwargs.get("body_size_pt"),
+        "line_spacing": kwargs.get("line_spacing"),
+        "alignment": kwargs.get("body_alignment"),
+    }
+    title_style = _merge_style(title_style, flat_title)
+    body_style = _merge_style(body_style, flat_body)
+
+    instructions = str(kwargs.get("format_instructions") or "")
+    if instructions:
+        title_clause = _instruction_clause(instructions, "标题")
+        body_clause = _instruction_clause(instructions, "正文")
+        if "黑体" in instructions:
+            title_style["font_name"] = "黑体"
+            title_style["east_asia_font"] = "黑体"
+        if "宋体" in instructions:
+            body_style["font_name"] = "宋体"
+            body_style["east_asia_font"] = "宋体"
+        title_size = _size_in_clause(title_clause)
+        body_size = _size_in_clause(body_clause)
+        if title_size is not None:
+            title_style["font_size_pt"] = title_size
+        if body_size is not None:
+            body_style["font_size_pt"] = body_size
+        if "1.5" in instructions or "1.5倍" in instructions or "1.5行距" in instructions:
+            body_style["line_spacing"] = 1.5
+        if "居中" in instructions:
+            title_style["alignment"] = "center"
+        if "加粗" in instructions:
+            title_style["bold"] = True
+
+    return title_style, body_style
+
+
+def _apply_run_style(run: Any, style: dict[str, Any]) -> None:
+    from docx.shared import Pt
+
+    font_name = style.get("font_name")
+    if font_name:
+        run.font.name = str(font_name)
+    east_asia_font = style.get("east_asia_font") or font_name
+    if east_asia_font:
+        _set_east_asia_font(run, str(east_asia_font))
+    size_pt = _size_to_pt(style.get("font_size_pt") or style.get("size"))
+    if size_pt is not None:
+        run.font.size = Pt(size_pt)
+    bold = _coerce_bool(style.get("bold"))
+    if bold is not None:
+        run.bold = bold
+
+
+def _apply_paragraph_style(paragraph: Any, style: dict[str, Any]) -> None:
+    if not style:
+        return
+    alignment = _alignment_from_value(style.get("alignment"))
+    if alignment is not None:
+        paragraph.alignment = alignment
+    if style.get("line_spacing") is not None:
+        try:
+            paragraph.paragraph_format.line_spacing = float(style["line_spacing"])
+        except (TypeError, ValueError):
+            pass
+    for run in paragraph.runs:
+        _apply_run_style(run, style)
+
+
+def _is_heading_paragraph(paragraph: Any) -> bool:
+    style_name = getattr(getattr(paragraph, "style", None), "name", "") or ""
+    return style_name.startswith("Heading") or style_name == "Title"
+
+
+def _iter_all_paragraphs(doc: Any) -> Any:
+    yield from doc.paragraphs
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                yield from cell.paragraphs
+
+
+def _apply_document_styles(
+    doc: Any,
+    title_style: dict[str, Any] | None = None,
+    body_style: dict[str, Any] | None = None,
+) -> None:
+    title_style = title_style or {}
+    body_style = body_style or {}
+    seen_title = False
+    for paragraph in _iter_all_paragraphs(doc):
+        if not paragraph.text.strip():
+            continue
+        if _is_heading_paragraph(paragraph):
+            if title_style and not seen_title:
+                _apply_paragraph_style(paragraph, title_style)
+                seen_title = True
+            continue
+        if body_style:
+            _apply_paragraph_style(paragraph, body_style)
 
 
 class DocxReadTool(Tool):
@@ -14,6 +345,14 @@ class DocxReadTool(Tool):
     name = "docx_read"
     description = "Read and extract text content from a Word (.docx) document."
 
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+    ):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+
     @property
     def parameters(self) -> dict[str, Any]:
         return {
@@ -21,14 +360,38 @@ class DocxReadTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to the .docx file to read",
+                    "description": "Path to the .docx file to read. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path to the .docx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the .docx file to read. Alias for filename.",
                 },
             },
-            "required": ["file_path"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
-        file_path = Path(kwargs.get("file_path") or kwargs.get("path", ""))
+        raw_path = _raw_output_path(kwargs)
+        if not raw_path.strip():
+            return "Error: filename is required"
+        try:
+            file_path = _resolve_output_path(
+                raw_path, self._workspace, self._allowed_dir,
+            )
+            file_path = _ensure_suffix(file_path, ".docx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
+        except PermissionError as e:
+            return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
         if not file_path.exists():
             return f"Error: file not found: {file_path}"
         try:
@@ -83,14 +446,15 @@ def _resolve_output_path(
     return resolved
 
 
-class DocxWriteTool(Tool):
+class CreateDocxTool(Tool):
     """Create or overwrite a Word (.docx) document."""
 
-    name = "docx_write"
+    name = "create_docx"
     description = (
-        "Create a new Word (.docx) document with the given content. "
-        "Content is markdown-like: each line is a paragraph, "
-        "'# ' lines are headings."
+        "Create a Word (.docx) document in the workspace files directory. "
+        "Supports title, paragraphs, headings, tables, images, and common "
+        "Word formatting such as Chinese fonts, font sizes, alignment, bold, "
+        "and line spacing."
     )
 
     def __init__(
@@ -108,44 +472,305 @@ class DocxWriteTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path for the output .docx file",
+                    "description": "Path for the output .docx file. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path for the output .docx file",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the output .docx file. Alias for filename.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional document title",
                 },
                 "content": {
+                    "description": (
+                        "Document content. Use a string for markdown-like text, "
+                        "or an array of blocks: {type: paragraph|heading|table|image, ...}."
+                    ),
+                },
+                "paragraphs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional paragraph list",
+                },
+                "tables": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "rows": {"type": "array", "items": {"type": "array"}},
+                            "style": {"type": "string"},
+                        },
+                        "required": ["rows"],
+                    },
+                    "description": "Optional tables to append",
+                },
+                "style_preset": {
                     "type": "string",
-                    "description": "Markdown-like content. Each line = paragraph. '# Title' = heading.",
+                    "enum": ["chinese_document", "chinese_essay"],
+                    "description": (
+                        "Optional formatting preset. Use chinese_document or "
+                        "chinese_essay for Chinese Word requirements such as "
+                        "标题黑体三号加粗居中、正文宋体小四、1.5 行距."
+                    ),
+                },
+                "title_style": {
+                    "type": "object",
+                    "description": (
+                        "Formatting for the main title. Supports font_name, "
+                        "east_asia_font, font_size_pt, bold, alignment. "
+                        "Use for requests like 标题黑体加粗三号字居中."
+                    ),
+                },
+                "body_style": {
+                    "type": "object",
+                    "description": (
+                        "Formatting for body paragraphs and table text. "
+                        "Supports font_name, east_asia_font, font_size_pt, "
+                        "line_spacing, alignment. Use for requests like "
+                        "正文宋体小四、段落 1.5 行距."
+                    ),
+                },
+                "format_instructions": {
+                    "type": "string",
+                    "description": (
+                        "Natural language formatting instructions to apply, "
+                        "for example: 正文宋体小四，段落1.5行距，标题黑体加粗三号字居中."
+                    ),
                 },
             },
-            "required": ["file_path", "content"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
         from docx import Document
 
-        raw_path = kwargs.get("file_path") or kwargs.get("path", "")
-        content = kwargs["content"]
+        raw_path = _raw_output_path(kwargs)
+        content = kwargs.get("content", "")
+        if not raw_path.strip():
+            return "Error: filename is required"
 
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
             )
+            file_path = _ensure_suffix(file_path, ".docx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
             return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
+        if not (
+            kwargs.get("title")
+            or content
+            or kwargs.get("paragraphs")
+            or kwargs.get("tables")
+        ):
+            return "Error: provide title, content, paragraphs, or tables"
 
         try:
             doc = Document()
-            for line in content.split("\n"):
-                line = line.strip()
-                if not line:
-                    continue
-                if line.startswith("# "):
-                    doc.add_heading(line[2:], level=1)
-                elif line.startswith("## "):
-                    doc.add_heading(line[3:], level=2)
-                else:
-                    doc.add_paragraph(line)
+            if kwargs.get("title"):
+                doc.add_heading(str(kwargs["title"]), level=0)
+            if isinstance(content, list):
+                _add_docx_content(doc, content)
+            elif content:
+                _add_markdown_like_text(doc, content)
+            for paragraph in kwargs.get("paragraphs", []) or []:
+                doc.add_paragraph(str(paragraph))
+            for table_data in kwargs.get("tables", []) or []:
+                _add_docx_content(doc, [{"type": "table", **table_data}])
+
+            title_style, body_style = _style_from_kwargs(kwargs)
+            _apply_document_styles(doc, title_style, body_style)
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
             doc.save(str(file_path))
-            return f"Created: {file_path} ({len(content)} chars)"
+            return f"Created: {file_path}"
         except Exception as e:
             return f"Error writing {raw_path}: {e}"
+
+
+class DocxWriteTool(CreateDocxTool):
+    """Backward-compatible alias for create_docx."""
+
+    name = "docx_write"
+    description = (
+        "Create a new Word (.docx) document with the given content. "
+        "Prefer create_docx for new calls."
+    )
+
+
+class EditDocxTool(Tool):
+    """Edit an existing Word (.docx) document."""
+
+    name = "edit_docx"
+    description = (
+        "Edit an existing Word (.docx) document in the workspace files directory. "
+        "Supports text replacement, appending paragraphs, and applying common "
+        "Word formatting such as Chinese fonts, font sizes, alignment, bold, "
+        "and line spacing."
+    )
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+    ):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the .docx file. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path to the .docx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the .docx file. Alias for filename.",
+                },
+                "old_text": {
+                    "type": "string",
+                    "description": "Text to replace.",
+                },
+                "new_text": {
+                    "type": "string",
+                    "description": "Replacement text.",
+                },
+                "append_paragraphs": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Paragraphs to append to the end of the document.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Text content to append as paragraphs.",
+                },
+                "style_preset": {
+                    "type": "string",
+                    "enum": ["chinese_document", "chinese_essay"],
+                    "description": (
+                        "Optional formatting preset. Use chinese_document or "
+                        "chinese_essay for Chinese Word requirements such as "
+                        "标题黑体三号加粗居中、正文宋体小四、1.5 行距."
+                    ),
+                },
+                "title_style": {
+                    "type": "object",
+                    "description": (
+                        "Formatting for the main title. Supports font_name, "
+                        "east_asia_font, font_size_pt, bold, alignment. "
+                        "Use for requests like 标题黑体加粗三号字居中."
+                    ),
+                },
+                "body_style": {
+                    "type": "object",
+                    "description": (
+                        "Formatting for body paragraphs and table text. "
+                        "Supports font_name, east_asia_font, font_size_pt, "
+                        "line_spacing, alignment. Use for requests like "
+                        "正文宋体小四、段落 1.5 行距."
+                    ),
+                },
+                "format_instructions": {
+                    "type": "string",
+                    "description": (
+                        "Natural language formatting instructions to apply, "
+                        "for example: 正文宋体小四，段落1.5行距，标题黑体加粗三号字居中."
+                    ),
+                },
+            },
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from docx import Document
+
+        raw_path = _raw_output_path(kwargs)
+        if not raw_path.strip():
+            return "Error: filename is required"
+
+        try:
+            file_path = _resolve_output_path(
+                raw_path, self._workspace, self._allowed_dir,
+            )
+            file_path = _ensure_suffix(file_path, ".docx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
+        except PermissionError as e:
+            return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
+
+        if not file_path.exists():
+            return f"Error: file not found: {file_path}"
+
+        old_text = kwargs.get("old_text")
+        new_text = kwargs.get("new_text")
+        append_paragraphs = list(kwargs.get("append_paragraphs") or [])
+        if kwargs.get("content"):
+            append_paragraphs.extend(
+                line.strip()
+                for line in str(kwargs["content"]).splitlines()
+                if line.strip()
+            )
+        title_style, body_style = _style_from_kwargs(kwargs)
+        has_formatting = bool(title_style or body_style)
+
+        if not (old_text and new_text is not None) and not append_paragraphs and not has_formatting:
+            return (
+                "Error: provide old_text/new_text, append_paragraphs/content, "
+                "or formatting instructions"
+            )
+
+        try:
+            doc = Document(str(file_path))
+            replacements = 0
+            if old_text and new_text is not None:
+                for paragraph in doc.paragraphs:
+                    if old_text in paragraph.text:
+                        paragraph.text = paragraph.text.replace(old_text, str(new_text))
+                        replacements += 1
+                for table in doc.tables:
+                    for row in table.rows:
+                        for cell in row.cells:
+                            for paragraph in cell.paragraphs:
+                                if old_text in paragraph.text:
+                                    paragraph.text = paragraph.text.replace(old_text, str(new_text))
+                                    replacements += 1
+                if replacements == 0:
+                    return f"Error: old_text not found in {file_path}"
+
+            for paragraph in append_paragraphs:
+                doc.add_paragraph(str(paragraph))
+
+            if has_formatting:
+                _apply_document_styles(doc, title_style, body_style)
+
+            doc.save(str(file_path))
+            return (
+                f"Edited: {file_path} "
+                f"({replacements} replacement(s), {len(append_paragraphs)} appended"
+                f"{', formatted' if has_formatting else ''})"
+            )
+        except Exception as e:
+            return f"Error editing {raw_path}: {e}"

--- a/miqi/documents/pptx_tool.py
+++ b/miqi/documents/pptx_tool.py
@@ -8,6 +8,35 @@ from typing import Any
 from miqi.agent.tools.base import Tool
 
 
+def _raw_output_path(kwargs: dict[str, Any]) -> str:
+    return str(
+        kwargs.get("filename")
+        or kwargs.get("file_path")
+        or kwargs.get("path")
+        or ""
+    )
+
+
+def _ensure_suffix(path: Path, suffix: str) -> Path:
+    if not path.name or path.name in {".", ".."}:
+        raise ValueError("output filename is required")
+    if path.suffix.lower() == suffix:
+        return path
+    return path.with_suffix(suffix)
+
+
+def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | None) -> None:
+    effective_dir = allowed_dir or workspace
+    if effective_dir is None:
+        return
+    try:
+        path.resolve().relative_to(effective_dir.resolve())
+    except ValueError:
+        raise PermissionError(
+            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
+        )
+
+
 def _resolve_output_path(
     file_path: str,
     workspace: Path | None,
@@ -52,6 +81,14 @@ class PptxReadTool(Tool):
     name = "pptx_read"
     description = "Read and extract text content from a PowerPoint (.pptx) file."
 
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+    ):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+
     @property
     def parameters(self) -> dict[str, Any]:
         return {
@@ -59,14 +96,38 @@ class PptxReadTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to the .pptx file to read",
+                    "description": "Path to the .pptx file to read. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path to the .pptx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the .pptx file to read. Alias for filename.",
                 },
             },
-            "required": ["file_path"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
-        file_path = Path(kwargs["file_path"])
+        raw_path = _raw_output_path(kwargs)
+        if not raw_path.strip():
+            return "Error: filename is required"
+        try:
+            file_path = _resolve_output_path(
+                raw_path, self._workspace, self._allowed_dir,
+            )
+            file_path = _ensure_suffix(file_path, ".pptx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
+        except PermissionError as e:
+            return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
         if not file_path.exists():
             return f"Error: file not found: {file_path}"
         try:
@@ -87,13 +148,13 @@ class PptxReadTool(Tool):
             return f"Error reading {file_path.name}: {e}"
 
 
-class PptxWriteTool(Tool):
+class CreatePptxTool(Tool):
     """Create a PowerPoint (.pptx) presentation."""
 
-    name = "pptx_write"
+    name = "create_pptx"
     description = (
-        "Create a new PowerPoint (.pptx) file. "
-        "Provide 'slides' as [{title: str, content: str}, ...]."
+        "Create a PowerPoint (.pptx) presentation in the workspace files directory. "
+        "Supports multiple slides with titles, bullets, body text, and images."
     )
 
     def __init__(
@@ -111,7 +172,15 @@ class PptxWriteTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path for the output .pptx file",
+                    "description": "Path for the output .pptx file. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path for the output .pptx file",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the output .pptx file. Alias for filename.",
                 },
                 "slides": {
                     "type": "array",
@@ -119,44 +188,96 @@ class PptxWriteTool(Tool):
                         "type": "object",
                         "properties": {
                             "title": {"type": "string"},
-                            "content": {"type": "string"},
+                            "subtitle": {"type": "string"},
+                            "content": {
+                                "description": "Slide body text or an array of body lines.",
+                            },
+                            "bullets": {"type": "array", "items": {"type": "string"}},
+                            "image_path": {"type": "string"},
                         },
-                        "required": ["title", "content"],
                     },
-                    "description": "List of slides with title and content",
+                    "description": "List of slides with title, content, bullets, or image_path",
                 },
             },
-            "required": ["file_path", "slides"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
         from pptx import Presentation
+        from pptx.util import Inches
 
-        raw_path = kwargs.get("file_path") or kwargs.get("path", "")
-        slides = kwargs["slides"]
+        raw_path = _raw_output_path(kwargs)
+        slides = kwargs.get("slides") or []
+        if not raw_path.strip():
+            return "Error: filename is required"
 
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
             )
+            file_path = _ensure_suffix(file_path, ".pptx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
             return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
+        if not slides:
+            return "Error: slides is required"
 
         try:
             prs = Presentation()
             for slide_data in slides:
-                slide_layout = prs.slide_layouts[1]  # Title and Content
+                slide_layout = prs.slide_layouts[1]
                 slide = prs.slides.add_slide(slide_layout)
                 title = slide.shapes.title
                 if title:
-                    title.text = slide_data.get("title", "")
-                # Add content to body placeholder
+                    title.text = str(slide_data.get("title", ""))
                 body = slide.placeholders[1] if len(slide.placeholders) > 1 else None
                 if body and hasattr(body, "text_frame"):
-                    body.text_frame.text = slide_data.get("content", "")
+                    text_frame = body.text_frame
+                    text_frame.clear()
+                    content_items: list[Any] = []
+                    if slide_data.get("subtitle"):
+                        content_items.append(slide_data["subtitle"])
+                    content = slide_data.get("content")
+                    if isinstance(content, list):
+                        content_items.extend(content)
+                    elif content:
+                        content_items.append(content)
+                    bullets = slide_data.get("bullets") or []
+                    for item_index, item in enumerate(content_items):
+                        if item_index == 0:
+                            text_frame.text = str(item)
+                        else:
+                            paragraph = text_frame.add_paragraph()
+                            paragraph.text = str(item)
+                            paragraph.level = 0
+                    for bullet in bullets:
+                        paragraph = text_frame.add_paragraph()
+                        paragraph.text = str(bullet)
+                        paragraph.level = 0
+                image_path = slide_data.get("image_path")
+                if image_path:
+                    slide.shapes.add_picture(
+                        str(image_path),
+                        Inches(float(slide_data.get("image_left", 5.5))),
+                        Inches(float(slide_data.get("image_top", 1.5))),
+                        width=Inches(float(slide_data.get("image_width", 3.0))),
+                    )
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
             prs.save(str(file_path))
             return f"Created: {file_path} ({len(slides)} slides)"
         except Exception as e:
             return f"Error writing {raw_path}: {e}"
+
+
+class PptxWriteTool(CreatePptxTool):
+    """Backward-compatible alias for create_pptx."""
+
+    name = "pptx_write"
+    description = "Create a new PowerPoint (.pptx) file. Prefer create_pptx for new calls."

--- a/miqi/documents/xlsx_tool.py
+++ b/miqi/documents/xlsx_tool.py
@@ -8,29 +8,46 @@ from typing import Any
 from miqi.agent.tools.base import Tool
 
 
+def _raw_output_path(kwargs: dict[str, Any]) -> str:
+    return str(
+        kwargs.get("filename")
+        or kwargs.get("file_path")
+        or kwargs.get("path")
+        or ""
+    )
+
+
+def _ensure_suffix(path: Path, suffix: str) -> Path:
+    if not path.name or path.name in {".", ".."}:
+        raise ValueError("output filename is required")
+    if path.suffix.lower() == suffix:
+        return path
+    return path.with_suffix(suffix)
+
+
+def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | None) -> None:
+    effective_dir = allowed_dir or workspace
+    if effective_dir is None:
+        return
+    try:
+        path.resolve().relative_to(effective_dir.resolve())
+    except ValueError:
+        raise PermissionError(
+            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
+        )
+
+
 def _resolve_output_path(
     file_path: str,
     workspace: Path | None,
     allowed_dir: Path | None,
 ) -> Path:
-    """Resolve an output path and enforce workspace/directory bounds.
-
-    Office document write tools always write inside the workspace:
-    - Relative paths are resolved against *workspace*.
-    - If *allowed_dir* is ``None`` but *workspace* is set, *workspace*
-      is used as the effective boundary (defense-in-depth default).
-    - Absolute paths outside the effective boundary are rejected.
-
-    Raises:
-        PermissionError: if the resolved path is outside the effective boundary.
-    """
+    """Resolve an output path and enforce workspace/directory bounds."""
     p = Path(file_path).expanduser()
     if not p.is_absolute() and workspace is not None:
         p = workspace / p
     resolved = p.resolve()
 
-    # Defense-in-depth: when no explicit allowed_dir is given, office
-    # write tools default to workspace as the boundary.
     effective_dir = allowed_dir
     if effective_dir is None and workspace is not None:
         effective_dir = workspace.resolve()
@@ -46,11 +63,133 @@ def _resolve_output_path(
     return resolved
 
 
+def _cell_value_matches(actual: Any, expected: Any) -> bool:
+    if actual == expected:
+        return True
+    try:
+        return float(actual) == float(expected)
+    except (TypeError, ValueError):
+        return str(actual) == str(expected)
+
+
+def _find_vertical_range(ws: Any, values: list[Any]) -> tuple[int, int, int, int] | None:
+    if not values:
+        return None
+    length = len(values)
+    for col in range(1, ws.max_column + 1):
+        for start_row in range(1, ws.max_row - length + 2):
+            if all(
+                _cell_value_matches(ws.cell(start_row + offset, col).value, value)
+                for offset, value in enumerate(values)
+            ):
+                return col, start_row, col, start_row + length - 1
+    return None
+
+
+def _find_named_series_range(
+    ws: Any,
+    name: Any,
+    values: list[Any],
+) -> tuple[int, int, int, int] | None:
+    if not values:
+        return None
+    for row in range(1, ws.max_row + 1):
+        for col in range(1, ws.max_column + 1):
+            if not _cell_value_matches(ws.cell(row, col).value, name):
+                continue
+            if row + len(values) > ws.max_row:
+                continue
+            if all(
+                _cell_value_matches(ws.cell(row + 1 + offset, col).value, value)
+                for offset, value in enumerate(values)
+            ):
+                return col, row, col, row + len(values)
+    return None
+
+
+def _add_chart(ws: Any, chart_spec: dict[str, Any]) -> bool:
+    from openpyxl.chart import BarChart, LineChart, PieChart, Reference
+
+    chart_type = str(chart_spec.get("type", "bar")).lower()
+    chart = (
+        LineChart()
+        if chart_type == "line"
+        else PieChart()
+        if chart_type == "pie"
+        else BarChart()
+    )
+    chart.title = str(chart_spec.get("title", ""))
+    anchor = str(chart_spec.get("anchor") or chart_spec.get("anchor_cell") or "E2")
+
+    data_range = chart_spec.get("data_range")
+    if data_range:
+        data = Reference(ws, range_string=f"'{ws.title}'!{data_range}")
+        chart.add_data(
+            data,
+            titles_from_data=bool(chart_spec.get("titles_from_data", True)),
+        )
+    else:
+        series_specs = chart_spec.get("series") or []
+        if not isinstance(series_specs, list) or not series_specs:
+            return False
+        added_series = False
+        for series in series_specs:
+            if not isinstance(series, dict):
+                continue
+            found = _find_named_series_range(
+                ws,
+                series.get("name"),
+                list(series.get("values") or []),
+            )
+            if found is None:
+                continue
+            min_col, min_row, max_col, max_row = found
+            data = Reference(
+                ws,
+                min_col=min_col,
+                min_row=min_row,
+                max_col=max_col,
+                max_row=max_row,
+            )
+            chart.add_data(data, titles_from_data=True)
+            added_series = True
+        if not added_series:
+            return False
+
+    category_range = chart_spec.get("category_range")
+    if category_range:
+        cats = Reference(ws, range_string=f"'{ws.title}'!{category_range}")
+        chart.set_categories(cats)
+    elif isinstance(chart_spec.get("categories"), list):
+        found = _find_vertical_range(ws, list(chart_spec["categories"]))
+        if found is not None:
+            min_col, min_row, max_col, max_row = found
+            cats = Reference(
+                ws,
+                min_col=min_col,
+                min_row=min_row,
+                max_col=max_col,
+                max_row=max_row,
+            )
+            chart.set_categories(cats)
+
+    ws.add_chart(chart, anchor)
+    return True
+
+
 class XlsxReadTool(Tool):
     """Read data from an Excel (.xlsx) spreadsheet."""
 
     name = "xlsx_read"
-    description = "Read and extract data from an Excel (.xlsx) file. Returns sheet names and content."
+    description = "Read and extract data from an Excel (.xlsx) file."
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+    ):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -59,22 +198,47 @@ class XlsxReadTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path to the .xlsx file to read",
+                    "description": "Path to the .xlsx file to read. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path to the .xlsx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the .xlsx file to read. Alias for filename.",
                 },
                 "sheet_name": {
                     "type": "string",
-                    "description": "Optional: specific sheet name to read. Reads first sheet if omitted.",
+                    "description": "Optional sheet name to read. Reads first sheet if omitted.",
                 },
             },
-            "required": ["file_path"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
-        file_path = Path(kwargs.get("file_path") or kwargs.get("path", ""))
+        raw_path = _raw_output_path(kwargs)
+        if not raw_path.strip():
+            return "Error: filename is required"
+        try:
+            file_path = _resolve_output_path(
+                raw_path, self._workspace, self._allowed_dir,
+            )
+            file_path = _ensure_suffix(file_path, ".xlsx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
+        except PermissionError as e:
+            return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
         if not file_path.exists():
             return f"Error: file not found: {file_path}"
         try:
             from openpyxl import load_workbook
+
             wb = load_workbook(str(file_path), read_only=True, data_only=True)
             sheet_name = kwargs.get("sheet_name")
             if sheet_name and sheet_name in wb.sheetnames:
@@ -82,27 +246,27 @@ class XlsxReadTool(Tool):
             else:
                 ws = wb.active
 
-            lines = [f"Sheet: {ws.title} ({ws.max_row} rows × {ws.max_column} cols)", ""]
+            lines = [f"Sheet: {ws.title} ({ws.max_row} rows x {ws.max_column} cols)", ""]
             for row in ws.iter_rows(values_only=True, max_row=min(ws.max_row, 200)):
                 cells = [str(c) if c is not None else "" for c in row]
                 lines.append(" | ".join(cells))
-            wb.close()
 
             if ws.max_row > 200:
                 lines.append(f"\n... ({ws.max_row - 200} more rows)")
 
+            wb.close()
             return "\n".join(lines)
         except Exception as e:
             return f"Error reading {file_path.name}: {e}"
 
 
-class XlsxWriteTool(Tool):
+class CreateXlsxTool(Tool):
     """Create an Excel (.xlsx) spreadsheet."""
 
-    name = "xlsx_write"
+    name = "create_xlsx"
     description = (
-        "Create a new Excel (.xlsx) file. "
-        "Provide 'sheets' as {sheet_name: [[row1_col1, row1_col2], [row2_col1, ...]]}."
+        "Create an Excel (.xlsx) workbook in the workspace files directory. "
+        "Supports multiple sheets, formulas, and simple charts."
     )
 
     def __init__(
@@ -120,45 +284,225 @@ class XlsxWriteTool(Tool):
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Path for the output .xlsx file",
+                    "description": "Path for the output .xlsx file. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path for the output .xlsx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path for the output .xlsx file. Alias for filename.",
                 },
                 "sheets": {
-                    "type": "object",
-                    "description": "Dict of sheet_name → list of row lists",
+                    "description": (
+                        "Either {sheet_name: rows} or "
+                        "[{name: string, rows: [[...]], charts: [...]}]. "
+                        "Formula strings beginning with '=' are preserved."
+                    ),
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": (
+                        "Rows for a single-sheet workbook. Use this when the "
+                        "user asks for one sheet and no sheets array is needed."
+                    ),
+                },
+                "sheet_name": {
+                    "type": "string",
+                    "description": "Sheet name to use with top-level rows.",
+                },
+                "charts": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Charts to add when using top-level rows.",
                 },
             },
-            "required": ["file_path", "sheets"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
         }
 
     async def execute(self, **kwargs: Any) -> str:
         from openpyxl import Workbook
 
-        raw_path = kwargs.get("file_path") or kwargs.get("path", "")
-        sheets = kwargs["sheets"]
+        raw_path = _raw_output_path(kwargs)
+        sheets = kwargs.get("sheets")
+        rows = kwargs.get("rows")
+        if not raw_path.strip():
+            return "Error: filename is required"
 
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
             )
+            file_path = _ensure_suffix(file_path, ".xlsx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
             return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
+        if sheets is None and rows is None:
+            return "Error: sheets or rows is required"
 
         try:
             wb = Workbook()
-            wb.remove(wb.active)  # Remove default sheet
+            wb.remove(wb.active)
 
-            first = True
-            for sheet_name, rows in sheets.items():
-                if first:
-                    ws = wb.create_sheet(sheet_name, 0)
-                    first = False
-                else:
-                    ws = wb.create_sheet(sheet_name)
-                for row_data in rows:
+            if sheets is None:
+                sheet_specs = [
+                    {
+                        "name": kwargs.get("sheet_name") or kwargs.get("name") or "Sheet1",
+                        "rows": rows,
+                        "charts": kwargs.get("charts") or [],
+                    }
+                ]
+            elif isinstance(sheets, dict):
+                sheet_specs = [
+                    {"name": sheet_name, "rows": rows}
+                    for sheet_name, rows in sheets.items()
+                ]
+            elif isinstance(sheets, list):
+                sheet_specs = sheets
+            else:
+                return "Error: sheets must be an object or array"
+
+            if not sheet_specs:
+                return "Error: sheets must contain at least one sheet"
+
+            created_sheets = 0
+            for index, spec in enumerate(sheet_specs):
+                if not isinstance(spec, dict):
+                    continue
+                sheet_name = str(spec.get("name") or f"Sheet{index + 1}")[:31]
+                ws = wb.create_sheet(sheet_name, index)
+                created_sheets += 1
+                for row_data in spec.get("rows", []) or []:
                     ws.append(row_data)
+                for chart_spec in spec.get("charts", []) or []:
+                    if not isinstance(chart_spec, dict):
+                        continue
+                    _add_chart(ws, chart_spec)
+
+            if created_sheets == 0:
+                return "Error: sheets must contain sheet objects"
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
             wb.save(str(file_path))
-            return f"Created: {file_path} ({len(sheets)} sheet(s))"
+            return f"Created: {file_path} ({len(wb.sheetnames)} sheet(s))"
         except Exception as e:
             return f"Error writing {raw_path}: {e}"
+
+
+class XlsxWriteTool(CreateXlsxTool):
+    """Backward-compatible alias for create_xlsx."""
+
+    name = "xlsx_write"
+    description = "Create a new Excel (.xlsx) file. Prefer create_xlsx for new calls."
+
+
+class AppendXlsxTool(Tool):
+    """Append rows to an existing Excel (.xlsx) workbook."""
+
+    name = "append_xlsx"
+    description = (
+        "Append rows to an existing Excel (.xlsx) workbook in the workspace files directory."
+    )
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        allowed_dir: Path | None = None,
+    ):
+        self._workspace = workspace
+        self._allowed_dir = allowed_dir
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the .xlsx file. Alias for filename.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Filename or relative path to the .xlsx file.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Path to the .xlsx file. Alias for filename.",
+                },
+                "sheet_name": {
+                    "type": "string",
+                    "description": "Sheet to append to. Defaults to the active sheet.",
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": "Rows to append.",
+                },
+                "create_sheet": {
+                    "type": "boolean",
+                    "description": "Create sheet_name if it does not exist.",
+                },
+            },
+            "required": ["rows"],
+            "anyOf": [
+                {"required": ["filename"]},
+                {"required": ["file_path"]},
+                {"required": ["path"]},
+            ],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        from openpyxl import load_workbook
+
+        raw_path = _raw_output_path(kwargs)
+        if not raw_path.strip():
+            return "Error: filename is required"
+
+        try:
+            file_path = _resolve_output_path(
+                raw_path, self._workspace, self._allowed_dir,
+            )
+            file_path = _ensure_suffix(file_path, ".xlsx")
+            _enforce_boundary(file_path, self._allowed_dir, self._workspace)
+        except PermissionError as e:
+            return f"Error: Permission denied: {e}"
+        except ValueError as e:
+            return f"Error: {e}"
+
+        if not file_path.exists():
+            return f"Error: file not found: {file_path}"
+
+        rows = kwargs.get("rows") or []
+        if not rows:
+            return "Error: rows is required"
+
+        try:
+            wb = load_workbook(str(file_path))
+            sheet_name = kwargs.get("sheet_name")
+            if sheet_name:
+                if sheet_name in wb.sheetnames:
+                    ws = wb[sheet_name]
+                elif kwargs.get("create_sheet", False):
+                    ws = wb.create_sheet(str(sheet_name)[:31])
+                else:
+                    wb.close()
+                    return f"Error: sheet not found: {sheet_name}"
+            else:
+                ws = wb.active
+
+            for row in rows:
+                ws.append(row)
+
+            wb.save(str(file_path))
+            wb.close()
+            return f"Appended: {file_path} ({len(rows)} row(s) to {ws.title})"
+        except Exception as e:
+            return f"Error editing {raw_path}: {e}"

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -620,8 +620,13 @@ class ToolOrchestrator:
         if tool in (
             "write_file", "edit_file", "delete_file",
             "docx_write", "pptx_write", "xlsx_write",
+            "create_docx", "create_pptx", "create_xlsx",
+            "edit_docx", "append_xlsx",
         ):
-            path = (meta.get("details", {}) or {}).get("path", "")
+            path = (
+                (meta.get("details", {}) or {}).get("path", "")
+                or (meta.get("details", {}) or {}).get("filename", "")
+            )
             if not path:
                 return None
             return f"{tool}:{path}"
@@ -781,6 +786,8 @@ class ToolOrchestrator:
         _FILE_MUTATION_TOOLS = frozenset({
             "write_file", "edit_file", "delete_file", "apply_patch",
             "docx_write", "pptx_write", "xlsx_write",
+            "create_docx", "create_pptx", "create_xlsx",
+            "edit_docx", "append_xlsx",
         })
         kwargs = {**ctx.arguments}
         if ctx.tool_name == "exec" or ctx.tool_name in _FILE_MUTATION_TOOLS:

--- a/miqi/execution/permission_engine.py
+++ b/miqi/execution/permission_engine.py
@@ -25,6 +25,38 @@ from miqi.execution.exec_policy import PolicyVerdict
 _SHELL_METACHAR_PATTERN = re.compile(r"[;&|`$(){}\[\]<>!\n\r]")
 
 
+def _office_target_path(tool_name: str, arguments: dict[str, Any]) -> str:
+    path = (
+        arguments.get("path", "")
+        or arguments.get("file_path", "")
+        or arguments.get("filename", "")
+    )
+    if not path:
+        return ""
+    suffix_by_tool = {
+        "create_docx": ".docx",
+        "docx_write": ".docx",
+        "edit_docx": ".docx",
+        "create_xlsx": ".xlsx",
+        "xlsx_write": ".xlsx",
+        "append_xlsx": ".xlsx",
+        "create_pptx": ".pptx",
+        "pptx_write": ".pptx",
+    }
+    suffix = suffix_by_tool.get(tool_name)
+    if suffix is None:
+        return str(path)
+    path_str = str(path)
+    path_lower = path_str.lower()
+    slash_idx = max(path_str.rfind("/"), path_str.rfind("\\"))
+    dot_idx = path_str.rfind(".")
+    if dot_idx > slash_idx and path_lower[dot_idx:] == suffix:
+        return str(path)
+    if dot_idx > slash_idx:
+        return path_str[:dot_idx] + suffix
+    return path_str + suffix
+
+
 class PermissionVerdict(str, Enum):
     ALLOW = "allow"
     DENY = "deny"
@@ -202,9 +234,11 @@ class PermissionEngine:
         _FILE_WRITE_TOOLS = frozenset({
             "write_file", "edit_file", "delete_file", "apply_patch",
             "docx_write", "pptx_write", "xlsx_write",
+            "create_docx", "create_pptx", "create_xlsx",
+            "edit_docx", "append_xlsx",
         })
         if tool_name in _FILE_WRITE_TOOLS:
-            path = ctx.arguments.get("path", "") or ctx.arguments.get("file_path", "")
+            path = _office_target_path(tool_name, ctx.arguments)
             return self._apply_approval_policy(
                 PermissionDecision(
                     verdict=PermissionVerdict.APPROVAL_REQUIRED,
@@ -270,6 +304,8 @@ class PermissionEngine:
         if tool == "exec":
             return f"exec:{ctx.arguments.get('command', '')}"
         if tool in ("write_file", "edit_file", "delete_file", "apply_patch",
-                      "docx_write", "pptx_write", "xlsx_write"):
-            return f"{tool}:{ctx.arguments.get('path', '') or ctx.arguments.get('file_path', '')}"
+                      "docx_write", "pptx_write", "xlsx_write",
+                      "create_docx", "create_pptx", "create_xlsx",
+                      "edit_docx", "append_xlsx"):
+            return f"{tool}:{_office_target_path(tool, ctx.arguments)}"
         return f"{tool}:{hash(str(ctx.arguments))}"

--- a/miqi/execution/sandbox_policy.py
+++ b/miqi/execution/sandbox_policy.py
@@ -18,6 +18,38 @@ from miqi.protocol.permissions import (
 )
 
 
+def _office_target_path(tool_name: str, arguments: Any) -> str:
+    path = (
+        arguments.get("path")
+        or arguments.get("file_path")
+        or arguments.get("filename", "")
+    )
+    if not path:
+        return ""
+    suffix_by_tool = {
+        "create_docx": ".docx",
+        "docx_write": ".docx",
+        "edit_docx": ".docx",
+        "create_xlsx": ".xlsx",
+        "xlsx_write": ".xlsx",
+        "append_xlsx": ".xlsx",
+        "create_pptx": ".pptx",
+        "pptx_write": ".pptx",
+    }
+    suffix = suffix_by_tool.get(tool_name)
+    if suffix is None:
+        return str(path)
+    path_str = str(path)
+    path_lower = path_str.lower()
+    slash_idx = max(path_str.rfind("/"), path_str.rfind("\\"))
+    dot_idx = path_str.rfind(".")
+    if dot_idx > slash_idx and path_lower[dot_idx:] == suffix:
+        return str(path)
+    if dot_idx > slash_idx:
+        return path_str[:dot_idx] + suffix
+    return path_str + suffix
+
+
 class SandboxType(str, Enum):
     """Available sandbox isolation levels."""
     NONE = "none"          # No sandbox — direct execution
@@ -84,6 +116,11 @@ class SandboxPolicyEngine:
         "docx_write",
         "pptx_write",
         "xlsx_write",
+        "create_docx",
+        "create_pptx",
+        "create_xlsx",
+        "edit_docx",
+        "append_xlsx",
     })
 
     def __init__(
@@ -295,7 +332,7 @@ class SandboxPolicyEngine:
         # target path.  write_file / edit_file / delete_file use "path";
         # office document write tools use "file_path".
         if tool_name in SandboxPolicyEngine.FILE_MUTATION_TOOLS:
-            path = ctx.arguments.get("path") or ctx.arguments.get("file_path", "")
+            path = _office_target_path(tool_name, ctx.arguments)
             rules = []
             if path:
                 rules.append(FileSystemPathRule(

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -307,7 +307,13 @@ def _classify_tool_kind(name: str) -> str:
     """Classify a tool name as tool_call, command_execution, or file_change."""
     if name in ("bash", "exec", "shell"):
         return "command_execution"
-    if name in ("write", "edit", "edit_diff", "apply_patch", "delete", "move", "write_file", "edit_file"):
+    if name in (
+        "write", "edit", "edit_diff", "apply_patch", "delete", "move",
+        "write_file", "edit_file",
+        "create_docx", "create_pptx", "create_xlsx",
+        "edit_docx", "append_xlsx",
+        "docx_write", "pptx_write", "xlsx_write",
+    ):
         return "file_change"
     return "tool_call"
 

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -608,7 +608,11 @@ class AgentControl:
     @staticmethod
     def _format_tool_hint(name: str, args: dict) -> str:
         """Format a tool call as a concise display hint."""
-        val = next(iter(args.values()), "") if args else ""
+        val = ""
+        if args:
+            val = args.get("path") or args.get("file_path") or args.get("filename")
+            if val is None:
+                val = next(iter(args.values()), "")
         if not isinstance(val, str):
             return name
         if len(val) > 50:

--- a/miqi/runtime/agent_registry.py
+++ b/miqi/runtime/agent_registry.py
@@ -59,6 +59,8 @@ class AgentRegistry:
                 "read_file", "write_file", "edit_file", "list_dir",
                 "exec", "web_search", "web_fetch",
                 "memory", "plan_create", "plan_update",
+                "create_docx", "create_pptx", "create_xlsx",
+                "edit_docx", "append_xlsx",
                 "docx_read", "docx_write", "pptx_read", "pptx_write",
                 "xlsx_read", "xlsx_write",
                 "session_search", "task_begin", "task_end",
@@ -87,6 +89,8 @@ class AgentRegistry:
             system_prompt=self._build_doc_agent_prompt(),
             available_tools=[
                 "read_file", "write_file", "list_dir",
+                "create_docx", "create_pptx", "create_xlsx",
+                "edit_docx", "append_xlsx",
                 "docx_read", "docx_write",
                 "pptx_read", "pptx_write",
                 "xlsx_read", "xlsx_write",

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -215,19 +215,24 @@ def create_runtime_tool_registry(
     registry.register(SkillManageTool(workspace=workspace))
 
     # 6. Office document tools
-    from miqi.documents.docx_tool import DocxReadTool, DocxWriteTool
-    from miqi.documents.pptx_tool import PptxReadTool, PptxWriteTool
-    from miqi.documents.xlsx_tool import XlsxReadTool, XlsxWriteTool
+    from miqi.documents.docx_tool import CreateDocxTool, DocxReadTool, DocxWriteTool, EditDocxTool
+    from miqi.documents.pptx_tool import CreatePptxTool, PptxReadTool, PptxWriteTool
+    from miqi.documents.xlsx_tool import AppendXlsxTool, CreateXlsxTool, XlsxReadTool, XlsxWriteTool
 
-    registry.register(DocxReadTool())
+    registry.register(DocxReadTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     # Office write tools always write inside the workspace, independently
     # of the `restrict_to_workspace` config (which only controls
     # WriteFileTool / EditFileTool).
+    registry.register(CreateDocxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(DocxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))
-    registry.register(PptxReadTool())
+    registry.register(EditDocxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(PptxReadTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(CreatePptxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(PptxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))
-    registry.register(XlsxReadTool())
+    registry.register(XlsxReadTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(CreateXlsxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(XlsxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(AppendXlsxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
 
     # ── Optional tools (require external dependencies) ─────────────────
 

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -11,6 +11,7 @@ single-turn execution path for sub-agent jobs.
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -343,7 +344,10 @@ class TurnRunner:
                         "arguments": (
                             tool_call.arguments_json
                             if hasattr(tool_call, "arguments_json")
-                            else "{}"
+                            else json.dumps(
+                                getattr(tool_call, "arguments", {}) or {},
+                                ensure_ascii=False,
+                            )
                         ),
                     },
                 })
@@ -433,7 +437,11 @@ class TurnRunner:
     @staticmethod
     def _format_tool_hint(name: str, args: dict) -> str:
         """Format a tool call as a concise display hint."""
-        val = next(iter(args.values()), "") if args else ""
+        val = ""
+        if args:
+            val = args.get("path") or args.get("file_path") or args.get("filename")
+            if val is None:
+                val = next(iter(args.values()), "")
         if not isinstance(val, str):
             return name
         if len(val) > 50:

--- a/tests/documents/test_office_create_tools.py
+++ b/tests/documents/test_office_create_tools.py
@@ -1,0 +1,440 @@
+"""Tests for Office document creation tools."""
+
+import pytest
+
+
+def _east_asia_font(run):
+    from docx.oxml.ns import qn
+
+    r_fonts = run._element.rPr.rFonts
+    return r_fonts.get(qn("w:eastAsia")) if r_fonts is not None else None
+
+
+@pytest.mark.asyncio
+async def test_create_docx_supports_title_paragraphs_and_tables(tmp_path):
+    from docx import Document
+
+    from miqi.documents.docx_tool import CreateDocxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateDocxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="report",
+        title="Quarterly Report",
+        paragraphs=["Summary paragraph."],
+        tables=[{"rows": [["Metric", "Value"], ["Revenue", 42]]}],
+    )
+
+    path = files_dir / "report.docx"
+    assert "Created:" in result
+    assert path.exists()
+
+    doc = Document(str(path))
+    texts = [p.text for p in doc.paragraphs if p.text.strip()]
+    assert "Quarterly Report" in texts
+    assert "Summary paragraph." in texts
+    assert doc.tables[0].cell(1, 0).text == "Revenue"
+
+
+@pytest.mark.asyncio
+async def test_create_docx_parses_markdown_heading_levels(tmp_path):
+    from docx import Document
+
+    from miqi.documents.docx_tool import CreateDocxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateDocxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="headings",
+        content="# Level 1\n### Level 3\n正文",
+    )
+
+    path = files_dir / "headings.docx"
+    assert "Created:" in result
+
+    doc = Document(str(path))
+    paragraphs = [p for p in doc.paragraphs if p.text.strip()]
+    assert [p.text for p in paragraphs] == ["Level 1", "Level 3", "正文"]
+    assert paragraphs[0].style.name == "Heading 1"
+    assert paragraphs[1].style.name == "Heading 3"
+
+
+@pytest.mark.asyncio
+async def test_docx_read_resolves_workspace_relative_paths(tmp_path):
+    from miqi.documents.docx_tool import CreateDocxTool, DocxReadTool
+
+    files_dir = tmp_path / "files"
+    create = CreateDocxTool(workspace=files_dir, allowed_dir=files_dir)
+    await create.execute(filename="relative_doc", title="Relative Title")
+
+    read = DocxReadTool(workspace=files_dir, allowed_dir=files_dir)
+    result = await read.execute(filename="relative_doc.docx")
+
+    assert "Relative Title" in result
+
+
+@pytest.mark.asyncio
+async def test_create_docx_applies_chinese_title_and_body_formatting(tmp_path):
+    from docx import Document
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Pt
+
+    from miqi.documents.docx_tool import CreateDocxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateDocxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="essay",
+        title="那山，那水，那故乡",
+        paragraphs=["小时候，故乡在我眼中不过是一个地理名词。"],
+        style_preset="chinese_document",
+    )
+
+    path = files_dir / "essay.docx"
+    assert "Created:" in result
+
+    doc = Document(str(path))
+    title = next(p for p in doc.paragraphs if p.text == "那山，那水，那故乡")
+    body = next(p for p in doc.paragraphs if p.text.startswith("小时候"))
+
+    assert title.alignment == WD_ALIGN_PARAGRAPH.CENTER
+    assert title.runs[0].bold is True
+    assert title.runs[0].font.size == Pt(16)
+    assert _east_asia_font(title.runs[0]) == "黑体"
+    assert body.runs[0].font.size == Pt(12)
+    assert _east_asia_font(body.runs[0]) == "宋体"
+    assert body.paragraph_format.line_spacing == 1.5
+
+
+@pytest.mark.asyncio
+async def test_edit_docx_can_apply_formatting_without_text_change(tmp_path):
+    from docx import Document
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    from docx.shared import Pt
+
+    from miqi.documents.docx_tool import EditDocxTool
+
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    path = files_dir / "essay.docx"
+    doc = Document()
+    doc.add_heading("那山，那水，那故乡", level=0)
+    doc.add_paragraph("小时候，故乡在我眼中不过是一个地理名词。")
+    doc.save(str(path))
+
+    tool = EditDocxTool(workspace=files_dir, allowed_dir=files_dir)
+    result = await tool.execute(
+        filename="essay.docx",
+        format_instructions="正文宋体小四，段落1.5行距，标题黑体加粗，三号字居中",
+    )
+
+    assert "formatted" in result
+    edited = Document(str(path))
+    title = next(p for p in edited.paragraphs if p.text == "那山，那水，那故乡")
+    body = next(p for p in edited.paragraphs if p.text.startswith("小时候"))
+
+    assert title.alignment == WD_ALIGN_PARAGRAPH.CENTER
+    assert title.runs[0].bold is True
+    assert title.runs[0].font.size == Pt(16)
+    assert _east_asia_font(title.runs[0]) == "黑体"
+    assert body.runs[0].font.size == Pt(12)
+    assert _east_asia_font(body.runs[0]) == "宋体"
+    assert body.paragraph_format.line_spacing == 1.5
+
+
+@pytest.mark.asyncio
+async def test_edit_docx_format_instructions_override_bad_structured_style(tmp_path):
+    from docx import Document
+    from docx.shared import Pt
+
+    from miqi.documents.docx_tool import EditDocxTool
+
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    path = files_dir / "essay.docx"
+    doc = Document()
+    doc.add_heading("那山，那水，那故乡", level=1)
+    doc.add_paragraph("小时候，故乡在我眼中不过是一个地理名词。")
+    doc.save(str(path))
+
+    tool = EditDocxTool(workspace=files_dir, allowed_dir=files_dir)
+    result = await tool.execute(
+        filename="essay.docx",
+        title_style={"font_size_pt": 14},
+        body_style={"font_size_pt": 16},
+        format_instructions="正文宋体小四，段落1.5行距，标题黑体加粗，三号字居中",
+    )
+
+    assert "formatted" in result
+    edited = Document(str(path))
+    title = next(p for p in edited.paragraphs if p.text == "那山，那水，那故乡")
+    body = next(p for p in edited.paragraphs if p.text.startswith("小时候"))
+
+    assert title.runs[0].font.size == Pt(16)
+    assert body.runs[0].font.size == Pt(12)
+
+
+@pytest.mark.asyncio
+async def test_create_xlsx_supports_multiple_sheets_formulas_and_charts(tmp_path):
+    from openpyxl import load_workbook
+
+    from miqi.documents.xlsx_tool import CreateXlsxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateXlsxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="analysis",
+        sheets=[
+            {
+                "name": "Sales",
+                "rows": [["Month", "Sales"], ["Jan", 10], ["Feb", 20], ["Total", "=SUM(B2:B3)"]],
+                "charts": [
+                    {
+                        "type": "bar",
+                        "title": "Sales",
+                        "data_range": "B1:B3",
+                        "category_range": "A2:A3",
+                        "anchor": "D2",
+                    }
+                ],
+            },
+            {"name": "Notes", "rows": [["Ready"]]},
+        ],
+    )
+
+    path = files_dir / "analysis.xlsx"
+    assert "Created:" in result
+    assert path.exists()
+
+    wb = load_workbook(str(path), data_only=False)
+    assert wb.sheetnames == ["Sales", "Notes"]
+    assert wb["Sales"]["B4"].value == "=SUM(B2:B3)"
+    assert len(wb["Sales"]._charts) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_xlsx_accepts_series_based_chart_specs(tmp_path):
+    from openpyxl import load_workbook
+
+    from miqi.documents.xlsx_tool import CreateXlsxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateXlsxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="sales_analysis",
+        sheets=[
+            {
+                "name": "Sales",
+                "rows": [
+                    ["Month", "Product A", "Product B", "Total"],
+                    ["Jan", 100, 80, "=SUM(B2:C2)"],
+                    ["Feb", 120, 90, "=SUM(B3:C3)"],
+                    ["Mar", 150, 110, "=SUM(B4:C4)"],
+                    ["Apr", 130, 140, "=SUM(B5:C5)"],
+                ],
+                "charts": [
+                    {
+                        "type": "bar",
+                        "title": "Monthly Sales",
+                        "categories": ["Jan", "Feb", "Mar", "Apr"],
+                        "series": [
+                            {"name": "Product A", "values": [100, 120, 150, 130]},
+                            {"name": "Product B", "values": [80, 90, 110, 140]},
+                        ],
+                        "anchor_cell": "F2",
+                    }
+                ],
+            }
+        ],
+    )
+
+    path = files_dir / "sales_analysis.xlsx"
+    assert "Created:" in result
+    wb = load_workbook(str(path), data_only=False)
+    assert len(wb["Sales"]._charts) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_xlsx_accepts_top_level_rows_and_rejects_invalid_sheets(tmp_path):
+    from openpyxl import load_workbook
+
+    from miqi.documents.xlsx_tool import CreateXlsxTool, XlsxReadTool
+
+    files_dir = tmp_path / "files"
+    tool = CreateXlsxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="top_rows",
+        sheet_name="Data",
+        rows=[["A", "B"], [1, 2]],
+    )
+
+    path = files_dir / "top_rows.xlsx"
+    assert "Created:" in result
+    wb = load_workbook(str(path), data_only=False)
+    assert wb.sheetnames == ["Data"]
+    assert wb["Data"]["B2"].value == 2
+
+    read = XlsxReadTool(workspace=files_dir, allowed_dir=files_dir)
+    read_result = await read.execute(filename="top_rows.xlsx", sheet_name="Data")
+    assert "1 | 2" in read_result
+
+    invalid = await tool.execute(filename="bad", sheets="not valid", rows=[["A"]])
+    assert "sheets must be an object or array" in invalid
+
+
+@pytest.mark.asyncio
+async def test_create_pptx_supports_multiple_slides_and_bullets(tmp_path):
+    from pptx import Presentation
+
+    from miqi.documents.pptx_tool import CreatePptxTool
+
+    files_dir = tmp_path / "files"
+    tool = CreatePptxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="deck",
+        slides=[
+            {"title": "Overview", "content": "Opening"},
+            {"title": "Plan", "bullets": ["Build", "Verify", "Ship"]},
+        ],
+    )
+
+    path = files_dir / "deck.pptx"
+    assert "Created:" in result
+    assert path.exists()
+
+    prs = Presentation(str(path))
+    assert len(prs.slides) == 2
+    text = "\n".join(
+        shape.text
+        for slide in prs.slides
+        for shape in slide.shapes
+        if hasattr(shape, "text")
+    )
+    assert "Overview" in text
+    assert "Build" in text
+
+
+@pytest.mark.asyncio
+async def test_create_pptx_supports_subtitle_array_content_and_relative_read(tmp_path):
+    from pptx import Presentation
+
+    from miqi.documents.pptx_tool import CreatePptxTool, PptxReadTool
+
+    files_dir = tmp_path / "files"
+    tool = CreatePptxTool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(
+        filename="deck",
+        slides=[
+            {"title": "Cover", "subtitle": "Sub title"},
+            {"title": "Agenda", "content": ["A", "B"]},
+        ],
+    )
+
+    path = files_dir / "deck.pptx"
+    assert "Created:" in result
+    prs = Presentation(str(path))
+    text = "\n".join(
+        shape.text
+        for slide in prs.slides
+        for shape in slide.shapes
+        if hasattr(shape, "text")
+    )
+    assert "Sub title" in text
+    assert "A" in text
+    assert "B" in text
+    assert "['A', 'B']" not in text
+
+    read = PptxReadTool(workspace=files_dir, allowed_dir=files_dir)
+    read_result = await read.execute(filename="deck.pptx")
+    assert "Presentation: 2 slides" in read_result
+
+
+@pytest.mark.asyncio
+async def test_edit_docx_replaces_and_appends_text(tmp_path):
+    from docx import Document
+
+    from miqi.documents.docx_tool import EditDocxTool
+
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    path = files_dir / "report.docx"
+    doc = Document()
+    doc.add_paragraph("Draft status")
+    doc.save(str(path))
+
+    tool = EditDocxTool(workspace=files_dir, allowed_dir=files_dir)
+    result = await tool.execute(
+        filename="report.docx",
+        old_text="Draft",
+        new_text="Final",
+        append_paragraphs=["Approved"],
+    )
+
+    assert "Edited:" in result
+    edited = Document(str(path))
+    texts = [p.text for p in edited.paragraphs if p.text.strip()]
+    assert "Final status" in texts
+    assert "Approved" in texts
+
+
+@pytest.mark.asyncio
+async def test_append_xlsx_appends_rows_to_sheet(tmp_path):
+    from openpyxl import Workbook, load_workbook
+
+    from miqi.documents.xlsx_tool import AppendXlsxTool
+
+    files_dir = tmp_path / "files"
+    files_dir.mkdir()
+    path = files_dir / "data.xlsx"
+    wb = Workbook()
+    wb.active.title = "Data"
+    wb.active.append(["A", "B"])
+    wb.save(str(path))
+
+    tool = AppendXlsxTool(workspace=files_dir, allowed_dir=files_dir)
+    result = await tool.execute(
+        filename="data.xlsx",
+        sheet_name="Data",
+        rows=[[1, 2], [3, 4]],
+    )
+
+    assert "Appended:" in result
+    edited = load_workbook(str(path))
+    assert edited["Data"]["A2"].value == 1
+    assert edited["Data"]["B3"].value == 4
+
+
+@pytest.mark.parametrize(
+    "tool_cls, kwargs, expected_name",
+    [
+        pytest.param("docx", {"filename": "../escape", "content": "x"}, "escape.docx"),
+        pytest.param("xlsx", {"filename": "../escape", "sheets": {}}, "escape.xlsx"),
+        pytest.param("pptx", {"filename": "../escape", "slides": []}, "escape.pptx"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_office_tools_reject_path_traversal(
+    tmp_path, tool_cls, kwargs, expected_name,
+):
+    if tool_cls == "docx":
+        from miqi.documents.docx_tool import CreateDocxTool as Tool
+    elif tool_cls == "xlsx":
+        from miqi.documents.xlsx_tool import CreateXlsxTool as Tool
+    else:
+        from miqi.documents.pptx_tool import CreatePptxTool as Tool
+
+    files_dir = tmp_path / "files"
+    tool = Tool(workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(**kwargs)
+
+    assert "Permission denied" in result
+    assert not (tmp_path / expected_name).exists()

--- a/tests/execution/test_file_mutation_approval.py
+++ b/tests/execution/test_file_mutation_approval.py
@@ -74,7 +74,11 @@ async def test_file_write_tools_require_approval(tool_name):
     assert decision.allow_permanent is True
 
 
-_OFFICE_WRITE_NAMES = ["docx_write", "pptx_write", "xlsx_write"]
+_OFFICE_WRITE_NAMES = [
+    "docx_write", "pptx_write", "xlsx_write",
+    "create_docx", "create_pptx", "create_xlsx",
+    "edit_docx", "append_xlsx",
+]
 
 
 @pytest.mark.parametrize("tool_name", _OFFICE_WRITE_NAMES)
@@ -101,6 +105,23 @@ async def test_office_doc_write_tools_require_approval(tool_name):
     assert decision.allow_permanent is True, (
         f"{tool_name} should support allow_permanent"
     )
+
+
+@pytest.mark.asyncio
+async def test_create_docx_permission_key_uses_final_suffix():
+    """Approval allowlist keys should match the final file path create_docx writes."""
+    engine = PermissionEngine()
+
+    class FakeCtx:
+        pass
+
+    ctx = FakeCtx()
+    ctx.tool_name = "create_docx"
+    ctx.arguments = {"filename": "/tmp/report"}
+
+    decision = await engine.check(ctx)
+    assert decision.details["path"] == "/tmp/report.docx"
+    assert engine._make_key(ctx) == "create_docx:/tmp/report.docx"
 
 
 # ── PermissionEngine: read-only file tools auto-allow ──────────────────────
@@ -151,6 +172,11 @@ def test_agent_tool_registry_contains_file_mutation_tools(tmp_path):
     assert "list_dir" in names
 
     # Office tools
+    assert "create_docx" in names
+    assert "create_pptx" in names
+    assert "create_xlsx" in names
+    assert "edit_docx" in names
+    assert "append_xlsx" in names
     assert "docx_write" in names
     assert "pptx_write" in names
     assert "xlsx_write" in names

--- a/tests/execution/test_sandbox_policy.py
+++ b/tests/execution/test_sandbox_policy.py
@@ -266,6 +266,8 @@ async def test_filesystem_policy_for_write():
 _FILE_MUTATION_TOOL_NAMES = [
     "write_file", "edit_file", "delete_file",
     "docx_write", "pptx_write", "xlsx_write",
+    "create_docx", "create_pptx", "create_xlsx",
+    "edit_docx", "append_xlsx",
 ]
 
 
@@ -363,6 +365,20 @@ async def test_filesystem_policy_for_xlsx_write_includes_write_rule():
 
 
 @pytest.mark.asyncio
+async def test_filesystem_policy_for_create_docx_uses_final_suffix():
+    """create_docx auto-adds .docx, so the sandbox must allow the final path."""
+    from miqi.protocol.permissions import FileSystemAccessMode
+
+    engine = SandboxPolicyEngine()
+    ctx = FakeContext("create_docx", {"filename": "/tmp/report"})
+    selection = await engine.select(ctx)
+    assert len(selection.filesystem_policy.rules) >= 1
+    rule = selection.filesystem_policy.rules[0]
+    assert rule.path == "/tmp/report.docx"
+    assert rule.mode == FileSystemAccessMode.WRITE
+
+
+@pytest.mark.asyncio
 async def test_sandbox_denied_error_for_file_mutation_is_actionable():
     """Phase 34: SandboxDeniedError for file mutation must list actionable info."""
     engine = SandboxPolicyEngine(allow_fallback_to_none=True)
@@ -382,6 +398,8 @@ def test_file_mutation_tools_matches_policy_set():
     orch_set = frozenset({
         "write_file", "edit_file", "delete_file", "apply_patch",
         "docx_write", "pptx_write", "xlsx_write",
+        "create_docx", "create_pptx", "create_xlsx",
+        "edit_docx", "append_xlsx",
     })
     assert orch_set == SandboxPolicyEngine.FILE_MUTATION_TOOLS, (
         "Orchestrator's _FILE_MUTATION_TOOLS must match "

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -42,6 +42,11 @@ def test_runtime_tool_registry_factory_registers_core_tools(fake_config, tmp_pat
     assert "skill_manage" in names
 
     # Office document tools
+    assert "create_docx" in names
+    assert "create_pptx" in names
+    assert "create_xlsx" in names
+    assert "edit_docx" in names
+    assert "append_xlsx" in names
     assert "docx_read" in names
     assert "docx_write" in names
     assert "pptx_read" in names


### PR DESCRIPTION
﻿## 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

为 workspace 增加原生 Office 文档创建、读取和编辑工具，并接入权限、沙箱、工具注册和 Task Assets 流程。

## 背景/问题

Closes #144。

用户需要在 workspace 中直接生成正式办公文档，而不是生成 Markdown、纯文本或临时脚本后再手动转换。本 PR 增加 DOCX / XLSX / PPTX 原生能力，并解决 Office 二进制文件在写入、预览、权限审批和任务资产展示中的边界问题。

## 变更内容

- 新增/扩展 Word 工具：`create_docx`、`edit_docx`、`docx_read`，并保留 `docx_write` 兼容别名。
- 新增/扩展 Excel 工具：`create_xlsx`、`append_xlsx`、`xlsx_read`，并保留 `xlsx_write` 兼容别名。
- 新增/扩展 PowerPoint 工具：`create_pptx`、`pptx_read`，并保留 `pptx_write` 兼容别名。
- 接入 runtime registry、agent tool registry、permission approval、sandbox policy、Task Assets 路径解析和 workspace 边界校验。
- `write_file` 对 `.docx/.xlsx/.pptx` 提前拒绝，避免把 Office 二进制文件写坏或弹出无意义审批。
- Office 预览明确提示二进制文件不可文本预览，Office 文件 diff 按钮禁用。
- 修复 tool-call history 中工具参数丢失为 `{}` 的问题，避免模型重复调用空参数 Office 工具。
- 处理 CodeRabbit review：DOCX 文本替换保留 run 级格式；PPT bullets-only 不再产生首行空白；XLSX append 异常路径关闭 workbook；移除前端不可达分支。
- 对 `<br>` / `<br/>` 文本做换行归一化，避免长项目符号或摘要内容把 HTML break 原样写进 DOCX/PPTX。

## 日志/验证证据

```text
D:\Desktop\144\MiQi\.venv\Scripts\python.exe -m pytest tests\documents\test_office_create_tools.py -q
19 passed in 1.33s

D:\Desktop\144\MiQi\.venv\Scripts\python.exe -m pytest tests\documents\test_office_create_tools.py tests\runtime\test_tool_registry_factory.py tests\execution\test_sandbox_policy.py tests\execution\test_file_mutation_approval.py -q
125 passed in 2.40s

D:\Desktop\144\MiQi\.venv\Scripts\python.exe -m pytest -q -m "not sandbox" --tb=short
2384 passed, 20 skipped, 1 deselected, 6 warnings in 361.40s

npm.cmd run typecheck:web
仍失败于两个已知旧问题，和本 PR 无关：
- src/renderer/components/Sidebar.tsx: SessionInfo.message_count
- src/renderer/features/wsl/WslStatusPage.tsx: key 类型
```

Word 验收截图：
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/0bd8a113-90a2-43bc-8081-4420bb509c46" />
<img width="738" height="664" alt="182375026e4165adf82bcf6edd2f6736" src="https://github.com/user-attachments/assets/eaf2b333-a828-4685-babb-f4d46bfe38ea" />

Excel 验收截图：
<img width="494" height="461" alt="image" src="https://github.com/user-attachments/assets/225c5fcb-cd9a-4ab1-950a-f10f10a4163a" />
<img width="1040" height="315" alt="image" src="https://github.com/user-attachments/assets/4a541666-8b46-48c5-8911-07e087bfc5f3" />

PPT 验收截图：
<img width="632" height="375" alt="image" src="https://github.com/user-attachments/assets/c12eb030-8890-423c-8d64-73ad6eb1486e" />
<img width="1944" height="978" alt="image" src="https://github.com/user-attachments/assets/b7080904-fd88-4fb6-a18d-ff26a0f46214" />

## 测试情况

- [x] Office 工具单测通过：DOCX / XLSX / PPTX 创建、读取、编辑、格式化、图表和路径边界。
- [x] 权限/沙箱/registry 组合测试通过。
- [x] Windows 本地全量非 sandbox pytest 通过。
- [x] 前端 typecheck 已运行；当前失败为既有旧问题，不属于本 PR。

## 相关后续 Issue

以下问题在验收过程中发现，但不属于 Office 工具核心实现，已单独跟踪：

- #171
- #172
