### PR TITLE
fix(session): sync metadata updated_at with latest message

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -8,6 +8,13 @@ import type { SessionInfo } from '../../shared/ipc';
 
 type FilterTab = 'ALL' | 'IN-PROGRESS' | 'REVIEW' | 'COMPLETED';
 
+const FILTER_TAB_LABELS: Record<FilterTab, string> = {
+  ALL: '全部',
+  'IN-PROGRESS': '进行中',
+  REVIEW: '待审阅',
+  COMPLETED: '已完成',
+};
+
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 480;
 const DEFAULT_WIDTH = 260;
@@ -25,11 +32,11 @@ function relativeTime(iso?: string): string {
   const d = new Date(iso);
   const now = new Date();
   const diff = now.getTime() - d.getTime();
-  if (diff < 60_000) return 'Just now';
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} mins ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} hours ago`;
-  if (diff < 2 * 86_400_000) return 'Yesterday';
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  if (diff < 60_000) return '刚刚';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  if (diff < 2 * 86_400_000) return '昨天';
+  return d.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' });
 }
 
 interface SidebarProps {
@@ -133,16 +140,16 @@ export function Sidebar({
         className="absolute top-0 right-0 w-1.5 h-full cursor-col-resize hover:bg-[var(--accent)]/30 transition-colors z-10"
         style={{ marginRight: -2 }}
       />
-      {/* Header: glitch M logo + Tasks title */}
+      {/* Header: glitch M logo + tasks title */}
       <div className="flex items-center gap-2.5 px-4 py-3 shrink-0">
         <MiQiLogo size={28} />
         <span className="text-sm font-semibold" style={{ color: 'var(--text)' }}>
-          Tasks
+          任务
         </span>
         <button
           onClick={onNewSession}
           className="ml-auto w-6 h-6 rounded flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
-          title="New Session"
+          title="新建会话"
         >
           <Plus size={14} style={{ color: 'var(--text-faint)' }} />
         </button>
@@ -166,7 +173,7 @@ export function Sidebar({
                 background: isActive ? 'var(--surface-muted)' : 'transparent',
               }}
             >
-              {tab}
+              {FILTER_TAB_LABELS[tab]}
             </button>
           );
         })}
@@ -182,7 +189,7 @@ export function Sidebar({
           <div className="flex flex-col items-center gap-2 py-8 text-center">
             <ListChecks size={20} style={{ color: 'var(--text-faint)', opacity: 0.4 }} />
             <p className="text-xs" style={{ color: 'var(--text-faint)' }}>
-              No active tasks
+              暂无任务
             </p>
           </div>
         ) : (
@@ -196,33 +203,33 @@ export function Sidebar({
                   key={s.key}
                   items={[
                     {
-                      label: 'Mark as In Progress',
+                      label: '标记为进行中',
                       onSelect: () => setStatus(s.key, 'IN-PROGRESS'),
                     },
                     {
-                      label: 'Mark as Pending',
+                      label: '标记为待处理',
                       onSelect: () => setStatus(s.key, 'PENDING'),
                     },
                     {
-                      label: 'Mark as Review',
+                      label: '标记为待审阅',
                       onSelect: () => setStatus(s.key, 'REVIEW'),
                     },
                     {
-                      label: 'Mark as Completed',
+                      label: '标记为已完成',
                       divider: true,
                       onSelect: () => setStatus(s.key, 'COMPLETED'),
                     },
                     {
-                      label: 'Mark as CC',
+                      label: '标记为 CC',
                       onSelect: () => setStatus(s.key, 'CC'),
                     },
                     {
-                      label: 'Reset to Default',
+                      label: '重置状态',
                       danger: true,
                       onSelect: () => clearStatus(s.key),
                     },
                     {
-                      label: 'Archive',
+                      label: '归档',
                       divider: true,
                       onSelect: async () => {
                         try {
@@ -269,8 +276,8 @@ export function Sidebar({
                         style={{ color: 'var(--text-muted)' }}
                       >
                         {s.message_count != null
-                          ? `${s.message_count} messages`
-                          : 'No description'}
+                          ? `${s.message_count} 条消息`
+                          : '暂无描述'}
                       </p>
                     </button>
                   )}
@@ -291,7 +298,7 @@ export function Sidebar({
           style={{ color: 'var(--text-faint)' }}
           onClick={() => onNavChange?.('settings')}
         >
-          System Settings
+          系统设置
         </span>
         <span
           className="text-[10px] font-mono"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -137,6 +137,46 @@ export function buildTaskHeaderMeta(
   return `${relativeTimeLabel(updatedAt, now)} · ${fileLabel}`;
 }
 
+export function buildTaskShareText({
+  title,
+  meta,
+  messages,
+  files,
+}: {
+  title: string;
+  meta: string;
+  messages: Message[];
+  files: TrackedFile[];
+}): string {
+  const visibleMessages = messages
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .slice(-8);
+  const messageLines =
+    visibleMessages.length > 0
+      ? visibleMessages.map((message) => {
+          const role = message.role === 'user' ? '用户' : 'MiQi';
+          const content = message.content.trim().replace(/\s+/g, ' ');
+          return `- ${role}: ${content || '(空消息)'}`;
+        })
+      : ['- 暂无对话内容'];
+  const fileLines =
+    files.length > 0
+      ? files.map((file) => `- ${file.name} (${file.op})`)
+      : ['- 暂无文件'];
+
+  return [
+    `# ${title}`,
+    '',
+    meta,
+    '',
+    '## 最近对话',
+    ...messageLines,
+    '',
+    '## 相关文件',
+    ...fileLines,
+  ].join('\n');
+}
+
 /** Extract file path + operation from a tool-hint progress text.
  *  Nanobot tool hints look like:
  *    "Read: /abs/path/to/file.ts"
@@ -525,6 +565,7 @@ export function ChatConsole({
     Record<string, { stdout: string; stderr: string; running: boolean }>
   >({});
   const [merging, setMerging] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const userScrolledUp = useRef(false);
   const justOpened = useRef(false);
@@ -1391,6 +1432,18 @@ export function ChatConsole({
     };
   }, [clockTick, messages, sessionUpdatedAt, trackedFiles.length]);
 
+  const handleShareTask = useCallback(async () => {
+    const text = buildTaskShareText({
+      title: sessionTitle,
+      meta: taskHeaderInfo.meta,
+      messages,
+      files: trackedFiles,
+    });
+    await navigator.clipboard.writeText(text);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }, [messages, sessionTitle, taskHeaderInfo.meta, trackedFiles]);
+
   return (
     <div
       className="flex flex-col h-full"
@@ -1563,15 +1616,16 @@ export function ChatConsole({
               </div>
             </div>
             <button
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap opacity-50 shrink-0"
+              onClick={handleShareTask}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap shrink-0"
               style={{
                 background: 'var(--surface-muted)',
                 border: '1px solid var(--border-subtle)',
-                color: 'var(--text-muted)',
-                cursor: 'not-allowed',
+                color: shareCopied ? 'var(--success)' : 'var(--text-muted)',
+                cursor: 'pointer',
               }}
-              title="即将支持"
-              aria-label="分享任务，即将支持"
+              title="复制任务摘要"
+              aria-label="复制任务摘要"
             >
               <svg
                 width="12"
@@ -1587,7 +1641,7 @@ export function ChatConsole({
                 <polyline points="16 6 12 2 8 6" />
                 <line x1="12" y1="2" x2="12" y2="15" />
               </svg>
-              分享任务
+              {shareCopied ? '已复制' : '分享任务'}
             </button>
             <Tooltip content="Toggle assets panel">
               <button

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -131,10 +131,12 @@ function relativeTimeLabel(timestamp?: number | string | null, now = Date.now())
 export function buildTaskHeaderMeta(
   updatedAt: number | string | null | undefined,
   fileCount: number,
+  activePluginCount: number,
   now = Date.now()
 ): string {
   const fileLabel = `${fileCount} 个文件`;
-  return `${relativeTimeLabel(updatedAt, now)} · ${fileLabel}`;
+  const pluginLabel = `${activePluginCount} 个启用插件`;
+  return `${relativeTimeLabel(updatedAt, now)} · ${fileLabel} · ${pluginLabel}`;
 }
 
 export function buildTaskShareText({
@@ -175,6 +177,63 @@ export function buildTaskShareText({
     '## 相关文件',
     ...fileLines,
   ].join('\n');
+}
+
+export function buildTaskReproContext({
+  sessionKey,
+  title,
+  meta,
+  messages,
+  files,
+}: {
+  sessionKey: string;
+  title: string;
+  meta: string;
+  messages: Message[];
+  files: TrackedFile[];
+}): string {
+  const visibleMessages = messages
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .slice(-12);
+  const messageLines =
+    visibleMessages.length > 0
+      ? visibleMessages.map((message) => {
+          const role = message.role === 'user' ? '用户' : 'MiQi';
+          const content = message.content.trim().replace(/\s+/g, ' ');
+          return `- ${role}: ${content || '(空消息)'}`;
+        })
+      : ['- 暂无对话内容'];
+  const fileLines =
+    files.length > 0
+      ? files.map((file) => `- [${file.op}] ${file.path || file.name}`)
+      : ['- 暂无文件'];
+
+  return [
+    '# MiQi 任务复现上下文',
+    '',
+    `- 会话: ${sessionKey}`,
+    `- 标题: ${title}`,
+    `- 状态: ${meta}`,
+    '',
+    '## 最近对话',
+    ...messageLines,
+    '',
+    '## 相关文件',
+    ...fileLines,
+  ].join('\n');
+}
+
+export function getTaskShareDownloadName(title: string, timestamp = Date.now()): string {
+  const safeTitle =
+    title
+      .trim()
+      .replace(/[\\/:*?"<>|\u0000-\u001f]+/g, '-')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 48) || 'miqi-task';
+  const stamp = new Date(timestamp).toISOString().replace(/[:.]/g, '-');
+  return `${safeTitle}-${stamp}.md`;
 }
 
 /** Extract file path + operation from a tool-hint progress text.
@@ -510,6 +569,28 @@ export function ChatConsole({
     return () => window.clearInterval(timer);
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    const loadActivePlugins = async () => {
+      try {
+        const result = await window.miqi.plugins.list();
+        const plugins = (result as unknown as { plugins?: Array<{ status?: string }> })?.plugins;
+        if (!cancelled) {
+          setActivePluginCount((plugins ?? []).filter((plugin) => plugin.status === 'active').length);
+        }
+      } catch {
+        if (!cancelled) setActivePluginCount(0);
+      }
+    };
+
+    loadActivePlugins();
+    const timer = window.setInterval(loadActivePlugins, 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, []);
+
   // Task Assets panel resize
   const handlePanelResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -565,7 +646,10 @@ export function ChatConsole({
     Record<string, { stdout: string; stderr: string; running: boolean }>
   >({});
   const [merging, setMerging] = useState(false);
-  const [shareCopied, setShareCopied] = useState(false);
+  const [activePluginCount, setActivePluginCount] = useState(0);
+  const [shareStatus, setShareStatus] = useState<'idle' | 'copied' | 'exported' | 'context'>(
+    'idle'
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const userScrolledUp = useRef(false);
   const justOpened = useRef(false);
@@ -573,6 +657,7 @@ export function ChatConsole({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const unsubsRef = useRef<Array<() => void>>([]);
   const finalCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shareFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentSessionRef = useRef(sessionKey);
   // Track the active thread ID for new-protocol thread-aware conversations
   const currentThreadIdRef = useRef<string | null>(null);
@@ -756,8 +841,23 @@ export function ChatConsole({
     }
   }, []);
 
+  const showShareFeedback = useCallback((status: 'copied' | 'exported' | 'context') => {
+    if (shareFeedbackTimerRef.current) {
+      clearTimeout(shareFeedbackTimerRef.current);
+    }
+    setShareStatus(status);
+    shareFeedbackTimerRef.current = setTimeout(() => {
+      setShareStatus('idle');
+      shareFeedbackTimerRef.current = null;
+    }, 2000);
+  }, []);
+
   const cleanupListeners = useCallback(() => {
     clearFinalCleanupTimer();
+    if (shareFeedbackTimerRef.current) {
+      clearTimeout(shareFeedbackTimerRef.current);
+      shareFeedbackTimerRef.current = null;
+    }
     for (const unsub of unsubsRef.current) unsub();
     unsubsRef.current = [];
   }, [clearFinalCleanupTimer]);
@@ -1409,14 +1509,15 @@ export function ChatConsole({
     const raw = sessionKey.replace(/^desktop:/, '');
     const ts = parseInt(raw, 10);
     if (!isNaN(ts) && raw.length >= 13) {
-      return new Intl.DateTimeFormat('en-US', {
-        month: 'short',
+      return new Intl.DateTimeFormat('zh-CN', {
+        month: 'long',
         day: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
+        hour12: false,
       }).format(new Date(ts));
     }
-    return raw.replace(/_/g, ' ') || 'New Task';
+    return raw.replace(/_/g, ' ') || '新任务';
   }, [messages, sessionKey]);
 
   const taskHeaderInfo = useMemo(() => {
@@ -1428,21 +1529,85 @@ export function ChatConsole({
     return {
       updatedLabel: relativeTimeLabel(updatedAt, clockTick),
       fileLabel: `${trackedFiles.length} 个文件`,
-      meta: buildTaskHeaderMeta(updatedAt, trackedFiles.length, clockTick),
+      pluginLabel: `${activePluginCount} 个启用插件`,
+      meta: buildTaskHeaderMeta(updatedAt, trackedFiles.length, activePluginCount, clockTick),
     };
-  }, [clockTick, messages, sessionUpdatedAt, trackedFiles.length]);
+  }, [activePluginCount, clockTick, messages, sessionUpdatedAt, trackedFiles.length]);
 
-  const handleShareTask = useCallback(async () => {
+  const getTaskShareSummary = useCallback(
+    () =>
+      buildTaskShareText({
+        title: sessionTitle,
+        meta: taskHeaderInfo.meta,
+        messages,
+        files: trackedFiles,
+      }),
+    [messages, sessionTitle, taskHeaderInfo.meta, trackedFiles]
+  );
+
+  const handleCopyTaskSummary = useCallback(async () => {
+    await navigator.clipboard.writeText(getTaskShareSummary());
+    showShareFeedback('copied');
+  }, [getTaskShareSummary, showShareFeedback]);
+
+  const handleExportTaskMarkdown = useCallback(() => {
+    const text = getTaskShareSummary();
+    const blob = new Blob([text], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = getTaskShareDownloadName(sessionTitle);
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    showShareFeedback('exported');
+  }, [getTaskShareSummary, sessionTitle, showShareFeedback]);
+
+  const handleCopyReproContext = useCallback(async () => {
     const text = buildTaskShareText({
       title: sessionTitle,
       meta: taskHeaderInfo.meta,
       messages,
       files: trackedFiles,
     });
-    await navigator.clipboard.writeText(text);
-    setShareCopied(true);
-    setTimeout(() => setShareCopied(false), 2000);
-  }, [messages, sessionTitle, taskHeaderInfo.meta, trackedFiles]);
+    const context = buildTaskReproContext({
+      sessionKey,
+      title: sessionTitle,
+      meta: taskHeaderInfo.meta,
+      messages,
+      files: trackedFiles,
+    });
+    await navigator.clipboard.writeText(context || text);
+    showShareFeedback('context');
+  }, [messages, sessionKey, sessionTitle, showShareFeedback, taskHeaderInfo.meta, trackedFiles]);
+
+  const shareMenuItems = useMemo<ContextMenuAction[]>(
+    () => [
+      { label: '复制摘要', shortcut: '推荐', onSelect: handleCopyTaskSummary },
+      { label: '导出 Markdown', onSelect: handleExportTaskMarkdown },
+      {
+        label: '复制上下文',
+        shortcut: `${messages.filter((message) => message.role === 'user' || message.role === 'assistant').length} 条`,
+        divider: true,
+        onSelect: handleCopyReproContext,
+      },
+    ],
+    [handleCopyReproContext, handleCopyTaskSummary, handleExportTaskMarkdown, messages]
+  );
+
+  const shareButtonLabel =
+    shareStatus === 'copied'
+      ? '已复制摘要'
+      : shareStatus === 'exported'
+        ? '已导出'
+        : shareStatus === 'context'
+          ? '已复制上下文'
+          : '分享任务';
+
+  const shareButtonTone = shareStatus === 'idle' ? 'var(--text)' : 'var(--success)';
+  const shareButtonBackground = 'var(--surface-muted)';
+  const shareButtonBorder = 'var(--border-subtle)';
 
   return (
     <div
@@ -1528,7 +1693,7 @@ export function ChatConsole({
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.3-4.3" />
           </svg>
-          <span className="select-none">Search or use commands...</span>
+          <span className="select-none">搜索或输入命令...</span>
         </div>
 
         {/* Right: Badges + user + actions */}
@@ -1551,15 +1716,15 @@ export function ChatConsole({
 
           {/* More menu */}
           <ContextMenu
-            items={[{ label: 'Delete conversation', danger: true, onSelect: handleDeleteSession }]}
+            items={[{ label: '删除对话', danger: true, onSelect: handleDeleteSession }]}
           >
             {({ onContextMenu }) => (
-              <Tooltip content="More conversation actions">
+              <Tooltip content="更多对话操作">
                 <button
                   className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
                   onClick={onContextMenu}
-                  aria-label="More conversation actions"
-                  title="More conversation actions"
+                  aria-label="更多对话操作"
+                  title="更多对话操作"
                 >
                   <MoreHorizontal size={14} style={{ color: 'var(--text-faint)' }} />
                 </button>
@@ -1590,65 +1755,63 @@ export function ChatConsole({
               </h2>
               <span className="tag-inprogress shrink-0">{'\u8fdb\u884c\u4e2d'}</span>
               <div
-                className="flex items-center gap-1.5 shrink-0"
+                className="flex min-w-0 items-center gap-1.5 shrink-0 text-[12px] leading-none whitespace-nowrap"
                 aria-label={taskHeaderInfo.meta}
+                style={{ color: 'var(--text-faint)' }}
               >
-                <span
-                  className="text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
-                  style={{
-                    color: 'var(--text-muted)',
-                    background: 'var(--surface-muted)',
-                    border: '1px solid var(--border-subtle)',
-                  }}
-                >
-                  {taskHeaderInfo.updatedLabel}
-                </span>
-                <span
-                  className="text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
-                  style={{
-                    color: 'var(--text-muted)',
-                    background: 'var(--surface-muted)',
-                    border: '1px solid var(--border-subtle)',
-                  }}
-                >
-                  {taskHeaderInfo.fileLabel}
-                </span>
+                <span>{taskHeaderInfo.updatedLabel}</span>
+                <span aria-hidden="true">·</span>
+                <span>{taskHeaderInfo.fileLabel}</span>
+                <span aria-hidden="true">·</span>
+                <span>{taskHeaderInfo.pluginLabel}</span>
               </div>
             </div>
-            <button
-              onClick={handleShareTask}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap shrink-0"
+            <div
+              className="flex shrink-0 items-stretch overflow-hidden rounded-md shadow-[0_1px_0_rgba(18,18,18,0.05)]"
               style={{
-                background: 'var(--surface-muted)',
-                border: '1px solid var(--border-subtle)',
-                color: shareCopied ? 'var(--success)' : 'var(--text-muted)',
-                cursor: 'pointer',
+                background: shareButtonBackground,
+                border: `1px solid ${shareButtonBorder}`,
               }}
-              title="复制任务摘要"
-              aria-label="复制任务摘要"
             >
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+              <button
+                onClick={handleCopyTaskSummary}
+                className="flex h-7 min-w-[96px] items-center justify-center gap-1.5 px-3 text-xs font-semibold transition-colors whitespace-nowrap hover:brightness-95"
+                style={{
+                  color: shareButtonTone,
+                  cursor: 'pointer',
+                }}
+                title="复制任务摘要"
+                aria-label="复制任务摘要"
               >
-                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
-                <polyline points="16 6 12 2 8 6" />
-                <line x1="12" y1="2" x2="12" y2="15" />
-              </svg>
-              {shareCopied ? '已复制' : '分享任务'}
-            </button>
-            <Tooltip content="Toggle assets panel">
+                {shareStatus === 'idle' ? <Send size={12} /> : <Check size={12} />}
+                {shareButtonLabel}
+              </button>
+              <ContextMenu items={shareMenuItems} minWidth={180}>
+                {({ onContextMenu }) => (
+                  <Tooltip content="复制摘要、导出 Markdown 或复制上下文">
+                    <button
+                      onClick={onContextMenu}
+                      className="flex h-7 w-7 items-center justify-center transition-colors hover:brightness-95"
+                      style={{
+                        borderLeft: `1px solid ${shareButtonBorder}`,
+                        color: shareStatus === 'idle' ? 'var(--text-muted)' : 'var(--success)',
+                      }}
+                      title="更多分享方式"
+                      aria-label="更多分享方式"
+                      aria-haspopup="menu"
+                    >
+                      <ChevronDown size={12} />
+                    </button>
+                  </Tooltip>
+                )}
+              </ContextMenu>
+            </div>
+            <Tooltip content="显示或隐藏文件面板">
               <button
                 onClick={() => setPanelOpen((v) => !v)}
                 className="p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors shrink-0 ml-1"
-                title="Toggle assets panel"
-                aria-label="Toggle assets panel"
+                title="显示或隐藏文件面板"
+                aria-label="显示或隐藏文件面板"
               >
                 <LayoutGrid size={14} style={{ color: 'var(--text-faint)' }} />
               </button>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -116,6 +116,26 @@ interface TrackedFile {
 
 const OFFICE_FILE_RE = /\.(docx|xlsx|pptx)$/i;
 
+function relativeTimeLabel(timestamp?: number | string | null): string {
+  if (timestamp === undefined || timestamp === null) return '尚未更新';
+  const value = typeof timestamp === 'number' ? timestamp : Date.parse(timestamp);
+  if (!Number.isFinite(value)) return '尚未更新';
+
+  const diff = Date.now() - value;
+  if (diff < 60_000) return '刚刚更新';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前更新`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前更新`;
+  return `${Math.floor(diff / 86_400_000)} 天前更新`;
+}
+
+export function buildTaskHeaderMeta(
+  updatedAt: number | string | null | undefined,
+  fileCount: number
+): string {
+  const fileLabel = `${fileCount} 个文件`;
+  return `${relativeTimeLabel(updatedAt)} · ${fileLabel}`;
+}
+
 /** Extract file path + operation from a tool-hint progress text.
  *  Nanobot tool hints look like:
  *    "Read: /abs/path/to/file.ts"
@@ -432,6 +452,7 @@ export function ChatConsole({
   onOpenProviderSettings?: () => void;
 }) {
   const [messages, setMessages] = useState<Message[]>([]);
+  const [sessionUpdatedAt, setSessionUpdatedAt] = useState<string | null>(null);
   const [input, setInput] = useState('');
   const [streaming, setStreaming] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
@@ -600,6 +621,7 @@ export function ChatConsole({
     currentThreadIdRef.current = null; // Reset on session change
     setHistoryLoaded(false);
     setMessages([]);
+    setSessionUpdatedAt(null);
     setTrackedFiles([]);
     justOpened.current = true;
     userScrolledUp.current = false; // reset for new session
@@ -610,6 +632,7 @@ export function ChatConsole({
         const rawMsgs: any[] = (detail as any)?.messages ?? [];
         const uiMsgs = sessionMsgsToUi(rawMsgs);
         setMessages(uiMsgs);
+        setSessionUpdatedAt((detail as any)?.updated_at ?? null);
         // Restore tracked files from dedicated tracked_files.json
         const tfResult = await window.miqi.sessions.getTrackedFiles(sessionKey);
         if (currentSessionRef.current !== sessionKey) return;
@@ -1348,6 +1371,14 @@ export function ChatConsole({
     return raw.replace(/_/g, ' ') || 'New Task';
   }, [messages, sessionKey]);
 
+  const taskHeaderMeta = useMemo(() => {
+    const latestMessageAt = messages.reduce<number | null>((latest, message) => {
+      if (!Number.isFinite(message.timestamp)) return latest;
+      return latest === null || message.timestamp > latest ? message.timestamp : latest;
+    }, null);
+    return buildTaskHeaderMeta(latestMessageAt ?? sessionUpdatedAt, trackedFiles.length);
+  }, [messages, sessionUpdatedAt, trackedFiles.length]);
+
   return (
     <div
       className="flex flex-col h-full"
@@ -1479,21 +1510,24 @@ export function ChatConsole({
         <div className="flex flex-col flex-1 overflow-hidden">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
-            className="flex items-center gap-3 px-5 h-8 border-b shrink-0"
+            className="flex items-center gap-2 px-5 h-9 border-b shrink-0"
             style={{
               background: 'var(--surface)',
               borderColor: 'var(--border-subtle)',
             }}
           >
             <h2
-              className="text-[18px] font-semibold truncate leading-tight"
+              className="text-[17px] font-semibold truncate leading-[1.35]"
               style={{ color: 'var(--text)' }}
             >
               {sessionTitle}
             </h2>
-            <span className="tag-inprogress shrink-0">IN PROGRESS</span>
-            <span className="text-[13px] shrink-0" style={{ color: 'var(--text-muted)' }}>
-              Updated 2 mins ago · 2 linked files · 2 Active Plugins
+            <span className="tag-inprogress shrink-0">{'\u8fdb\u884c\u4e2d'}</span>
+            <span
+              className="text-[12px] shrink-0 whitespace-nowrap"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              {taskHeaderMeta}
             </span>
             <button
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap ml-auto opacity-50"
@@ -1503,8 +1537,8 @@ export function ChatConsole({
                 color: 'var(--text-muted)',
                 cursor: 'not-allowed',
               }}
-              title="Coming soon"
-              aria-label="Share task, coming soon"
+              title="即将支持"
+              aria-label="分享任务，即将支持"
             >
               <svg
                 width="12"
@@ -1520,7 +1554,7 @@ export function ChatConsole({
                 <polyline points="16 6 12 2 8 6" />
                 <line x1="12" y1="2" x2="12" y2="15" />
               </svg>
-              Share Task
+              分享任务
             </button>
             <Tooltip content="Toggle assets panel">
               <button

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -116,12 +116,12 @@ interface TrackedFile {
 
 const OFFICE_FILE_RE = /\.(docx|xlsx|pptx)$/i;
 
-function relativeTimeLabel(timestamp?: number | string | null): string {
+function relativeTimeLabel(timestamp?: number | string | null, now = Date.now()): string {
   if (timestamp === undefined || timestamp === null) return '尚未更新';
   const value = typeof timestamp === 'number' ? timestamp : Date.parse(timestamp);
   if (!Number.isFinite(value)) return '尚未更新';
 
-  const diff = Date.now() - value;
+  const diff = now - value;
   if (diff < 60_000) return '刚刚更新';
   if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前更新`;
   if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前更新`;
@@ -130,10 +130,11 @@ function relativeTimeLabel(timestamp?: number | string | null): string {
 
 export function buildTaskHeaderMeta(
   updatedAt: number | string | null | undefined,
-  fileCount: number
+  fileCount: number,
+  now = Date.now()
 ): string {
   const fileLabel = `${fileCount} 个文件`;
-  return `${relativeTimeLabel(updatedAt)} · ${fileLabel}`;
+  return `${relativeTimeLabel(updatedAt, now)} · ${fileLabel}`;
 }
 
 /** Extract file path + operation from a tool-hint progress text.
@@ -453,6 +454,7 @@ export function ChatConsole({
 }) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [sessionUpdatedAt, setSessionUpdatedAt] = useState<string | null>(null);
+  const [clockTick, setClockTick] = useState(() => Date.now());
   const [input, setInput] = useState('');
   const [streaming, setStreaming] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
@@ -462,6 +464,11 @@ export function ChatConsole({
   const [panelOpen, setPanelOpen] = useState(true);
   const [panelWidth, setPanelWidth] = useState(280);
   const panelResizing = useRef(false);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setClockTick(Date.now()), 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   // Task Assets panel resize
   const handlePanelResizeStart = useCallback((e: React.MouseEvent) => {
@@ -1371,13 +1378,18 @@ export function ChatConsole({
     return raw.replace(/_/g, ' ') || 'New Task';
   }, [messages, sessionKey]);
 
-  const taskHeaderMeta = useMemo(() => {
+  const taskHeaderInfo = useMemo(() => {
     const latestMessageAt = messages.reduce<number | null>((latest, message) => {
       if (!Number.isFinite(message.timestamp)) return latest;
       return latest === null || message.timestamp > latest ? message.timestamp : latest;
     }, null);
-    return buildTaskHeaderMeta(latestMessageAt ?? sessionUpdatedAt, trackedFiles.length);
-  }, [messages, sessionUpdatedAt, trackedFiles.length]);
+    const updatedAt = latestMessageAt ?? sessionUpdatedAt;
+    return {
+      updatedLabel: relativeTimeLabel(updatedAt, clockTick),
+      fileLabel: `${trackedFiles.length} 个文件`,
+      meta: buildTaskHeaderMeta(updatedAt, trackedFiles.length, clockTick),
+    };
+  }, [clockTick, messages, sessionUpdatedAt, trackedFiles.length]);
 
   return (
     <div
@@ -1510,27 +1522,48 @@ export function ChatConsole({
         <div className="flex flex-col flex-1 overflow-hidden">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
-            className="flex items-center gap-2 px-5 h-9 border-b shrink-0"
+            className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
             style={{
               background: 'var(--surface)',
               borderColor: 'var(--border-subtle)',
             }}
           >
-            <h2
-              className="text-[17px] font-semibold truncate leading-[1.35]"
-              style={{ color: 'var(--text)' }}
-            >
-              {sessionTitle}
-            </h2>
-            <span className="tag-inprogress shrink-0">{'\u8fdb\u884c\u4e2d'}</span>
-            <span
-              className="text-[12px] shrink-0 whitespace-nowrap"
-              style={{ color: 'var(--text-muted)' }}
-            >
-              {taskHeaderMeta}
-            </span>
+            <div className="min-w-0 flex-1 flex items-center gap-2.5">
+              <h2
+                className="text-[16px] font-semibold truncate leading-[1.35]"
+                style={{ color: 'var(--text)' }}
+              >
+                {sessionTitle}
+              </h2>
+              <span className="tag-inprogress shrink-0">{'\u8fdb\u884c\u4e2d'}</span>
+              <div
+                className="flex items-center gap-1.5 shrink-0"
+                aria-label={taskHeaderInfo.meta}
+              >
+                <span
+                  className="text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
+                  style={{
+                    color: 'var(--text-muted)',
+                    background: 'var(--surface-muted)',
+                    border: '1px solid var(--border-subtle)',
+                  }}
+                >
+                  {taskHeaderInfo.updatedLabel}
+                </span>
+                <span
+                  className="text-[11px] leading-none rounded-full px-2 py-1 whitespace-nowrap"
+                  style={{
+                    color: 'var(--text-muted)',
+                    background: 'var(--surface-muted)',
+                    border: '1px solid var(--border-subtle)',
+                  }}
+                >
+                  {taskHeaderInfo.fileLabel}
+                </span>
+              </div>
+            </div>
             <button
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap ml-auto opacity-50"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors whitespace-nowrap opacity-50 shrink-0"
               style={{
                 background: 'var(--surface-muted)',
                 border: '1px solid var(--border-subtle)',
@@ -1592,10 +1625,10 @@ export function ChatConsole({
                   </div>
                   <div className="flex flex-col items-center gap-1">
                     <p className="text-[15px] font-medium" style={{ color: 'var(--text-muted)' }}>
-                      Start with a file, issue, or edit request
+                      从文件、问题或修改请求开始
                     </p>
                     <p className="text-xs" style={{ color: 'var(--text-faint)' }}>
-                      Start a conversation to begin
+                      发起一段对话即可开始
                     </p>
                   </div>
                 </div>

--- a/apps/desktop/src/renderer/hooks/useSessionStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionStatus.ts
@@ -43,7 +43,7 @@ export function useSessionStatus() {
     switch (status) {
       case 'IN-PROGRESS':
         return {
-          label: 'IN-PROGRESS',
+          label: '进行中',
           bg: 'var(--tag-inprogress-bg)',
           color: 'var(--tag-inprogress-text)',
           cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-inprogress-bg))',
@@ -51,7 +51,7 @@ export function useSessionStatus() {
         };
       case 'REVIEW':
         return {
-          label: 'REVIEW',
+          label: '待审阅',
           bg: 'var(--tag-review-bg)',
           color: 'var(--tag-review-text)',
           cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-review-bg))',
@@ -59,7 +59,7 @@ export function useSessionStatus() {
         };
       case 'COMPLETED':
         return {
-          label: 'COMPLETED',
+          label: '已完成',
           bg: 'var(--tag-completed-bg)',
           color: 'var(--tag-completed-text)',
           cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-completed-bg))',
@@ -76,7 +76,7 @@ export function useSessionStatus() {
       case 'PENDING':
       default:
         return {
-          label: 'PENDING',
+          label: '待处理',
           bg: 'var(--surface-muted)',
           color: 'var(--text-faint)',
           cardBg: 'var(--surface)',

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -238,13 +238,13 @@ code {
   align-items: center;
   white-space: nowrap;
   word-break: keep-all;
-  line-height: 1;
-  font-size: 10px;
+  line-height: 1.15;
+  font-size: 11px;
   font-weight: 600;
-  padding: 4px 8px;
-  border-radius: 999px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 4px;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .tag-cc {

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sessionMsgsToUi } from '../src/renderer/features/chat/ChatConsole';
+import { buildTaskHeaderMeta, sessionMsgsToUi } from '../src/renderer/features/chat/ChatConsole';
 
 describe('sessionMsgsToUi', () => {
   it('shows only the final assistant text within a tool-heavy turn', () => {
@@ -50,5 +50,15 @@ describe('sessionMsgsToUi', () => {
     expect(
       messages.filter((message) => message.role === 'assistant').map((message) => message.content)
     ).toEqual(['first final', 'second final']);
+  });
+});
+
+describe('buildTaskHeaderMeta', () => {
+  it('uses real file count and omits fake plugin/link placeholders', () => {
+    const label = buildTaskHeaderMeta(Date.now(), 2);
+
+    expect(label).toContain('2 个文件');
+    expect(label).not.toContain('linked files');
+    expect(label).not.toContain('Active Plugins');
   });
 });

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildTaskHeaderMeta, sessionMsgsToUi } from '../src/renderer/features/chat/ChatConsole';
+import {
+  buildTaskHeaderMeta,
+  buildTaskShareText,
+  sessionMsgsToUi,
+} from '../src/renderer/features/chat/ChatConsole';
 
 describe('sessionMsgsToUi', () => {
   it('shows only the final assistant text within a tool-heavy turn', () => {
@@ -60,5 +64,27 @@ describe('buildTaskHeaderMeta', () => {
     expect(label).toContain('2 个文件');
     expect(label).not.toContain('linked files');
     expect(label).not.toContain('Active Plugins');
+  });
+});
+
+describe('buildTaskShareText', () => {
+  it('builds a shareable task summary with recent messages and files', () => {
+    const text = buildTaskShareText({
+      title: '测试任务',
+      meta: '刚刚更新 · 1 个文件',
+      messages: [
+        { role: 'user', content: '请修改 README', timestamp: 1 },
+        { role: 'assistant', content: '已完成修改', timestamp: 2 },
+        { role: 'progress', content: 'Write: README.md', timestamp: 3 },
+      ],
+      files: [{ path: 'README.md', name: 'README.md', op: 'edit', lastSeen: 4 }],
+    });
+
+    expect(text).toContain('# 测试任务');
+    expect(text).toContain('刚刚更新 · 1 个文件');
+    expect(text).toContain('- 用户: 请修改 README');
+    expect(text).toContain('- MiQi: 已完成修改');
+    expect(text).toContain('- README.md (edit)');
+    expect(text).not.toContain('Write: README.md');
   });
 });

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildTaskReproContext,
   buildTaskHeaderMeta,
   buildTaskShareText,
+  getTaskShareDownloadName,
   sessionMsgsToUi,
 } from '../src/renderer/features/chat/ChatConsole';
 
@@ -59,9 +61,10 @@ describe('sessionMsgsToUi', () => {
 
 describe('buildTaskHeaderMeta', () => {
   it('uses real file count and omits fake plugin/link placeholders', () => {
-    const label = buildTaskHeaderMeta(Date.now(), 2);
+    const label = buildTaskHeaderMeta(Date.now(), 2, 3);
 
     expect(label).toContain('2 个文件');
+    expect(label).toContain('3 个启用插件');
     expect(label).not.toContain('linked files');
     expect(label).not.toContain('Active Plugins');
   });
@@ -86,5 +89,37 @@ describe('buildTaskShareText', () => {
     expect(text).toContain('- MiQi: 已完成修改');
     expect(text).toContain('- README.md (edit)');
     expect(text).not.toContain('Write: README.md');
+  });
+});
+
+describe('task share helpers', () => {
+  it('builds a reproduction context with session id and full file paths', () => {
+    const text = buildTaskReproContext({
+      sessionKey: 'desktop:issue-243',
+      title: '修复任务更新时间',
+      meta: '刚刚更新 · 1 个文件',
+      messages: [
+        { role: 'user', content: '顶部也要显示真实文件数', timestamp: 1 },
+        { role: 'assistant', content: '已接入 trackedFiles.length', timestamp: 2 },
+      ],
+      files: [
+        {
+          path: 'apps/desktop/src/renderer/features/chat/ChatConsole.tsx',
+          name: 'ChatConsole.tsx',
+          op: 'edit',
+          lastSeen: 3,
+        },
+      ],
+    });
+
+    expect(text).toContain('desktop:issue-243');
+    expect(text).toContain('- 用户: 顶部也要显示真实文件数');
+    expect(text).toContain('[edit] apps/desktop/src/renderer/features/chat/ChatConsole.tsx');
+  });
+
+  it('sanitizes exported markdown filenames', () => {
+    const name = getTaskShareDownloadName('修复: 顶部/侧边 文件?', 1783993200000);
+
+    expect(name).toBe('修复-顶部-侧边-文件-2026-07-14T01-40-00-000Z.md');
   });
 });

--- a/apps/desktop/tests/e2e/full-electron.spec.ts
+++ b/apps/desktop/tests/e2e/full-electron.spec.ts
@@ -64,8 +64,8 @@ test.describe('Native Electron E2E', () => {
     ).toBeVisible({ timeout: 10_000 });
 
     // Core UI landmarks — use stable text selectors that exist in BOTH old and new UI
-    await expect(page.getByText('Tasks').first()).toBeVisible();
-    await expect(page.locator('button[title="New Session"]')).toBeVisible();
+    await expect(page.getByText('任务').first()).toBeVisible();
+    await expect(page.locator('button[title="新建会话"]')).toBeVisible();
   });
 
   test('right panel shows Task Assets', async () => {

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -121,7 +121,7 @@ export async function getSidebarSessionCount(page: Page): Promise<number> {
 /** Create a new conversation via sidebar "+" button and wait for it to be ready.
  *  In the redesigned UI there is no "New Chat" header button — sidebar "+" is the canonical way. */
 export async function createNewConversation(page: Page): Promise<string> {
-  const sidebarPlusBtn = page.locator('button[title="New Session"]');
+  const sidebarPlusBtn = page.locator('button[title="New Session"], button[title="新建会话"]');
   await expect(sidebarPlusBtn).toBeVisible();
   await sidebarPlusBtn.click();
   // Wait for the new session to load — input becomes enabled when ChatConsole mounts
@@ -144,7 +144,7 @@ export async function switchToSessionWithMarker(
   marker: string,
 ): Promise<boolean> {
   // Ensure the Tasks section is scrolled into view
-  const tasksHeader = page.getByText('Tasks').first();
+  const tasksHeader = page.getByText(/^(Tasks|任务)$/).first();
   await tasksHeader.scrollIntoViewIfNeeded().catch(() => {});
 
   const items = getSidebarSessionItems(page);

--- a/apps/desktop/tests/e2e/sandbox-toggle.spec.ts
+++ b/apps/desktop/tests/e2e/sandbox-toggle.spec.ts
@@ -58,7 +58,7 @@ test.describe.serial('Sandbox Toggle E2E', () => {
 
   // -- Helper: navigate to Settings General tab --
   async function openSettings(page: Page) {
-    const settingsBtn = page.getByText('System Settings');
+    const settingsBtn = page.getByText(/^(System Settings|系统设置)$/);
     await expect(settingsBtn).toBeVisible({ timeout: 10_000 });
     await settingsBtn.click();
     await page.waitForTimeout(1500);

--- a/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
+++ b/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
@@ -7,7 +7,7 @@ test.describe('Issue #140 Web search settings', () => {
     await page.goto('/');
     await page.waitForSelector('#root', { state: 'visible' });
 
-    await page.getByText('System Settings').click();
+    await page.getByText(/^(System Settings|系统设置)$/).click();
     await page.getByRole('tab').filter({ hasText: /Web/ }).click();
 
     const webSearch = page

--- a/apps/desktop/tests/smoke/issue-185-provider-status.spec.ts
+++ b/apps/desktop/tests/smoke/issue-185-provider-status.spec.ts
@@ -68,7 +68,7 @@ test('Provider settings shows filled, verified, failed, and active provider stat
 
   await page.goto('/');
   await page.waitForSelector('#root', { state: 'visible' });
-  await page.getByText('System Settings').click();
+  await page.getByText(/^(System Settings|系统设置)$/).click();
   await page.getByRole('tab', { name: '模型' }).click();
 
   await expect(page.getByText('模型提供商')).toBeVisible();

--- a/apps/desktop/tests/smoke/logs.spec.ts
+++ b/apps/desktop/tests/smoke/logs.spec.ts
@@ -26,7 +26,7 @@ async function injectMockAndGoto(
 
 /** Click "System Settings" in the sidebar bottom bar to open SettingsPage */
 async function navigateToSettings(page: import('@playwright/test').Page) {
-  await page.getByText('System Settings').click();
+  await page.getByText(/^(System Settings|系统设置)$/).click();
   await expect(page.getByRole('heading', { name: '设置' })).toBeVisible({ timeout: 3000 });
 }
 
@@ -466,7 +466,7 @@ test.describe('Logs Tab — Edge Cases', () => {
     await expect(errorHeading).toBeVisible();
 
     // Settings should not be accessible
-    await expect(page.getByText('System Settings')).not.toBeVisible();
+    await expect(page.getByText(/^(System Settings|系统设置)$/)).not.toBeVisible();
   });
 
   test('auto-scroll checkbox can be toggled', async ({ page }) => {

--- a/apps/desktop/tests/smoke/smoke.spec.ts
+++ b/apps/desktop/tests/smoke/smoke.spec.ts
@@ -73,10 +73,10 @@ test.describe('Sidebar Navigation', () => {
     await injectMockAndGoto(page);
 
     // Tasks section header — stable text across redesigns
-    await expect(page.getByText('Tasks')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText(/^(Tasks|任务)$/)).toBeVisible({ timeout: 3000 });
 
     // Plus button for new session — stable title attribute
-    await expect(page.locator('[title="New Session"]')).toBeVisible();
+    await expect(page.locator('[title="New Session"], [title="新建会话"]')).toBeVisible();
 
     // At least one session card should render
     const session1 = page.getByText('Test conversation 1');
@@ -98,7 +98,7 @@ test.describe('Sidebar Navigation', () => {
   test('new session button is present', async ({ page }) => {
     await injectMockAndGoto(page);
 
-    const newSessionBtn = page.locator('[title="New Session"]');
+    const newSessionBtn = page.locator('[title="New Session"], [title="新建会话"]');
     await expect(newSessionBtn).toBeVisible();
   });
 
@@ -106,7 +106,7 @@ test.describe('Sidebar Navigation', () => {
     await injectMockAndGoto(page);
 
     // The sessions section header should say "Tasks"
-    await expect(page.getByText('Tasks')).toBeVisible({ timeout: 3000 });
+    await expect(page.getByText(/^(Tasks|任务)$/)).toBeVisible({ timeout: 3000 });
   });
 
 });

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -27,14 +27,22 @@ class Session:
 
     def add_message(self, role: str, content: str, **kwargs: Any) -> None:
         """Add a message to the session."""
+        now = datetime.now()
         msg = {
             "role": role,
             "content": content,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": now.isoformat(),
             **kwargs,
         }
         self.messages.append(msg)
-        self.updated_at = datetime.now()
+        msg_ts = msg.get("timestamp")
+        if isinstance(msg_ts, str):
+            try:
+                self.updated_at = datetime.fromisoformat(msg_ts)
+            except Exception:
+                self.updated_at = now
+        else:
+            self.updated_at = now
 
     def get_history(self, max_messages: int = 500) -> list[dict[str, Any]]:
         """Return unconsolidated history, aligned to a user turn."""
@@ -261,6 +269,7 @@ class SessionManager:
         self._migrate_flat_to_dir(session.key)
         path = self._get_session_path(session.key)
         path.parent.mkdir(parents=True, exist_ok=True)
+        self._sync_updated_at_from_messages(session)
 
         should_rewrite = not path.exists() or len(session.messages) < session.saved_count
 
@@ -272,15 +281,7 @@ class SessionManager:
 
         if should_rewrite:
             with open(path, "w", encoding="utf-8") as f:
-                metadata_line = {
-                    "_type": "metadata",
-                    "key": session.key,
-                    "owner_client_id": session.metadata.get("owner_client_id"),
-                    "created_at": session.created_at.isoformat(),
-                    "updated_at": session.updated_at.isoformat(),
-                    "metadata": session.metadata,
-                    "last_consolidated": session.last_consolidated,
-                }
+                metadata_line = self._metadata_line_for_session(session)
                 f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
                 for msg in session.messages:
                     f.write(json.dumps(msg, ensure_ascii=False) + "\n")
@@ -292,6 +293,7 @@ class SessionManager:
                 with open(path, "a", encoding="utf-8") as f:
                     for msg in new_messages:
                         f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                self._rewrite_metadata_line(path, session)
                 path.chmod(0o600)  # Restrict to owner only (SEC-07)
                 session.saved_count = len(session.messages)
 
@@ -626,6 +628,62 @@ class SessionManager:
         except Exception:
             return None
 
+    @staticmethod
+    def _latest_message_timestamp(session: Session) -> datetime | None:
+        latest: datetime | None = None
+        for msg in session.messages:
+            msg_ts = msg.get("timestamp")
+            if not isinstance(msg_ts, str):
+                continue
+            try:
+                parsed = datetime.fromisoformat(msg_ts)
+            except Exception:
+                continue
+            if latest is None or parsed > latest:
+                latest = parsed
+        return latest
+
+    def _sync_updated_at_from_messages(self, session: Session) -> None:
+        latest = self._latest_message_timestamp(session)
+        if latest is not None:
+            session.updated_at = latest
+
+    def _metadata_line_for_session(self, session: Session) -> dict[str, Any]:
+        return {
+            "_type": "metadata",
+            "key": session.key,
+            "owner_client_id": session.metadata.get("owner_client_id"),
+            "created_at": session.created_at.isoformat(),
+            "updated_at": session.updated_at.isoformat(),
+            "metadata": session.metadata,
+            "last_consolidated": session.last_consolidated,
+        }
+
+    def _rewrite_metadata_line(self, path: Path, session: Session) -> None:
+        metadata_line = self._metadata_line_for_session(session)
+        original_lines = path.read_text(encoding="utf-8").splitlines()
+        rewritten_lines: list[str] = []
+        replaced = False
+
+        for line in original_lines:
+            if not replaced:
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    obj = None
+                if isinstance(obj, dict) and obj.get("_type") == "metadata":
+                    rewritten_lines.append(json.dumps(metadata_line, ensure_ascii=False))
+                    replaced = True
+                    continue
+            rewritten_lines.append(line)
+
+        if not replaced:
+            rewritten_lines.insert(0, json.dumps(metadata_line, ensure_ascii=False))
+
+        tmp_path = path.with_name(f"{path.name}.tmp")
+        tmp_path.write_text("\n".join(rewritten_lines) + "\n", encoding="utf-8")
+        tmp_path.replace(path)
+
     # ── Ownership ──────────────────────────────────────────────────────
 
     def _read_owner(self, key: str) -> str | None:
@@ -739,18 +797,10 @@ class SessionManager:
         session.last_consolidated = min(session.last_consolidated, len(session.messages))
 
         session.saved_count = len(session.messages)
-        session.updated_at = datetime.now()
+        self._sync_updated_at_from_messages(session)
 
         with open(path, "w", encoding="utf-8") as f:
-            metadata_line = {
-                "_type": "metadata",
-                "key": session.key,
-                "owner_client_id": session.metadata.get("owner_client_id"),
-                "created_at": session.created_at.isoformat(),
-                "updated_at": session.updated_at.isoformat(),
-                "metadata": session.metadata,
-                "last_consolidated": session.last_consolidated,
-            }
+            metadata_line = self._metadata_line_for_session(session)
             f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
             for msg in session.messages:
                 f.write(json.dumps(msg, ensure_ascii=False) + "\n")

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -1,9 +1,12 @@
 """Session management for conversation history."""
 
 import json
+import os
 import shutil
+import tempfile
+import threading
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +14,19 @@ from loguru import logger
 
 from miqi.paths import get_legacy_data_dir
 from miqi.utils.helpers import ensure_dir, safe_filename
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def _parse_iso_datetime(value: str) -> datetime | None:
+    try:
+        return _normalize_datetime(datetime.fromisoformat(value))
+    except ValueError:
+        return None
 
 
 @dataclass
@@ -34,15 +50,18 @@ class Session:
             "timestamp": now.isoformat(),
             **kwargs,
         }
-        self.messages.append(msg)
         msg_ts = msg.get("timestamp")
         if isinstance(msg_ts, str):
-            try:
-                self.updated_at = datetime.fromisoformat(msg_ts)
-            except Exception:
+            parsed_ts = _parse_iso_datetime(msg_ts)
+            if parsed_ts is None:
+                msg["timestamp"] = now.isoformat()
                 self.updated_at = now
+            else:
+                self.updated_at = parsed_ts
         else:
+            msg["timestamp"] = now.isoformat()
             self.updated_at = now
+        self.messages.append(msg)
 
     def get_history(self, max_messages: int = 500) -> list[dict[str, Any]]:
         """Return unconsolidated history, aligned to a user turn."""
@@ -118,6 +137,8 @@ class SessionManager:
         self.compact_threshold_bytes = max(1, compact_threshold_bytes)
         self.compact_keep_messages = max(1, compact_keep_messages)
         self._cache: dict[str, Session] = {}
+        self._session_locks: dict[str, threading.RLock] = {}
+        self._session_locks_guard = threading.Lock()
 
     def get_session_dir(self, key: str) -> Path:
         safe_key = safe_filename(key.replace(":", "_"))
@@ -126,6 +147,14 @@ class SessionManager:
     def _get_session_path(self, key: str) -> Path:
         """Get the file path for a session key."""
         return self.get_session_dir(key) / "conversation.jsonl"
+
+    def _get_session_lock(self, key: str) -> threading.RLock:
+        with self._session_locks_guard:
+            lock = self._session_locks.get(key)
+            if lock is None:
+                lock = threading.RLock()
+                self._session_locks[key] = lock
+            return lock
 
     def _migrate_flat_to_dir(self, key: str) -> None:
         """If old flat .jsonl exists and new dir does not, migrate."""
@@ -266,39 +295,42 @@ class SessionManager:
 
     def save(self, session: Session) -> None:
         """Persist session changes with append-only writes when possible."""
-        self._migrate_flat_to_dir(session.key)
-        path = self._get_session_path(session.key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self._sync_updated_at_from_messages(session)
+        with self._get_session_lock(session.key):
+            self._migrate_flat_to_dir(session.key)
+            path = self._get_session_path(session.key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._sync_updated_at_from_messages(session)
 
-        should_rewrite = not path.exists() or len(session.messages) < session.saved_count
+            should_rewrite = (
+                not path.exists() or len(session.messages) < session.saved_count
+            )
 
-        # Force rewrite if owner_client_id was set but not yet on disk
-        if not should_rewrite and session.metadata.get("owner_client_id"):
-            owner_on_disk = self._read_owner(session.key)
-            if owner_on_disk is None:
-                should_rewrite = True
+            # Force rewrite if owner_client_id was set but not yet on disk
+            if not should_rewrite and session.metadata.get("owner_client_id"):
+                owner_on_disk = self._read_owner(session.key)
+                if owner_on_disk is None:
+                    should_rewrite = True
 
-        if should_rewrite:
-            with open(path, "w", encoding="utf-8") as f:
-                metadata_line = self._metadata_line_for_session(session)
-                f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
-                for msg in session.messages:
-                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
-            path.chmod(0o600)  # Restrict to owner only (SEC-07)
-            session.saved_count = len(session.messages)
-        else:
-            new_messages = session.messages[session.saved_count :]
-            if new_messages:
-                with open(path, "a", encoding="utf-8") as f:
-                    for msg in new_messages:
+            if should_rewrite:
+                with open(path, "w", encoding="utf-8") as f:
+                    metadata_line = self._metadata_line_for_session(session)
+                    f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
+                    for msg in session.messages:
                         f.write(json.dumps(msg, ensure_ascii=False) + "\n")
-                self._rewrite_metadata_line(path, session)
                 path.chmod(0o600)  # Restrict to owner only (SEC-07)
                 session.saved_count = len(session.messages)
+            else:
+                new_messages = session.messages[session.saved_count :]
+                if new_messages:
+                    with open(path, "a", encoding="utf-8") as f:
+                        for msg in new_messages:
+                            f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                    self._rewrite_metadata_line(path, session)
+                    path.chmod(0o600)  # Restrict to owner only (SEC-07)
+                    session.saved_count = len(session.messages)
 
-        self._cache[session.key] = session
-        self.compact_if_needed(session.key)
+            self._cache[session.key] = session
+            self.compact_if_needed(session.key)
 
     # ── Tracked files (sidebar) ───────────────────────────────────────
 
@@ -606,9 +638,8 @@ class SessionManager:
                         continue
                     msg_ts = obj.get("timestamp")
                     if isinstance(msg_ts, str):
-                        try:
-                            ts = datetime.fromisoformat(msg_ts)
-                        except Exception:
+                        ts = _parse_iso_datetime(msg_ts)
+                        if ts is None:
                             continue
                         if latest_msg_ts is None or ts > latest_msg_ts:
                             latest_msg_ts = ts
@@ -618,10 +649,7 @@ class SessionManager:
                 meta_ts_raw = metadata.get("updated_at")
                 meta_ts: datetime | None = None
                 if isinstance(meta_ts_raw, str):
-                    try:
-                        meta_ts = datetime.fromisoformat(meta_ts_raw)
-                    except Exception:
-                        meta_ts = None
+                    meta_ts = _parse_iso_datetime(meta_ts_raw)
                 if meta_ts is None or latest_msg_ts > meta_ts:
                     metadata["updated_at"] = latest_msg_ts.isoformat()
             return metadata
@@ -635,9 +663,8 @@ class SessionManager:
             msg_ts = msg.get("timestamp")
             if not isinstance(msg_ts, str):
                 continue
-            try:
-                parsed = datetime.fromisoformat(msg_ts)
-            except Exception:
+            parsed = _parse_iso_datetime(msg_ts)
+            if parsed is None:
                 continue
             if latest is None or parsed > latest:
                 latest = parsed
@@ -669,7 +696,7 @@ class SessionManager:
             if not replaced:
                 try:
                     obj = json.loads(line)
-                except Exception:
+                except json.JSONDecodeError:
                     obj = None
                 if isinstance(obj, dict) and obj.get("_type") == "metadata":
                     rewritten_lines.append(json.dumps(metadata_line, ensure_ascii=False))
@@ -680,9 +707,25 @@ class SessionManager:
         if not replaced:
             rewritten_lines.insert(0, json.dumps(metadata_line, ensure_ascii=False))
 
-        tmp_path = path.with_name(f"{path.name}.tmp")
-        tmp_path.write_text("\n".join(rewritten_lines) + "\n", encoding="utf-8")
-        tmp_path.replace(path)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            os.chmod(tmp_path, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write("\n".join(rewritten_lines) + "\n")
+            tmp_path.replace(path)
+        except OSError:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     # ── Ownership ──────────────────────────────────────────────────────
 
@@ -784,29 +827,32 @@ class SessionManager:
 
     def compact(self, key: str) -> bool:
         """Compact a session by rewriting with only recent messages."""
-        path = self._get_session_path(key)
-        if not path.exists():
-            return False
+        with self._get_session_lock(key):
+            path = self._get_session_path(key)
+            if not path.exists():
+                return False
 
-        session = self.get_or_create(key)
-        original_len = len(session.messages)
-        if original_len > self.compact_keep_messages:
-            drop_count = original_len - self.compact_keep_messages
-            session.messages = session.messages[-self.compact_keep_messages :]
-            session.last_consolidated = max(0, session.last_consolidated - drop_count)
-        session.last_consolidated = min(session.last_consolidated, len(session.messages))
+            session = self.get_or_create(key)
+            original_len = len(session.messages)
+            if original_len > self.compact_keep_messages:
+                drop_count = original_len - self.compact_keep_messages
+                session.messages = session.messages[-self.compact_keep_messages :]
+                session.last_consolidated = max(0, session.last_consolidated - drop_count)
+            session.last_consolidated = min(
+                session.last_consolidated, len(session.messages),
+            )
 
-        session.saved_count = len(session.messages)
-        self._sync_updated_at_from_messages(session)
+            session.saved_count = len(session.messages)
+            self._sync_updated_at_from_messages(session)
 
-        with open(path, "w", encoding="utf-8") as f:
-            metadata_line = self._metadata_line_for_session(session)
-            f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
-            for msg in session.messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+            with open(path, "w", encoding="utf-8") as f:
+                metadata_line = self._metadata_line_for_session(session)
+                f.write(json.dumps(metadata_line, ensure_ascii=False) + "\n")
+                for msg in session.messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
 
-        self._cache[key] = session
-        return True
+            self._cache[key] = session
+            return True
 
     def compact_all(self) -> int:
         """Compact all existing session files and return compacted count."""

--- a/tests/session/test_updated_at_metadata.py
+++ b/tests/session/test_updated_at_metadata.py
@@ -50,3 +50,44 @@ def test_compact_preserves_latest_message_timestamp_as_updated_at(tmp_path):
     lines = path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 3
     assert json.loads(lines[0])["updated_at"] == "2026-01-01T00:07:00"
+
+
+def test_invalid_message_timestamp_is_canonicalized_before_save(tmp_path):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("chat:invalid")
+
+    session.add_message("user", "first", timestamp="2026-01-01T00:00:00")
+    session.add_message("assistant", "second", timestamp="not-a-date")
+    manager.save(session)
+
+    path = _conversation_path(tmp_path, "chat_invalid")
+    lines = path.read_text(encoding="utf-8").splitlines()
+    second_message = json.loads(lines[2])
+    metadata = json.loads(lines[0])
+
+    assert second_message["timestamp"] != "not-a-date"
+    assert second_message["timestamp"] == metadata["updated_at"]
+
+
+def test_mixed_timezone_message_timestamps_are_comparable(tmp_path):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("chat:tz")
+
+    session.add_message("user", "aware", timestamp="2026-01-01T00:05:00+00:00")
+    session.add_message("assistant", "naive", timestamp="2026-01-01T00:01:00")
+    manager.save(session)
+
+    path = _conversation_path(tmp_path, "chat_tz")
+    metadata = _read_metadata(path)
+
+    assert session.messages[0]["timestamp"] == "2026-01-01T00:05:00+00:00"
+    assert metadata["updated_at"] == "2026-01-01T00:05:00"
+    assert manager.list_sessions()[0]["updated_at"] == "2026-01-01T00:05:00"
+
+
+def test_session_lock_is_reused_for_same_key(tmp_path):
+    manager = SessionManager(tmp_path)
+
+    assert manager._get_session_lock("chat:locked") is manager._get_session_lock(
+        "chat:locked",
+    )

--- a/tests/session/test_updated_at_metadata.py
+++ b/tests/session/test_updated_at_metadata.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from miqi.session.manager import SessionManager
+
+
+def _conversation_path(tmp_path: Path, key: str) -> Path:
+    return tmp_path / "sessions" / key / "conversation.jsonl"
+
+
+def _read_metadata(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.loads(f.readline())
+
+
+def test_append_save_rewrites_metadata_updated_at(tmp_path):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("chat:1")
+
+    session.add_message("user", "first", timestamp="2026-01-01T00:00:00")
+    manager.save(session)
+
+    path = _conversation_path(tmp_path, "chat_1")
+    assert _read_metadata(path)["updated_at"] == "2026-01-01T00:00:00"
+
+    session.add_message("assistant", "second", timestamp="2026-01-01T00:05:00")
+    manager.save(session)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert json.loads(lines[0])["updated_at"] == "2026-01-01T00:05:00"
+    assert manager.list_sessions()[0]["updated_at"] == "2026-01-01T00:05:00"
+
+
+def test_compact_preserves_latest_message_timestamp_as_updated_at(tmp_path):
+    manager = SessionManager(
+        tmp_path,
+        compact_threshold_messages=999,
+        compact_keep_messages=2,
+    )
+    session = manager.get_or_create("chat:2")
+    session.add_message("user", "first", timestamp="2026-01-01T00:00:00")
+    session.add_message("assistant", "second", timestamp="2026-01-01T00:03:00")
+    session.add_message("user", "third", timestamp="2026-01-01T00:07:00")
+    manager.save(session)
+
+    assert manager.compact("chat:2") is True
+
+    path = _conversation_path(tmp_path, "chat_2")
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert json.loads(lines[0])["updated_at"] == "2026-01-01T00:07:00"


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [x] 测试
- [x] UI 调整

## 变更概述

修复会话更新时间显示不准确的问题：会话 JSONL metadata 首行的 `updated_at` 现在会随最新消息时间同步，依赖 metadata 的列表/排序不会再读到旧时间。

同时清理桌面聊天顶部任务栏的假占位信息：不再显示 `Updated 2 mins ago · 2 linked files · 2 Active Plugins`，改为中文状态、真实相对更新时间和真实文件数量。顶部相对时间每 60 秒刷新一次；文件数量与右侧 Task Assets 使用同一数据源。

Fixes #243

## 背景/问题

用户侧看到的问题发生在桌面会话 UI：会话更新时间可能显示为旧时间。根因在数据源，append-only 保存新消息时只追加消息行，没有同步更新 `conversation.jsonl` 首行 metadata 的 `updated_at`。依赖 metadata 的会话列表因此可能展示或排序到过期时间。

顶部任务栏原本还有一组硬编码英文占位信息，会让用户误以为存在已链接文件和 Active Plugins 数据；这些数据没有可靠来源，所以本次移除插件数量，仅保留可从当前状态得到的真实更新时间与文件数量。

## 变更内容

- `miqi/session/manager.py`
  - `Session.add_message()` 使用同一个时间戳写入消息并更新 `session.updated_at`。
  - `SessionManager.save()` 在追加新消息后回写 metadata 首行的 `updated_at`。
  - `compact()` 保持 `updated_at` 为最新消息时间，而不是压缩发生时间。
  - 增加 metadata 原子回写和会话级锁，避免异常中断或并发保存造成 metadata 损坏。
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 顶部任务栏改为中文状态、相对更新时间和文件数量。
  - 相对时间每 60 秒刷新，不需要用户操作。
  - 文件数量来自 `trackedFiles.length`，与右侧 Task Assets 保持一致。
  - 移除没有可靠数据源的 Active Plugins 占位。
  - 微调中文标题区高度、字号、行高和信息胶囊样式。
- `apps/desktop/src/renderer/components/Sidebar.tsx`
  - 侧栏首屏任务标题、过滤 tab、状态、时间和空状态中文化。
- 测试
  - 新增/更新 session metadata 回归测试。
  - 新增顶部 metadata 文案测试，确保不再出现旧英文假占位。
  - 更新受中文化影响的 Electron E2E selector。

## 日志/验证证据
```
.venv\Scripts\python.exe -m pytest tests/session/test_updated_at_metadata.py tests/session/test_ownership.py tests/test_consolidate_offset.py

collected 82 items
82 passed in 1.06s

npm.cmd run typecheck:web

> miqi-desktop@0.5.0 typecheck:web
> tsc --noEmit -p tsconfig.web.json

npx.cmd vitest run tests/chatConsoleMessages.test.ts

Test Files  1 passed (1)
Tests       3 passed (3)
```

## 测试情况

已通过：

- `.venv\Scripts\python.exe -m pytest tests/session/test_updated_at_metadata.py tests/session/test_ownership.py tests/test_consolidate_offset.py`
- `npm.cmd run typecheck:web`
- `npx.cmd vitest run tests/chatConsoleMessages.test.ts`

说明：一次并发验证时本机 Node/PowerShell 因分页文件/内存不足报过资源错误；改为顺序执行后上述验证均通过。

## 截图

本地已截图验证桌面端顶部任务栏：旧英文假数据已消失，顶部显示中文状态、相对更新时间和文件数量。截图文件：
<img width="1266" height="853" alt="image" src="https://github.com/user-attachments/assets/ec8b5b46-9ab6-4c4b-8a4c-a9622da63e36" />