### PR TITLE
fix(wsl-e2e): initialize WSL user + verify sandbox dirs after creation

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -88,6 +88,9 @@ jobs:
         run: |
           Write-Host "Installing WSL Ubuntu..."
           wsl --install -d Ubuntu --no-launch
+          Write-Host "Initializing WSL user..."
+          wsl -d Ubuntu -- bash -c "id -u miqi 2>/dev/null || useradd -m miqi"
+          wsl -d Ubuntu -- bash -c "mkdir -p /tmp/miqi-sandboxes && chmod 777 /tmp/miqi-sandboxes"
           Write-Host "WSL distro list:"
           wsl -l -v
 
@@ -123,6 +126,9 @@ jobs:
         run: |
           Write-Host "Installing WSL Ubuntu..."
           wsl --install -d Ubuntu --no-launch
+          Write-Host "Initializing WSL user..."
+          wsl -d Ubuntu -- bash -c "id -u miqi 2>/dev/null || useradd -m miqi"
+          wsl -d Ubuntu -- bash -c "mkdir -p /tmp/miqi-sandboxes && chmod 777 /tmp/miqi-sandboxes"
           Write-Host "WSL distro list:"
           wsl -l -v
 

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -629,11 +629,20 @@ class BwrapSandbox:
 
         # Create per-session directory structure inside Linux/WSL
         rc, out, err = await self._run_linux_command(
-            f"mkdir -p '{self.sandbox_home}' '{self.sandbox_workspace}'"
+            f"mkdir -p '{self._linux_base_dir}' '{self.sandbox_home}' '{self.sandbox_workspace}'"
         )
         if rc != 0:
             raise BwrapSandboxError(
                 f"Failed to create sandbox directories: {err}"
+            )
+
+        # Verify directories actually exist
+        rc, _, err = await self._run_linux_command(
+            f"test -d '{self.sandbox_home}' && test -d '{self.sandbox_workspace}'"
+        )
+        if rc != 0:
+            raise BwrapSandboxError(
+                f"Sandbox directories not found after creation: {err}"
             )
 
         # Copy workspace into sandbox if it exists


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

Cherry-pick d6c9e3cd 修复 wsl-e2e CI 因 sandbox 目录缺失导致的失败。

## 背景/问题

PR #220 squash merge 后，wsl-e2e CI 在 develop 分支上持续失败。错误：

```
bwrap: Can't find source path /tmp/miqi-sandboxes/miqi-desktop_desktop_1783787522934/home/miqi: No such file or directory
```

根因：squash merge 未包含 commit d6c9e3cd，该 commit 在 WSL 初始化阶段创建了 miqi 用户和 `/tmp/miqi-sandboxes` 目录，并在 bwrap sandbox 创建后添加了目录存在性验证。

## 变更内容

- `.github/workflows/python-tests.yml`：两个 WSL job 步骤（test-wsl / test-wsl-installer）中添加了 useradd miqi 和 mkdir /tmp/miqi-sandboxes（+12 行）
- `miqi/sandbox/bwrap.py`：mkdir 命令中加入 `_linux_base_dir`，并在创建后添加 `test -d` 目录存在性验证（+4/-1 行）

## 日志/验证证据

```
bwrap: Can't find source path /tmp/miqi-sandboxes/miqi-desktop_desktop_1783787522934/home/miqi: No such file or directory
```

PR #220 wsl-e2e CI run 29159776045 中 sandbox 目录缺失错误。

## 测试情况

- 目标 CI: wsl-e2e (test-wsl) 和 wsl-e2e-installer (test-wsl-installer)
- 修改后 WSL job 启动时将创建 miqi 用户并验证 sandbox 目录存在性
- bwrap sandbox 创建后会执行 `test -d` 验证关键目录

## 截图

无需截图。
