### PR TITLE
feat(skill): add MOF synthesis price agent skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,3 @@ plan/*
 .debug/
 .playwright-mcp/
 *.png
-mof-synthesis-price-agent/

--- a/miqi/skills/mof-synthesis-price-agent/SKILL.md
+++ b/miqi/skills/mof-synthesis-price-agent/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: mof-synthesis-price-agent
+description: Use when Codex needs to process MOF, COF, or coordination-polymer synthesis papers from /mof-synthesis-price-agent, DOI, doi/link CSV/TSV/XLSX, local PDF, cleaned text, agent JSON, or existing pipeline CSVs into synthesis routes, reagent lists, supplier pricing, GHS/fire-risk enrichment, feasibility screening, and HTML/Markdown/PDF reports. Use for Chinese or English requests such as 处理MOF论文, 提取MOF合成路线和试剂, 估算采购成本, 生成MOF采购/可行性报告, prepare DOI CSV for MOF papers, replace DeepSeek extraction with Codex agent extraction, or continue a MOF price pipeline. Do not use for BVSE ion migration, LAMMPS gas permeation, CIF cleaning, generic literature review, reaction prediction/design, automated purchasing, SDS/EHS approval, or regulatory compliance certification.
+---
+
+# MOF Synthesis Price Agent
+
+Use this skill when the user invokes `/mof-synthesis-price-agent` or asks to run or continue the MOF synthesis/pricing/report workflow. The user provides an input plus a natural-language request; Codex handles internal routing and tool commands.
+
+## Default Behavior
+
+Default to the most complete workflow supported by the user's input:
+
+1. Identify the input type: DOI, DOI CSV/TSV/XLSX, local PDF/file folder, cleaned `.txt`, agent JSON, or existing CSV prefix.
+2. Run `scripts/mof_workflow.py <input>` as the deterministic router when an input path, DOI, or prefix is available.
+3. If the router returns `needs_agent_extraction`, read the cleaned text, apply the extraction references, produce agent JSON, then run `scripts/mof_workflow.py <agent.json>` to continue.
+4. Use Codex agent extraction for the former DeepSeek Call A/B/C/D and feasibility verdict.
+5. Reuse deterministic project tools for PDF/SI download, text extraction, pricing/GHS enrichment, CSV writing, and report generation.
+6. Report the completion state and evidence boundary.
+
+Run a single stage only when the user explicitly asks for a named stage such as download only, extraction only, enrichment only, report only, feasibility only, rerun report, debug CAS, or prepare DOI CSV.
+
+## Required References
+
+Read only the reference files needed for the current task:
+
+- `references/workflow.md`: input routing, stage map, completion states, and project command flow.
+- `references/agent-extraction-rules.md`: mandatory rules for agent replacement of DeepSeek Call A/B/C/D and verdict.
+- `references/agent-prompt-template.md`: ready-to-use extraction prompt template for cleaned text, validation repair, and long-text handling.
+- `references/schemas.md`: JSON schemas, CSV headers, and validation requirements.
+- `references/failure-handling.md`: stop/degrade/retry behavior.
+- `references/evidence-boundaries.md`: scientific, pricing, safety, and compliance claim limits.
+- `references/cnki-doi-preflight.md`: fast handling for CNKI DOI metadata, non-MOF scope checks, encoding, and gated-fulltext timing.
+- `references/real-sample-validation.md`: Reality Run acceptance criteria and recommended real-paper smoke samples.
+
+## Core Rules
+
+- Do not require `DEEPSEEK_API_KEY`, `.env`, or any external LLM API for extraction. The Codex agent must produce structured routes, reagents, summaries, and feasibility verdicts directly from the evidence in the paper text and CSV artifacts.
+- Do not call the original DeepSeek-bound full `pipeline.py`, `batch.py`, `llm/synthesis_extractor.py`, or `enrich/feasibility.py` on the default path. Use the router and deterministic stage scripts instead.
+- Do not print, read aloud, store, or ask for secrets unless the user explicitly chooses to use an external API outside this skill's default path.
+- Preserve the fixed boundary: MOF/COF/coordination-polymer synthesis information, reagent purchasing/pricing, GHS/fire-risk screening, and feasibility reporting. Do not expand into reaction prediction, automated purchasing, regulatory certification, or general literature review.
+- For CNKI DOI inputs, especially `10.*j.cnki*` or `link.cnki.net/doi/...`, run the CNKI DOI preflight before dynamic search/PDF probing. If the resolved title is clearly not MOF/COF/coordination-polymer, stop at `evidence_boundary` and generate a metadata-only report instead of inventing routes, reagents, or prices.
+- When publisher access is gated and only metadata is available, limit exploratory DOI/detail/PDF probing to short, bounded attempts; then produce an evidence-boundary output inventory and ask for PDF, exported text, or the experimental section.
+- Keep claims evidence-bound. Prices are scraped/observed estimates; safety and fire-risk outputs are screening aids; SDS/EHS review remains required before lab work.
+- For each material/reagent, keep only the top 10 value quotes in detailed pricing outputs and reports, sorted by positive CNY price ascending. Do not flood the final Markdown with all scraped supplier rows.
+- Render all money in reports as ASCII `CNY 97.00`; do not use `¥`, `￥`, or the mojibake character `楼` in HTML, Markdown, or PDF outputs.
+- Show a purchase link only when it has been verified as a reachable direct supplier product page. If a quote has a price but the product URL cannot be live-verified, keep the price for screening and mark the link as unverified/blank rather than emitting a fake or dead buy link.
+- Validate all agent-generated JSON against `references/schemas.md` before writing CSVs. If validation fails, self-repair once using the validation error and source evidence. If it still fails, stop at an evidence boundary instead of writing misleading outputs.
+- Mark degraded completion when optional outputs fail but core evidence is still useful, such as HTML/MD report generated but PDF rendering failed, pricing partially unavailable, SI download failed, or optional supplier source blocked.
+- Treat hand-written fixtures as schema tests only. The skill is reality-ready only after at least one real DOI/PDF/text sample reaches `complete`, `degraded_complete`, `needs_agent_extraction`, or a documented `evidence_boundary` with output inventory.
+
+## Tooling Pattern
+
+- Prefer the existing project root in the current workspace when files such as `extract/text_extractor.py`, `enrich/chembook_scraper.py`, and `report.py` are present.
+- On the known `g0048` server (`ruiqi@36.103.234.242`, port `2242`), use `/home/ruiqi/miniconda3/envs/mofsimbench/bin/python` as the preferred Python interpreter for this skill before searching other environments. Verified imports include `pandas`, `openpyxl`, `requests`, `bs4`, `lxml`, `pdfplumber`, `fitz`/PyMuPDF, `reportlab`, `pypdf`, `html5lib`, `tabulate`, plus the scientific packages used by neighboring MOF skills.
+- On the local Codex desktop runtime, the default `python` already imports `pandas`, `openpyxl`, `requests`, `bs4`, `lxml`, `pdfplumber`, and `reportlab`; use server Python only when the input/project/output is intended to run on the server.
+- Start with `scripts/mof_workflow.py <input>` for DOI, DOI files/tables, PDF/PDF folders, cleaned text, agent JSON, or existing CSV prefixes. Treat its JSON output as the run contract.
+- If no MOF project root is available and the input is a CNKI DOI, run `scripts/cnki_doi_preflight.py <doi>` as a lightweight fallback before reporting failure. Use its metadata to decide whether the correct state is `evidence_boundary` rather than `failed`.
+- Use `scripts/write_agent_outputs.py` only through the router unless debugging schema validation.
+- Use `scripts/prepare_doi_csv.py` through the router when the user provides a spreadsheet or loose DOI/link table that needs normalization to `doi,link`.
+- Let `scripts/mof_workflow.py` call deterministic project commands for text extraction, pricing/GHS enrichment, and report generation. Do not show those commands to the user unless debugging.
+
+## Agent Extraction Handoff
+
+When `mof_workflow.py` returns `completion_state: needs_agent_extraction`:
+
+1. Read `references/agent-extraction-rules.md`, `references/agent-prompt-template.md`, `references/schemas.md`, and `references/evidence-boundaries.md`.
+2. If `batch_ledger` is present, process every ledger row whose `status` is `needs_agent_extraction`; otherwise process the single returned `prefix`.
+3. For each prefix, read the cleaned text path listed in `created_files` or `prefix + "_cleaned.txt"`.
+4. Produce one JSON file named `prefix + "_agent_extraction.json"` with `synthesis_routes`, `reagents`, `synthesis_summary`, and optional `feasibility`.
+5. Run `scripts/mof_workflow.py <agent_json>` to validate, write CSVs, enrich prices/GHS, and generate reports.
+6. If JSON validation fails, repair once using the validation error and source evidence. Stop that paper at `evidence_boundary` if it fails again.
+7. For batch runs, update the user-facing summary from the ledger plus every final router status; do not stop after only creating the ledger.
+
+## Completion Report
+
+Finish with:
+
+- Input used and stage(s) run.
+- Output paths created or reused.
+- Counts: routes, reagents, enriched rows, price entries when available.
+- Completion state: `complete`, `degraded_complete`, `needs_agent_extraction`, `failed`, or `evidence_boundary`.
+- Skipped/failed stages and next action.
+- Coarse timing when access probing or dynamic publisher pages consumed meaningful time.
+- Explicit caveat that safety/pricing conclusions are screening outputs when relevant.
+- Reality Run evidence when claiming readiness: real input type, command/tool path used, outputs created, degraded stages, and privacy/evidence-boundary result.

--- a/miqi/skills/mof-synthesis-price-agent/agents/openai.yaml
+++ b/miqi/skills/mof-synthesis-price-agent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MOF Synthesis Price Agent"
+  short_description: "Extract MOF synthesis routes, prices, and reports"
+  default_prompt: "Use $mof-synthesis-price-agent to process a MOF paper DOI, PDF, text, JSON, or CSV prefix into synthesis, pricing, and feasibility reports."

--- a/miqi/skills/mof-synthesis-price-agent/eval/manual_scoring.md
+++ b/miqi/skills/mof-synthesis-price-agent/eval/manual_scoring.md
@@ -1,0 +1,23 @@
+# MOF Synthesis Price Agent Eval
+
+## Trigger Accuracy
+
+- Recall target: valid DOI/PDF/text/JSON/CSV-prefix requests should trigger.
+- Precision target: BVSE, LAMMPS, CIF cleaning, generic literature review, reaction prediction, automated purchasing, SDS/EHS certification, and regulatory compliance should not trigger.
+- Ambiguous target: broad "整理 MOF 文献" style prompts should clarify the intended workflow.
+
+## Output Quality
+
+- The default path must stay DeepSeek-free and use Codex extraction plus deterministic router scripts.
+- CSV outputs must conform to `references/schemas.md`.
+- Final reports must separate completed, degraded, skipped, failed, and evidence-boundary stages.
+
+## Reality Readiness
+
+- Real samples are required for readiness claims; synthetic fixtures only prove schemas.
+- Accept `needs_agent_extraction` as a valid Reality Run intermediate when DOI/PDF/text acquisition succeeds and cleaned text is created.
+- Accept `evidence_boundary` when a real artifact cannot provide usable synthesis evidence, as long as the blocker is explicit.
+
+## Privacy
+
+- Redact local user paths, server names, OAuth/login traces, and credential-like strings before sharing eval excerpts.

--- a/miqi/skills/mof-synthesis-price-agent/eval/quality_assertions.json
+++ b/miqi/skills/mof-synthesis-price-agent/eval/quality_assertions.json
@@ -1,0 +1,46 @@
+{
+  "skill": "mof-synthesis-price-agent",
+  "level": "Reliable",
+  "quality_scenarios": [
+    {
+      "case_id": "quality-001",
+      "assertion": "Default path does not require DEEPSEEK_API_KEY or call DeepSeek-bound pipeline.py/batch.py extraction.",
+      "status": "todo"
+    },
+    {
+      "case_id": "quality-002",
+      "assertion": "Agent JSON must validate routes and reagents before writing CSV files.",
+      "status": "todo"
+    },
+    {
+      "case_id": "quality-003",
+      "assertion": "Completion report lists input, stages, outputs, counts, completion state, failed/skipped stages, and safety/pricing caveats.",
+      "status": "todo"
+    },
+    {
+      "case_id": "reality-001",
+      "assertion": "At least one real DOI/PDF/text sample produces needs_agent_extraction, complete, degraded_complete, or evidence_boundary with output inventory.",
+      "status": "todo"
+    },
+    {
+      "case_id": "privacy-001",
+      "assertion": "Skill docs, evals, and reports do not contain secrets, OAuth/login traces, or unredacted private server paths.",
+      "status": "todo"
+    },
+    {
+      "case_id": "scope-001",
+      "assertion": "CNKI DOI inputs that resolve to non-MOF materials stop at evidence_boundary with metadata-only outputs and no inferred reagent/price rows.",
+      "status": "todo"
+    },
+    {
+      "case_id": "encoding-001",
+      "assertion": "Chinese JSON/Markdown validation uses explicit UTF-8 and user-facing CSVs are UTF-8-SIG.",
+      "status": "todo"
+    },
+    {
+      "case_id": "efficiency-001",
+      "assertion": "Gated publisher/CNKI runs record coarse timing and avoid repeated unbounded dynamic search attempts after metadata-only evidence is established.",
+      "status": "todo"
+    }
+  ]
+}

--- a/miqi/skills/mof-synthesis-price-agent/eval/trigger_suite.json
+++ b/miqi/skills/mof-synthesis-price-agent/eval/trigger_suite.json
@@ -1,0 +1,67 @@
+{
+  "skill": "mof-synthesis-price-agent",
+  "level": "Reliable",
+  "thresholds": {
+    "recall": 0.85,
+    "precision": 0.85,
+    "ambiguous_handling": 0.85
+  },
+  "cases": [
+    {
+      "case_id": "mof-trigger-001",
+      "category": "direct",
+      "expected": "should_trigger",
+      "prompt": "处理这个 MOF 论文 DOI，提取合成路线、试剂价格和可行性报告：10.1038/46248",
+      "why": "Direct MOF DOI-to-report workflow."
+    },
+    {
+      "case_id": "mof-trigger-002",
+      "category": "paraphrased",
+      "expected": "should_trigger",
+      "prompt": "I have a folder of MOF paper PDFs; turn them into reagent CSVs with GHS/pricing enrichment and reports.",
+      "why": "Valid PDF-folder workflow."
+    },
+    {
+      "case_id": "mof-trigger-003",
+      "category": "complex",
+      "expected": "should_trigger",
+      "prompt": "继续这个 MOF price pipeline，已有 *_routes.csv 和 *_reagents.csv prefix，补价格、GHS 和 HTML/Markdown 报告。",
+      "why": "Existing CSV prefix continuation."
+    },
+    {
+      "case_id": "mof-trigger-004",
+      "category": "near-miss",
+      "expected": "should_not_trigger",
+      "prompt": "帮我做 MOF 的 BVSE 离子迁移路径和能垒分析。",
+      "why": "BVSE ion migration belongs to bvse-mof."
+    },
+    {
+      "case_id": "mof-trigger-005",
+      "category": "near-miss",
+      "expected": "should_not_trigger",
+      "prompt": "帮我预测一个全新的 MOF 反应路线并自动下单购买试剂。",
+      "why": "Reaction prediction and automated purchasing are explicit non-goals."
+    },
+    {
+      "case_id": "mof-trigger-006",
+      "category": "near-miss",
+      "expected": "should_not_trigger",
+      "prompt": "把 MOF-5 的 CIF 清洗一下然后跑 LAMMPS He/CH4 膜渗透筛选。",
+      "why": "CIF cleaning and LAMMPS permeation belong to neighboring skills."
+    },
+    {
+      "case_id": "mof-trigger-007",
+      "category": "ambiguous",
+      "expected": "clarify",
+      "prompt": "整理这些 MOF 文献。",
+      "why": "Could mean generic literature review, DOI table preparation, or synthesis/pricing extraction."
+    },
+    {
+      "case_id": "mof-trigger-008",
+      "category": "scope-boundary",
+      "expected": "should_trigger",
+      "prompt": "用 $mof-synthesis-price-agent 处理这篇论文，生成合成路线、试剂价格和可行性报告：10.13815/j.cnki.jmtc(ns).2025.02.002",
+      "why": "Explicit skill invocation should run the preflight and stop at evidence_boundary if the resolved paper is non-MOF."
+    }
+  ]
+}

--- a/miqi/skills/mof-synthesis-price-agent/references/agent-extraction-rules.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/agent-extraction-rules.md
@@ -1,0 +1,72 @@
+# Agent Extraction Rules
+
+These rules replace the SOP's DeepSeek Call A/B/C/D and feasibility verdict. The Codex agent must use only paper text, existing CSV artifacts, and scraped enrichment data as evidence.
+
+## Call A: Synthesis Routes
+
+Output `{"synthesis_routes": [...]}`.
+
+Rules:
+
+- Extract final characterizable MOF/COF/coordination-polymer products, not isolated intermediates unless the paper treats them as final tested materials.
+- Merge dependent steps into one route when a later step uses an earlier product as precursor, including post-synthetic modification, anion exchange, metalation, oxidation/reduction, vapor/thermal treatment, or solvent exchange that creates the final material.
+- Merge variants that differ only by metal, counterion, modulator, solvent, or closely related substituent when the procedure is the same; list all target names in `target_compound`.
+- Keep explicit control or optimization routes separate when they skip a step or intentionally compare conditions.
+- For fully referenced syntheses with no procedure in the paper, set `source_text` to null or the minimal quoted evidence and do not invent details.
+- `procedure_text` should summarize from commercial/lab-available starting materials to final product, preferably in Chinese and <=200 Chinese characters when possible.
+- `source_text` must be verbatim evidence from the paper when available. Do not paraphrase it.
+
+Pre-output checks:
+
+- No route target should appear as a reagent in its own route.
+- No intermediate route should remain if another route consumes it to make a final target.
+- Route indices are zero-based in downstream CSV.
+
+## Call B: Reagents
+
+Output `{"reagents": [...]}` using the routes from Call A.
+
+Rules:
+
+- Extract only reagents used to make the MOF/COF/coordination-polymer route, not catalytic test substrates, characterization chemicals, or unrelated ligand-upstream purification chemicals.
+- Assign every reagent to the route where it is actually used. Use `route_index=-1` only when the same reagent appears with the same role and substantially same use across all routes.
+- Do not include any route's final `target_compound` as a reagent for that same route.
+- Include commercial ligands, metal salts, solvents, modulators, catalysts, and workup/solvent-exchange reagents that directly affect the final material synthesis.
+- Use role values only: `reactant`, `solvent`, `catalyst`, `ligand`, `modulator`, `workup`.
+- Use real CAS for commercial chemicals when known from paper text or reliable common-chemical knowledge. Use null for custom MOF/intermediate/coordination-complex products. Do not invent CAS.
+- Fill `amount` when the paper gives it. Fill `equiv` when the value is numeric; otherwise place nonnumeric equivalents such as "excess" or "ca. 3 equiv" in `amount` or the procedure evidence rather than inventing a number.
+- Preserve paper names in `name`; do not translate the primary name.
+
+## Call C: Verification And Completion
+
+Verify the reagent list against the text and route evidence.
+
+- Mark a reagent confirmed when it appears by name, synonym, abbreviation, or chemically necessary SI-referenced step.
+- Add missing direct synthesis reagents found during verification.
+- Remove hallucinated reagents, final products, catalysis substrates, and ligand-upstream chemicals outside the MOF assembly route.
+- If verification would remove >80% of Call B reagents, treat it as verification malfunction and fall back to Call B after reporting the issue.
+- Deduplicate by `(normalized name, route_index, role)`.
+
+## Call D: Synthesis Summary
+
+Generate Markdown text, not JSON.
+
+- Use sections:
+  - `### 一、主合成路线（Primary）`
+  - `### 二、对照/优化路线（Control）`
+  - `### 三、引用路线（Reference）`
+- Keep <=500 Chinese characters when possible.
+- Summarize target materials, key ligand/metal sources, strategy, temperature, time, and key workup.
+- Do not add unsupported reaction mechanisms or performance claims.
+
+## Feasibility Verdict
+
+Output `{"llm_verdict": "..."}` with <=100 Chinese characters.
+
+- Base the verdict only on enriched reagent data, route data, pricing, GHS/fire-risk fields, controlled flags, and missing data.
+- Mention specific high-risk or missing-data reagents when relevant.
+- Do not state that synthesis is safe or approved; use screening language such as "建议先核对 SDS/EHS".
+
+## Fire-Risk Fallback
+
+Prefer scraped ChemicalBook/GHS/fire fields. If missing, the agent may infer cautiously from known chemical class and GHS evidence, but must mark the basis as inferred and use `unknown` when evidence is weak.

--- a/miqi/skills/mof-synthesis-price-agent/references/agent-prompt-template.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/agent-prompt-template.md
@@ -1,0 +1,65 @@
+# Agent Prompt Template
+
+Use this template when the task includes cleaned paper text and the agent must replace DeepSeek extraction.
+
+## Extraction Prompt
+
+```text
+You are using $mof-synthesis-price-agent. Read these references first:
+- references/agent-extraction-rules.md
+- references/schemas.md
+- references/evidence-boundaries.md
+
+Task:
+Extract MOF/COF/coordination-polymer synthesis information from the provided cleaned paper text.
+
+Output one JSON object with:
+{
+  "synthesis_routes": [...],
+  "reagents": [...],
+  "synthesis_summary": "Markdown summary using the required Chinese section headings",
+  "feasibility": null
+}
+
+Hard requirements:
+- Do not use DeepSeek or any external LLM API.
+- Use only the paper text as evidence.
+- Preserve verbatim source evidence in source_text when available.
+- Do not include final products as their own reagents.
+- Use route_index=-1 only for true universal reagents.
+- Use null instead of invented CAS, amount, equiv, or safety fields.
+- If evidence is insufficient, return a short evidence-boundary explanation instead of guessing.
+
+Paper text:
+<<<PASTE CLEANED TEXT HERE>>>
+```
+
+## Validation Repair Prompt
+
+Use once when `scripts/write_agent_outputs.py` rejects the JSON.
+
+```text
+The JSON failed validation:
+<<<PASTE VALIDATION ERROR>>>
+
+Repair only the JSON. Do not add prose. Keep all facts evidence-bound and do not invent missing data.
+```
+
+## Long Text Handling
+
+If the cleaned text is too long for reliable extraction:
+
+1. Identify synthesis, experimental, preparation, supporting information, and procedure sections.
+2. Keep route-relevant paragraphs plus enough surrounding context for target names and route mapping.
+3. Exclude references, author info, characterization-only sections, catalysis tests, NMR/XRD/BET/TGA tables, and unrelated ligand-upstream details unless they directly define a MOF route reagent.
+4. Run extraction on the condensed evidence.
+5. Record that long-text condensation was performed in the final completion report.
+
+## Batch Handling
+
+For multiple papers, process one paper at a time and keep a per-paper ledger:
+
+| paper_id | input | prefix | status | routes | reagents | degraded_reason | next_action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+Mixed success across a batch is `degraded_complete`, not total failure, when at least one paper produces usable outputs.

--- a/miqi/skills/mof-synthesis-price-agent/references/cnki-doi-preflight.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/cnki-doi-preflight.md
@@ -1,0 +1,55 @@
+# CNKI DOI Preflight
+
+Use this reference when a DOI or URL looks like a CNKI DOI, for example:
+
+- `10.13815/j.cnki...`
+- `https://link.cnki.net/doi/...`
+- `https://doi.cnki.net/...`
+
+## Fast Path
+
+Before trying dynamic CNKI search pages, login-gated detail pages, or PDF download endpoints:
+
+1. Run the CNKI preflight helper when available:
+
+```powershell
+python "<skill-dir>\scripts\cnki_doi_preflight.py" "<doi>"
+```
+
+2. Treat the returned JSON as a pre-acquisition evidence record.
+3. If `material_scope` is `not_mof`, stop the MOF workflow at `evidence_boundary` unless the user explicitly asks to process non-MOF materials with a separate workflow.
+4. If `material_scope` is `unknown` and only title/authors are available, continue acquisition only if the requested scope still fits MOF/COF/coordination-polymer extraction or the user provides a local PDF/text.
+5. If CNKI PDF/full text is gated, do not spend more than one short retry path on dynamic search/API probing. Produce a metadata-only evidence-boundary report and ask for PDF, exported text, or experimental section evidence.
+
+## Scope Rules
+
+Positive title hints include:
+
+- MOF, MOFs, metal-organic framework, metal organic framework
+- COF, covalent organic framework
+- coordination polymer, 配位聚合物
+- 金属有机框架, 共价有机框架
+
+Negative title hints include:
+
+- LDH, LDHs, layered double hydroxide, 层状双金属氢氧化物
+- electrocatalysis-only LDH, hydroxide, oxide, sulfide, phosphide, alloy, battery electrode, unless the title/text explicitly says MOF/COF/coordination polymer
+
+When negative hints dominate and no positive MOF/COF/coordination-polymer hint appears, set `completion_state=evidence_boundary`; do not invent MOF routes or generic reagent lists.
+
+## Encoding And Validation
+
+- Read and write Chinese JSON/Markdown with explicit UTF-8.
+- In PowerShell validation, use `Get-Content -Encoding UTF8`, not the default encoding.
+- Write CSVs with UTF-8-SIG when they are user-facing or Excel-targeted.
+
+## Timing Discipline
+
+Record coarse timing when a run hits a gated publisher path:
+
+- DOI preflight time
+- detail/PDF acquisition attempts and timeout count
+- report-writing time
+- final completion state
+
+This timing note can be a short section in the final answer or a `timing` object in metadata JSON. It helps distinguish real extraction cost from access-probing cost.

--- a/miqi/skills/mof-synthesis-price-agent/references/evidence-boundaries.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/evidence-boundaries.md
@@ -1,0 +1,35 @@
+# Evidence Boundaries
+
+## Supported Claims
+
+The skill may claim:
+
+- Routes and reagents were extracted from the provided paper text or SI evidence.
+- Pricing and supplier links were observed from scraper outputs at run time.
+- GHS/fire-risk fields came from scraped data or were explicitly marked as inferred/unknown.
+- Feasibility is a screening estimate based on available reagent, price, hazard, and missing-data evidence.
+
+## Unsupported Claims
+
+Do not claim:
+
+- The route is experimentally validated beyond what the paper reports.
+- Prices are current, complete, lowest available in the market, or legally binding.
+- A synthesis is safe, approved, compliant, or ready for lab execution.
+- Fire-risk classification is official when inferred from partial evidence.
+- The workflow predicts new reactions or designs new MOFs.
+- The skill has purchased reagents or checked institutional procurement rules.
+
+## Required Caveats
+
+When reporting final results, include caveats when relevant:
+
+- "价格为抓取时的在线报价/询价信息筛查，不代表真实采购成本。"
+- "安全/GHS/火灾风险为实验前筛查，不替代 SDS 和 EHS 审核。"
+- "缺少 CAS、GHS、报价或 SI 时，结论处于证据边界。"
+
+## Privacy And Secrets
+
+- Do not print API keys, cookies, tokens, or institutional credentials.
+- Do not write real credentials into skill files or generated reports.
+- Prefer local environment variables only when a user explicitly opts into an external service; this skill does not need DeepSeek by default.

--- a/miqi/skills/mof-synthesis-price-agent/references/failure-handling.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/failure-handling.md
@@ -1,0 +1,49 @@
+# Failure Handling
+
+## Stop
+
+Stop and report `failed` or `evidence_boundary` when:
+
+- Input path does not exist.
+- DOI/CSV contains no valid DOI-like values.
+- PDF text extraction returns no usable text and OCR is not available.
+- Cleaned text is too short or lacks synthesis/procedure evidence.
+- Agent JSON fails schema validation after one repair attempt.
+- Core project scripts are missing from the selected project root.
+- A DOI preflight resolves to a clearly non-MOF/COF/coordination-polymer material, such as LDH/oxide/hydroxide/electrocatalyst-only papers without MOF evidence.
+- Publisher or CNKI pages expose only metadata and no full text, SI, experimental section, or downloadable PDF after short bounded attempts.
+
+## Degrade And Continue
+
+Continue as `degraded_complete` when:
+
+- SI download fails but main PDF text is usable.
+- Some supplier sources are blocked, slow, or return no price.
+- Some reagents have CAS but no price/GHS data.
+- PDF report generation fails but HTML/Markdown report exists.
+- Optional fire-risk inference is weak; mark `unknown` instead of inventing a class.
+
+## Retry
+
+- Retry transient network or scraper failures once when the command supports it.
+- Do not change multiple parameter classes at once.
+- Preserve logs or terminal summaries in the final report.
+- For CNKI or other gated publisher paths, record coarse timing and timeout counts so future runs can identify access-probing waste.
+- For agent JSON repair, provide the validation error and relevant source evidence, then retry once.
+
+## Ask User
+
+Ask for input when:
+
+- Multiple plausible project roots exist and no current root contains the MOF pipeline scripts.
+- The user requests a regulatory, purchasing, or safety approval action beyond screening.
+- A commercial/license-sensitive download or credentialed access is required.
+- The paper text is unavailable and no DOI/PDF/link is provided.
+- A non-MOF paper was provided but the user still wants synthesis/pricing support under a different material workflow.
+
+## Known Project-Specific Behaviors
+
+- Existing `pipeline.py` and `batch.py` call DeepSeek-bound code in the original project. When using this skill's default agent path, avoid those calls for Step 3 and instead split the workflow into deterministic text extraction, agent extraction, enrichment, and reporting.
+- `report.py` can generate HTML and Markdown even when PDF rendering has optional dependency issues.
+- CAS-less custom intermediates should not be treated as failed pricing rows.
+- PowerShell may misread UTF-8 Chinese files with the default encoding. Validate JSON/Markdown with `Get-Content -Encoding UTF8`; write user-facing CSV with UTF-8-SIG.

--- a/miqi/skills/mof-synthesis-price-agent/references/real-sample-validation.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/real-sample-validation.md
@@ -1,0 +1,38 @@
+# Real Sample Validation
+
+Use this reference when validating that the MOF synthesis price workflow works on real evidence instead of synthetic fixtures.
+
+## Reality Run Acceptance
+
+A valid Reality Run must include:
+
+- real input: DOI, publisher/author PDF, local PDF, cleaned text extracted from a real paper, or a DOI/link table pointing to real papers
+- command/tool entrypoint: usually `scripts/mof_workflow.py <input> --project-root <project>`
+- output inventory: cleaned text, agent JSON when extraction is needed, routes/reagents CSV, enrichment CSVs when available, and HTML/Markdown/PDF report when report generation is available
+- completion state: `complete`, `degraded_complete`, `needs_agent_extraction`, `failed`, or `evidence_boundary`
+- explicit caveats: pricing is scraped/observed screening data, safety is not SDS/EHS approval, and synthesis extraction is limited to paper evidence
+
+## Recommended Smoke Samples
+
+Use known real MOF papers with public DOI/PDF evidence when available:
+
+- MOF-5 / IRMOF-1: DOI `10.1038/46248`; acceptable when a public author PDF or local PDF is available.
+- HKUST-1 / MOF-199: DOI `10.1126/science.283.5405.1148`; acceptable when the PDF or cleaned text is already available.
+
+If download is blocked, use a local PDF or cleaned text derived from the real paper. Record the blocker and keep the run at `needs_agent_extraction` or `evidence_boundary` instead of claiming full completion.
+
+## Negative Reality Sample
+
+Keep at least one real DOI that should stop cleanly at the scope boundary:
+
+- CNKI DOI `10.13815/j.cnki.jmtc(ns).2025.02.002` resolves to `溶剂热法制备NiCo-LDHs及其电催化析氧性能研究`, a NiCo-LDH paper rather than a MOF/COF/coordination-polymer synthesis paper. A correct run should use CNKI DOI preflight, produce metadata-only `evidence_boundary` outputs, avoid generic reagent guesses, and mention that PDF/experimental text is required for any non-MOF synthesis/pricing workflow.
+
+## Fixture Boundary
+
+Synthetic or hand-written JSON/CSV fixtures are allowed only for:
+
+- schema validation
+- CSV writer smoke tests
+- report rendering smoke tests
+
+They do not prove extraction quality, DOI/PDF acquisition, scientific completeness, price availability, or reality readiness.

--- a/miqi/skills/mof-synthesis-price-agent/references/schemas.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/schemas.md
@@ -1,0 +1,118 @@
+# Schemas And CSV Contract
+
+## JSON Schemas
+
+`SynthesisRoute`:
+
+```json
+{
+  "target_compound": "string",
+  "yield_percent": 78.0,
+  "temperature": "105 C",
+  "duration": "24 h",
+  "atmosphere": "air",
+  "procedure_text": "string",
+  "source": "main_text",
+  "route_type": "primary",
+  "source_text": "verbatim text or null"
+}
+```
+
+Required: `target_compound`, `procedure_text`, `source`. `source` must be `main_text` or `SI`. `route_type` defaults to `primary`.
+
+`Reagent`:
+
+```json
+{
+  "name": "DMF",
+  "name_zh": null,
+  "name_en": null,
+  "cas": "68-12-2",
+  "role": "solvent",
+  "amount": "30 mL",
+  "equiv": null,
+  "route_index": 0,
+  "is_controlled": false,
+  "pricing": [],
+  "fire_hazard": null,
+  "fire_hazard_basis": null,
+  "ghs_hazards": null,
+  "scraped_at": null
+}
+```
+
+Required: `name`, `role`, `route_index`, `is_controlled`. `role` must be one of `reactant`, `solvent`, `catalyst`, `ligand`, `modulator`, `workup`.
+
+`PriceEntry`:
+
+```json
+{
+  "supplier": "string",
+  "spec": "500 mL",
+  "purity": "99%",
+  "price_cny": 88.0,
+  "purchase_url": "https://example.com"
+}
+```
+
+`Feasibility`:
+
+```json
+{
+  "estimated_cost_cny": 188.0,
+  "has_toxic_reagent": false,
+  "has_high_fire_risk": false,
+  "has_controlled_substance": false,
+  "missing_data": [],
+  "llm_verdict": "screening verdict"
+}
+```
+
+## Agent Output Files
+
+`scripts/write_agent_outputs.py` accepts:
+
+```json
+{
+  "synthesis_routes": [],
+  "reagents": [],
+  "synthesis_summary": "",
+  "feasibility": {}
+}
+```
+
+At minimum, provide routes and reagents for Step 3 output.
+
+## CSV Headers
+
+`*_routes.csv`:
+
+```text
+route_index,target_compound,yield_percent,temperature,duration,atmosphere,procedure_text,source,route_type,source_text
+```
+
+`*_reagents.csv`:
+
+```text
+name,cas,role,amount,equiv,is_controlled,route_index,target_compound
+```
+
+`*_enriched.csv`:
+
+```text
+name,name_zh,name_en,cas,role,route_index,target_compound,ghs_hazards,fire_hazard,fire_hazard_basis,min_price_cny,cheapest_supplier,cheapest_spec,cheapest_url,pricing_count,scraped_at
+```
+
+`*_pricing.csv`:
+
+```text
+name,cas,role,route_index,supplier,spec,purity,price_cny,purchase_url
+```
+
+## Validation Rules
+
+- `route_index` must be `-1` or a valid zero-based route index.
+- A reagent name must not exactly match its own route target after normalization.
+- Empty routes from sufficient synthesis text are an evidence-boundary stop.
+- Empty reagents from sufficient synthesis text require one agent self-repair attempt.
+- CSVs must be written with UTF-8-SIG for Excel compatibility.

--- a/miqi/skills/mof-synthesis-price-agent/references/workflow.md
+++ b/miqi/skills/mof-synthesis-price-agent/references/workflow.md
@@ -1,0 +1,66 @@
+# Workflow Contract
+
+## Input Routing
+
+Choose the first matching route:
+
+| Input | Default action | Required next evidence |
+| --- | --- | --- |
+| DOI such as `10.xxxx/...` | Run `scripts/mof_workflow.py <doi>`; download PDF/SI and extract text when project tooling is available | cleaned text and `needs_agent_extraction` |
+| CSV/TSV/XLSX with `doi` and optional `link` | Run `scripts/mof_workflow.py <table>`; normalize DOI/link and batch deterministic acquisition | per-DOI cleaned text, ledger, or failure record |
+| Local PDF or folder of PDFs | Extract text from each PDF | cleaned text |
+| Cleaned `.txt` | Start agent extraction directly | paper text |
+| Agent extraction JSON | Validate/write standard CSV, then enrich/report | matching route/reagent CSVs |
+| Existing prefix with `*_routes.csv`, `*_reagents.csv`, `*_enriched.csv`, `*_pricing.csv` | Continue from the latest complete stage | matching CSV set |
+| Single CAS | Run single-compound enrichment/debug only | CAS and optional compound name |
+
+Inputs are alternatives, not all required. A full DOI/PDF workflow creates intermediate files automatically.
+
+## Stage Map
+
+| Stage | Purpose | Deterministic tool | Agent role | Output |
+| --- | --- | --- | --- | --- |
+| 0. Preflight | Identify input, project root, dependencies, output prefix | `scripts/mof_workflow.py` | decide route and stage scope | status JSON and output prefix |
+| 1. Text acquisition | Download/extract/reuse paper text | `scripts/mof_workflow.py`, `fetch/*`, `extract/text_extractor.py`, or existing txt | judge if text is sufficient | `*_cleaned.txt` |
+| 2. Structured extraction | Replace DeepSeek Call A/B/C/D | `scripts/write_agent_outputs.py` for writing | produce and validate routes, reagents, summary | `*_routes.csv`, `*_reagents.csv`, optional JSON |
+| 3. Enrichment | Price/GHS/fire-risk data | `enrich/chembook_scraper.py --batch <prefix>` | handle missing evidence and inferred fire-risk caveats | `*_enriched.csv`, `*_pricing.csv` |
+| 4. Feasibility | Cost/risk screening | optional JSON writer | produce feasibility JSON and <=100 char verdict | feasibility JSON or report metadata |
+| 5. Report | Human-readable outputs | `report.py <prefix>` | summarize completion and caveats | `*_report.html`, `*_report.md`, `*_report.pdf` |
+
+## Completion States
+
+- `complete`: required stages for the requested scope succeeded and outputs exist.
+- `degraded_complete`: core outputs exist but optional data is missing, such as SI, some pricing, one supplier source, or PDF report.
+- `needs_agent_extraction`: deterministic acquisition succeeded and Codex must now read cleaned text, generate agent JSON, and call the router again.
+- `failed`: requested scope cannot produce usable output due to invalid input, missing core tool, command failure, or corrupt artifact.
+- `evidence_boundary`: source evidence is insufficient for a truthful extraction or claim, such as no text layer, too-short text, no synthesis section, or schema validation failure after one repair.
+
+## Router Status JSON
+
+`scripts/mof_workflow.py` returns:
+
+```json
+{
+  "input_type": "pdf|cleaned_txt|agent_json|csv_prefix|doi|doi_table",
+  "prefix": "output/skill_runs/example",
+  "created_files": [],
+  "next_action": "human-readable next step",
+  "completion_state": "complete|degraded_complete|needs_agent_extraction|failed|evidence_boundary",
+  "missing_or_failed": [],
+  "counts": {}
+}
+```
+
+Treat this JSON as the handoff contract. If `completion_state` is `needs_agent_extraction`, do not stop; perform Codex agent extraction and then rerun the router on the generated agent JSON.
+
+## Default Commands
+
+Use the router from the project root or any current workspace that contains the MOF project:
+
+```powershell
+python "<skill-dir>\scripts\mof_workflow.py" <input> --project-root "<mof-project-root>"
+```
+
+If `--project-root` is omitted, the router searches the current directory, `MOF_PRICE_PROJECT`, and nearby skill/project locations for `extract/`, `enrich/`, and `report.py`.
+
+Do not call the original full `pipeline.py` or `batch.py` in the default path because those enter DeepSeek-bound extraction. Split the workflow through router acquisition, Codex agent extraction, router enrichment, and router report generation.

--- a/miqi/skills/mof-synthesis-price-agent/scripts/cnki_doi_preflight.py
+++ b/miqi/skills/mof-synthesis-price-agent/scripts/cnki_doi_preflight.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+"""Fast CNKI DOI metadata preflight for evidence-boundary decisions."""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+import time
+from html.parser import HTMLParser
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+DOI_RE = re.compile(r"10\.\d{4,}/[^\s,;\"'<>]+", re.I)
+FIELD_BOUNDARY_RE = re.compile(r"(题名|作者|来源|出版机构|出版年|DOI码|注册时间)\s*[:：]|以下是您获得", re.S)
+POSITIVE_RE = re.compile(
+    r"\bMOFs?\b|\bCOFs?\b|metal[- ]organic framework|covalent organic framework|"
+    r"coordination polymer|金属有机框架|共价有机框架|配位聚合物",
+    re.I,
+)
+NEGATIVE_RE = re.compile(
+    r"\bLDHs?\b|layered double hydroxide|层状双金属氢氧化物|氢氧化物|氧化物|硫化物|"
+    r"磷化物|合金|析氧|电催化",
+    re.I,
+)
+
+
+class TextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = data.strip()
+        if text:
+            self.parts.append(text)
+
+
+def _extract_doi(value: str) -> str:
+    match = DOI_RE.search(value)
+    if not match:
+        raise ValueError("No DOI-like value found.")
+    return match.group(0)
+
+
+def _fetch_cnki_handler(doi: str, timeout: int) -> tuple[str, str]:
+    url = "https://doi.cnki.net/resolution/handler?doi=" + quote(doi, safe="")
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urlopen(req, timeout=timeout) as resp:
+        raw = resp.read()
+        charset = resp.headers.get_content_charset() or "utf-8"
+    return url, raw.decode(charset, errors="replace")
+
+
+def _field(text: str, label: str) -> str | None:
+    pattern = re.compile(re.escape(label) + r"\s*[:：]\s*(.*?)(?=" + FIELD_BOUNDARY_RE.pattern + r"|$)", re.S)
+    match = pattern.search(text)
+    if not match:
+        return None
+    value = re.sub(r"\s+", " ", match.group(1)).strip(" ;；")
+    if label == "注册时间":
+        date_match = re.search(r"\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}", value)
+        if date_match:
+            value = date_match.group(0)
+    return html.unescape(value) or None
+
+
+def _scope(title: str | None) -> str:
+    if not title:
+        return "unknown"
+    positive = bool(POSITIVE_RE.search(title))
+    negative = bool(NEGATIVE_RE.search(title))
+    if positive:
+        return "mof_like"
+    if negative:
+        return "not_mof"
+    return "unknown"
+
+
+def preflight(value: str, timeout: int) -> dict[str, object]:
+    started = time.perf_counter()
+    doi = _extract_doi(value)
+    result: dict[str, object] = {
+        "input": value,
+        "doi": doi,
+        "source": "cnki_doi_handler",
+        "status": "failed",
+        "url": None,
+        "title": None,
+        "authors": [],
+        "publication_institution": None,
+        "doi_registration_time": None,
+        "material_scope": "unknown",
+        "completion_state_hint": "failed",
+        "elapsed_ms": None,
+        "error": None,
+    }
+    try:
+        url, body = _fetch_cnki_handler(doi, timeout)
+        parser = TextParser()
+        parser.feed(body)
+        text = "\n".join(parser.parts)
+        title = _field(text, "题名")
+        authors_raw = _field(text, "作者") or ""
+        authors = [item for item in re.split(r"[;；]\s*", authors_raw) if item]
+        result.update(
+            {
+                "status": "reachable",
+                "url": url,
+                "title": title,
+                "authors": authors,
+                "publication_institution": _field(text, "出版机构"),
+                "doi_registration_time": _field(text, "注册时间"),
+                "material_scope": _scope(title),
+            }
+        )
+        result["completion_state_hint"] = (
+            "evidence_boundary" if result["material_scope"] == "not_mof" else "continue_or_need_full_text"
+        )
+    except Exception as exc:
+        result["error"] = str(exc)
+    finally:
+        result["elapsed_ms"] = round((time.perf_counter() - started) * 1000)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Preflight CNKI DOI metadata and MOF scope.")
+    parser.add_argument("doi_or_url")
+    parser.add_argument("--timeout", type=int, default=10)
+    args = parser.parse_args()
+    data = preflight(args.doi_or_url, args.timeout)
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+    return 0 if data["status"] == "reachable" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/miqi/skills/mof-synthesis-price-agent/scripts/mof_workflow.py
+++ b/miqi/skills/mof-synthesis-price-agent/scripts/mof_workflow.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python
+"""Deterministic workflow helper for the MOF synthesis price skill.
+
+This script intentionally does not call DeepSeek or any external LLM. It routes
+inputs, performs deterministic project-tool stages, and returns JSON status so
+Codex can decide when agent extraction is required.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import unquote, urlparse
+from typing import Any
+
+
+DOI_RE = re.compile(r"10\.\d{4,}/[^\s,;\"'<>]+", re.I)
+CAS_RE = re.compile(r"^\d{2,7}-\d{2}-\d$")
+CNKI_RE = re.compile(r"j\.cnki|cnki\.net/doi|doi\.cnki\.net", re.I)
+SYNTHESIS_HINT_RE = re.compile(
+    r"synth|prepar|experimental|procedure|solvothermal|hydrothermal|配制|合成|制备|实验",
+    re.I,
+)
+
+
+@dataclass
+class WorkflowState:
+    input: str
+    input_type: str = "unknown"
+    project_root: str = ""
+    prefix: str = ""
+    created_files: list[str] = field(default_factory=list)
+    next_action: str = ""
+    completion_state: str = "failed"
+    missing_or_failed: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+    batch_ledger: str | None = None
+    stage_timeout: int = 600
+
+    def add_file(self, path: str | Path | None) -> None:
+        if not path:
+            return
+        p = str(path)
+        if p not in self.created_files:
+            self.created_files.append(p)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "input": self.input,
+            "input_type": self.input_type,
+            "project_root": self.project_root,
+            "prefix": self.prefix,
+            "created_files": self.created_files,
+            "next_action": self.next_action,
+            "completion_state": self.completion_state,
+            "missing_or_failed": self.missing_or_failed,
+            "counts": self.counts,
+            "batch_ledger": self.batch_ledger,
+        }
+
+
+def _json_print(state: WorkflowState | dict[str, Any]) -> None:
+    data = state.to_dict() if isinstance(state, WorkflowState) else state
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _die(state: WorkflowState, message: str, state_name: str = "failed") -> WorkflowState:
+    state.completion_state = state_name
+    state.next_action = message
+    state.missing_or_failed.append(message)
+    return state
+
+
+def _slug(value: str) -> str:
+    value = DOI_RE.search(value).group(0) if DOI_RE.search(value) else value
+    return re.sub(r'[<>:"/\\|?*\x00-\x1f\s]+', "_", value.strip()).strip("_")[:120] or "mof_input"
+
+
+def _script_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _skill_root() -> Path:
+    return _script_root().parent
+
+
+def _find_project_root(explicit: str | None) -> Path:
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit))
+    candidates.extend([
+        Path.cwd(),
+        Path(os.environ["MOF_PRICE_PROJECT"]) if os.environ.get("MOF_PRICE_PROJECT") else None,
+        _skill_root().parent,
+    ])
+    required = [
+        "extract/text_extractor.py",
+        "enrich/chembook_scraper.py",
+        "report.py",
+    ]
+    for base in [candidate for candidate in candidates if candidate is not None]:
+        try:
+            root = base.resolve()
+        except OSError:
+            continue
+        if all((root / item).exists() for item in required):
+            return root
+    raise FileNotFoundError("Cannot find project root with extract/, enrich/, and report.py.")
+
+
+def _run(cmd: list[str], cwd: Path, state: WorkflowState) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=state.stage_timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        return subprocess.CompletedProcess(
+            cmd,
+            124,
+            stdout=stdout,
+            stderr=f"Command timed out after {state.stage_timeout}s: {' '.join(cmd)}",
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        state.missing_or_failed.append(f"Command failed to start: {' '.join(cmd)}: {exc}")
+        raise
+
+
+def _count_csv_rows(path: Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open(encoding="utf-8-sig", newline="") as f:
+        return sum(1 for _ in csv.DictReader(f))
+
+
+def _detect(input_value: str) -> tuple[str, Path | None, str | None]:
+    text = input_value.strip().strip('"')
+    p = Path(text)
+    if p.exists():
+        if p.is_dir():
+            if list(p.glob("*.pdf")):
+                return "pdf_folder", p, None
+            return "directory", p, None
+        suffix = p.suffix.lower()
+        if suffix == ".pdf":
+            return "pdf", p, None
+        if suffix == ".txt":
+            content = p.read_text(encoding="utf-8", errors="ignore")
+            stripped = content.strip()
+            if CAS_RE.fullmatch(stripped):
+                return "single_cas", None, stripped
+            if DOI_RE.search(content) and len(content.strip().splitlines()) <= 100:
+                return "doi_text_file", p, None
+            return "cleaned_txt", p, None
+        if suffix in {".json"}:
+            return "agent_json", p, None
+        if suffix in {".csv", ".tsv", ".xlsx", ".xls"}:
+            # Existing prefix may be passed as a CSV path.
+            if suffix == ".csv" and p.name.endswith(("_routes.csv", "_reagents.csv", "_enriched.csv", "_pricing.csv")):
+                stem = re.sub(r"_(routes|reagents|enriched|pricing)\.csv$", "", str(p), flags=re.I)
+                return "csv_prefix", Path(stem), None
+            return "doi_table", p, None
+    if DOI_RE.fullmatch(text) or DOI_RE.search(text):
+        return "doi", None, DOI_RE.search(text).group(0)
+    if CAS_RE.fullmatch(text):
+        return "single_cas", None, text
+    prefix = Path(text)
+    if any(prefix.parent.glob(prefix.name + "_*.csv")):
+        return "csv_prefix", prefix, None
+    return "unknown", p, None
+
+
+def _cnki_preflight_fallback(input_value: str, state: WorkflowState) -> WorkflowState:
+    try:
+        from cnki_doi_preflight import preflight
+    except Exception as exc:
+        return _die(state, f"Cannot import CNKI DOI preflight helper: {exc}")
+
+    data = preflight(input_value, timeout=min(10, max(1, state.stage_timeout)))
+    state.input_type = "doi"
+    state.counts["cnki_preflight_elapsed_ms"] = int(data.get("elapsed_ms") or 0)
+    state.counts["routes"] = 0
+    state.counts["reagents"] = 0
+    if data.get("status") != "reachable":
+        return _die(state, f"CNKI DOI preflight failed: {data.get('error') or 'metadata unavailable'}", "failed")
+
+    title = data.get("title") or ""
+    scope = data.get("material_scope") or "unknown"
+    state.created_files = []
+    if scope == "not_mof":
+        state.completion_state = "evidence_boundary"
+        state.next_action = (
+            f"CNKI DOI preflight resolved a non-MOF/COF/coordination-polymer title: {title}. "
+            "Do not infer MOF routes/reagents/prices; ask for a non-MOF workflow or the paper PDF/experimental section."
+        )
+        state.missing_or_failed.append("Input is outside MOF/COF/coordination-polymer scope.")
+        return state
+
+    state.completion_state = "evidence_boundary"
+    state.next_action = (
+        "CNKI DOI metadata is reachable, but no MOF project root/full text is available. "
+        "Provide a local PDF, exported text, or project root to continue."
+    )
+    state.missing_or_failed.append("Project root/full text unavailable after CNKI metadata preflight.")
+    return state
+
+
+def _needs_agent_from_text(path: Path, prefix: Path, state: WorkflowState, input_type: str = "cleaned_txt") -> WorkflowState:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    state.input_type = input_type
+    state.prefix = str(prefix)
+    state.add_file(path)
+    if len(text.strip()) < 500 or not SYNTHESIS_HINT_RE.search(text):
+        return _die(
+            state,
+            "Cleaned text is too short or lacks synthesis/procedure evidence.",
+            "evidence_boundary",
+        )
+    state.completion_state = "needs_agent_extraction"
+    state.next_action = (
+        "Read cleaned_text, produce agent JSON with synthesis_routes/reagents/summary/feasibility, "
+        "then run this helper on that JSON to continue enrichment and report."
+    )
+    state.counts["cleaned_text_chars"] = len(text)
+    return state
+
+
+def _extract_pdf(pdf: Path, prefix: Path, project_root: Path, state: WorkflowState) -> WorkflowState:
+    out_txt = prefix.parent / f"{prefix.name}_cleaned.txt"
+    out_txt.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [sys.executable, "extract/text_extractor.py", str(pdf), "-o", str(out_txt), "--preview", "0"]
+    result = _run(cmd, project_root, state)
+    if result.returncode != 0:
+        return _die(state, result.stderr.strip() or result.stdout.strip() or "PDF text extraction failed.")
+    if not out_txt.exists() or not out_txt.read_text(encoding="utf-8", errors="ignore").strip():
+        return _die(state, "PDF text extraction returned no usable text; OCR/manual text is required.", "evidence_boundary")
+    state.add_file(out_txt)
+    return _needs_agent_from_text(out_txt, prefix, state, input_type=state.input_type)
+
+
+def _download_doi(doi: str, link: str, prefix: Path, project_root: Path, state: WorkflowState) -> WorkflowState:
+    downloads = project_root / "downloads"
+    downloads.mkdir(exist_ok=True)
+
+    fallback_pdf = _download_link_fallback(doi, link, downloads, state)
+    if fallback_pdf:
+        state.add_file(fallback_pdf)
+        return _extract_pdf(fallback_pdf, prefix, project_root, state)
+
+    try:
+        sys.path.insert(0, str(project_root))
+        from fetch.paper_fetcher import fetch_pdf  # type: ignore
+    except Exception as exc:
+        return _die(state, f"Cannot import DOI fetch tools: {exc}")
+
+    # Keep this deterministic and secret-free: do not instantiate the project
+    # Config class because it reads DEEPSEEK_API_KEY from .env/env by default.
+    cfg = SimpleNamespace(
+        fetch_timeout=60,
+        scrape_retry=3,
+        scrape_delay_min=1.0,
+        scrape_delay_max=3.0,
+        unpaywall_email=os.environ.get("UNPAYWALL_EMAIL", ""),
+        scihub_mirrors=[
+            "https://sci-hub.ee",
+            "https://sci-hub.ru",
+        ],
+    )
+    pdf_result = fetch_pdf(doi, cfg, downloads)
+    if pdf_result.status == "fetch_failed" or not pdf_result.pdf_path:
+        return _die(state, pdf_result.error or "PDF download failed.")
+    state.add_file(pdf_result.pdf_path)
+    return _extract_pdf(Path(pdf_result.pdf_path), prefix, project_root, state)
+
+
+def _handle_single_cas(cas: str, output_dir: Path, project_root: Path, state: WorkflowState) -> WorkflowState:
+    prefix = output_dir / cas.replace("/", "-")
+    state.input_type = "single_cas"
+    state.prefix = str(prefix)
+    cmd = [
+        sys.executable,
+        "enrich/chembook_scraper.py",
+        cas,
+        "--name",
+        "compound",
+        "-o",
+        str(prefix),
+    ]
+    result = _run(cmd, project_root, state)
+    pricing_csv = prefix.parent / f"{prefix.name}_pricing.csv"
+    if pricing_csv.exists():
+        state.add_file(pricing_csv)
+        state.counts["price_entries"] = _count_csv_rows(pricing_csv)
+    if result.returncode != 0 and not pricing_csv.exists():
+        return _die(state, result.stderr.strip() or result.stdout.strip() or "Single CAS enrichment failed.")
+    state.completion_state = "complete" if pricing_csv.exists() else "degraded_complete"
+    state.next_action = "Use the pricing CSV as single-CAS scraper/debug evidence; this is not a full paper pipeline."
+    if result.returncode != 0:
+        state.missing_or_failed.append(result.stderr.strip() or result.stdout.strip() or "Single CAS enrichment had warnings.")
+    return state
+
+
+def _download_link_fallback(doi: str, link: str, downloads: Path, state: WorkflowState) -> Path | None:
+    """Best-effort direct PDF fallback for doi,link tables.
+
+    The link column is often a DOI landing page, which may still be blocked; only
+    accept responses that are real PDF bytes so we do not save HTML as a paper.
+    """
+    if not link or not link.lower().startswith(("http://", "https://")):
+        return None
+    try:
+        import requests
+    except Exception as exc:
+        state.missing_or_failed.append(f"Direct link fallback unavailable: requests import failed: {exc}")
+        return None
+
+    candidates = [link]
+    parsed = urlparse(link)
+    if parsed.netloc.lower().endswith("doi.org"):
+        return None
+    if link.lower().endswith(".pdf") is False and "/pdf" not in link.lower():
+        candidates.extend([
+            link.rstrip("/") + ".pdf",
+            link.replace("/article/", "/content/pdf/").rstrip("/") + ".pdf",
+        ])
+
+    headers = {"User-Agent": "Mozilla/5.0", "Accept": "application/pdf,text/html,*/*;q=0.8"}
+    safe = _slug(doi)
+    for url in dict.fromkeys(candidates):
+        try:
+            resp = requests.get(url, headers=headers, timeout=state.stage_timeout, allow_redirects=True)
+            if resp.status_code >= 400:
+                continue
+            content = resp.content
+            content_type = resp.headers.get("content-type", "").lower()
+            final_url = unquote(resp.url)
+            if not (content.startswith(b"%PDF-") or "application/pdf" in content_type or final_url.lower().endswith(".pdf")):
+                continue
+            if not content.startswith(b"%PDF-"):
+                continue
+            downloads.mkdir(parents=True, exist_ok=True)
+            out = downloads / f"{safe}_link.pdf"
+            out.write_bytes(content)
+            return out
+        except Exception as exc:
+            state.missing_or_failed.append(f"Direct link fallback failed for {url[:120]}: {exc}")
+    return None
+
+
+def _read_doi_pairs(path: Path, project_root: Path, state: WorkflowState) -> list[tuple[str, str]]:
+    suffix = path.suffix.lower()
+    prepared = path
+    if suffix in {".csv", ".xlsx", ".xls", ".tsv"} and not path.name.endswith("_prepared_dois.csv"):
+        prepared = path.with_name(path.stem + "_prepared_dois.csv")
+        cmd = [sys.executable, str(_script_root() / "prepare_doi_csv.py"), str(path), "-o", str(prepared)]
+        result = _run(cmd, project_root, state)
+        if result.returncode != 0:
+            state.missing_or_failed.append(result.stderr.strip() or result.stdout.strip() or "DOI table normalization failed.")
+            return []
+        state.add_file(prepared)
+
+    if prepared.suffix.lower() == ".txt":
+        pairs = []
+        for line in prepared.read_text(encoding="utf-8-sig", errors="ignore").splitlines():
+            m = DOI_RE.search(line)
+            if m:
+                pairs.append((m.group(0), ""))
+        return pairs
+
+    delimiter = "\t" if prepared.suffix.lower() == ".tsv" else ","
+    pairs: list[tuple[str, str]] = []
+    with prepared.open(encoding="utf-8-sig", newline="") as f:
+        sample = f.read(4096)
+        f.seek(0)
+        if "doi" not in sample.lower() and DOI_RE.search(sample):
+            return [(m.group(0), "") for m in DOI_RE.finditer(sample)]
+        reader = csv.DictReader(f, delimiter=delimiter)
+        for row in reader:
+            doi = row.get("doi", "").strip()
+            link = row.get("link", "").strip()
+            if doi:
+                pairs.append((doi, link))
+    return pairs
+
+
+def _handle_batch(path: Path, project_root: Path, output_dir: Path, state: WorkflowState) -> WorkflowState:
+    pairs = _read_doi_pairs(path, project_root, state)
+    if not pairs:
+        return _die(state, "No valid DOI values found in the input.", "failed")
+    ledger_rows: list[dict[str, Any]] = []
+    any_success = False
+    for doi, link in pairs:
+        prefix = output_dir / _slug(doi) / _slug(doi)
+        child = WorkflowState(
+            input=doi,
+            input_type="doi",
+            project_root=str(project_root),
+            prefix=str(prefix),
+            stage_timeout=state.stage_timeout,
+        )
+        child = _download_doi(doi, link, prefix, project_root, child)
+        any_success = any_success or child.completion_state in {"needs_agent_extraction", "complete", "degraded_complete"}
+        ledger_rows.append({
+            "input": doi,
+            "prefix": child.prefix,
+            "status": child.completion_state,
+            "next_action": child.next_action,
+            "missing_or_failed": " | ".join(child.missing_or_failed),
+        })
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ledger_csv = output_dir / "batch_ledger.csv"
+    ledger_json = output_dir / "batch_ledger.json"
+    with ledger_csv.open("w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.DictWriter(f, fieldnames=["input", "prefix", "status", "next_action", "missing_or_failed"])
+        writer.writeheader()
+        writer.writerows(ledger_rows)
+    ledger_json.write_text(json.dumps(ledger_rows, ensure_ascii=False, indent=2), encoding="utf-8")
+    state.add_file(ledger_csv)
+    state.add_file(ledger_json)
+    state.batch_ledger = str(ledger_csv)
+    state.counts["batch_inputs"] = len(pairs)
+    for row in ledger_rows:
+        key = f"batch_{row['status']}"
+        state.counts[key] = state.counts.get(key, 0) + 1
+    if any(r["status"] == "needs_agent_extraction" for r in ledger_rows):
+        state.completion_state = "needs_agent_extraction"
+        state.next_action = (
+            "For every ledger row with status=needs_agent_extraction, read <prefix>_cleaned.txt, "
+            "write <prefix>_agent_extraction.json with Codex agent extraction, run this helper on each JSON, "
+            "then summarize the final per-paper reports."
+        )
+    elif any_success:
+        state.completion_state = "degraded_complete"
+        state.next_action = "Review the ledger; no remaining row is waiting for agent extraction."
+    else:
+        state.completion_state = "failed"
+        state.next_action = "No DOI could be downloaded/extracted; provide local PDFs or direct PDF links."
+    if not any_success:
+        state.missing_or_failed.append("No DOI could be downloaded/extracted.")
+    return state
+
+
+def _continue_from_json(json_path: Path, prefix: Path, project_root: Path, state: WorkflowState, skip_enrich: bool, skip_report: bool, price_mode: str = "fast") -> WorkflowState:
+    cmd = [sys.executable, str(_script_root() / "write_agent_outputs.py"), str(json_path), str(prefix)]
+    result = _run(cmd, project_root, state)
+    if result.returncode != 0:
+        return _die(state, result.stderr.strip() or result.stdout.strip() or "Agent JSON validation/write failed.", "evidence_boundary")
+    for suffix in ["_agent_extraction.json", "_synthesis_summary.md", "_feasibility.json", "_routes.csv", "_reagents.csv"]:
+        p = prefix.parent / f"{prefix.name}{suffix}"
+        if p.exists():
+            state.add_file(p)
+    if skip_enrich:
+        state.completion_state = "complete"
+        state.counts.update({
+            "routes": _count_csv_rows(prefix.parent / f"{prefix.name}_routes.csv"),
+            "reagents": _count_csv_rows(prefix.parent / f"{prefix.name}_reagents.csv"),
+        })
+        state.next_action = "Run router again without --skip-enrich to scrape pricing/GHS and generate reports."
+        return state
+    return _enrich_and_report(prefix, project_root, state, skip_report=skip_report, price_mode=price_mode)
+
+
+def _required_csv_status(prefix: Path) -> tuple[list[str], dict[str, int]]:
+    required_headers = {
+        "_routes.csv": {"route_index", "target_compound", "procedure_text", "source"},
+        "_reagents.csv": {"name", "role", "route_index", "target_compound"},
+    }
+    missing: list[str] = []
+    counts: dict[str, int] = {}
+    for suffix, required in required_headers.items():
+        path = prefix.parent / f"{prefix.name}{suffix}"
+        label = suffix.removeprefix("_").removesuffix(".csv")
+        if not path.exists():
+            missing.append(f"Missing required CSV: {path}")
+            counts[label] = 0
+            continue
+        with path.open(encoding="utf-8-sig", newline="") as f:
+            reader = csv.DictReader(f)
+            headers = set(reader.fieldnames or [])
+            absent = sorted(required - headers)
+            if absent:
+                missing.append(f"{path} is missing required column(s): {', '.join(absent)}")
+            rows = list(reader)
+            counts[label] = len(rows)
+            if not rows:
+                missing.append(f"{path} has no data rows.")
+    return missing, counts
+
+
+def _enrich_and_report(prefix: Path, project_root: Path, state: WorkflowState, skip_report: bool = False, price_mode: str = "fast") -> WorkflowState:
+    missing_required, required_counts = _required_csv_status(prefix)
+    state.counts.update(required_counts)
+    if missing_required:
+        state.missing_or_failed.extend(missing_required)
+        state.next_action = "Provide a complete CSV prefix with valid *_routes.csv and *_reagents.csv, or rerun from agent JSON."
+        state.completion_state = "failed"
+        return state
+
+    reagents_csv = prefix.parent / f"{prefix.name}_reagents.csv"
+
+    enriched_csv = prefix.parent / f"{prefix.name}_enriched.csv"
+    pricing_csv = prefix.parent / f"{prefix.name}_pricing.csv"
+    if not (enriched_csv.exists() and pricing_csv.exists()):
+        result = _run([sys.executable, "enrich/chembook_scraper.py", "--batch", str(prefix), "--price-mode", price_mode], project_root, state)
+        if result.returncode != 0:
+            state.missing_or_failed.append(result.stderr.strip() or result.stdout.strip() or "Pricing/GHS enrichment failed.")
+            state.completion_state = "degraded_complete"
+            state.next_action = "Review enrichment failure; report generation may still be possible if enriched/pricing CSVs exist."
+        profile_csv = prefix.parent / f"{prefix.name}_pricing_profile.csv"
+        for p in [enriched_csv, pricing_csv, profile_csv]:
+            if p.exists():
+                state.add_file(p)
+
+    if skip_report:
+        state.completion_state = "complete"
+        state.counts.update({
+            "routes": _count_csv_rows(prefix.parent / f"{prefix.name}_routes.csv"),
+            "reagents": _count_csv_rows(reagents_csv),
+            "enriched_rows": _count_csv_rows(enriched_csv),
+            "price_entries": _count_csv_rows(pricing_csv),
+            "pricing_profile_rows": _count_csv_rows(prefix.parent / f"{prefix.name}_pricing_profile.csv"),
+        })
+        state.next_action = "Run router again without --skip-report to generate HTML/MD/PDF reports."
+        return state
+
+    result = _run([sys.executable, "report.py", str(prefix)], project_root, state)
+    html = prefix.parent / f"{prefix.name}_report.html"
+    md = prefix.parent / f"{prefix.name}_report.md"
+    pdf = prefix.parent / f"{prefix.name}_report.pdf"
+    for p in [html, md, pdf]:
+        if p.exists():
+            state.add_file(p)
+    if result.returncode != 0 and not (html.exists() or md.exists()):
+        return _die(state, result.stderr.strip() or result.stdout.strip() or "Report generation failed.")
+    if result.returncode != 0 or not pdf.exists():
+        state.completion_state = "degraded_complete"
+        state.missing_or_failed.append("PDF report may be missing; HTML/MD report is the primary fallback.")
+    elif state.completion_state not in {"degraded_complete"}:
+        state.completion_state = "complete"
+
+    state.counts.update({
+        "routes": _count_csv_rows(prefix.parent / f"{prefix.name}_routes.csv"),
+        "reagents": _count_csv_rows(reagents_csv),
+        "enriched_rows": _count_csv_rows(enriched_csv),
+        "price_entries": _count_csv_rows(pricing_csv),
+        "pricing_profile_rows": _count_csv_rows(prefix.parent / f"{prefix.name}_pricing_profile.csv"),
+    })
+    state.next_action = "Open the report first; use CSV/JSON files for audit or continuation."
+    return state
+
+
+def run_auto(
+    input_value: str,
+    project_root_arg: str | None,
+    output_dir_arg: str,
+    skip_enrich: bool = False,
+    skip_report: bool = False,
+    stage_timeout: int = 600,
+    price_mode: str = "fast",
+) -> WorkflowState:
+    state = WorkflowState(input=input_value, stage_timeout=stage_timeout)
+    input_type, path, doi = _detect(input_value)
+    state.input_type = input_type
+    try:
+        project_root = _find_project_root(project_root_arg)
+    except Exception as exc:
+        if input_type == "doi" and CNKI_RE.search(input_value):
+            return _cnki_preflight_fallback(input_value, state)
+        return _die(state, str(exc))
+    state.project_root = str(project_root)
+    output_dir = Path(output_dir_arg)
+    if not output_dir.is_absolute():
+        output_dir = project_root / output_dir
+
+    if input_type == "unknown":
+        return _die(state, "Input was not recognized as DOI, path, JSON, PDF, text, table, or CSV prefix.")
+    if input_type == "directory":
+        return _die(state, "Directory has no PDFs and is not a recognized CSV prefix.")
+
+    if input_type == "doi":
+        assert doi
+        prefix = output_dir / _slug(doi) / _slug(doi)
+        state.prefix = str(prefix)
+        return _download_doi(doi, "", prefix, project_root, state)
+    if input_type == "single_cas":
+        assert doi
+        return _handle_single_cas(doi, output_dir, project_root, state)
+    if input_type == "doi_text_file":
+        assert path
+        return _handle_batch(path, project_root, output_dir / path.stem, state)
+    if input_type == "doi_table":
+        assert path
+        return _handle_batch(path, project_root, output_dir / path.stem, state)
+    if input_type == "pdf":
+        assert path
+        prefix = output_dir / path.stem
+        state.prefix = str(prefix)
+        return _extract_pdf(path, prefix, project_root, state)
+    if input_type == "pdf_folder":
+        assert path
+        rows: list[dict[str, Any]] = []
+        any_success = False
+        for pdf in sorted(path.glob("*.pdf")):
+            prefix = output_dir / path.name / pdf.stem
+            child = WorkflowState(
+                input=str(pdf),
+                input_type="pdf",
+                project_root=str(project_root),
+                prefix=str(prefix),
+                stage_timeout=state.stage_timeout,
+            )
+            child = _extract_pdf(pdf, prefix, project_root, child)
+            any_success = any_success or child.completion_state == "needs_agent_extraction"
+            rows.append({"input": str(pdf), "prefix": child.prefix, "status": child.completion_state, "next_action": child.next_action, "missing_or_failed": " | ".join(child.missing_or_failed)})
+        ledger = output_dir / path.name / "batch_ledger.csv"
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.open("w", newline="", encoding="utf-8-sig") as f:
+            writer = csv.DictWriter(f, fieldnames=["input", "prefix", "status", "next_action", "missing_or_failed"])
+            writer.writeheader()
+            writer.writerows(rows)
+        state.add_file(ledger)
+        state.batch_ledger = str(ledger)
+        for row in rows:
+            key = f"batch_{row['status']}"
+            state.counts[key] = state.counts.get(key, 0) + 1
+        state.completion_state = "needs_agent_extraction" if any_success else "failed"
+        state.next_action = (
+            "For every ledger row with status=needs_agent_extraction, read <prefix>_cleaned.txt, "
+            "write <prefix>_agent_extraction.json with Codex agent extraction, run this helper on each JSON, "
+            "then summarize the final per-paper reports."
+        ) if any_success else "No PDF in the folder produced usable text."
+        return state
+    if input_type == "cleaned_txt":
+        assert path
+        prefix = output_dir / path.stem.removesuffix("_cleaned")
+        return _needs_agent_from_text(path, prefix, state)
+    if input_type == "agent_json":
+        assert path
+        prefix = output_dir / path.stem.removesuffix("_agent_extraction")
+        state.prefix = str(prefix)
+        return _continue_from_json(path, prefix, project_root, state, skip_enrich=skip_enrich, skip_report=skip_report, price_mode=price_mode)
+    if input_type == "csv_prefix":
+        assert path
+        state.prefix = str(path)
+        return _enrich_and_report(path, project_root, state, skip_report=skip_report, price_mode=price_mode)
+    return _die(state, f"Unhandled input type: {input_type}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MOF skill deterministic workflow helper.")
+    parser.add_argument("input", help="DOI, path, table, JSON, text, PDF, folder, or CSV prefix.")
+    parser.add_argument("--project-root", help="Project root containing extract/, enrich/, report.py.")
+    parser.add_argument("-o", "--output-dir", default="output/skill_runs", help="Output directory for generated artifacts.")
+    parser.add_argument("--json", action="store_true", help="Print JSON status (default behavior).")
+    parser.add_argument("--skip-enrich", action="store_true", help="Stop after validated routes/reagents CSVs are written from agent JSON.")
+    parser.add_argument("--skip-report", action="store_true", help="Run enrichment if needed but skip report generation.")
+    parser.add_argument("--stage-timeout", type=int, default=600, help="Seconds before a deterministic subprocess degrades or fails.")
+    parser.add_argument("--price-mode", choices=["fast", "full"], default="fast", help="Pricing mode passed to enrichment.")
+    args = parser.parse_args()
+
+    # Do not inherit stale DeepSeek credentials into subprocess paths.
+    os.environ.pop("DEEPSEEK_API_KEY", None)
+
+    state = run_auto(
+        args.input,
+        args.project_root,
+        args.output_dir,
+        skip_enrich=args.skip_enrich,
+        skip_report=args.skip_report,
+        stage_timeout=args.stage_timeout,
+        price_mode=args.price_mode,
+    )
+    _json_print(state)
+    return 0 if state.completion_state in {"complete", "degraded_complete", "needs_agent_extraction", "evidence_boundary"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/miqi/skills/mof-synthesis-price-agent/scripts/prepare_doi_csv.py
+++ b/miqi/skills/mof-synthesis-price-agent/scripts/prepare_doi_csv.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+"""Normalize DOI/link tables to a UTF-8-SIG CSV with columns doi,link."""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+DOI_RE = re.compile(r"10\.\d{4,}/[^\s,;\"']+", re.I)
+
+
+def _clean_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return "" if text.lower() in {"nan", "none", "null"} else text
+
+
+def _extract_doi(value: Any) -> str:
+    match = DOI_RE.search(_clean_cell(value))
+    if not match:
+        return ""
+    doi = match.group(0)
+    doi = re.sub(r"^https?://(?:dx\.)?doi\.org/", "", doi, flags=re.I)
+    return doi.rstrip(".。),，;；]】}>")
+
+
+def _looks_like_link(value: Any) -> str:
+    text = _clean_cell(value)
+    if text.startswith(("http://", "https://")):
+        return text
+    return ""
+
+
+def _read_rows(path: Path, sheet: str | int | None) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix in {".csv", ".tsv"}:
+        delimiter = "\t" if suffix == ".tsv" else ","
+        for encoding in ("utf-8-sig", "utf-8", "gbk"):
+            try:
+                with path.open("r", encoding=encoding, newline="") as f:
+                    return list(csv.DictReader(f, delimiter=delimiter))
+            except UnicodeDecodeError:
+                continue
+        raise UnicodeDecodeError("unknown", b"", 0, 1, "Unable to decode CSV/TSV as utf-8-sig, utf-8, or gbk.")
+    if suffix in {".xlsx", ".xls"}:
+        try:
+            import pandas as pd
+        except ImportError as exc:
+            raise RuntimeError("pandas/openpyxl is required for Excel input.") from exc
+        df = pd.read_excel(path, sheet_name=sheet if sheet is not None else 0)
+        return df.to_dict("records")
+    raise ValueError("Input must be .csv, .tsv, .xlsx, or .xls.")
+
+
+def normalize(path: Path, output: Path, doi_column: str | None, link_column: str | None, sheet: str | int | None) -> int:
+    rows = _read_rows(path, sheet)
+    seen: set[str] = set()
+    pairs: list[tuple[str, str]] = []
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        keys = list(row.keys())
+        doi = ""
+        if doi_column and doi_column in row:
+            doi = _extract_doi(row.get(doi_column))
+        if not doi:
+            for key in keys:
+                if str(key).strip().lower() == "doi":
+                    doi = _extract_doi(row.get(key))
+                    break
+        if not doi:
+            for key in keys[:10]:
+                doi = _extract_doi(row.get(key))
+                if doi:
+                    break
+        if not doi or doi in seen:
+            continue
+
+        link = ""
+        if link_column and link_column in row:
+            link = _looks_like_link(row.get(link_column))
+        if not link:
+            for key in keys:
+                if str(key).strip().lower() == "link":
+                    link = _looks_like_link(row.get(key))
+                    break
+        if not link:
+            for key in keys:
+                link = _looks_like_link(row.get(key))
+                if link:
+                    break
+        seen.add(doi)
+        pairs.append((doi, link))
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.writer(f)
+        writer.writerow(["doi", "link"])
+        writer.writerows(pairs)
+    return len(pairs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prepare a doi,link CSV for the MOF paper pipeline.")
+    parser.add_argument("input", type=Path, help="Source CSV/TSV/XLSX/XLS file.")
+    parser.add_argument("-o", "--output", type=Path, default=Path("dois.csv"), help="Output CSV path.")
+    parser.add_argument("--doi-column", help="Explicit DOI column name.")
+    parser.add_argument("--link-column", help="Explicit link column name.")
+    parser.add_argument("--sheet", help="Excel sheet name or zero-based index.")
+    args = parser.parse_args()
+
+    sheet: str | int | None = args.sheet
+    if isinstance(sheet, str) and sheet.isdigit():
+        sheet = int(sheet)
+
+    try:
+        count = normalize(args.input, args.output, args.doi_column, args.link_column, sheet)
+        if count:
+            print(f"Wrote {count} DOI row(s) to {args.output}")
+            return 0
+        print("未找到有效 DOI。请确认表格中至少有一列包含 10.xxxx/... 格式 DOI。", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"DOI/link 表格规范化失败：{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/miqi/skills/mof-synthesis-price-agent/scripts/write_agent_outputs.py
+++ b/miqi/skills/mof-synthesis-price-agent/scripts/write_agent_outputs.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+"""Write Codex-agent MOF extraction JSON to the project CSV contract.
+
+Input JSON shape:
+{
+  "synthesis_routes": [...],
+  "reagents": [...],
+  "synthesis_summary": "...",      # optional
+  "feasibility": {...}              # optional
+}
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROLES = {"reactant", "solvent", "catalyst", "ligand", "modulator", "workup"}
+SOURCES = {"main_text", "SI"}
+
+
+def _norm(value: Any) -> str:
+    return re.sub(r"[\s,;，；()（）\[\]]+", "", str(value or "").lower())
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8-sig") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("Top-level JSON must be an object.")
+    return data
+
+
+def _as_float_or_none(value: Any, field: str) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be numeric or null, got {value!r}") from exc
+
+
+def _as_bool(value: Any, field: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "y", "1"}:
+            return True
+        if lowered in {"false", "no", "n", "0"}:
+            return False
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    raise ValueError(f"{field} must be boolean-like, got {value!r}")
+
+
+def _as_int(value: Any, field: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be an integer, got {value!r}") from exc
+
+
+def validate(data: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    routes = data.get("synthesis_routes", [])
+    reagents = data.get("reagents", [])
+    if not isinstance(routes, list):
+        raise ValueError("synthesis_routes must be a list.")
+    if not isinstance(reagents, list):
+        raise ValueError("reagents must be a list.")
+    if not routes:
+        raise ValueError("synthesis_routes is empty.")
+
+    clean_routes: list[dict[str, Any]] = []
+    for idx, route in enumerate(routes):
+        if not isinstance(route, dict):
+            raise ValueError(f"synthesis_routes[{idx}] must be an object.")
+        target = str(route.get("target_compound") or "").strip()
+        procedure = str(route.get("procedure_text") or "").strip()
+        source = route.get("source") or "main_text"
+        if not target:
+            raise ValueError(f"synthesis_routes[{idx}].target_compound is required.")
+        if not procedure:
+            raise ValueError(f"synthesis_routes[{idx}].procedure_text is required.")
+        if source not in SOURCES:
+            raise ValueError(f"synthesis_routes[{idx}].source must be main_text or SI.")
+        clean_routes.append({
+            "target_compound": target,
+            "yield_percent": _as_float_or_none(route.get("yield_percent"), f"synthesis_routes[{idx}].yield_percent"),
+            "temperature": route.get("temperature"),
+            "duration": route.get("duration"),
+            "atmosphere": route.get("atmosphere"),
+            "procedure_text": procedure,
+            "source": source,
+            "route_type": route.get("route_type") or "primary",
+            "source_text": route.get("source_text"),
+        })
+
+    targets_by_route = {i: _norm(r["target_compound"]) for i, r in enumerate(clean_routes)}
+    clean_reagents: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str]] = set()
+    for idx, reagent in enumerate(reagents):
+        if not isinstance(reagent, dict):
+            raise ValueError(f"reagents[{idx}] must be an object.")
+        name = str(reagent.get("name") or "").strip()
+        role = reagent.get("role")
+        route_index = _as_int(reagent.get("route_index", 0), f"reagents[{idx}].route_index")
+        if not name:
+            raise ValueError(f"reagents[{idx}].name is required.")
+        if role not in ROLES:
+            raise ValueError(f"reagents[{idx}].role must be one of {sorted(ROLES)}, got {role!r}.")
+        if route_index != -1 and route_index not in targets_by_route:
+            raise ValueError(f"reagents[{idx}].route_index {route_index} is not valid for {len(clean_routes)} route(s).")
+        if route_index != -1 and _norm(name) == targets_by_route[route_index]:
+            raise ValueError(f"reagents[{idx}] appears to be the final product for its own route: {name!r}.")
+        key = (_norm(name), route_index, str(role))
+        if key in seen:
+            continue
+        seen.add(key)
+        clean_reagents.append({
+            "name": name,
+            "name_zh": reagent.get("name_zh"),
+            "name_en": reagent.get("name_en"),
+            "cas": reagent.get("cas"),
+            "role": role,
+            "amount": reagent.get("amount"),
+            "equiv": reagent.get("equiv"),
+            "route_index": route_index,
+            "is_controlled": _as_bool(reagent.get("is_controlled", False), f"reagents[{idx}].is_controlled"),
+            "pricing": reagent.get("pricing") or [],
+            "fire_hazard": reagent.get("fire_hazard"),
+            "fire_hazard_basis": reagent.get("fire_hazard_basis"),
+            "ghs_hazards": reagent.get("ghs_hazards"),
+            "scraped_at": reagent.get("scraped_at"),
+        })
+
+    if not clean_reagents:
+        raise ValueError("reagents is empty.")
+    return clean_routes, clean_reagents
+
+
+def write_routes(routes: list[dict[str, Any]], prefix: Path) -> Path:
+    path = prefix.parent / f"{prefix.name}_routes.csv"
+    fields = [
+        "route_index", "target_compound", "yield_percent", "temperature",
+        "duration", "atmosphere", "procedure_text", "source", "route_type", "source_text",
+    ]
+    with path.open("w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for idx, route in enumerate(routes):
+            writer.writerow({
+                "route_index": idx,
+                "target_compound": route["target_compound"],
+                "yield_percent": route.get("yield_percent"),
+                "temperature": route.get("temperature") or "",
+                "duration": route.get("duration") or "",
+                "atmosphere": route.get("atmosphere") or "",
+                "procedure_text": route["procedure_text"],
+                "source": route["source"],
+                "route_type": route.get("route_type") or "primary",
+                "source_text": route.get("source_text") or "",
+            })
+    return path
+
+
+def write_reagents(reagents: list[dict[str, Any]], routes: list[dict[str, Any]], prefix: Path) -> Path:
+    path = prefix.parent / f"{prefix.name}_reagents.csv"
+    route_map = {idx: route["target_compound"] for idx, route in enumerate(routes)}
+    fields = ["name", "cas", "role", "amount", "equiv", "is_controlled", "route_index", "target_compound"]
+    with path.open("w", newline="", encoding="utf-8-sig") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for reagent in reagents:
+            route_index = reagent["route_index"]
+            writer.writerow({
+                "name": reagent["name"],
+                "cas": reagent.get("cas") or "",
+                "role": reagent["role"],
+                "amount": reagent.get("amount") or "",
+                "equiv": reagent.get("equiv") if reagent.get("equiv") is not None else "",
+                "is_controlled": reagent["is_controlled"],
+                "route_index": route_index,
+                "target_compound": "universal" if route_index == -1 else route_map.get(route_index, ""),
+            })
+    return path
+
+
+def write_optional_artifacts(data: dict[str, Any], prefix: Path, routes: list[dict[str, Any]], reagents: list[dict[str, Any]]) -> list[Path]:
+    paths: list[Path] = []
+    summary = data.get("synthesis_summary")
+    if isinstance(summary, str) and summary.strip():
+        path = prefix.parent / f"{prefix.name}_synthesis_summary.md"
+        path.write_text(summary, encoding="utf-8")
+        paths.append(path)
+    feasibility = data.get("feasibility")
+    if isinstance(feasibility, dict) and feasibility:
+        path = prefix.parent / f"{prefix.name}_feasibility.json"
+        path.write_text(json.dumps(feasibility, ensure_ascii=False, indent=2), encoding="utf-8")
+        paths.append(path)
+    extraction_path = prefix.parent / f"{prefix.name}_agent_extraction.json"
+    extraction_path.write_text(
+        json.dumps({
+            "synthesis_routes": routes,
+            "reagents": reagents,
+            "synthesis_summary": summary or "",
+            "feasibility": feasibility,
+        }, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    paths.append(extraction_path)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write agent MOF extraction JSON to standard pipeline CSV files.")
+    parser.add_argument("input_json", type=Path, help="Agent extraction JSON file.")
+    parser.add_argument("output_prefix", type=Path, help="Output prefix, e.g. output/paper_cleaned.")
+    parser.add_argument("--write-json-copy", action="store_true", help="Deprecated; validated JSON is always saved beside the CSV files.")
+    parser.add_argument("--status-json", type=Path, help="Optional path for a compact machine-readable status JSON.")
+    args = parser.parse_args()
+
+    try:
+        data = _load_json(args.input_json)
+        routes, reagents = validate(data)
+        args.output_prefix.parent.mkdir(parents=True, exist_ok=True)
+        routes_path = write_routes(routes, args.output_prefix)
+        reagents_path = write_reagents(reagents, routes, args.output_prefix)
+        optional_paths = write_optional_artifacts(data, args.output_prefix, routes, reagents)
+        created = [str(p) for p in optional_paths] + [str(routes_path), str(reagents_path)]
+        if args.status_json:
+            args.status_json.parent.mkdir(parents=True, exist_ok=True)
+            args.status_json.write_text(
+                json.dumps({
+                    "completion_state": "complete",
+                    "prefix": str(args.output_prefix),
+                    "created_files": created,
+                    "counts": {"routes": len(routes), "reagents": len(reagents)},
+                    "next_action": "Run enrichment/report workflow for this prefix.",
+                    "missing_or_failed": [],
+                }, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        for artifact in optional_paths:
+            print(artifact)
+        print(routes_path)
+        print(reagents_path)
+        return 0
+    except Exception as exc:
+        if "args" in locals() and getattr(args, "status_json", None):
+            args.status_json.parent.mkdir(parents=True, exist_ok=True)
+            args.status_json.write_text(
+                json.dumps({
+                    "completion_state": "evidence_boundary",
+                    "prefix": str(getattr(args, "output_prefix", "")),
+                    "created_files": [],
+                    "counts": {},
+                    "next_action": "Repair the agent JSON once using the validation error and source evidence.",
+                    "missing_or_failed": [str(exc)],
+                }, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

将 MOF 合成定价 Agent skill 集成到 MiQi 技能系统，支持从 MOF 论文自动提取合成路线、试剂清单、供应商报价，生成 HTML/Markdown/PDF 报告。

## 背景/问题

`3skills/mof_price_skill/` 包含完整的 MOF 论文→报价→报告 pipeline。WorkBuddy 版本 SKILL.md 和 Python 辅助脚本已就绪。需要集成到 MiQi 项目中，替代 DeepSeek API 调用，改为 MiQi AI Agent 直接做结构化抽取。

Closes #231

## 变更内容

### 新增文件（18 files, +1966 lines）

```
miqi/skills/mof-synthesis-price-agent/
├── SKILL.md                          # 主技能描述（中文/英文触发词）
├── agents/openai.yaml                # OpenAI 兼容模型配置
├── eval/                             # 质量断言和测试触发器
├── references/                       # 8 个参考文档
│   ├── workflow.md                   # 输入路由/阶段映射/完成状态
│   ├── agent-extraction-rules.md     # Agent 替代 DeepSeek 的强制规则
│   ├── agent-prompt-template.md      # 抽取 prompt 模板
│   ├── schemas.md                    # JSON/CSV schema 和验证要求
│   ├── evidence-boundaries.md        # 科学/定价/安全声明边界
│   ├── failure-handling.md           # 停止/降级/重试行为
│   ├── cnki-doi-preflight.md         # CNKI DOI 快速处理
│   └── real-sample-validation.md     # Reality Run 验收标准
└── scripts/                          # 4 个 Python 辅助脚本
    ├── mof_workflow.py               # 确定性路由器（无 LLM）
    ├── cnki_doi_preflight.py         # CNKI DOI 预检
    ├── write_agent_outputs.py        # Agent JSON 写入 CSVs
    └── prepare_doi_csv.py            # DOI 表格规范化
```

### .gitignore

移除 `mof-synthesis-price-agent/` 规则，允许追踪技能文件。

## 日志/验证证据

```bash
# 标准输出示例（3skills/mof_price_skill/标准输出/）：
# - 2 条合成路线（NH2-UiO-66 + UiO-66）
# - 4 种试剂（ZrCl4, NH2-BDC, H2-BDC, DMF）
# - 每种试剂 Top 10 供应商报价
# - HTML + Markdown + PDF 三格式报告
```

## 测试情况

- [ ] 配置 MOF 项目根目录（extract/, enrich/, report.py）
- [ ] Python 依赖检查（pandas, pdfplumber, reportlab, requests, bs4, lxml, tabulate）
- [ ] `/mof-synthesis-price-agent` 命令可用
- [ ] Agent extraction 替代 DeepSeek 验证

## 截图

无需截图（数据 pipeline）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end workflow for processing MOF, COF, and coordination-polymer synthesis inputs from DOIs, PDFs, text, JSON, CSVs, and CAS numbers.
  * Added synthesis route extraction, reagent validation, pricing, feasibility screening, and report generation.
  * Added DOI table normalization, CNKI metadata preflight, batch processing, completion statuses, and evidence-boundary handling.

* **Documentation**
  * Added workflow guidance, schemas, extraction rules, failure handling, evaluation criteria, privacy guidance, and real-sample validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->