### PR TITLE
fix(desktop): address issue 230 UI defects

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import tailwindcss from '@tailwindcss/vite'
+import pkg from './package.json'
 
 export default defineConfig({
   main: {
@@ -30,6 +31,9 @@ export default defineConfig({
   },
   renderer: {
     root: resolve(__dirname, 'src/renderer'),
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
+    },
     build: {
       outDir: 'out/renderer',
       rollupOptions: {

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -6,7 +6,7 @@ import { ContextMenu } from './ContextMenu';
 import { useSessionStatus, type SessionStatus } from '../hooks/useSessionStatus';
 import type { SessionInfo } from '../../shared/ipc';
 
-type FilterTab = 'ALL' | 'IN-PROGRESS' | 'REVIEW' | 'CC';
+type FilterTab = 'ALL' | 'IN-PROGRESS' | 'REVIEW' | 'COMPLETED';
 
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
@@ -106,14 +106,14 @@ export function Sidebar({
     return () => { unsub(); };
   }, [loadSessions]);
 
-  const FILTER_TABS: FilterTab[] = ['ALL', 'IN-PROGRESS', 'REVIEW', 'CC'];
+  const FILTER_TABS: FilterTab[] = ['ALL', 'IN-PROGRESS', 'REVIEW', 'COMPLETED'];
 
   const filteredSessions = sessions.filter((s) => {
     if (filter === 'ALL') return true;
     const status = getStatus(s.key);
     if (filter === 'IN-PROGRESS') return status === 'IN-PROGRESS';
     if (filter === 'REVIEW') return status === 'REVIEW';
-    if (filter === 'CC') return status === 'CC';
+    if (filter === 'COMPLETED') return status === 'COMPLETED';
     return true;
   });
 
@@ -148,8 +148,8 @@ export function Sidebar({
         </button>
       </div>
 
-      {/* Filter tabs: ALL / IN PROGRESS / REVIEW / CC */}
-      <div className="flex gap-1 px-4 pb-3 shrink-0">
+      {/* Filter tabs */}
+      <div className="flex flex-nowrap gap-0.5 px-3 pb-3 shrink-0 overflow-x-auto">
         {FILTER_TABS.map((tab) => {
           const isActive = filter === tab;
           return (
@@ -157,7 +157,7 @@ export function Sidebar({
               key={tab}
               onClick={() => setFilter(tab)}
               className={cn(
-                'px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors',
+                'shrink-0 whitespace-nowrap px-1.5 py-1 rounded-md text-[10px] font-medium transition-colors',
                 isActive
                   ? 'text-[var(--text)]'
                   : 'text-[var(--text-faint)] hover:text-[var(--text-muted)]',
@@ -246,7 +246,7 @@ export function Sidebar({
                       {/* Top row: pill status label left · time right */}
                       <div className="flex items-center justify-between mb-2">
                         <span
-                          className="text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full"
+                          className="text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full whitespace-nowrap shrink-0"
                           style={{ background: status.bg, color: status.color }}
                         >
                           {status.label}
@@ -297,7 +297,7 @@ export function Sidebar({
           className="text-[10px] font-mono"
           style={{ color: 'var(--text-faint)' }}
         >
-          PRO v0.4.29
+          PRO v{__APP_VERSION__}
         </span>
       </div>
     </div>

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -24,12 +24,7 @@ function isBypassEnabled(status: ApprovalBypassStatus | null): boolean {
 
 function getBypassLabel(status: ApprovalBypassStatus | null): string {
   if (status?.bypassAll) return 'BYPASS ALL';
-  const labels: string[] = [];
-  if (status?.bypassCommandApproval) labels.push('CMD');
-  if (status?.bypassFileWriteApproval) labels.push('FILE');
-  if (status?.bypassToolConfirmation) labels.push('TOOL');
-  if (status?.bypassNetworkApproval) labels.push('NET');
-  return labels.length > 0 ? `BYPASS: ${labels.join('/')}` : 'BYPASS';
+  return 'BYPASS';
 }
 
 function getBypassTitle(status: ApprovalBypassStatus | null): string {
@@ -96,7 +91,7 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
           MiQi
         </span>
         <span className="text-xs font-light opacity-50" style={{ color: 'var(--topbar-text)' }}>
-          Workbench
+          Desktop
         </span>
       </div>
 
@@ -116,9 +111,10 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
               border: '1px solid var(--approval-warning-border)',
             }}
             title={getBypassTitle(approvalBypass)}
+            aria-label={getBypassTitle(approvalBypass)}
           >
             <AlertTriangle size={11} className="shrink-0" />
-            <span>{getBypassLabel(approvalBypass)}</span>
+            <span className="whitespace-nowrap">{getBypassLabel(approvalBypass)}</span>
           </button>
         )}
         {/* Sync state */}

--- a/apps/desktop/src/renderer/env.d.ts
+++ b/apps/desktop/src/renderer/env.d.ts
@@ -1,6 +1,8 @@
 import type { MiQiAPI } from '../preload/index';
 
 declare global {
+  const __APP_VERSION__: string;
+
   interface Window {
     miqi: MiQiAPI;
   }

--- a/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
+++ b/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
@@ -138,10 +138,10 @@ export function ApprovalsPage() {
   // Category filter for pending tab
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
   const CATEGORIES = [
-    { key: 'all', label: 'All' },
-    { key: 'exec', label: 'Shell' },
-    { key: 'file_write', label: 'Files' },
-    { key: 'network', label: 'Network' },
+    { key: 'all', label: '全部' },
+    { key: 'exec', label: '命令' },
+    { key: 'file_write', label: '文件' },
+    { key: 'network', label: '网络' },
   ];
 
   // Global bypass settings
@@ -316,7 +316,7 @@ export function ApprovalsPage() {
     {
       key: 'bypassCommandApproval',
       label: '命令审批',
-      description: '危险 shell 命令不再弹窗确认',
+      description: '危险命令不再弹窗确认',
     },
     {
       key: 'bypassFileWriteApproval',
@@ -326,7 +326,7 @@ export function ApprovalsPage() {
     {
       key: 'bypassToolConfirmation',
       label: '工具确认',
-      description: '需要 confirmation 的工具调用直接放行',
+      description: '需要确认的工具调用直接放行',
     },
     {
       key: 'bypassNetworkApproval',
@@ -361,7 +361,7 @@ export function ApprovalsPage() {
         <div>
           <h1 className="text-base font-semibold text-[var(--text)]">命令审批</h1>
           <p className="text-xs text-[var(--text-muted)] mt-0.5">
-            Agent 执行危险 shell 命令前需要授权。
+            智能体执行危险命令前需要授权。
           </p>
         </div>
         <button
@@ -424,7 +424,7 @@ export function ApprovalsPage() {
                 )}
               </div>
               <p className="text-xs text-[var(--text-muted)] mt-1">
-                开启后，Agent 执行对应操作时会跳过审批弹窗。
+                开启后，智能体执行对应操作时会跳过审批弹窗。
               </p>
             </div>
             <button
@@ -518,7 +518,7 @@ export function ApprovalsPage() {
                 </span>
               </div>
               <div className="text-[var(--text-faint)]">·</div>
-              <span className="text-[var(--text-muted)]">超时：{data.timeout}秒</span>
+              <span className="text-[var(--text-muted)]">超时：{data.timeout ?? 60}秒</span>
               <div className="text-[var(--text-faint)]">·</div>
               <span className="text-[var(--text-muted)]">{data.pending?.length ?? 0} 个待审批</span>
             </div>
@@ -542,7 +542,7 @@ export function ApprovalsPage() {
                     )}
                     <button
                       onClick={() => setShowAdd(true)}
-                      className="flex items-center gap-1 text-xs text-[var(--accent)] hover:underline"
+                      className="flex items-center gap-1 text-xs text-[var(--text-muted)] hover:text-[var(--text)] hover:underline"
                     >
                       <Plus size={12} /> 新增
                     </button>
@@ -768,9 +768,9 @@ export function ApprovalsPage() {
                           const isExpanded = expandedPending.has(p.approval_id);
                           const remaining = Math.max(
                             0,
-                            Math.ceil(data.timeout - (Date.now() / 1000 - p.created_at))
+                            Math.ceil((data.timeout ?? 60) - (Date.now() / 1000 - p.created_at))
                           );
-                          const pct = (remaining / data.timeout) * 100;
+                          const pct = (remaining / (data.timeout || 60)) * 100;
                           const isLow = remaining <= 5;
                           return (
                             <div key={p.approval_id}>
@@ -843,7 +843,7 @@ export function ApprovalsPage() {
                                       {remaining > 0 ? `${remaining}秒` : '已超时'}
                                     </span>
                                     <span className="text-[var(--text-faint)]">
-                                      / {data.timeout}秒
+                                      / {data.timeout ?? 60}秒
                                     </span>
                                   </div>
                                 </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Button } from '../../components/ui/Button';
 import { Textarea } from '../../components/ui/Textarea';
+import { Tooltip } from '../../components/ui/Tooltip';
 import { ContextMenu, type ContextMenuAction } from '../../components/ContextMenu';
 import { cn } from '../../lib/utils';
 import {
@@ -855,14 +856,17 @@ export function ChatConsole({
       lastEventAt = Date.now();
       // Handle stream deltas from exec (Phase 7 inline tool progress)
       if (data.stream && data.delta && data.tool_call_id) {
+        const stream = data.stream;
+        const delta = data.delta;
+        const toolCallId = data.tool_call_id;
         setExecOutputs((prev) => {
-          const current = prev[data.tool_call_id] || { stdout: '', stderr: '', running: true };
+          const current = prev[toolCallId] || { stdout: '', stderr: '', running: true };
+          const streamKey = stream === 'stdout' ? 'stdout' : 'stderr';
           return {
             ...prev,
-            [data.tool_call_id]: {
+            [toolCallId]: {
               ...current,
-              [data.stream === 'stdout' ? 'stdout' : 'stderr']:
-                current[data.stream === 'stdout' ? 'stdout' : 'stderr'] + data.delta,
+              [streamKey]: current[streamKey] + delta,
             },
           };
         });
@@ -1289,7 +1293,7 @@ export function ChatConsole({
       >
         {/* Left: Logo */}
         <span className="text-sm font-bold whitespace-nowrap shrink-0" style={{ color: 'var(--text)' }}>
-          MiQi Workbench
+          MiQi Desktop
         </span>
 
         {/* Center: Search */}
@@ -1327,12 +1331,16 @@ export function ChatConsole({
             items={[{ label: 'Delete conversation', danger: true, onSelect: handleDeleteSession }]}
           >
             {({ onContextMenu }) => (
-              <button
-                className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
-                onClick={onContextMenu}
-              >
-                <MoreHorizontal size={14} style={{ color: 'var(--text-faint)' }} />
-              </button>
+              <Tooltip content="More conversation actions">
+                <button
+                  className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
+                  onClick={onContextMenu}
+                  aria-label="More conversation actions"
+                  title="More conversation actions"
+                >
+                  <MoreHorizontal size={14} style={{ color: 'var(--text-faint)' }} />
+                </button>
+              </Tooltip>
             )}
           </ContextMenu>
 
@@ -1358,13 +1366,19 @@ export function ChatConsole({
               {sessionTitle}
             </h2>
             <span className="tag-inprogress shrink-0">IN PROGRESS</span>
-            <span className="text-[11px] shrink-0" style={{ color: 'var(--text-faint)' }}>
+            <span className="text-[13px] shrink-0" style={{ color: '#4B5563' }}>
               Updated 2 mins ago · 2 linked files · 2 Active Plugins
             </span>
             <button
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap ml-auto opacity-50"
-              style={{ background: 'var(--accent)', color: '#121212', cursor: 'not-allowed' }}
+              style={{
+                background: 'var(--surface-muted)',
+                border: '1px solid var(--border-subtle)',
+                color: 'var(--text-muted)',
+                cursor: 'not-allowed',
+              }}
               title="Coming soon"
+              aria-label="Share task, coming soon"
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/>
@@ -1373,13 +1387,16 @@ export function ChatConsole({
               </svg>
               Share Task
             </button>
-            <button
-              onClick={() => setPanelOpen((v) => !v)}
-              className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors shrink-0 ml-1"
-              title="Toggle assets panel"
-            >
-              <LayoutGrid size={14} style={{ color: 'var(--text-faint)' }} />
-            </button>
+            <Tooltip content="Toggle assets panel">
+              <button
+                onClick={() => setPanelOpen((v) => !v)}
+                className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors shrink-0 ml-1"
+                title="Toggle assets panel"
+                aria-label="Toggle assets panel"
+              >
+                <LayoutGrid size={14} style={{ color: 'var(--text-faint)' }} />
+              </button>
+            </Tooltip>
           </div>
           {/* Messages */}
           <div
@@ -1406,7 +1423,7 @@ export function ChatConsole({
                   </div>
                   <div className="flex flex-col items-center gap-1">
                     <p className="text-[15px] font-medium" style={{ color: 'var(--text-muted)' }}>
-                      Ask Agent to analyze or edit files...
+                      Start with a file, issue, or edit request
                     </p>
                     <p className="text-xs" style={{ color: 'var(--text-faint)' }}>
                       Start a conversation to begin
@@ -1493,6 +1510,7 @@ export function ChatConsole({
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
                   title="Attach file or image"
+                  aria-label="Attach file or image"
                 >
                   <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
                 </button>
@@ -1746,6 +1764,12 @@ export function ChatConsole({
               <button
                 onClick={handleMergeAll}
                 disabled={merging || trackedFiles.length === 0}
+                aria-describedby={trackedFiles.length === 0 ? 'merge-all-disabled-reason' : undefined}
+                title={
+                  trackedFiles.length === 0
+                    ? 'No changed files are available to merge'
+                    : 'Merge all tracked changes'
+                }
                 className="w-full py-2.5 rounded-xl text-xs font-semibold flex items-center justify-center gap-2 transition-colors"
                 style={{
                   background:
@@ -1759,6 +1783,15 @@ export function ChatConsole({
                 {merging ? <Loader2 size={13} className="animate-spin" /> : <GitMerge size={13} />}
                 {merging ? 'MERGING...' : 'MERGE ALL CHANGES'}
               </button>
+              {trackedFiles.length === 0 && (
+                <p
+                  id="merge-all-disabled-reason"
+                  className="mt-1.5 text-[11px] text-center"
+                  style={{ color: '#4B5563' }}
+                >
+                  No changed files are available to merge.
+                </p>
+              )}
             </div>
           </div>
         )}

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -107,10 +107,10 @@ function GeneralTab({ onReopenSetup }: { onReopenSetup?: () => void }) {
 
   return (
     <div className="p-6 max-w-lg flex flex-col gap-4">
-      <h3 className="text-sm font-semibold text-[var(--text)]">Agent 配置</h3>
+      <h3 className="text-sm font-semibold text-[var(--text)]">智能体配置</h3>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-medium text-[var(--text-muted)]">Agent 名称</label>
+        <label className="text-xs font-medium text-[var(--text-muted)]">智能体名称</label>
         <Input
           value={agentName}
           onChange={(e) => setAgentName(e.target.value)}
@@ -919,7 +919,7 @@ export function SettingsPage({ onReopenSetup, tab = 'general' }: { onReopenSetup
     <div className="flex flex-col h-full">
       <div className="px-6 py-4 border-b border-[var(--border-subtle)]">
         <h2 className="text-sm font-semibold text-[var(--text)]">设置</h2>
-        <p className="text-xs text-[var(--text-faint)] mt-0.5">配置 MiQi Agent 和外观</p>
+        <p className="text-xs text-[var(--text-faint)] mt-0.5">配置 MiQi 智能体和外观</p>
       </div>
 
       <Tabs.Root
@@ -932,14 +932,14 @@ export function SettingsPage({ onReopenSetup, tab = 'general' }: { onReopenSetup
             { value: 'general', label: '通用' },
             { value: 'providers', label: '模型' },
             { value: 'channels', label: '渠道' },
-            { value: 'agents', label: 'Agents' },
+            { value: 'agents', label: '智能体' },
             { value: 'skills', label: '技能' },
             { value: 'mcps', label: 'MCPs' },
             { value: 'memory', label: '记忆' },
             { value: 'experience', label: '经验' },
             { value: 'approvals', label: '审批' },
             { value: 'workspace', label: '工作区' },
-            { value: 'webtools', label: 'Web 工具' },
+            { value: 'webtools', label: '网页工具' },
             { value: 'permissions', label: '权限' },
             { value: 'plugins', label: '插件' },
             { value: 'wsl', label: 'WSL' },

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -73,8 +73,8 @@
   --tag-review-text: #a06000;
   --tag-completed-bg: rgba(32,102,208,0.12);   /* COMPLETED 标签（蓝色） */
   --tag-completed-text: #2066D0;
-  --tag-inprogress-bg: #e0ecff;  /* IN-PROGRESS 标签（浅蓝） */
-  --tag-inprogress-text: #2066D0;
+  --tag-inprogress-bg: #1D4ED8;  /* IN-PROGRESS 标签（深蓝，满足对比度） */
+  --tag-inprogress-text: #FFFFFF;
   --tag-cc-bg: rgba(124,58,237,0.12);          /* CC 标签（紫色） */
   --tag-cc-text: #7C3AED;
 
@@ -218,10 +218,15 @@ code {
 .tag-inprogress {
   background: var(--tag-inprogress-bg);
   color: var(--tag-inprogress-text);
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  word-break: keep-all;
+  line-height: 1;
   font-size: 10px;
   font-weight: 600;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -691,6 +691,9 @@ export interface TrackedFileInfo {
 export interface ChatProgress {
   text: string;
   tool_hint: boolean;
+  stream?: 'stdout' | 'stderr';
+  delta?: string;
+  tool_call_id?: string;
   /** Session key for frontend-side event filtering (fix #212).
    *  Optional for backward compatibility with backends that don't yet
    *  emit this field.  Should become required once all backends are

--- a/apps/desktop/tests/e2e/full-electron.spec.ts
+++ b/apps/desktop/tests/e2e/full-electron.spec.ts
@@ -56,7 +56,7 @@ test.describe('Native Electron E2E', () => {
   // ═══════════════════════════════════════════════════════════════
 
   test('app launches and renders correctly', async () => {
-    await expect(page.getByText('MiQi Workbench')).toBeVisible({
+    await expect(page.getByText('MiQi Desktop', { exact: true })).toBeVisible({
       timeout: 10_000,
     });
     await expect(
@@ -314,7 +314,7 @@ test.describe('Native Electron E2E', () => {
       });
       const page2 = await app2.firstWindow();
       await page2.waitForLoadState('domcontentloaded');
-      try { await page2.getByText('MiQi Workbench').waitFor({ timeout: 30000 }); } catch {}
+      try { await page2.getByText('MiQi Desktop', { exact: true }).waitFor({ timeout: 30000 }); } catch {}
       await waitForInputReady(page2, 30000);
 
       // Wait for bridge to initialize, then reload so ChatConsole re-fires


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 变更概述

收窄为仅修复 #230 提到的工作区与设置/审批页 UI 缺陷，已回退此前额外的界面改造方向。本次 PR 聚焦文本截断、状态标签断行/对比度、审批页中英混搭、可访问标签、禁用原因说明、品牌/版本名收敛与空状态重复文案。

## 背景/问题

#230 的视觉审计指出工作区与「设置 → 审批」存在 11 项必现 UI 问题，包括 `COMPLETED` 被截断、`IN-PROGRESS` 断行、审批页 `Agent/shell/confirmation` 中英混用、图标按钮无标签、`MERGE ALL CHANGES` 禁用无解释、产品名/版本号过多等。

## 变更内容

- 工作区侧栏第 4 个筛选项改为完整 `COMPLETED`，并让筛选标签单行显示，状态 pill 禁止换行。
- `IN PROGRESS` 标签改用 #1D4ED8 深蓝和白字，并补充 nowrap/keep-all，元信息行提高到 13px / #4B5563。
- 审批页混搭文案改为中文，设置页标签仅收敛明显混搭项，保留 `MCPs` / `WSL` 等专有名词。
- 工作区右上 icon-only 按钮补充 tooltip/title/aria-label，附件按钮补充 aria-label。
- `MERGE ALL CHANGES` 禁用时增加 title、aria-describedby 和可见原因说明。
- 收敛产品名：`MiQi Workbench` 改为 `MiQi Desktop`；左下版本号改为从桌面端版本动态注入，避免发布后继续显示写死版本。
- 空状态标题改为与输入框 placeholder 不重复的文案；审批页「新增」链接改为中性色，降低橙色语义过载。
- 为已有 chat progress stream 字段补齐 IPC 类型，保持 typecheck 通过。

## 日志/验证证据

```
npm.cmd run typecheck
结果：通过

npm.cmd run build
结果：通过
备注：build 仅输出现有 Radix 依赖的 "use client" was ignored 打包警告，无新增错误。

git diff --check
结果：通过
```

## 测试情况

已在 `apps/desktop` 执行类型检查和生产构建，覆盖 renderer/node TS 编译与 electron-vite build。PR 已 rebase 到最新 `develop`，当前无代码冲突。

## 截图

图片 1：左侧任务筛选 Tab，`COMPLETED` 完整显示，侧边栏拖窄后不溢出到右侧内容区。
<img width="1264" height="821" alt="1" src="https://github.com/user-attachments/assets/724b395e-0067-47f2-b91c-1c5a350d5e7a" />

图片 2：工作区顶部状态行，`IN PROGRESS` 不再断行，深蓝底色对比度更高，元信息行更清晰。
<img width="1264" height="821" alt="2" src="https://github.com/user-attachments/assets/aaf84e40-fbd0-41b7-be94-9d1e4f33bc3c" />

图片 3：工作区右上 icon-only 按钮，三点菜单和面板切换图标补充 tooltip/title/aria-label。
<img width="1264" height="821" alt="3" src="https://github.com/user-attachments/assets/b09c9e6f-e251-4776-bd2a-ae0adfbbaad8" />

图片 4：底部/右侧 Merge 按钮，禁用态显示 `No changed files are available to merge.`，hover 也有禁用原因。
<img width="1264" height="821" alt="4" src="https://github.com/user-attachments/assets/6ae845a2-b817-45dc-b933-9eb13d770d99" />

图片 5：空状态文案，中间标题改为 `Start with a file, issue, or edit request`，不再与输入框 placeholder 重复。
<img width="1264" height="821" alt="5" src="https://github.com/user-attachments/assets/31a12f0d-d3c9-4dd4-ae03-5a8f7f129c48" />

图片 6：设置 → 审批页，`Agent/shell/confirmation` 混搭文案改为中文，分类改为 `全部 / 命令 / 文件 / 网络`。
<img width="1264" height="821" alt="6" src="https://github.com/user-attachments/assets/8c2de383-163e-4e91-9506-ec235b913ae4" />

图片 7：设置页顶部 Tab，`Agents` 改为 `智能体`，`Web 工具` 改为 `网页工具`，`MCPs` / `WSL` 保留专有名词。
<img width="1264" height="821" alt="7" src="https://github.com/user-attachments/assets/99f2bed2-f04d-446a-bf8b-bf5b21805b7a" />

图片 8：产品名与版本收敛，顶部 `MiQi Workbench` 改为 `MiQi Desktop`，左下版本号改为动态 `PRO v{desktop version}`；右上保留 `MiQi Agent / Core Agent`。
<img width="1264" height="821" alt="8" src="https://github.com/user-attachments/assets/88895f5a-4fae-4a84-b1d3-1fbf46f3b3ca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the app version to the sidebar footer automatically.
  * Improved accessibility with clearer labels and tooltips for key controls.
  * Added clearer guidance when no files are available to merge.

* **Improvements**
  * Updated branding from “Workbench” to “Desktop”.
  * Renamed the completed-task filter and made filter tabs horizontally scrollable.
  * Refined approval, settings, and chat wording, including Chinese translations.
  * Improved status badges and prevented label wrapping.

* **Bug Fixes**
  * Added a 60-second fallback when approval timeout information is unavailable.
  * Improved streaming command output display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->