### PR TITLE
fix: make bridge hot reload opt-in

### DIFF
--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -232,6 +232,7 @@ beforeEach(() => {
 afterEach(() => {
   // Restore env set by cleanup/hot-reload tests to avoid cross-test leakage
   delete process.env['ELECTRON_RENDERER_URL'];
+  delete process.env['MIQI_BRIDGE_HOT_RELOAD'];
 });
 
 describe('BridgeManager lifecycle', () => {

--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -232,7 +232,6 @@ beforeEach(() => {
 afterEach(() => {
   // Restore env set by cleanup/hot-reload tests to avoid cross-test leakage
   delete process.env['ELECTRON_RENDERER_URL'];
-  delete process.env['MIQI_BRIDGE_HOT_RELOAD'];
 });
 
 describe('BridgeManager lifecycle', () => {
@@ -682,19 +681,6 @@ describe('BridgeManager lifecycle', () => {
     expect(bridge.sandboxAvailable).toBe(false);
   }, 10_000);
 
-  it('does not start hot reload watcher when MIQI_BRIDGE_HOT_RELOAD=0', async () => {
-    process.env['ELECTRON_RENDERER_URL'] = 'test';
-    process.env['MIQI_BRIDGE_HOT_RELOAD'] = '0';
-    const BridgeManager = await importBridgeManager();
-    const proc = createMockProcess();
-    const bridge = new BridgeManager('/fake/root');
-
-    await startBridge(proc, bridge);
-
-    expect(watchCallbacks.length).toBe(0);
-    expect((bridge as any).fileWatcher).toBeNull();
-  });
-
   it('starts hot reload watcher by default in dev renderer mode', async () => {
     process.env['ELECTRON_RENDERER_URL'] = 'test';
     const BridgeManager = await importBridgeManager();
@@ -704,6 +690,37 @@ describe('BridgeManager lifecycle', () => {
     await startBridge(proc, bridge);
 
     expect((bridge as any).hotReloadEnabled).toBe(true);
+  });
+
+  it('skips hot reload restart when there are pending requests', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'test';
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge);
+    expect((bridge as any).hotReloadEnabled).toBe(true);
+
+    // Inject a pending request to simulate an active session
+    (bridge as any).pending.set('req-1', {
+      resolve: () => {},
+      reject: () => {},
+      method: 'chat.send',
+      timestamp: Date.now(),
+    });
+
+    // Trigger file change — should skip restart because pending > 0
+    const logs: string[] = [];
+    const origAddLog = (bridge as any).addLog.bind(bridge);
+    (bridge as any).addLog = (msg: string) => {
+      logs.push(msg);
+      origAddLog(msg);
+    };
+
+    (bridge as any).handleFileChange('test.py');
+
+    // Should have logged about skipping, not restarted
+    expect(logs.some((l: string) => l.includes('Skipping restart'))).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -680,6 +680,30 @@ describe('BridgeManager lifecycle', () => {
 
     expect(bridge.sandboxAvailable).toBe(false);
   }, 10_000);
+
+  it('does not start hot reload watcher when MIQI_BRIDGE_HOT_RELOAD=0', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'test';
+    process.env['MIQI_BRIDGE_HOT_RELOAD'] = '0';
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge);
+
+    expect(watchCallbacks.length).toBe(0);
+    expect((bridge as any).fileWatcher).toBeNull();
+  });
+
+  it('starts hot reload watcher by default in dev renderer mode', async () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'test';
+    const BridgeManager = await importBridgeManager();
+    const proc = createMockProcess();
+    const bridge = new BridgeManager('/fake/root');
+
+    await startBridge(proc, bridge);
+
+    expect((bridge as any).hotReloadEnabled).toBe(true);
+  });
 });
 
 describe('BridgeManager sandbox tracking', () => {

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -186,10 +186,13 @@ export class BridgeManager extends EventEmitter {
     super();
     // In dev: __dirname = apps/desktop/out/main → projectRoot is 4 levels up
     this.projectRoot = projectRoot || join(__dirname, '..', '..', '..', '..');
-    // Hot reload is opt-in because restarting the Python bridge drops runtime
-    // state and cancels pending requests. Enable only when actively editing
-    // backend code.
-    this.hotReloadEnabled = process.env['MIQI_BRIDGE_HOT_RELOAD'] === '1';
+    // Hot reload is ON by default in dev mode for development convenience.
+    // Set MIQI_BRIDGE_HOT_RELOAD=0 to opt-out (e.g., when configuring models
+    // or doing chat QA — bridge restarts cancel pending requests).
+    this.hotReloadEnabled =
+      process.env['MIQI_BRIDGE_HOT_RELOAD'] !== '0' &&
+      (process.env['NODE_ENV'] === 'development' ||
+       process.env['ELECTRON_RENDERER_URL'] !== undefined);
   }
 
   /** Whether the bridge has completed the initialize/initialized handshake. */

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -187,12 +187,9 @@ export class BridgeManager extends EventEmitter {
     // In dev: __dirname = apps/desktop/out/main → projectRoot is 4 levels up
     this.projectRoot = projectRoot || join(__dirname, '..', '..', '..', '..');
     // Hot reload is ON by default in dev mode for development convenience.
-    // Set MIQI_BRIDGE_HOT_RELOAD=0 to opt-out (e.g., when configuring models
-    // or doing chat QA — bridge restarts cancel pending requests).
     this.hotReloadEnabled =
-      process.env['MIQI_BRIDGE_HOT_RELOAD'] !== '0' &&
-      (process.env['NODE_ENV'] === 'development' ||
-       process.env['ELECTRON_RENDERER_URL'] !== undefined);
+      process.env['NODE_ENV'] === 'development' ||
+      process.env['ELECTRON_RENDERER_URL'] !== undefined;
   }
 
   /** Whether the bridge has completed the initialize/initialized handshake. */
@@ -639,6 +636,14 @@ export class BridgeManager extends EventEmitter {
 
     if (this.state !== 'running' || !this.initialized || this.restartInProgress) {
       this.addLog(`[Hot Reload] Ignoring change while bridge is ${this.state}`);
+      return;
+    }
+
+    // Don't restart if there are active requests — avoid killing sessions
+    if (this.pending.size > 0) {
+      this.addLog(
+        `[Hot Reload] Skipping restart — ${this.pending.size} pending request(s)`,
+      );
       return;
     }
 

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -186,10 +186,10 @@ export class BridgeManager extends EventEmitter {
     super();
     // In dev: __dirname = apps/desktop/out/main → projectRoot is 4 levels up
     this.projectRoot = projectRoot || join(__dirname, '..', '..', '..', '..');
-    // Enable hot reload in development mode
-    this.hotReloadEnabled =
-      process.env['NODE_ENV'] === 'development' ||
-      process.env['ELECTRON_RENDERER_URL'] !== undefined;
+    // Hot reload is opt-in because restarting the Python bridge drops runtime
+    // state and cancels pending requests. Enable only when actively editing
+    // backend code.
+    this.hotReloadEnabled = process.env['MIQI_BRIDGE_HOT_RELOAD'] === '1';
   }
 
   /** Whether the bridge has completed the initialize/initialized handshake. */


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [x] 测试
- [ ] 其他

## 变更概述

修复 #239：hot reload 不再杀死活跃会话。保持默认开启（mentor 要求），但在有 pending request 时跳过重启。

Closes #239。

## 背景/问题

旧逻辑：`handleFileChange` 检测到 Python 文件变化后无条件 restart，`restart()` 里 rejection 所有 pending request → 活跃的聊天会话被杀死，用户配置模型/测试对话时被打断。

核心矛盾不是 hot reload 开关，而是 **restart 没考虑是否有活跃会话**。

## 变更内容

### `bridge.ts`
- **Constructor**: 恢复原始逻辑，默认开启 hot reload（`NODE_ENV === 'development' || ELECTRON_RENDERER_URL !== undefined`）
- **`handleFileChange`**: 新增 `this.pending.size > 0` 检查 — 有活跃请求时跳过重启，打印日志 `[Hot Reload] Skipping restart — N pending request(s)`
- 无需环境变量 opt-out

### `bridge.test.ts`
- 保留"默认开启"测试
- 新增"有 pending 请求时跳过重启"测试

## 设计思路

mentor 指出"先思考这个问题"。真正的根因不是 hot reload 开关，而是 restart 无条件杀死所有 pending request。修复根因后，hot reload 可以放心默认开启 — 无活跃会话时正常重启，有活跃会话时自动跳过。

## 日志/验证证据
```
typecheck: PASS
vitest bridge.test.ts: 待 CI 验证
```
## 测试情况

- Web typecheck: PASS
- bridge.test.ts: 新增 skip-restart 测试
- 手动验证：dev 模式下编辑 .py 文件 → 无活跃会话时重启，有活跃会话时跳过

## 截图

（纯后端行为变更，无 UI 变化）
