### PR TITLE
feat(desktop): add settings hover animations

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -287,7 +287,7 @@ export function Sidebar({
         style={{ borderColor: 'var(--sidebar-border)' }}
       >
         <span
-          className="text-[11px] cursor-pointer hover:text-[var(--text)] transition-colors"
+          className="text-[11px] cursor-pointer hover:text-[var(--text)] settings-hover-sidebar"
           style={{ color: 'var(--text-faint)' }}
           onClick={() => onNavChange?.('settings')}
         >

--- a/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
+++ b/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
@@ -380,7 +380,7 @@ export function ApprovalsPage() {
             <button
               key={t.key}
               onClick={() => setTab(t.key)}
-              className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium transition-colors border-b-2 -mb-px ${
+              className={`settings-hover-tab flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 -mb-px ${
                 tab === t.key
                   ? 'border-[var(--accent)] text-[var(--accent)]'
                   : 'border-transparent text-[var(--text-muted)] hover:text-[var(--text)]'
@@ -504,7 +504,7 @@ export function ApprovalsPage() {
         ) : (
           <>
             {/* Status bar (always shown) */}
-            <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl px-5 py-3 flex items-center gap-4 text-sm mb-5">
+            <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl px-5 py-3 flex items-center gap-4 text-sm mb-5">
               <div className="flex items-center gap-2">
                 <Shield
                   size={14}
@@ -525,7 +525,7 @@ export function ApprovalsPage() {
 
             {/* ── TAB: Whitelist ──────────────────────────────────────── */}
             {tab === 'whitelist' && (
-              <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
+              <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
                 <div className="flex items-center justify-between px-5 py-2 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]">
                   <span className="text-xs font-semibold uppercase tracking-widest text-[var(--text-faint)]">
                     永久白名单（{data.permanent_entries?.length ?? 0}）
@@ -653,7 +653,7 @@ export function ApprovalsPage() {
 
             {/* ── TAB: History ────────────────────────────────────────── */}
             {tab === 'history' && (
-              <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
+              <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
                 <div className="px-5 py-2 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]">
                   <span className="text-xs font-semibold uppercase tracking-widest text-[var(--text-faint)]">
                     审批历史（{history.length}）
@@ -736,7 +736,7 @@ export function ApprovalsPage() {
                 return (
                   <div
                     data-tick={tick}
-                    className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden"
+                    className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden"
                   >
                     <div className="px-5 py-2 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)] flex items-center justify-between">
                       <span className="text-xs font-semibold uppercase tracking-widest text-[var(--text-faint)]">

--- a/apps/desktop/src/renderer/features/channels/ChannelsPage.tsx
+++ b/apps/desktop/src/renderer/features/channels/ChannelsPage.tsx
@@ -107,7 +107,7 @@ function FeishuSection({ config, onChange }: FeishuSectionProps) {
   ) => onChange({ ...config, [key]: val });
 
   return (
-    <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
+    <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
       {/* Channel header */}
       <div className="flex items-center justify-between px-5 py-3 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]">
         <div className="flex items-center gap-2">
@@ -282,7 +282,7 @@ export function ChannelsPage() {
         ) : (
           <>
             {/* Global switches */}
-            <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl px-5 divide-y divide-[var(--border-subtle)]">
+            <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl px-5 divide-y divide-[var(--border-subtle)]">
               <div className="py-2 text-xs font-semibold uppercase tracking-widest text-[var(--text-faint)]">
                 全局行为
               </div>

--- a/apps/desktop/src/renderer/features/mcps/MCPsPage.tsx
+++ b/apps/desktop/src/renderer/features/mcps/MCPsPage.tsx
@@ -440,7 +440,7 @@ export function MCPsPage() {
             {servers.map((srv) => (
               <div
                 key={srv.name}
-                className="rounded-xl border p-4 transition-colors"
+                className="settings-hover-card rounded-xl border p-4 transition-colors"
                 style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
               >
                 <div className="flex items-start justify-between gap-3">

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -281,7 +281,7 @@ function WebToolsTab() {
     <button
       onClick={() => set(value)}
       className={cn(
-        'px-3 py-1.5 rounded-lg text-xs border transition-colors',
+        'settings-hover-tab px-3 py-1.5 rounded-lg text-xs border',
         current === value
           ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
           : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)]'
@@ -434,7 +434,7 @@ function AppearanceTab() {
               key={m}
               onClick={() => applyTheme(m)}
               className={cn(
-                'px-4 py-2 rounded-lg text-xs border transition-colors',
+                'settings-hover-tab px-4 py-2 rounded-lg text-xs border',
                 theme === m
                   ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
                   : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)] hover:text-[var(--text)]'
@@ -573,7 +573,7 @@ function LogsTab() {
             key={tab.value}
             onClick={() => setLogTab(tab.value)}
             className={cn(
-              'px-3 py-1 rounded-lg text-xs border transition-colors',
+              'settings-hover-tab px-3 py-1 rounded-lg text-xs border',
               logTab === tab.value
                 ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
                 : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)]'
@@ -744,7 +744,7 @@ function ArchivedTab({ onRestore }: { onRestore?: (key: string) => void }) {
       {sessions.length === 0 ? (
         <div className="text-xs text-[var(--text-faint)] text-center py-12">暂无已归档的对话</div>
       ) : (
-        <div className="flex flex-col border border-[var(--border-subtle)] rounded-lg overflow-hidden">
+        <div className="settings-hover-card flex flex-col border border-[var(--border-subtle)] rounded-lg overflow-hidden">
           {sessions.map((s) => (
             <div
               key={s.key}
@@ -865,7 +865,7 @@ function DocsTab() {
         {DOCS_TREE.map((section) => (
           <div
             key={section.href}
-            className="border border-[var(--border-subtle)] rounded-lg overflow-hidden"
+            className="settings-hover-card border border-[var(--border-subtle)] rounded-lg overflow-hidden"
           >
             <a
               href={DOCS_BASE + section.href}
@@ -952,7 +952,7 @@ export function SettingsPage({ onReopenSetup, tab = 'general' }: { onReopenSetup
               key={tab.value}
               value={tab.value}
               className={cn(
-                'px-4 py-2.5 text-xs font-medium border-b-2 -mb-px transition-colors whitespace-nowrap',
+                'settings-hover-tab px-4 py-2.5 text-xs font-medium border-b-2 -mb-px whitespace-nowrap',
                 'text-[var(--text-muted)] border-transparent',
                 'hover:text-[var(--text)]',
                 'data-[state=active]:text-[var(--accent)] data-[state=active]:border-[var(--accent)]'

--- a/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
+++ b/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
@@ -457,7 +457,7 @@ export function SkillsPage() {
 
                 {/* Content */}
                 <div className="flex-1 overflow-auto p-6">
-                  <div className="text-sm text-[var(--text)] leading-relaxed bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg p-4 prose prose-sm max-w-none">
+                  <div className="settings-hover-card text-sm text-[var(--text)] leading-relaxed bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg p-4 prose prose-sm max-w-none">
                     <ReactMarkdown remarkPlugins={[remarkGfm]}>{detail.content}</ReactMarkdown>
                   </div>
                 </div>

--- a/apps/desktop/src/renderer/features/wsl/WslStatusPage.tsx
+++ b/apps/desktop/src/renderer/features/wsl/WslStatusPage.tsx
@@ -302,7 +302,7 @@ export default function WslStatusPage() {
             </div>
 
             {/* Detail table */}
-            <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-2xl overflow-hidden">
+            <div className="settings-hover-card bg-[var(--surface)] border border-[var(--border-subtle)] rounded-2xl overflow-hidden">
               <div className="px-5 py-3 border-b border-[var(--border-subtle)] bg-[var(--surface-muted)]">
                 <span className="text-xs font-semibold text-[var(--text)]">详细信息</span>
               </div>

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -242,6 +242,51 @@ code {
   text-transform: uppercase;
 }
 
+.settings-hover-tab {
+  transition:
+    color 160ms ease-out,
+    border-color 160ms ease-out,
+    background-color 160ms ease-out,
+    transform 160ms ease-out;
+  transform: translateZ(0);
+  will-change: transform;
+}
+
+.settings-hover-tab:hover {
+  transform: translateZ(0) scale(1.08);
+}
+
+.settings-hover-card {
+  transition:
+    background-color 180ms ease-out,
+    border-color 180ms ease-out,
+    box-shadow 180ms ease-out,
+    transform 180ms ease-out;
+  transform: translateZ(0);
+  will-change: transform;
+}
+
+.settings-hover-card:hover {
+  background-color: color-mix(in srgb, var(--surface) 94%, var(--accent-soft));
+  border-color: var(--accent);
+  transform: translate3d(0, -6px, 0);
+  box-shadow:
+    0 18px 42px rgba(42, 42, 72, 0.2),
+    0 6px 14px rgba(42, 42, 72, 0.12),
+    0 0 0 1px rgba(255, 193, 7, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-hover-tab,
+  .settings-hover-tab:hover,
+  .settings-hover-card,
+  .settings-hover-card:hover {
+    transition: none;
+    transform: none;
+    will-change: auto;
+  }
+}
+
 @keyframes approval-bypass-island-in {
   from {
     opacity: 0;

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -280,11 +280,25 @@ code {
   .settings-hover-tab,
   .settings-hover-tab:hover,
   .settings-hover-card,
-  .settings-hover-card:hover {
+  .settings-hover-card:hover,
+  .settings-hover-sidebar,
+  .settings-hover-sidebar:hover {
     transition: none;
     transform: none;
     will-change: auto;
   }
+}
+
+.settings-hover-sidebar {
+  transition:
+    color 160ms ease-out,
+    transform 160ms ease-out;
+  transform: translateZ(0);
+  will-change: transform;
+}
+
+.settings-hover-sidebar:hover {
+  transform: translateZ(0) scale(1.1);
 }
 
 @keyframes approval-bypass-island-in {


### PR DESCRIPTION
## 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 重构
- [ ] 测试
- [ ] 其他

## 变更概述

为设置页面的标签按钮和主要卡片区域补充 hover 动效，提升交互反馈。

## 背景/问题

Closes #248。当前设置页标签切换主要依赖颜色变化，卡片区域缺少悬浮反馈；issue 要求增加轻量的缩放、上浮和阴影效果，并保持 CSS transition/transform 实现。

## 变更内容

- 在 `apps/desktop/src/renderer/styles/globals.css` 增加 `settings-hover-tab` 与 `settings-hover-card` 公共动效 class。
- 标签按钮 hover 使用 `scale(1.08)`，过渡使用 `ease-out`，并通过 transform 保持 GPU 友好。
- 卡片区域 hover 使用 `translate3d(0, -6px, 0)`，同时增强阴影、黄色边框和轻微暖色背景，确保 hover 效果肉眼可见。
- 为顶部设置 tabs、设置页内二级 tabs，以及审批、渠道、MCP、技能、WSL、归档、文档等设置页卡片区域接入动效。
- 增加 `prefers-reduced-motion: reduce` 处理，系统减少动态效果时关闭 transform/transition。

## 日志/验证证据

```
D:\Desktop\230\MiQi> git diff --check
# 无输出，检查通过

D:\Desktop\230\MiQi\apps\desktop> npm.cmd run typecheck
> miqi-desktop@0.5.0 typecheck
> npm run typecheck:node && npm run typecheck:web
> tsc --noEmit -p tsconfig.node.json
> tsc --noEmit -p tsconfig.web.json
# 通过

D:\Desktop\230\MiQi\apps\desktop> npm.cmd run build
> miqi-desktop@0.5.0 build
> electron-vite build
built in 256ms
built in 233ms
built in 5.21s
# 通过；仅有 Radix 包 "use client" 被忽略的既有打包警告
```

## 测试情况

- 已执行 `git diff --check`，通过。
- 已执行 `npm.cmd run typecheck`，通过。
- 已执行 `npm.cmd run build`，通过。
- 已基于最新 `origin/develop` rebase，无代码冲突。
- 已本地启动 `npm.cmd run dev`，确认 MiQi 使用 `D:\Desktop\230\MiQi` 当前分支。

## 截图

Draft 阶段截图待补，建议后续替换为以下 3 组截图/GIF：

1. 设置页顶部 Tab hover：进入 `设置`，鼠标放到顶部任意 Tab，例如 `审批`。预期：Tab 有轻微放大动画，文字/下划线仍保持原有交互。
<img width="1264" height="782" alt="image" src="https://github.com/user-attachments/assets/2ed1c6c7-4d0c-4ecb-91b4-ad67d5604916" />

2. 审批页二级 Tab hover：进入 `设置 -> 审批`，鼠标放到 `永久白名单 / 历史记录 / 待审批` 中任意一项。预期：二级 Tab 有轻微放大动画。
<img width="1264" height="782" alt="image" src="https://github.com/user-attachments/assets/05d408f6-426a-45a6-afe1-4b6dfa0b2f84" />


3. 审批页卡片 hover：进入 `设置 -> 审批`，鼠标放到 `审批绕过模式`、`审批系统` 或 `永久白名单（4）` 整块白色卡片上。预期：卡片上浮，边框变为黄色，背景轻微偏暖，并出现更明显阴影。
<img width="1264" height="782" alt="image" src="https://github.com/user-attachments/assets/ea7439c6-04c1-4e18-89cf-a5d35ae3a47e" />

