### PR TITLE
[FEATURE] 默认使用 ddgs 提供零配置 Web Search

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1110,8 +1110,6 @@ for m in ("pydantic", "httpx", "loguru"):
       soul_preset,
       brave_api_key,
       search_provider,
-      search_ollama_api_base,
-      search_ollama_api_key,
       fetch_provider,
       fetch_ollama_api_base,
       fetch_ollama_api_key,
@@ -1127,8 +1125,6 @@ for m in ("pydantic", "httpx", "loguru"):
       soul_preset?: string | null;
       brave_api_key?: string | null;
       search_provider?: string | null;
-      search_ollama_api_base?: string | null;
-      search_ollama_api_key?: string | null;
       fetch_provider?: string | null;
       fetch_ollama_api_base?: string | null;
       fetch_ollama_api_key?: string | null;
@@ -1176,8 +1172,6 @@ for m in ("pydantic", "httpx", "loguru"):
     const search = (web['search'] as Record<string, unknown> | undefined) ?? {};
     if (search_provider) search['provider'] = search_provider;
     if (brave_api_key) search['apiKey'] = brave_api_key;
-    if (search_ollama_api_base) search['ollamaApiBase'] = search_ollama_api_base;
-    if (search_ollama_api_key) search['ollamaApiKey'] = search_ollama_api_key;
     web['search'] = search;
 
     // Web Fetch

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -204,10 +204,8 @@ function GeneralTab({ onReopenSetup }: { onReopenSetup?: () => void }) {
 // ---- Web Tools Tab ----
 function WebToolsTab() {
   // ---- Web Search ----
-  const [searchProvider, setSearchProvider] = useState('brave');
+  const [searchProvider, setSearchProvider] = useState('ddgs');
   const [braveKey, setBraveKey] = useState('');
-  const [searchOllamaBase, setSearchOllamaBase] = useState('');
-  const [searchOllamaKey, setSearchOllamaKey] = useState('');
 
   // ---- Web Fetch ----
   const [fetchProvider, setFetchProvider] = useState('builtin');
@@ -226,10 +224,10 @@ function WebToolsTab() {
     window.miqi.config
       .get()
       .then((cfg) => {
-        setSearchProvider(getNestedStr(cfg, 'tools', 'web', 'search', 'provider') || 'brave');
+        const storedSearchProvider =
+          getNestedStr(cfg, 'tools', 'web', 'search', 'provider') || 'ddgs';
+        setSearchProvider(storedSearchProvider === 'ollama' ? 'ddgs' : storedSearchProvider);
         setBraveKey(getNestedStr(cfg, 'tools', 'web', 'search', 'apiKey'));
-        setSearchOllamaBase(getNestedStr(cfg, 'tools', 'web', 'search', 'ollamaApiBase'));
-        setSearchOllamaKey(getNestedStr(cfg, 'tools', 'web', 'search', 'ollamaApiKey'));
         setFetchProvider(getNestedStr(cfg, 'tools', 'web', 'fetch', 'provider') || 'builtin');
         setFetchOllamaBase(getNestedStr(cfg, 'tools', 'web', 'fetch', 'ollamaApiBase'));
         setFetchOllamaKey(getNestedStr(cfg, 'tools', 'web', 'fetch', 'ollamaApiKey'));
@@ -248,8 +246,6 @@ function WebToolsTab() {
             search: {
               provider: searchProvider,
               apiKey: braveKey || undefined,
-              ollamaApiBase: searchOllamaBase || undefined,
-              ollamaApiKey: searchOllamaKey || undefined,
             },
             fetch: {
               provider: fetchProvider,
@@ -301,8 +297,8 @@ function WebToolsTab() {
       <section className="flex flex-col gap-3">
         <h3 className="text-sm font-semibold text-[var(--text)]">Web 搜索</h3>
         <div className="flex gap-2">
+          <ModeBtn value="ddgs" current={searchProvider} set={setSearchProvider} label="DuckDuckGo" />
           <ModeBtn value="brave" current={searchProvider} set={setSearchProvider} label="Brave" />
-          <ModeBtn value="ollama" current={searchProvider} set={setSearchProvider} label="Ollama" />
           <ModeBtn value="hybrid" current={searchProvider} set={setSearchProvider} label="Hybrid" />
         </div>
         {(searchProvider === 'brave' || searchProvider === 'hybrid') && (
@@ -321,32 +317,6 @@ function WebToolsTab() {
               <Button variant="ghost" size="icon" onClick={() => setShowKeys((v) => !v)}>
                 {showKeys ? <EyeOff size={14} /> : <Eye size={14} />}
               </Button>
-            </div>
-          </div>
-        )}
-        {(searchProvider === 'ollama' || searchProvider === 'hybrid') && (
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-[var(--text-muted)]">
-                Ollama web_search Base URL
-              </label>
-              <Input
-                value={searchOllamaBase}
-                onChange={(e) => setSearchOllamaBase(e.target.value)}
-                placeholder="https://ollama.com"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-[var(--text-muted)]">
-                Ollama web_search API Key
-              </label>
-              <Input
-                type={showKeys ? 'text' : 'password'}
-                value={searchOllamaKey}
-                onChange={(e) => setSearchOllamaKey(e.target.value)}
-                placeholder="ollama-key..."
-                className="font-mono text-xs"
-              />
             </div>
           </div>
         )}
@@ -380,7 +350,7 @@ function WebToolsTab() {
                 type={showKeys ? 'text' : 'password'}
                 value={fetchOllamaKey}
                 onChange={(e) => setFetchOllamaKey(e.target.value)}
-                placeholder="留空则复用 web_search Key"
+                placeholder="ollama-key..."
                 className="font-mono text-xs"
               />
             </div>

--- a/apps/desktop/src/renderer/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/renderer/features/setup/SetupWizard.tsx
@@ -29,7 +29,7 @@ import type {
 // ---------------------------------------------------------------------------
 type Step =
   'welcome' | 'environment' | 'wsl2' | 'provider' | 'webtools' | 'papers' | 'agent' | 'finish';
-type SearchMode = 'brave' | 'ollama' | 'hybrid';
+type SearchMode = 'ddgs' | 'brave' | 'hybrid';
 type FetchMode = 'builtin' | 'ollama' | 'hybrid';
 type PapersMode = 'hybrid' | 'semantic_scholar' | 'arxiv';
 
@@ -217,10 +217,8 @@ export function SetupWizard({
   const [testError, setTestError] = useState('');
 
   // ---- Web tools ----
-  const [searchMode, setSearchMode] = useState<SearchMode>('brave');
+  const [searchMode, setSearchMode] = useState<SearchMode>('ddgs');
   const [braveApiKey, setBraveApiKey] = useState('');
-  const [searchOllamaBase, setSearchOllamaBase] = useState('https://ollama.com');
-  const [searchOllamaKey, setSearchOllamaKey] = useState('');
   const [fetchMode, setFetchMode] = useState<FetchMode>('builtin');
   const [fetchOllamaBase, setFetchOllamaBase] = useState('https://ollama.com');
   const [fetchOllamaKey, setFetchOllamaKey] = useState('');
@@ -271,10 +269,9 @@ export function SetupWizard({
         if (web) {
           const search = web['search'] as Record<string, unknown> | undefined;
           if (search) {
-            if (search['provider']) setSearchMode(String(search['provider']) as SearchMode);
+            const provider = String(search['provider'] || 'ddgs');
+            setSearchMode(provider === 'ollama' ? 'ddgs' : (provider as SearchMode));
             if (search['apiKey']) setBraveApiKey(String(search['apiKey']));
-            if (search['ollamaApiBase']) setSearchOllamaBase(String(search['ollamaApiBase']));
-            if (search['ollamaApiKey']) setSearchOllamaKey(String(search['ollamaApiKey']));
           }
           const fetch = web['fetch'] as Record<string, unknown> | undefined;
           if (fetch) {
@@ -461,8 +458,6 @@ export function SetupWizard({
       soul_preset: soulPreset || null,
       search_provider: searchMode,
       brave_api_key: braveApiKey || null,
-      search_ollama_api_base: searchOllamaBase || null,
-      search_ollama_api_key: searchOllamaKey || null,
       fetch_provider: fetchMode,
       fetch_ollama_api_base: fetchOllamaBase || null,
       fetch_ollama_api_key: fetchOllamaKey || null,
@@ -889,7 +884,7 @@ export function SetupWizard({
         </div>
 
         <div className="flex gap-2">
-          {(['brave', 'ollama', 'hybrid'] as SearchMode[]).map((v) => (
+          {(['ddgs', 'brave', 'hybrid'] as SearchMode[]).map((v) => (
             <button
               key={v}
               onClick={() => setSearchMode(v)}
@@ -900,7 +895,7 @@ export function SetupWizard({
                   : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)]'
               )}
             >
-              {v === 'brave' ? 'Brave' : v === 'ollama' ? 'Ollama' : 'Hybrid'}
+              {v === 'ddgs' ? 'DuckDuckGo' : v === 'brave' ? 'Brave' : 'Hybrid'}
             </button>
           ))}
         </div>
@@ -909,7 +904,7 @@ export function SetupWizard({
           <div className="flex flex-col gap-1.5">
             <label className="text-xs font-medium text-[var(--text-muted)]">
               Brave Search API Key
-              {searchMode === 'hybrid' ? '（优先使用 Brave）' : ''}
+              {searchMode === 'hybrid' ? '（ddgs 优先，失败后回退 Brave）' : ''}
             </label>
             <Input
               type="password"
@@ -929,31 +924,6 @@ export function SetupWizard({
           </div>
         )}
 
-        {(searchMode === 'ollama' || searchMode === 'hybrid') && (
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-[var(--text-muted)]">
-                Ollama web_search Base URL
-              </label>
-              <Input
-                value={searchOllamaBase}
-                onChange={(e) => setSearchOllamaBase(e.target.value)}
-                placeholder="https://ollama.com"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-[var(--text-muted)]">
-                Ollama web_search API Key
-              </label>
-              <Input
-                type="password"
-                value={searchOllamaKey}
-                onChange={(e) => setSearchOllamaKey(e.target.value)}
-                placeholder="ollama-key..."
-              />
-            </div>
-          </div>
-        )}
       </section>
 
       {/* ---- Web Fetch ---- */}
@@ -989,7 +959,7 @@ export function SetupWizard({
               <Input
                 value={fetchOllamaBase}
                 onChange={(e) => setFetchOllamaBase(e.target.value)}
-                placeholder={searchOllamaBase || 'https://ollama.com'}
+                placeholder="https://ollama.com"
               />
             </div>
             <div className="flex flex-col gap-1.5">
@@ -1000,7 +970,7 @@ export function SetupWizard({
                 type="password"
                 value={fetchOllamaKey}
                 onChange={(e) => setFetchOllamaKey(e.target.value)}
-                placeholder="留空则复用 web_search Key"
+                placeholder="ollama-key..."
               />
             </div>
           </div>
@@ -1165,9 +1135,9 @@ export function SetupWizard({
 
   const renderFinish = () => {
     const searchLabels: Record<SearchMode, string> = {
+      ddgs: 'DuckDuckGo',
       brave: 'Brave',
-      ollama: 'Ollama',
-      hybrid: 'Hybrid (Brave + Ollama)',
+      hybrid: 'Hybrid (ddgs + Brave)',
     };
     const fetchLabels: Record<FetchMode, string> = {
       builtin: '内置',

--- a/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
+++ b/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { buildMockBridgeScript } from './mocks';
+
+test.describe('Issue #140 Web search settings', () => {
+  test('shows ddgs search options and keeps Ollama only for web fetch', async ({ page }) => {
+    await page.addInitScript({ content: buildMockBridgeScript() });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+
+    await page.getByText('System Settings').click();
+    await page.getByRole('tab').filter({ hasText: /Web/ }).click();
+
+    const webSearch = page
+      .locator('section')
+      .filter({ has: page.getByRole('button', { name: 'DuckDuckGo' }) });
+    await expect(webSearch).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'DuckDuckGo' })).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'Brave' })).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'Hybrid' })).toBeVisible();
+    await expect(webSearch).not.toContainText('Ollama');
+
+    const webFetch = page
+      .locator('section')
+      .filter({ has: page.getByRole('button', { name: 'Ollama' }) });
+    await expect(webFetch.getByRole('button', { name: 'Ollama' })).toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/issue-140/settings-webtools.png',
+      fullPage: true,
+    });
+  });
+});

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,8 +46,14 @@ MiQi Desktop 的全局配置存储在 `~/.miqi/config.json` 中。
   "tools": {
     "restrict_to_workspace": true,
     "web": {
-      "search_provider": "brave",
-      "brave_api_key": ""
+      "search": {
+        "provider": "ddgs",
+        "apiKey": "",
+        "maxResults": 5
+      },
+      "fetch": {
+        "provider": "builtin"
+      }
     },
     "exec": {
       "allowed_commands": [],
@@ -100,7 +106,9 @@ MiQi Desktop 的全局配置存储在 `~/.miqi/config.json` 中。
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `restrict_to_workspace` | bool | true | 文件操作限制在工作区 |
-| `web.search_provider` | string | "brave" | 搜索引擎 (brave/ollama/hybrid) |
+| `web.search.provider` | string | "ddgs" | 搜索引擎 (ddgs/brave/hybrid) |
+| `web.search.apiKey` | string | "" | Brave Search API Key，仅 brave/hybrid 使用 |
+| `web.search.maxResults` | int | 5 | 最大搜索结果数量 |
 | `exec.allowed_commands` | array | [] | Shell 命令白名单 |
 | `exec.blocked_commands` | array | [] | Shell 命令黑名单 |
 

--- a/miqi/agent/subagent.py
+++ b/miqi/agent/subagent.py
@@ -160,8 +160,6 @@ class SubagentManager:
                 provider=self.web_config.search.provider,
                 api_key=self.web_config.search.api_key or None,
                 max_results=self.web_config.search.max_results,
-                ollama_api_key=self.web_config.search.ollama_api_key or None,
-                ollama_api_base=self.web_config.search.ollama_api_base,
             ))
             tools.register(WebFetchTool(
                 provider=self.web_config.fetch.provider,

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -2,6 +2,7 @@
 
 import html
 import ipaddress
+import asyncio
 import json
 import logging
 import os
@@ -116,7 +117,7 @@ def _validate_url(url: str) -> tuple[bool, str]:
 
 
 class WebSearchTool(Tool):
-    """Search the web using Brave Search API."""
+    """Search the web using ddgs by default, with optional Brave fallback."""
 
     name = "web_search"
     description = "Search the web. Returns titles, URLs, and snippets."
@@ -138,29 +139,49 @@ class WebSearchTool(Tool):
         self,
         api_key: str | None = None,
         max_results: int = 5,
-        provider: str = "brave",
-        ollama_api_key: str | None = None,
-        ollama_api_base: str | None = None,
+        provider: str = "ddgs",
     ):
-        self.provider = provider
+        provider_name = (provider or "ddgs").lower()
+        self.provider = provider_name if provider_name in {"ddgs", "brave", "hybrid"} else "ddgs"
         self.api_key = api_key or os.environ.get("BRAVE_API_KEY", "")
         self.max_results = max_results
-        self.ollama_api_key = ollama_api_key or os.environ.get(
-            "OLLAMA_API_KEY", "")
-        self.ollama_api_base = (
-            ollama_api_base or "https://ollama.com").rstrip("/")
 
     async def execute(self, query: str, count: int | None = None, **kwargs: Any) -> str:
         n = min(max(count or self.max_results, 1), 10)
 
-        if self.provider == "ollama":
-            return await self._ollama_search(query, n)
+        if self.provider == "brave":
+            return await self._brave_search(query, n)
         if self.provider == "hybrid":
-            result = await self._brave_search(query, n)
-            if not result.startswith("Error:") and not result.startswith("No results"):
+            result = await self._ddgs_search(query, n)
+            if not result.startswith("Error:"):
                 return result
-            return await self._ollama_search(query, n)
-        return await self._brave_search(query, n)
+            return await self._brave_search(query, n)
+        return await self._ddgs_search(query, n)
+
+    async def _ddgs_search(self, query: str, n: int) -> str:
+        try:
+            from ddgs import DDGS
+        except ImportError:
+            return "Error: ddgs package not installed"
+
+        try:
+            results = await asyncio.to_thread(
+                lambda: list(DDGS().text(query, max_results=n))
+            )
+            if not results:
+                return f"No results for: {query}"
+
+            lines = [f"Results for: {query}\n"]
+            for i, item in enumerate(results[:n], 1):
+                title = item.get("title", "")
+                href = item.get("href") or item.get("url", "")
+                body = item.get("body") or item.get("description", "")
+                lines.append(f"{i}. {title}\n   {href}")
+                if body:
+                    lines.append(f"   {body}")
+            return "\n".join(lines)
+        except Exception as e:
+            return f"Error: {e}"
 
     async def _brave_search(self, query: str, n: int) -> str:
         if not self.api_key:
@@ -186,35 +207,6 @@ class WebSearchTool(Tool):
                 lines.append(
                     f"{i}. {item.get('title', '')}\n   {item.get('url', '')}")
                 if desc := item.get("description"):
-                    lines.append(f"   {desc}")
-            return "\n".join(lines)
-        except Exception as e:
-            return f"Error: {e}"
-
-    async def _ollama_search(self, query: str, n: int) -> str:
-        if not self.ollama_api_key:
-            return "Error: OLLAMA_API_KEY not configured for Ollama web_search"
-
-        endpoint = f"{self.ollama_api_base}/api/web_search"
-        try:
-            async with httpx.AsyncClient() as client:
-                r = await client.post(
-                    endpoint,
-                    json={"query": query, "max_results": n},
-                    headers={"Authorization": f"Bearer {self.ollama_api_key}"},
-                    timeout=15.0,
-                )
-                r.raise_for_status()
-
-            results = r.json().get("results", [])
-            if not results:
-                return f"No results for: {query}"
-
-            lines = [f"Results for: {query}\n"]
-            for i, item in enumerate(results[:n], 1):
-                lines.append(
-                    f"{i}. {item.get('title', '')}\n   {item.get('url', '')}")
-                if desc := item.get("content"):
                     lines.append(f"   {desc}")
             return "\n".join(lines)
         except Exception as e:

--- a/miqi/cli/commands.py
+++ b/miqi/cli/commands.py
@@ -360,17 +360,17 @@ def _interactive_onboard_setup(config) -> tuple[str, str]:
 
     console.print("\n[bold]2) Configure web search & fetch tools[/bold]")
     console.print("  Search provider options:")
-    console.print("    1. Brave")
-    console.print("    2. Ollama web_search")
-    console.print("    3. Hybrid (Brave first, fallback to Ollama)")
+    console.print("    1. DuckDuckGo (ddgs, default, no API key)")
+    console.print("    2. Brave Search")
+    console.print("    3. Hybrid (ddgs first, fallback to Brave)")
     search_mode = typer.prompt("Search mode", type=int, default=1, show_default=True)
 
     if search_mode == 2:
-        config.tools.web.search.provider = "ollama"
+        config.tools.web.search.provider = "brave"
     elif search_mode == 3:
         config.tools.web.search.provider = "hybrid"
     else:
-        config.tools.web.search.provider = "brave"
+        config.tools.web.search.provider = "ddgs"
 
     if config.tools.web.search.provider in {"brave", "hybrid"}:
         brave_key = typer.prompt("Brave Search API key", default="", show_default=False).strip()
@@ -379,47 +379,6 @@ def _interactive_onboard_setup(config) -> tuple[str, str]:
             console.print("[yellow]Brave key not set: Brave search may be unavailable.[/yellow]")
     else:
         config.tools.web.search.api_key = ""
-
-    if config.tools.web.search.provider in {"ollama", "hybrid"}:
-        default_ollama_base = (
-            config.providers.ollama_cloud.api_base
-            if config.providers.ollama_cloud.api_base
-            else "https://ollama.com"
-        )
-        default_ollama_key = config.providers.ollama_cloud.api_key or ""
-
-        config.tools.web.search.ollama_api_base = typer.prompt(
-            "Ollama web_search base URL",
-            default=default_ollama_base,
-            show_default=True,
-        ).strip()
-
-        if default_ollama_key:
-            use_provider_key = typer.confirm(
-                "Reuse providers.ollamaCloud.apiKey for Ollama web_search?",
-                default=True,
-            )
-            if use_provider_key:
-                config.tools.web.search.ollama_api_key = default_ollama_key
-            else:
-                config.tools.web.search.ollama_api_key = typer.prompt(
-                    "Ollama web_search API key",
-                    default="",
-                    show_default=False,
-                ).strip()
-        else:
-            config.tools.web.search.ollama_api_key = typer.prompt(
-                "Ollama web_search API key",
-                default="",
-                show_default=False,
-            ).strip()
-
-        if not config.tools.web.search.ollama_api_key:
-            console.print(
-                "[yellow]Ollama API key not set: Ollama web_search may be unavailable.[/yellow]"
-            )
-    else:
-        config.tools.web.search.ollama_api_key = ""
 
     console.print("\n  Fetch provider options:")
     console.print("    1. Built-in web_fetch (default)")
@@ -435,8 +394,8 @@ def _interactive_onboard_setup(config) -> tuple[str, str]:
         config.tools.web.fetch.provider = "builtin"
 
     if config.tools.web.fetch.provider in {"ollama", "hybrid"}:
-        default_fetch_base = config.tools.web.search.ollama_api_base or "https://ollama.com"
-        default_fetch_key = config.tools.web.search.ollama_api_key or ""
+        default_fetch_base = config.tools.web.fetch.ollama_api_base or "https://ollama.com"
+        default_fetch_key = config.tools.web.fetch.ollama_api_key or ""
         config.tools.web.fetch.ollama_api_base = typer.prompt(
             "Ollama web_fetch base URL",
             default=default_fetch_base,
@@ -444,11 +403,11 @@ def _interactive_onboard_setup(config) -> tuple[str, str]:
         ).strip()
 
         if default_fetch_key:
-            use_search_key = typer.confirm(
-                "Reuse Ollama web_search API key for web_fetch?",
+            keep_fetch_key = typer.confirm(
+                "Keep existing Ollama web_fetch API key?",
                 default=True,
             )
-            if use_search_key:
+            if keep_fetch_key:
                 config.tools.web.fetch.ollama_api_key = default_fetch_key
             else:
                 config.tools.web.fetch.ollama_api_key = typer.prompt(

--- a/miqi/cli/onboard.py
+++ b/miqi/cli/onboard.py
@@ -77,12 +77,22 @@ def register_onboard_command(
         if provider_name:
             console.print(f"  Provider: [cyan]{provider_name}[/cyan]")
         console.print(f"  Model: [cyan]{config.agents.defaults.model}[/cyan]")
-        if config.tools.web.search.api_key:
-            console.print("  Web search: [green]Brave enabled[/green]")
-        else:
-            console.print(
-                "  Web search: [yellow]Brave disabled[/yellow] (model-native search may still work)"
+        search_provider = config.tools.web.search.provider
+        if search_provider == "brave":
+            status = (
+                "[green]Brave enabled[/green]"
+                if config.tools.web.search.api_key
+                else "[yellow]Brave selected, API key missing[/yellow]"
             )
+        elif search_provider == "hybrid":
+            status = (
+                "[green]ddgs + Brave fallback[/green]"
+                if config.tools.web.search.api_key
+                else "[green]ddgs enabled[/green] ([yellow]Brave fallback missing key[/yellow])"
+            )
+        else:
+            status = "[green]ddgs enabled (no API key required)[/green]"
+        console.print(f"  Web search: {status}")
 
         console.print("\nNext steps:")
         console.print('  1. Chat: [cyan]miqi agent -m "Hello!"[/cyan]')

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -3,7 +3,7 @@
 import os
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings
 
@@ -339,11 +339,15 @@ class CronConfig(Base):
 class WebSearchConfig(Base):
     """Web search tool configuration."""
 
-    provider: str = "brave"  # brave | ollama | hybrid
+    provider: str = "ddgs"  # ddgs | brave | hybrid
     api_key: str = ""  # Brave Search API key
-    ollama_api_key: str = ""  # Ollama web search API key
-    ollama_api_base: str = "https://ollama.com"
     max_results: int = 5
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def normalize_provider(cls, value: object) -> str:
+        provider = str(value or "ddgs").lower()
+        return provider if provider in {"ddgs", "brave", "hybrid"} else "ddgs"
 
 
 class WebFetchConfig(Base):

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -160,11 +160,9 @@ def create_runtime_tool_registry(
 
     registry.register(
         WebSearchTool(
-            provider=getattr(search_cfg, "provider", "brave") if search_cfg is not None else "brave",
+            provider=getattr(search_cfg, "provider", "ddgs") if search_cfg is not None else "ddgs",
             api_key=getattr(search_cfg, "api_key", None) if search_cfg is not None else None,
             max_results=getattr(search_cfg, "max_results", 5) if search_cfg is not None else 5,
-            ollama_api_key=getattr(search_cfg, "ollama_api_key", None) if search_cfg is not None else None,
-            ollama_api_base=getattr(search_cfg, "ollama_api_base", None) if search_cfg is not None else None,
         )
     )
     registry.register(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "python-pptx>=1.0.2",
     "openpyxl>=3.1.5",
     "textual>=8.2.7",
+    "ddgs>=9.14.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -232,8 +232,7 @@ def test_interactive_onboard_configures_papers_and_skips_feishu(monkeypatch):
             1,  # provider number: OpenRouter
             "sk-or-v1-test",  # OpenRouter key
             "",  # model name => default
-            1,  # search mode: Brave
-            "",  # Brave key (optional)
+            1,  # search mode: DuckDuckGo/ddgs
             1,  # fetch mode: built-in
             1,  # papers provider: hybrid
             "",  # semantic scholar key optional
@@ -257,6 +256,8 @@ def test_interactive_onboard_configures_papers_and_skips_feishu(monkeypatch):
 
     assert agent_name == "miqi"
     assert soul == "balanced"
+    assert config.tools.web.search.provider == "ddgs"
+    assert config.tools.web.search.api_key == ""
     assert config.tools.papers.provider == "hybrid"
     assert config.tools.papers.timeout_seconds == 20
     assert config.tools.papers.default_limit == 8

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,79 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/53/6262c2256513e6f530d81642477cb19367270922063eaa2d7b781d8c723d/brotlicffi-1.2.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e015af99584c6db1490a69a210c765953e473e63adc2d891ac3062a737c9e851", size = 402265, upload-time = "2026-03-05T19:54:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d9/d5340b43cf5fbe7fe5a083d237e5338cc1caa73bea523be1c5e452c26290/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37cb587d32bf7168e2218c455e22e409ad1f3157c6c71945879a311f3e6b6abf", size = 406710, upload-time = "2026-03-05T19:54:07.272Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/dbced4c1e0792efdf23fd90ff6d2a320c64ff4dfef7aacc85c04fde9ddd2/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d6ba65dd528892b4d9960beba2ae011a753620bcfc66cf6fa3cee18d7b0baa4", size = 402787, upload-time = "2026-03-05T19:54:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/6f/534205ba7590c9a8716a614f270c5c2ec419b5b7079b3f9cd31b7b5580de/brotlicffi-1.2.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2a5575653b0672638ba039b82fda56854934d7a6a24d4b8b5033f73ab43cbc1", size = 375108, upload-time = "2026-03-05T19:54:10.079Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -439,6 +512,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "fake-useragent" },
+    { name = "httpx", extra = ["brotli", "http2", "socks"] },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/24/9d29eeb7dd4852c27c3673adcaf30c4dc55ced76b303c1fbb792ce7cae52/ddgs-9.14.4.tar.gz", hash = "sha256:f7b118a2b709a9e9c04a1dca6e96b98c25d4dfaca1a4b0a244d74454fcca48ef", size = 59742, upload-time = "2026-05-15T06:53:45.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/5f/32de4d99220eb559b7b1cd1c529a1856efa8097f7a3e10b6c207aa95e36c/ddgs-9.14.4-py3-none-any.whl", hash = "sha256:acb084c34bf1110c974caf7e5e5a2c1973beb4bd9e170bfd191fe5ed2d2b2d6c", size = 70638, upload-time = "2026-05-15T06:53:44.761Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +552,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
 ]
 
 [[package]]
@@ -597,6 +695,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +740,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -654,6 +774,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+brotli = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+]
+http2 = [
+    { name = "h2" },
+]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -683,6 +815,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1170,6 +1311,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anthropic" },
     { name = "croniter" },
+    { name = "ddgs" },
     { name = "httpx" },
     { name = "json-repair" },
     { name = "lark-oapi" },
@@ -1222,6 +1364,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.50.0,<1.0.0" },
     { name = "blake3", marker = "extra == 'trace'", specifier = ">=0.4.0,<1.0.0" },
     { name = "croniter", specifier = ">=6.0.0,<7.0.0" },
+    { name = "ddgs", specifier = ">=9.14.4" },
     { name = "fastembed", marker = "extra == 'trace'", specifier = ">=0.6.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "json-repair", specifier = ">=0.57.0,<1.0.0" },
@@ -1825,6 +1968,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/7efa54f38da7de8df6b70dfed173bb41a52b740b144e4be24c1172db4209/primp-1.3.1.tar.gz", hash = "sha256:b04a5941bf9c876d011c5defaf5a25be093d56e7270b8da52c9788b9df2a829a", size = 1360029, upload-time = "2026-05-23T17:39:25.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/80/c4885a783a7493e396d89a592ba19fce63ef6bd6ad47230924a884a30ec0/primp-1.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27b87e6370045a0c65c0e4dfdfacbfe637387d05673ce8ddcce400263f7c27f0", size = 5123967, upload-time = "2026-05-23T17:39:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c1/c965cc23f96a364803d44b4331f33e4465bb6f269add37e39d0ad77ffe33/primp-1.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:27a8804eb9a3f641f379ee2b443591428cf85c898816e93d04d3e7b6f229ebcb", size = 4743059, upload-time = "2026-05-23T17:39:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/f4248d8d833d43fd8ba78208f2f4bf7fba7d3aec8c516090a95d18d6f550/primp-1.3.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862974796552a51af8e276bb19c5d5e189168ab8bad216aef7ce3726a8d3b1dd", size = 5100121, upload-time = "2026-05-23T17:39:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/519e32e0184763e1a76c9321fdeac0bb9b30bf85746f12058feec0cc4a27/primp-1.3.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ceb24198994799706f4020a00173ba9c1b491aa9805b1e014d87946677bc3c5d", size = 4738042, upload-time = "2026-05-23T17:39:35.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/723cb40694b47ec79a142ed8492835c0ecae9fef7acbed014f04b018d1de/primp-1.3.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3298b8afcf0a88ba6622bfc18e78aeb11afbb7d5afa4774f24acf7491f54a2d", size = 5001773, upload-time = "2026-05-23T17:39:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/80a2e3bdab1c51d738b82ea210a5ab93986b443c561e792e42cae296ec10/primp-1.3.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8d38c5a6d0a863274cbcae9678f265fcdcead3c20d12d152244e88f5f2186b", size = 5334228, upload-time = "2026-05-23T17:39:24.214Z" },
+    { url = "https://files.pythonhosted.org/packages/19/70/c95b8054c7d1fe2d84226ec60a5f48ce6c95a08b7c8b1702d7742082f444/primp-1.3.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f831c78ddb5900873f51e294bf9bbb4bbfdac3a2f39ce4023f8c558d299332", size = 5157269, upload-time = "2026-05-23T17:38:48.142Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bb/9b66986b7ecf2eff987134cd94bde533142e3085d6f67531f1a369ceaaae/primp-1.3.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329d0c320841f65b39d80801d8bae126732b84ec1094ca17b14fda0bda1b20ff", size = 5347438, upload-time = "2026-05-23T17:39:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/5d127748d06f3c6a3367f3c4974e45b98cda61cd28ea79ef91ad3fe9e093/primp-1.3.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c3c67670c38a03e9e8da45b212243d35afc8efa018317c46ecdce47f05329d1", size = 5264862, upload-time = "2026-05-23T17:39:20.625Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f3/1aac229425cac142c48418e2de9f70597161ea936543b5e3c9e7476e1921/primp-1.3.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9409a31028a8c62a609d389554ad4f5339aad075130300cd443beef0336d7179", size = 4969889, upload-time = "2026-05-23T17:39:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/a94d6e6166139c76ae42eb941328679309ca85139e8753d639657a24474c/primp-1.3.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:88ca36c2bd1b7c64b96ad07ca367d2d111ac8e9670549be5f232da8bf795d21e", size = 5082679, upload-time = "2026-05-23T17:39:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/61/21d297db575ed660c6aaf35c9014c1874ace45d6dcb79d1a4d3d2608bffb/primp-1.3.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74d13800b501aa003fb05c263d38f8d61656c83a60b2951046c0fc412bc73976", size = 5605392, upload-time = "2026-05-23T17:39:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9262a7ebb1d980a2db0cd505bb902bb3e66acd8a1cb763a4c2921f2f6a5b/primp-1.3.1-cp310-abi3-win32.whl", hash = "sha256:09ada1752629fe89d7b128beeb59cb641f404af462e24177ba36aed1cf322299", size = 4270373, upload-time = "2026-05-23T17:38:44.98Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/68/f0c6a60fadff0c185aef232b951a6fa4bbb64511facc48d34734db14f16f/primp-1.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:c0d1e294466cd5ec7ef173eedf8df25cbdc050138d40447a906e92b8553e7765", size = 4661498, upload-time = "2026-05-23T17:39:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/232a52abc77384ac66b9c1741691dec3659b1207bb6c5e55c1e9b59d22f1/primp-1.3.1-cp310-abi3-win_arm64.whl", hash = "sha256:43304cb41cbb46f361de49faf1cbdba57f969f628c9297239c7ed8ef0cac420f", size = 4624481, upload-time = "2026-05-23T17:38:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/34333b26c533c3122b936dad829f0a6e04f32065d39673c92b157d97aa16/primp-1.3.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:72249a4540d0a8965f36eb9a86cd16801d1c7e8dac2f0b0fa23a0a5a03402d36", size = 5116098, upload-time = "2026-05-23T17:38:55.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/56/7fe14708adf9a5cb5d6a15ad840a3de036cebfaf20692a5bc3b72e188a73/primp-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db4e2eaa5707e47899eeba6026f420f9b0108a28c08d63f1826d0cab8d50f06f", size = 4736300, upload-time = "2026-05-23T17:38:51.792Z" },
+    { url = "https://files.pythonhosted.org/packages/31/cb/521a8c18e8808a75450b6e91dc62cc1149c0178b7d4a8697d3f9b73fa385/primp-1.3.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d62e7609c98b4bc99c9cecc47f16f332fb8fe1a023002176267b0043dedad0c7", size = 5093823, upload-time = "2026-05-23T17:38:50.059Z" },
+    { url = "https://files.pythonhosted.org/packages/57/84/90f776fe46aeb0e3b86df72c674c0651326dd6a61846dd86bddbabe903ac/primp-1.3.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d692e912c2b25271163ba7719df0afdb733a7e7c3073c9094e9001882463543", size = 4734511, upload-time = "2026-05-23T17:39:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/d9bfbc0df0394f18a98b512a65f4bcf3dd7d17bd871937127e1ce4549172/primp-1.3.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c08693517dc160a12c0f9e2565c5319173cef738893a303ff2fb28ecccbd84d", size = 4999315, upload-time = "2026-05-23T17:39:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d8/5a986957ee1874d08567d7749668cd78a063048d47d6e46a874742b7fed1/primp-1.3.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d134ebfa31adc619e4e48289fe3e7eebc8310141560e6a6a04269cc94893d9ab", size = 5329375, upload-time = "2026-05-23T17:39:30.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1d/321cac9902cc3992174ed530719141a0da2e426f54f8a90b7b971571d104/primp-1.3.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48e27e7c0e015a6de495cf79c0c8d599ba5f69d091af31572bec2de020522d9c", size = 5140921, upload-time = "2026-05-23T17:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/ccbe6b67e0e91beb5c9d5cf804354225d5a3a7a9adf84fee3d6acc53febd/primp-1.3.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c3d682df08c1b1f37b1f66b21fd173baebcfcb52490830b12292d8fe89b2147", size = 5344288, upload-time = "2026-05-23T17:39:18.965Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/a735751bd11558163e83e0961fc866e4f94634df9eb24937c5f59624e393/primp-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fabaac4280df0802377d34b869949d617a0ecf22ca7fd5f9bded3f5c981031f1", size = 5262909, upload-time = "2026-05-23T17:39:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8e/4e3d4520e2e751f2de825dbe2cb43f837d33a5528adc44255f9770ea125a/primp-1.3.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f510e5881e0a4c4b9e7dbc03722c316d58454388b88000a0e7bf18a4b36d601e", size = 4964809, upload-time = "2026-05-23T17:38:59.023Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/e7b7495687d07df693325a12c497a9e5185d5001b7b216f32019fa7437a0/primp-1.3.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0504de2901c97903a9c369856a4b186dc90a782d8320652c142b066e697d5a1a", size = 5083654, upload-time = "2026-05-23T17:39:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f9/e4652e93beb14a16cc4218cfb1ccc18eaca8ee7d93b517d614a135928ec9/primp-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c3b24e302d95d327e873834b9423823b9c8af2abf5e0bbf57a03f3354cfe528", size = 5594738, upload-time = "2026-05-23T17:39:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/49/e8c8a7bc6b741ab6f15896022eee4f906d04d7ccd15aeeb515dd04bbeb6d/primp-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:4346dcef805279028bf4a54bb87dd43d0920130e25b5790689f5c96c9ba0d9e5", size = 4262615, upload-time = "2026-05-23T17:39:13.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/84/7ae4a257dec6dff329d4a8d9051d907316095c27ffc8d1ea15c359e6eeb5/primp-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6c55f152a73b6d6af8ac37bdb648d8bbfd7e656f9ef40d87feb3c0d81cee930a", size = 4660584, upload-time = "2026-05-23T17:39:10.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/20/10e0d96bfaeef1f0cd339ccf9bb8feb4bf798fde93198f7a96c73441080a/primp-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:46a529d74583d6ceba52e15bf4c678fcf24e6d669c1ce935262d5490d1b25801", size = 4623226, upload-time = "2026-05-23T17:38:57.256Z" },
 ]
 
 [[package]]
@@ -2551,6 +2732,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 类型

- [ ] Bug 修复
- [x] ✨ 新功能
- [x] 📝 文档
- [ ] ♻️ 重构
- [x] 🧪 测试
- [ ] 🔧 其他

## 变更概述

为 Web Search 引入零配置默认后端：默认使用 `ddgs` / DuckDuckGo 搜索，无需 API Key；Brave Search 保留为可选增强后端；移除 Ollama Search 相关 UI 和后端搜索路径。

当前 PR 继续保持 Draft，用于验证 #140 的产品方向、实际搜索链路和 UI 范围。Refs #140。

## 背景/问题

#140 的核心不是单纯调整设置页，而是让搜索能力默认开箱即用：

- `ddgs` 无需账号和 API Key，适合作为默认搜索后端。
- Brave Search 需要 API Key，适合作为更稳定/高质量的可选增强。
- Ollama Search UI 增加维护成本，按 issue 要求从 Search 能力中移除。

注意：本 PR 只处理 Web Search 产品线。Ollama Web Fetch、Ollama LLM Provider 不属于本 issue 的删除范围，应继续保留。

关于 `ddgs` 稳定性：`ddgs` 是零配置免费通道，可能受上游搜索服务策略影响；因此 Brave 仍保留为稳定增强后端，`hybrid` 模式负责 `ddgs -> Brave` 回退。运行时如果需要进一步提示用户配置 Brave，应放到 #160 的按需配置引导里，不在本 PR 扩展为弹窗/Toast 机制。

## 变更内容

- `miqi/agent/tools/web.py`
  - `WebSearchTool` 默认 provider 改为 `ddgs`。
  - 使用 `DDGS().text(query, max_results=n)` 执行真实搜索。
  - `hybrid` 调整为 ddgs 优先，ddgs 出错时回退 Brave。
  - 移除 Ollama Search 实现路径。

- `miqi/config/schema.py` / `miqi/runtime/tool_registry_factory.py` / `miqi/agent/subagent.py`
  - Search 默认 provider 改为 `ddgs`。
  - Runtime 注册出来的 `web_search` 默认走 ddgs。
  - Search 配置中不再保留 Ollama Search API 字段。

- `apps/desktop/src/renderer/features/settings/SettingsPage.tsx`
  - Web 搜索只展示 `DuckDuckGo / Brave / Hybrid`。
  - 移除 Ollama Search 配置入口。
  - Web Fetch 中的 Ollama 继续保留。

- `apps/desktop/src/renderer/features/setup/SetupWizard.tsx` / `apps/desktop/src/main/ipc/index.ts`
  - 旧 Setup Wizard 中仍存在的 Web Search 配置页同步移除 Ollama Search。
  - 不在本 PR 做 #139 的 Wizard 流程重构。

- `miqi/cli/commands.py` / `miqi/cli/onboard.py` / `docs/configuration.md`
  - CLI onboarding 和文档同步 ddgs 默认值。
  - Brave 作为可选后端保留。

- `pyproject.toml` / `uv.lock`
  - 新增 `ddgs>=9.14.4` 依赖。

- `apps/desktop/tests/smoke/issue-140-webtools.spec.ts`
  - 新增 Settings -> Web 工具 smoke test，验证 Web Search 不再包含 Ollama，Web Fetch 仍保留 Ollama。

## 日志/验证证据

```
$ uv run python -c "import asyncio; from pathlib import Path; from miqi.config.schema import Config; from miqi.runtime.tool_registry_factory import create_runtime_tool_registry; cfg=Config(); reg=create_runtime_tool_registry(config=cfg, workspace=Path.cwd()); tool=reg.get('web_search'); print('registered=', tool is not None); print('provider=', getattr(tool, 'provider', None)); print(asyncio.run(reg.execute('web_search', {'query':'OpenAI','count':2}))[:800])"
registered= True
provider= ddgs
Results for: OpenAI

1. OpenAI
   https://en.wikipedia.org/wiki/OpenAI
   OpenAI is an American artificial intelligence (AI) research organization headquartered in San Francisco...
```

真实 UI 验证：

```
Settings -> Web 工具
Web 搜索: DuckDuckGo / Brave / Hybrid
Web Fetch: 内置 / Ollama / Hybrid
```

<img width="1266" height="853" alt="settings-webtools" src="https://github.com/user-attachments/assets/91dd3bb8-03bf-4c1a-bd3a-fb87e8d27fa9" />
<img width="554" height="373" alt="setup-env" src="https://github.com/user-attachments/assets/a07530ea-2848-4e9d-a98d-3c1799751a1e" />
<img width="554" height="373" alt="setup-wsl" src="https://github.com/user-attachments/assets/de2759f8-26df-4284-b39a-c1866efc94b9" />

残留扫描：

```
Select-String -Pattern 'Ollama web_search','searchOllama','_ollama_search','Hybrid (Brave + Ollama)','brave/ollama/hybrid'
# Search 相关残留无匹配；Fetch 相关 Ollama 保留。
```

## 测试情况

```
$ uv run pytest tests/test_commands.py -q
9 passed

$ uv run pytest tests/runtime/test_tool_registry_factory.py tests/execution/test_orchestrator_tool_validation.py -q
24 passed

$ npx.cmd playwright test tests/smoke/issue-140-webtools.spec.ts --config=playwright.config.ts --project=smoke
1 passed

$ npm.cmd run build
# passed；仅有既有 Radix/Vite "use client" bundle warnings

$ git diff --check
# passed
```

CI 当前说明：

- `electron-e2e` 已通过。
- `test (windows-latest)` 已通过。
- `test (ubuntu-latest)` 已通过。
- `Desktop CI / quick` 当前失败在 `issue-172-assistant-turn-collapse.spec.ts`，本地单独运行该 spec 通过，且该 workflow 在 `pull_request_target` 下 quick job 检出的是 base `develop`，不是 #175 head。
- `PR 模板校验` 已按校验脚本要求调整日志/验证证据格式。

## Draft 待确认

- 维护者手动验证 Settings -> Web 工具界面是否符合预期。
- 维护者确认 `ddgs` 作为默认零配置通道、Brave 作为稳定增强后端的产品定位。
- #139 / #159 负责 Setup Wizard 简化；#140 最终不应继续扩大为 Setup Wizard 重构。
- #160 负责运行时缺少必要配置时的引导；本 PR 不实现运行时弹窗或 Toast。
