### PR TITLE
fix(ci): skip issue template validation for enhancement-labeled issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,9 +118,10 @@ runs:
           const issueNumber = context.issue.number;
           const repo = context.repo;
 
-          // Skip feature requests
-          if (context.payload.issue.title?.startsWith(featurePrefix)) {
-            console.log('Feature request — skipping template validation');
+          // Skip feature requests and enhancements
+          const labels = (context.payload.issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+          if (context.payload.issue.title?.startsWith(featurePrefix) || labels.includes('enhancement')) {
+            console.log('Feature request / enhancement — skipping template validation');
             core.setOutput('valid', 'true');
             return;
           }
@@ -259,10 +260,11 @@ runs:
           let body = context.payload.issue.body || '';
           body = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
-          // Skip feature requests — they don't have bug-report sections
+          // Skip feature requests and enhancements — they don't have bug-report sections
           const featurePrefix = process.env.FEATURE_PREFIX || '[FEATURE]';
-          if (context.payload.issue.title?.startsWith(featurePrefix)) {
-            console.log('Feature request — skipping AI log review');
+          const labels = (context.payload.issue.labels || []).map(l => typeof l === 'string' ? l : l.name);
+          if (context.payload.issue.title?.startsWith(featurePrefix) || labels.includes('enhancement')) {
+            console.log('Feature request / enhancement — skipping AI log review');
             return;
           }
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

Issue 模板校验器误将 `enhancement` labeled 的 feature request 当作 bug 检查，报 "Bug 描述未填写" 等错误。

## 背景/问题

Issue #226（enhancement label, feat title）被 validator 错误拒绝，因为模板校验只检查标题是否以 `[FEATURE]` 开头，不检查标签。

## 变更内容

`action.yml` 两处修改：
- Template validation step: 新增 `labels.includes(enhancement)` 跳过条件
- AI log review step: 同上

```diff
- if (context.payload.issue.title?.startsWith(featurePrefix)) {
+ if (context.payload.issue.title?.startsWith(featurePrefix) || labels.includes(enhancement)) {
```

## 日志/验证证据

```
Issue #226: enhancement label + feat(skill) title → 被错误拒绝
```

## 测试情况

- [ ] 手动验证：创建 enhancement label issue → validator 跳过
- [ ] 手动验证：bug label issue → validator 仍正常检查

## 截图

无需截图

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issues labeled **enhancement** can now bypass template validation and AI log review.
  - Existing behavior for issues with titles using the configured feature prefix remains unchanged.
  - This provides a faster path for enhancement-related issues while preserving the existing checks for other issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->