### PR TITLE
fix(bridge): defer sandbox init to after ready signal to avoid first-install timeout

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -352,8 +352,9 @@ export class BridgeManager extends EventEmitter {
       // ── Ready handshake ────────────────────────────────────────────
       // Wait for the bridge to send {"type":"ready"} on stdout.
       // PyInstaller onefile exe first-run extraction to %TEMP% can take
-      // 5-15+ seconds — the old 1500 ms blind sleep was not enough.
-      // Fallback: 60 s timeout (generous for slow disks / first run).
+      // 5-15+ seconds.  First-run WSL dependency auto-install (apt-get
+      // install bubblewrap coreutils rsync) can take 60-120+ seconds.
+      // Timeout: 180 s to match the Python-side apt-get timeout.
       // ───────────────────────────────────────────────────────────────
       await new Promise<void>((_resolve, _reject) => {
         let settled = false;
@@ -386,10 +387,10 @@ export class BridgeManager extends EventEmitter {
         const timeout = setTimeout(() => {
           done(
             new Error(
-              'Bridge did not send ready signal within 60 s (PyInstaller extraction may be stuck)'
+              'Bridge did not send ready signal within 180 s (WSL dep install or PyInstaller extraction may be stuck)'
             )
           );
-        }, 60_000);
+        }, 180_000);
 
         lineReader.on('line', onReadyLine);
         bridgeProcess.once('close', onClose);

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -131,11 +131,45 @@ class BridgeRuntimeLoop:
         # 5. Signal ready to Desktop (Electron bridge.ts waits for this)
         self._send({"type": "ready"})
 
+        # 5.5. Start sandbox manager initialization in background.
+        # First-run auto-install of WSL deps (apt-get) can take 60-120 s,
+        # so we fire-and-forget it here after the ready signal to avoid
+        # blocking the bridge handshake timeout.
+        asyncio.create_task(self._init_sandbox_manager())
+
         # 6. Drain request queue
         await self._drain_loop()
 
         # 7. Shutdown
         await self._shutdown()
+
+    # ── Sandbox manager initialization (background) ─────────────────────────
+
+    async def _init_sandbox_manager(self) -> None:
+        """Initialize the sandbox manager as a background task.
+
+        Runs after the "ready" handshake so that first-run WSL dependency
+        auto-install (apt-get install bubblewrap coreutils rsync) does not
+        block the bridge startup timeout.  SandboxManager.get_or_create()
+        handles the not-yet-initialized state gracefully by checking
+        availability on demand.
+        """
+        if self._bridge_state is None:
+            return
+        try:
+            self._bridge_state._ensure_sandbox_manager()
+        except Exception:
+            return
+        sandbox_mgr = getattr(self._bridge_state, "_sandbox_manager", None)
+        if sandbox_mgr is None or sandbox_mgr == "disabled":
+            return
+        try:
+            await sandbox_mgr.initialize()
+            logger.info("Sandbox manager initialized")
+        except TypeError:
+            pass  # mock in tests — initialize() is not async
+        except Exception as exc:
+            logger.warning("Sandbox manager initialization failed: {}", exc)
 
     # ── AppServer initialization ───────────────────────────────────────────
 
@@ -200,16 +234,10 @@ class BridgeRuntimeLoop:
         from miqi.runtime.thread_app_handlers import register_codex_thread_handlers
         register_codex_thread_handlers(self._app_server)
 
-        # Initialize sandbox manager (shared across all agents)
-        if self._bridge_state is not None:
-            self._bridge_state._ensure_sandbox_manager()
-            sandbox_mgr = getattr(self._bridge_state, "_sandbox_manager", None)
-            if sandbox_mgr is not None and sandbox_mgr != "disabled":
-                try:
-                    await sandbox_mgr.initialize()
-                except TypeError:
-                    pass  # mock in tests — initialize() is not async
-                logger.info("Sandbox manager initialized")
+        # Sandbox manager initialization is deferred to _run() after the
+        # "ready" signal so that slow first-run auto-install of WSL
+        # dependencies (apt-get) does not block the bridge handshake.
+        # See _run() → _init_sandbox_manager().
 
         # Register Phase 37: Codex-style plugin and marketplace handlers
         from miqi.runtime.plugin_app_handlers import register_plugin_app_handlers

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -295,15 +295,21 @@ class SandboxManager:
         Thread-safe: uses threading.Lock for dict access, releases it during
         the slow sandbox.start() call so other threads are not blocked.
         """
-        if not self.enabled or not self._initialized:
+        if not self.enabled:
             return None
 
-        # Check bwrap availability on first create
-        if not await BwrapSandbox.is_available(
-            wsl_distro=self.wsl_distro,
-            auto_install_deps=self.auto_install_deps,
-        ):
-            return None
+        # Allow lazy initialization: if initialize() hasn't completed yet
+        # (it runs in background after the bridge ready signal), check
+        # availability on demand.  The _ensure_wsl_deps auto-install has
+        # its own cache so repeated calls are cheap after the first.
+        if not self._initialized:
+            if not await BwrapSandbox.is_available(
+                wsl_distro=self.wsl_distro,
+                auto_install_deps=self.auto_install_deps,
+            ):
+                return None
+            # Do NOT set _initialized here — let the background
+            # initialize() task handle that along with stale cleanup.
 
         sandbox_key = self._sandbox_key(session_key, client_id=client_id)
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复初次安装时 WSL 依赖自动安装（apt-get）阻塞 bridge 启动握手导致 60s 超时的问题。Closes #249.

## 背景/问题

**现象**: 首次安装的用户启动时 bridge ready 信号超时。
**根因**: `loop.py:_init_app_server()` 中 `await sandbox_mgr.initialize()` 触发 WSL apt-get（60-120+ s），阻塞了 `{"type":"ready"}` 发送。

## 变更内容

| 文件 | 改动 |
|------|------|
| `miqi/bridge/loop.py` | 沙箱初始化改为后台 `asyncio.create_task()`，ready 先行发送 |
| `miqi/sandbox/manager.py` | `get_or_create()` 懒初始化兼容 |
| `miqi/sandbox/bwrap.py` | 非阻塞锁 + poll-wait 防止并发 apt-get 竞态 |
| `apps/desktop/src/main/bridge.ts` | 超时 60s → 180s 安全网 |

## 测试情况

- [ ] 手动测试: `apt remove bubblewrap` 后冷启动
- [ ] 手动测试: 启动后立即发文件操作，验证无竞态
- [ ] 手动测试: 非首次安装，验证无回归
- [ ] E2E: `npx playwright test --project=electron`

## 截图

无需截图