### PR TITLE
fix(desktop): prevent config.get polling storm that caused false bridge death

### DIFF
--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -54,11 +54,15 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
 
   useEffect(() => {
     let cancelled = false;
+    let inFlight = false; // debounce guard: don't pile up requests when bridge is slow
+
     const loadApprovalBypass = async () => {
+      if (inFlight) return; // skip if previous request still pending
       if (!(window as any).miqi?.config?.get) {
         if (!cancelled) setApprovalBypass(null);
         return;
       }
+      inFlight = true;
       try {
         const cfg = await window.miqi.config.get();
         const approvals = (cfg.approvals ?? {}) as ApprovalBypassStatus;
@@ -66,12 +70,16 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
           setApprovalBypass(approvals);
         }
       } catch {
-        if (!cancelled) setApprovalBypass(null);
+        // Keep the last known good state — bridge may be temporarily busy
+        // Don't clear approvalBypass; a null here cascades into false
+        // "runtime not started" UI.  See PR #xxx.
+      } finally {
+        inFlight = false;
       }
     };
     loadApprovalBypass();
     window.addEventListener('miqi:approval-bypass-updated', loadApprovalBypass);
-    const timer = window.setInterval(loadApprovalBypass, 5000);
+    const timer = window.setInterval(loadApprovalBypass, 30_000);
     return () => {
       cancelled = true;
       window.removeEventListener('miqi:approval-bypass-updated', loadApprovalBypass);


### PR DESCRIPTION
## 根因

TopBar 每 **5 秒**轮询 `config.get`，每次超时 **30 秒**。当 bridge 忙于处理 AI 工具调用（如 MOF E2E 中 Read/WriteFile/exec）时，每个轮询排队等候，最终大量请求堵死 stdin queue。持续超时 → renderer 判为「运行时未启动」→ sandbox 连接丢失 → MERGE ALL CHANGES 变灰（`trackedFiles.length === 0`）。

**不是 bridge 真 crash，是负载导致的假死。**

## 修复

| 改动 | 说明 |
|---|---|
| 5s → 30s 间隔 | 减少 6 倍请求量 |
| 加 `inFlight` 去重锁 | 前一个请求未返回时跳过本次，杜绝排队 |
| 超时不清 `approvalBypass` | 保留最后一次有效状态，防止 UI 级联切到「运行时未启动」 |

## 验证

- 原问题场景（MOF E2E 测试期间 bridge 假死）不再出现
- E2E 通过的 v15 已在修复后的代码上验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved approval bypass status polling to prevent overlapping requests.
  * Reduced polling frequency to improve efficiency.
  * Preserved the last known approval bypass status when temporary errors occur.
  * Continued clearing the status when the bridge is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->