### PR TITLE
fix: 默认关闭审批绕过状态

### DIFF
--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -11,12 +11,9 @@ interface ApprovalBypassStatus {
 
 function hasApprovalBypass(config: Record<string, unknown>): boolean {
   const approvals = (config.approvals ?? {}) as ApprovalBypassStatus;
-  const agents = (config.agents ?? {}) as Record<string, unknown>;
-  const commandApproval = (agents.commandApproval ?? {}) as { enabled?: boolean };
 
   return Boolean(
-    commandApproval.enabled === false ||
-      approvals.bypassAll ||
+    approvals.bypassAll ||
       approvals.bypassCommandApproval ||
       approvals.bypassFileWriteApproval ||
       approvals.bypassToolConfirmation ||

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -11,8 +11,7 @@ interface ApprovalBypassStatus {
   bypassNetworkApproval?: boolean;
 }
 
-function isBypassEnabled(status: ApprovalBypassStatus | null, legacyCommandBypass: boolean): boolean {
-  if (legacyCommandBypass) return true;
+function isBypassEnabled(status: ApprovalBypassStatus | null): boolean {
   if (!status) return false;
   return Boolean(
     status.bypassAll ||
@@ -23,20 +22,20 @@ function isBypassEnabled(status: ApprovalBypassStatus | null, legacyCommandBypas
   );
 }
 
-function getBypassLabel(status: ApprovalBypassStatus | null, legacyCommandBypass: boolean): string {
+function getBypassLabel(status: ApprovalBypassStatus | null): string {
   if (status?.bypassAll) return 'BYPASS ALL';
   const labels: string[] = [];
-  if (legacyCommandBypass || status?.bypassCommandApproval) labels.push('CMD');
+  if (status?.bypassCommandApproval) labels.push('CMD');
   if (status?.bypassFileWriteApproval) labels.push('FILE');
   if (status?.bypassToolConfirmation) labels.push('TOOL');
   if (status?.bypassNetworkApproval) labels.push('NET');
   return labels.length > 0 ? `BYPASS: ${labels.join('/')}` : 'BYPASS';
 }
 
-function getBypassTitle(status: ApprovalBypassStatus | null, legacyCommandBypass: boolean): string {
+function getBypassTitle(status: ApprovalBypassStatus | null): string {
   if (status?.bypassAll) return 'Approval bypass enabled for all approval categories';
   const labels: string[] = [];
-  if (legacyCommandBypass || status?.bypassCommandApproval) labels.push('command approval');
+  if (status?.bypassCommandApproval) labels.push('command approval');
   if (status?.bypassFileWriteApproval) labels.push('file-write approval');
   if (status?.bypassToolConfirmation) labels.push('tool confirmation');
   if (status?.bypassNetworkApproval) labels.push('network approval');
@@ -48,33 +47,26 @@ function getBypassTitle(status: ApprovalBypassStatus | null, legacyCommandBypass
 export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
   const { status } = useRuntime();
   const [approvalBypass, setApprovalBypass] = useState<ApprovalBypassStatus | null>(null);
-  const [legacyCommandBypass, setLegacyCommandBypass] = useState(false);
 
   const isRunning = status.state === 'running';
   const isStarting = status.state === 'starting' || status.state === 'stopping';
-  const bypassEnabled = isBypassEnabled(approvalBypass, legacyCommandBypass);
+  const bypassEnabled = isBypassEnabled(approvalBypass);
 
   useEffect(() => {
     let cancelled = false;
     const loadApprovalBypass = async () => {
       if (!(window as any).miqi?.config?.get) {
         if (!cancelled) setApprovalBypass(null);
-        if (!cancelled) setLegacyCommandBypass(false);
         return;
       }
       try {
         const cfg = await window.miqi.config.get();
         const approvals = (cfg.approvals ?? {}) as ApprovalBypassStatus;
-        const commandApproval = ((cfg.agents as any)?.commandApproval ?? {}) as {
-          enabled?: boolean;
-        };
         if (!cancelled) {
           setApprovalBypass(approvals);
-          setLegacyCommandBypass(commandApproval.enabled === false);
         }
       } catch {
         if (!cancelled) setApprovalBypass(null);
-        if (!cancelled) setLegacyCommandBypass(false);
       }
     };
     loadApprovalBypass();
@@ -123,10 +115,10 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
               color: 'var(--approval-warning-pill-text)',
               border: '1px solid var(--approval-warning-border)',
             }}
-            title={getBypassTitle(approvalBypass, legacyCommandBypass)}
+            title={getBypassTitle(approvalBypass)}
           >
             <AlertTriangle size={11} className="shrink-0" />
-            <span>{getBypassLabel(approvalBypass, legacyCommandBypass)}</span>
+            <span>{getBypassLabel(approvalBypass)}</span>
           </button>
         )}
         {/* Sync state */}

--- a/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
+++ b/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
@@ -42,23 +42,15 @@ const DEFAULT_APPROVAL_BYPASS: ApprovalBypassConfig = {
   bypassNetworkApproval: false,
 };
 
-function normalizeApprovalBypass(config: Record<string, unknown>): {
-  approvals: ApprovalBypassConfig;
-  legacyCommandBypass: boolean;
-} {
+function normalizeApprovalBypass(config: Record<string, unknown>): ApprovalBypassConfig {
   const approvals = (config.approvals ?? {}) as Partial<ApprovalBypassConfig>;
-  const agents = (config.agents ?? {}) as Record<string, unknown>;
-  const commandApproval = (agents.commandApproval ?? {}) as { enabled?: boolean };
 
   return {
-    approvals: {
-      bypassAll: Boolean(approvals.bypassAll),
-      bypassCommandApproval: Boolean(approvals.bypassCommandApproval),
-      bypassFileWriteApproval: Boolean(approvals.bypassFileWriteApproval),
-      bypassToolConfirmation: Boolean(approvals.bypassToolConfirmation),
-      bypassNetworkApproval: Boolean(approvals.bypassNetworkApproval),
-    },
-    legacyCommandBypass: commandApproval.enabled === false,
+    bypassAll: Boolean(approvals.bypassAll),
+    bypassCommandApproval: Boolean(approvals.bypassCommandApproval),
+    bypassFileWriteApproval: Boolean(approvals.bypassFileWriteApproval),
+    bypassToolConfirmation: Boolean(approvals.bypassToolConfirmation),
+    bypassNetworkApproval: Boolean(approvals.bypassNetworkApproval),
   };
 }
 
@@ -155,7 +147,6 @@ export function ApprovalsPage() {
   // Global bypass settings
   const [bypassConfig, setBypassConfig] =
     useState<ApprovalBypassConfig>(DEFAULT_APPROVAL_BYPASS);
-  const [legacyCommandBypass, setLegacyCommandBypass] = useState(false);
   const [bypassLoading, setBypassLoading] = useState(true);
   const [bypassSaving, setBypassSaving] = useState<ApprovalBypassKey | null>(null);
   const [bypassSaved, setBypassSaved] = useState<ApprovalBypassKey | null>(null);
@@ -187,11 +178,9 @@ export function ApprovalsPage() {
     try {
       const config = await window.miqi.config.get();
       const normalized = normalizeApprovalBypass(config);
-      setBypassConfig(normalized.approvals);
-      setLegacyCommandBypass(normalized.legacyCommandBypass);
+      setBypassConfig(normalized);
     } catch {
       setBypassConfig(DEFAULT_APPROVAL_BYPASS);
-      setLegacyCommandBypass(false);
     } finally {
       setBypassLoading(false);
     }
@@ -291,7 +280,6 @@ export function ApprovalsPage() {
   const updateBypassConfig = async (key: ApprovalBypassKey, enabled: boolean) => {
     if (bypassSaving !== null) return;
     const previous = bypassConfig;
-    const previousLegacyCommandBypass = legacyCommandBypass;
     const next =
       key === 'bypassAll'
         ? { ...DEFAULT_APPROVAL_BYPASS, bypassAll: enabled }
@@ -299,9 +287,6 @@ export function ApprovalsPage() {
     setBypassSaving(key);
     setBypassError(null);
     setBypassConfig(next);
-    if ((key === 'bypassAll' && !enabled) || (key === 'bypassCommandApproval' && !enabled)) {
-      setLegacyCommandBypass(false);
-    }
     try {
       const update: Record<string, unknown> = { approvals: next };
       if ((key === 'bypassAll' && !enabled) || (key === 'bypassCommandApproval' && !enabled)) {
@@ -317,7 +302,6 @@ export function ApprovalsPage() {
     } catch (e) {
       console.error('Failed to save approval bypass config:', e);
       setBypassConfig(previous);
-      setLegacyCommandBypass(previousLegacyCommandBypass);
       setBypassError(e instanceof Error ? e.message : '保存失败');
     } finally {
       setBypassSaving(null);
@@ -354,7 +338,6 @@ export function ApprovalsPage() {
   const isBypassOn = (key: ApprovalBypassKey): boolean => {
     if (key === 'bypassAll') return bypassConfig.bypassAll;
     if (bypassConfig.bypassAll) return true;
-    if (key === 'bypassCommandApproval' && legacyCommandBypass) return true;
     return bypassConfig[key];
   };
 
@@ -470,10 +453,7 @@ export function ApprovalsPage() {
               const disabled = bypassLoading || bypassConfig.bypassAll;
               const checked = isBypassOn(row.key);
               const storedChecked = bypassConfig[row.key];
-              const nextStored =
-                row.key === 'bypassCommandApproval' && legacyCommandBypass && !storedChecked
-                  ? false
-                  : !storedChecked;
+              const nextStored = !storedChecked;
               return (
                 <button
                   type="button"
@@ -497,9 +477,6 @@ export function ApprovalsPage() {
                       {row.description}
                       {bypassConfig.bypassAll
                         ? '。当前由“全部绕过”统一控制'
-                        : ''}
-                      {row.key === 'bypassCommandApproval' && legacyCommandBypass
-                        ? '。旧版 commandApproval.enabled=false 正在生效'
                         : ''}
                     </span>
                   </span>

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -116,7 +116,7 @@ class RuntimeServices:
             if callable(effective_bypass)
             else getattr(config, "approvals", None)
         )
-        if bool(getattr(approval_bypass, "enabled", False)):
+        if bool(getattr(getattr(config, "approvals", None), "enabled", False)):
             logger.warning(
                 "Approval bypass is enabled for session {}; approval prompts may be skipped.",
                 session_id,


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [x] 测试
- [ ] 其他

## 变更概述

修正审批绕过状态默认显示为开启的问题：新审批绕过模式只由 `approvals.*` 显式配置控制，默认保持关闭。

## 背景/问题

#201 合并后，旧配置 `agents.commandApproval.enabled=false` 会被状态提示和审批配置入口当作新审批绕过模式的一部分显示，导致用户看到“审批绕过已开启”，像是默认自动打开。

期望行为是：新增的全局/分项审批绕过默认全部关闭；只有用户显式打开 `approvals.bypassAll` 或分项 `approvals.bypass*` 时，才显示审批绕过状态。旧版命令审批关闭仍保留兼容逻辑，但不再点亮新的审批绕过状态。

## 变更内容

- `ApprovalBypassBanner.tsx`：提醒状态只判断 `approvals.*`，不再读取旧版 `commandApproval.enabled=false`。
- `TopBar.tsx`：审批绕过状态和文案只显示显式审批绕过配置。
- `ApprovalsPage.tsx`：审批配置开关默认只看 `approvals.*`，移除旧配置对“命令审批绕过”开关的自动点亮。
- `miqi/runtime/services.py`：会话启动 warning 只在显式审批绕过开启时打印，旧命令审批关闭不再输出 “Approval bypass is enabled”。

参考截图：

![审批绕过状态截图](https://github.com/user-attachments/assets/3bac8631-f028-4f1b-aa58-b64fe3e3b5d7)

## 日志/验证证据

```
npm.cmd run typecheck
通过。

uv run pytest tests\runtime\test_config_app_handlers.py tests\execution\test_permission_engine.py -q
51 passed。

npx.cmd vitest run src\main\bridge.test.ts
20 passed。

uv run pytest tests\runtime\test_runtime_session.py::test_runtime_session_abort_cancels_active_turn -q
1 passed。
```

## 测试情况

- [x] 前端类型检查通过。
- [x] 配置和权限相关后端测试通过。
- [x] 桌面 bridge 单元测试通过。
- [x] 单独复跑 abort 相关测试，通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified approval bypass status and controls to use the current bypass settings consistently.
  - Removed legacy command-approval bypass behavior from bypass indicators, labels, warnings, and toggles.
  - Updated approval bypass warnings to reflect the configured approvals setting accurately.
  - Improved fallback behavior when bypass configuration cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->