### PR TITLE
fix(desktop): 只展示同一轮最新 assistant 回复

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -134,9 +134,66 @@ function basename(path: string): string {
 
 const DEFAULT_SESSION = 'desktop:default';
 
-function sessionMsgsToUi(rawMsgs: any[]): Message[] {
+function messageContentToString(content: unknown): string {
+  return typeof content === 'string' ? content : JSON.stringify(content);
+}
+
+function isAssistantTextMessage(msg: any): boolean {
+  return msg?.role === 'assistant' && !!msg.content && String(msg.content).trim().length > 0;
+}
+
+function isToolActivityMessage(msg: any): boolean {
+  return (
+    msg?.role === 'tool' ||
+    (msg?.role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0)
+  );
+}
+
+function collapseAssistantMessagesWithinTurns(rawMsgs: any[]): any[] {
+  const result: any[] = [];
+  let turnBuffer: any[] = [];
+
+  const flushTurn = () => {
+    if (turnBuffer.length === 0) return;
+
+    const lastAssistantTextIndex = (() => {
+      for (let i = turnBuffer.length - 1; i >= 0; i -= 1) {
+        if (isAssistantTextMessage(turnBuffer[i])) return i;
+      }
+      return -1;
+    })();
+
+    turnBuffer.forEach((msg, index) => {
+      if (
+        isAssistantTextMessage(msg) &&
+        isToolActivityMessage(msg) &&
+        index !== lastAssistantTextIndex
+      ) {
+        result.push({ ...msg, content: '' });
+        return;
+      }
+      if (isAssistantTextMessage(msg) && index !== lastAssistantTextIndex) return;
+      result.push(msg);
+    });
+    turnBuffer = [];
+  };
+
+  for (const msg of rawMsgs) {
+    if (msg?.role === 'user') {
+      flushTurn();
+      result.push(msg);
+      continue;
+    }
+    turnBuffer.push(msg);
+  }
+  flushTurn();
+
+  return result;
+}
+
+export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
   const result: Message[] = [];
-  for (const m of rawMsgs) {
+  for (const m of collapseAssistantMessagesWithinTurns(rawMsgs)) {
     const ts = m.timestamp ? new Date(m.timestamp).getTime() : Date.now();
 
     if (m.role === 'user' || m.role === 'assistant') {
@@ -173,7 +230,7 @@ function sessionMsgsToUi(rawMsgs: any[]): Message[] {
       if (m.role === 'user' || hasContent) {
         result.push({
           role: m.role as 'user' | 'assistant',
-          content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+          content: messageContentToString(m.content),
           timestamp: ts,
         });
       }
@@ -181,7 +238,7 @@ function sessionMsgsToUi(rawMsgs: any[]): Message[] {
       // Subagent result messages — render with the subagent style
       result.push({
         role: 'subagent',
-        content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        content: messageContentToString(m.content),
         timestamp: ts,
       });
     } else if (m.role === 'tool') {
@@ -229,6 +286,21 @@ function sessionMsgsToUi(rawMsgs: any[]): Message[] {
   }
 
   return merged;
+}
+
+function removeTransientTurnMessagesSinceLastUser(messages: Message[]): Message[] {
+  const lastUserIndex = (() => {
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (messages[i].role === 'user') return i;
+    }
+    return -1;
+  })();
+
+  return messages.filter((message, index) => {
+    if (index <= lastUserIndex) return true;
+    if (message.role === 'assistant') return false;
+    return message.role !== 'progress' || !!message.toolHint;
+  });
 }
 
 /** Parse tracked files from raw session messages (includes progress entries with _tool_hint). */
@@ -754,9 +826,15 @@ export function ChatConsole({
     });
 
     const unsubFinal = window.miqi.chat.onFinal((data: ChatFinal) => {
+      if (animId !== null) {
+        cancelAnimationFrame(animId);
+        animId = null;
+      }
       fullContent = data.content;
+      displayed = '';
       finalDone = true;
       setCurrentReqId(null);
+      setMessages((prev) => removeTransientTurnMessagesSinceLastUser(prev));
       if (data.tool_calls?.length) {
         const toolMessages = sessionMsgsToUi([
           {

--- a/apps/desktop/src/renderer/features/wsl/WslStatusPage.tsx
+++ b/apps/desktop/src/renderer/features/wsl/WslStatusPage.tsx
@@ -326,7 +326,7 @@ export default function WslStatusPage() {
                     ['磁盘可用', `${dsk?.free_gb ?? 0} GB`],
                   ].map(([k, v], i) => (
                     <tr
-                      key={k}
+                      key={String(k)}
                       className={i % 2 === 0 ? 'bg-[var(--surface)]' : 'bg-[var(--surface-muted)]'}
                     >
                       <td className="px-5 py-2.5 text-xs text-[var(--text-muted)] w-40">{k}</td>

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -245,6 +245,7 @@ export interface SessionInfo {
   created_at?: string;
   updated_at?: string;
   path?: string;
+  message_count?: number;
 }
 
 export interface SessionDetail {

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { sessionMsgsToUi } from '../src/renderer/features/chat/ChatConsole';
+
+describe('sessionMsgsToUi', () => {
+  it('shows only the final assistant text within a tool-heavy turn', () => {
+    const messages = sessionMsgsToUi([
+      { role: 'user', content: 'edit the file', timestamp: '2026-07-08T01:00:00.000Z' },
+      {
+        role: 'assistant',
+        content: 'I will update it now.',
+        tool_calls: [{ function: { name: 'read_file', arguments: '{"path":"a.md"}' } }],
+        timestamp: '2026-07-08T01:00:01.000Z',
+      },
+      {
+        role: 'tool',
+        name: 'read_file',
+        content: 'old content',
+        timestamp: '2026-07-08T01:00:02.000Z',
+      },
+      {
+        role: 'assistant',
+        content: 'The edit is complete.',
+        timestamp: '2026-07-08T01:00:03.000Z',
+      },
+      {
+        role: 'assistant',
+        content: 'Final summary: updated a.md and verified the result.',
+        timestamp: '2026-07-08T01:00:04.000Z',
+      },
+    ]);
+
+    const assistantMessages = messages.filter((message) => message.role === 'assistant');
+
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0].content).toBe(
+      'Final summary: updated a.md and verified the result.'
+    );
+    expect(messages.some((message) => message.role === 'progress' && message.toolHint)).toBe(true);
+  });
+
+  it('keeps final assistant text scoped to each user turn', () => {
+    const messages = sessionMsgsToUi([
+      { role: 'user', content: 'first', timestamp: '2026-07-08T01:00:00.000Z' },
+      { role: 'assistant', content: 'first draft', timestamp: '2026-07-08T01:00:01.000Z' },
+      { role: 'assistant', content: 'first final', timestamp: '2026-07-08T01:00:02.000Z' },
+      { role: 'user', content: 'second', timestamp: '2026-07-08T01:00:03.000Z' },
+      { role: 'assistant', content: 'second final', timestamp: '2026-07-08T01:00:04.000Z' },
+    ]);
+
+    expect(
+      messages.filter((message) => message.role === 'assistant').map((message) => message.content)
+    ).toEqual(['first final', 'second final']);
+  });
+});

--- a/apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts
+++ b/apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test } from '@playwright/test';
+import { buildMockBridgeScript } from './mocks';
+
+async function injectMockAndGoto(
+  page: import('@playwright/test').Page,
+  opts?: Parameters<typeof buildMockBridgeScript>[0]
+) {
+  await page.addInitScript({ content: buildMockBridgeScript(opts) });
+  await page.goto('/');
+  await page.waitForSelector('#root', { state: 'visible' });
+}
+
+test.describe('Issue #172 assistant turn collapse', () => {
+  test('hides transient assistant status text after final response arrives', async ({ page }) => {
+    await injectMockAndGoto(page);
+
+    const textarea = page.getByPlaceholder('Ask Agent to analyze or edit files...');
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+
+    await textarea.fill('make several tool calls');
+    await textarea.press('Enter');
+
+    await page.evaluate(() => {
+      (window as any).__miqiMock.progress({ text: 'I will start by checking the document.' });
+      (window as any).__miqiMock.toolProgress('read_file("report.md")', 'call_issue_172_read');
+      (window as any).__miqiMock.progress({ text: 'The document is updated.' });
+      (window as any).__miqiMock._fireFinal('Final answer: report.md was updated and verified.');
+    });
+
+    await expect(page.getByText('Final answer: report.md was updated and verified.')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText('I will start by checking the document.')).toHaveCount(0);
+    await expect(page.getByText('The document is updated.')).toHaveCount(0);
+    await expect(page.getByText('read_file')).toBeVisible();
+  });
+
+  test('replaces an earlier final bubble when a later final arrives in the same turn', async ({
+    page,
+  }) => {
+    await injectMockAndGoto(page);
+
+    const textarea = page.getByPlaceholder('Ask Agent to analyze or edit files...');
+    await expect(textarea).toBeVisible({ timeout: 5000 });
+
+    await textarea.fill('create a ppt');
+    await textarea.press('Enter');
+
+    await page.evaluate(() => {
+      (window as any).__miqiMock.rawFinal('文件已成');
+    });
+    await expect(page.getByText('文件已成')).toBeVisible({ timeout: 5000 });
+
+    await page.evaluate(() => {
+      (window as any).__miqiMock.toolProgress('create_pptx("office_tools_review_final.pptx")');
+      (window as any).__miqiMock.rawFinal(
+        '文件已成功创建！已创建的等效文件：office_tools_review_final.pptx'
+      );
+    });
+
+    await expect(page.getByText('文件已成功创建！已创建的等效文件：office_tools_review_final.pptx')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText('文件已成', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('create_pptx')).toBeVisible();
+  });
+
+  test('replays only final assistant text from historical multi-tool turns', async ({ page }) => {
+    await injectMockAndGoto(page, {
+      sessions: [
+        {
+          key: 'issue-172-session',
+          title: 'Issue 172 repro',
+          updated_at: Date.now(),
+          message_count: 5,
+        },
+      ],
+      sessionMessages: {
+        'issue-172-session': [
+          {
+            role: 'user',
+            content: 'edit the document',
+            timestamp: '2026-07-08T01:00:00.000Z',
+          },
+          {
+            role: 'assistant',
+            content: 'I will start by reading the file.',
+            tool_calls: [{ function: { name: 'read_file', arguments: '{"path":"report.md"}' } }],
+            timestamp: '2026-07-08T01:00:01.000Z',
+          },
+          {
+            role: 'tool',
+            name: 'read_file',
+            content: 'draft',
+            timestamp: '2026-07-08T01:00:02.000Z',
+          },
+          {
+            role: 'assistant',
+            content: 'The edit is done.',
+            timestamp: '2026-07-08T01:00:03.000Z',
+          },
+          {
+            role: 'assistant',
+            content: 'Final answer: document edited and checked.',
+            timestamp: '2026-07-08T01:00:04.000Z',
+          },
+        ],
+      },
+    });
+
+    await page.getByText('Issue 172 repro').click();
+
+    await expect(page.getByText('Final answer: document edited and checked.')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText('I will start by reading the file.')).toHaveCount(0);
+    await expect(page.getByText('The edit is done.')).toHaveCount(0);
+    await expect(page.getByText('read_file')).toBeVisible();
+  });
+});

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -9,6 +9,7 @@
 export interface MockBridgeOptions {
   runtimeStatus?: 'stopped' | 'running' | 'starting';
   sessions?: Array<{ key: string; title: string; updated_at: number; message_count: number }>;
+  sessionMessages?: Record<string, unknown[]>;
   preloadOk?: boolean;
 }
 
@@ -17,9 +18,15 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   const preloadOk = opts.preloadOk !== false;
   const initialSessions = opts.sessions || [
     { key: 'sess-001', title: 'Test conversation 1', updated_at: Date.now(), message_count: 5 },
-    { key: 'sess-002', title: 'Test conversation 2', updated_at: Date.now() - 3600000, message_count: 3 },
+    {
+      key: 'sess-002',
+      title: 'Test conversation 2',
+      updated_at: Date.now() - 3600000,
+      message_count: 3,
+    },
   ];
   const sessionsJson = JSON.stringify(initialSessions);
+  const sessionMessagesJson = JSON.stringify(opts.sessionMessages || {});
 
   return `
 (function() {
@@ -78,11 +85,12 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       list: function() { return Promise.resolve({ sessions: ${sessionsJson} }); },
       get: function(key) {
         var sessions = ${sessionsJson};
+        var sessionMessages = ${sessionMessagesJson};
         var found = null;
         for (var i = 0; i < sessions.length; i++) {
           if (sessions[i].key === key) { found = sessions[i]; break; }
         }
-        return Promise.resolve({ key: key, title: found ? found.title : key, messages: [], tracked_files: [] });
+        return Promise.resolve({ key: key, title: found ? found.title : key, messages: sessionMessages[key] || [], tracked_files: [] });
       },
       delete: function() { return Promise.resolve({ deleted: true }); },
       archive: function() { return Promise.resolve({ archived: true }); },
@@ -223,6 +231,11 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       setTimeout(function() {
         _fire('final', { content: content });
       }, 50);
+    },
+
+    /** Fire a final event immediately, without adding mock progress. */
+    rawFinal: function(content) {
+      _fire('final', { content: content });
     },
 
     /** Simulate a backend error */


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修复 Chat UI 在同一轮多工具调用中显示多段 assistant 正式回复的问题，只保留最新 final assistant 回复。

## 背景/问题

Closes #172。

在一次工具调用较多的任务中，同一轮可能先渲染短 assistant/final 文案，例如“文件已成”，后续工具调用或更完整 final 到来后，旧 assistant 气泡仍留在聊天区，导致用户误以为回答重复、截断或状态不一致。

根因：实时渲染路径只清理了普通 progress 状态行，没有清理本轮已经渲染出来的 assistant 气泡；历史回放路径也会把同一 user turn 内多个 assistant 文本都作为正式回复显示。

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 历史消息回放时按 user turn 折叠 assistant 文本，只保留该 turn 最后一条 assistant 正式回复。
  - 中间包含 tool_calls 的 assistant 消息继续保留为空内容，用于生成折叠工具进度行。
  - 实时收到新的 `chat:final` 时取消旧打字机动画，清理本轮已有 assistant 气泡和非工具 progress，只渲染最新 final。
- `apps/desktop/tests/chatConsoleMessages.test.ts`
  - 添加 turn 内多 assistant 文本折叠单测。
- `apps/desktop/tests/smoke/issue-172-assistant-turn-collapse.spec.ts`
  - 添加 issue #172 UI 复现测试，包括连续 final 覆盖场景。
- `apps/desktop/tests/smoke/mocks.ts`
  - 支持注入历史消息和即时触发 raw final。
- `apps/desktop/src/shared/ipc.ts`、`apps/desktop/src/renderer/features/wsl/WslStatusPage.tsx`
  - 修复阻塞 `typecheck:web` 的已有类型问题。

## 日志/验证证据

```
npm.cmd run typecheck:web
> tsc --noEmit -p tsconfig.web.json
PASS

npm.cmd run test -- --run tests/chatConsoleMessages.test.ts tests/progressUtils.test.ts
Test Files 2 passed (2)
Tests 18 passed (18)

npx.cmd playwright test --config=playwright.config.ts --project=smoke tests/smoke/issue-172-assistant-turn-collapse.spec.ts
Running 3 tests using 1 worker
3 passed (3.0s)

npm.cmd run build
> electron-vite build
PASS

真实手工验证：MiQi Desktop dev 实例重启后复测同类 Office/PPT 多工具调用任务；此前截图中的短 assistant 气泡“文件已成”不再残留，只显示工具折叠行和最新 final 回复。
```

### 修复前截图

见issue
<img width="656" height="308" alt="image" src="https://github.com/user-attachments/assets/6e086eab-d4fc-46f9-8e78-2a300b5b7fda" />


### 修复后截图
<img width="1264" height="821" alt="a018641c-ff7a-49a3-8bd8-8f9a5669ae89" src="https://github.com/user-attachments/assets/8144029f-738f-428f-ae19-d6faceb4c063" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/bd0b180f-4fbc-4c2a-90a4-7229e9f7f292" />


### 录屏

TODO: 如维护者要求录屏，请在这里补充视频链接。

## 测试情况

- [x] `npm.cmd run typecheck:web`
- [x] `npm.cmd run test -- --run tests/chatConsoleMessages.test.ts tests/progressUtils.test.ts`
- [x] `npx.cmd playwright test --config=playwright.config.ts --project=smoke tests/smoke/issue-172-assistant-turn-collapse.spec.ts`
- [x] `npm.cmd run build`
- [x] 手工复测真实 Desktop 多工具调用场景


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages now display more cleanly by collapsing intermediate assistant/tool activity into a single turn.
  * Session history can now include message counts for better display and tracking.
* **Bug Fixes**
  * Removed leftover transient assistant messages after a response finishes.
  * Improved handling of tool-heavy and multi-turn chat histories so final assistant replies stay in the correct turn.
  * Fixed a UI key handling issue in the WSL status page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->