### PR TITLE
fix(desktop): align dark mode surfaces

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1472,7 +1472,7 @@ export function ChatConsole({
           <div
             className="flex items-center gap-3 px-5 h-8 border-b shrink-0"
             style={{
-              background: '#FFFFFF',
+              background: 'var(--surface)',
               borderColor: 'var(--border-subtle)',
             }}
           >
@@ -1483,7 +1483,7 @@ export function ChatConsole({
               {sessionTitle}
             </h2>
             <span className="tag-inprogress shrink-0">IN PROGRESS</span>
-            <span className="text-[13px] shrink-0" style={{ color: '#4B5563' }}>
+            <span className="text-[13px] shrink-0" style={{ color: 'var(--text-muted)' }}>
               Updated 2 mins ago · 2 linked files · 2 Active Plugins
             </span>
             <button
@@ -1588,7 +1588,7 @@ export function ChatConsole({
           <div
             className="shrink-0 px-5 pb-4 pt-3"
             style={{
-              background: '#F2F5E8',
+              background: 'var(--background)',
             }}
           >
             <div className="max-w-[760px] mx-auto">
@@ -1628,7 +1628,7 @@ export function ChatConsole({
               <div
                 className="flex items-end gap-2 rounded-xl px-4 py-3.5 focus-within:ring-2 transition-all"
                 style={{
-                  background: '#FFFFFF',
+                  background: 'var(--surface)',
                   border: '1px solid var(--border)',
                   outline: 'none',
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
@@ -1912,7 +1912,7 @@ export function ChatConsole({
                 <p
                   id="merge-all-disabled-reason"
                   className="mt-1.5 text-[11px] text-center"
-                  style={{ color: '#4B5563' }}
+                  style={{ color: 'var(--text-muted)' }}
                 >
                   No changed files are available to merge.
                 </p>

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -554,16 +554,18 @@ function AppearanceTab() {
       <h3 className="text-sm font-semibold text-[var(--text)]">外观</h3>
       <div className="flex flex-col gap-1.5">
         <label className="text-xs font-medium text-[var(--text-muted)]">主题</label>
-        <div className="flex gap-2">
+        <div className="inline-flex w-fit items-center gap-1 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-1">
           {(['light', 'dark', 'system'] as ThemeMode[]).map((m) => (
             <button
               key={m}
               onClick={() => applyTheme(m)}
+              aria-pressed={theme === m}
               className={cn(
-                'settings-hover-tab px-4 py-2 rounded-lg text-xs border',
+                'settings-hover-tab rounded-md px-3.5 py-1.5 text-xs font-medium',
+                'focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/30',
                 theme === m
-                  ? 'bg-[var(--accent)] text-white border-[var(--accent)]'
-                  : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)] hover:text-[var(--text)]'
+                  ? 'bg-[var(--accent)] text-[var(--accent-text)] shadow-sm'
+                  : 'text-[var(--text-muted)] hover:bg-[var(--surface)] hover:text-[var(--text)]'
               )}
             >
               {m === 'light' ? '浅色' : m === 'dark' ? '深色' : '跟随系统'}

--- a/apps/desktop/src/renderer/hooks/useSessionStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionStatus.ts
@@ -46,41 +46,41 @@ export function useSessionStatus() {
           label: 'IN-PROGRESS',
           bg: 'var(--tag-inprogress-bg)',
           color: 'var(--tag-inprogress-text)',
-          cardBg: '#fffbe6',
-          cardBorder: '#f0e8c0',
+          cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-inprogress-bg))',
+          cardBorder: 'color-mix(in srgb, var(--border-subtle) 70%, var(--tag-inprogress-bg))',
         };
       case 'REVIEW':
         return {
           label: 'REVIEW',
           bg: 'var(--tag-review-bg)',
           color: 'var(--tag-review-text)',
-          cardBg: '#fefdf5',
-          cardBorder: '#f0e8c0',
+          cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-review-bg))',
+          cardBorder: 'color-mix(in srgb, var(--border-subtle) 70%, var(--tag-review-text))',
         };
       case 'COMPLETED':
         return {
           label: 'COMPLETED',
           bg: 'var(--tag-completed-bg)',
           color: 'var(--tag-completed-text)',
-          cardBg: '#f8fcf9',
-          cardBorder: '#d0e8d8',
+          cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-completed-bg))',
+          cardBorder: 'color-mix(in srgb, var(--border-subtle) 70%, var(--tag-completed-text))',
         };
       case 'CC':
         return {
           label: 'CC',
           bg: 'var(--tag-cc-bg)',
           color: 'var(--tag-cc-text)',
-          cardBg: '#f9f5ff',
-          cardBorder: '#d4c5f0',
+          cardBg: 'color-mix(in srgb, var(--surface) 88%, var(--tag-cc-bg))',
+          cardBorder: 'color-mix(in srgb, var(--border-subtle) 70%, var(--tag-cc-text))',
         };
       case 'PENDING':
       default:
         return {
           label: 'PENDING',
-          bg: '#f0f0ec',
-          color: '#888',
-          cardBg: '#fafaf9',
-          cardBorder: '#e8e8e0',
+          bg: 'var(--surface-muted)',
+          color: 'var(--text-faint)',
+          cardBg: 'var(--surface)',
+          cardBorder: 'var(--border-subtle)',
         };
     }
   }, []);

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -104,17 +104,33 @@
   --accent-hover: #e0b830;
   --accent-soft: #4a3a10;
   --accent-text: #121212;
+  --success: #4ade80;
+  --success-bg: rgba(74, 222, 128, 0.16);
+  --warning: #facc15;
+  --warning-bg: rgba(250, 204, 21, 0.16);
   --approval-warning: #fed7aa;
   --approval-warning-strong: #f97316;
   --approval-warning-bg: #3b2418;
   --approval-warning-border: #c2410c;
   --approval-warning-pill-bg: #f97316;
   --approval-warning-pill-text: #1f130b;
+  --danger: #f87171;
+  --danger-bg: rgba(248, 113, 113, 0.16);
+  --info: #60a5fa;
+  --info-bg: rgba(96, 165, 250, 0.16);
   --bubble-user-bg: #3a3a5a;
   --bubble-user-text: #FFFFFF;
   --bubble-ai-bg: #2e2e2e;
   --bubble-ai-text: #E4E4E0;
   --bubble-ai-border: #444444;
+  --tag-review-bg: rgba(250, 204, 21, 0.18);
+  --tag-review-text: #facc15;
+  --tag-completed-bg: rgba(96, 165, 250, 0.18);
+  --tag-completed-text: #93c5fd;
+  --tag-inprogress-bg: #2563eb;
+  --tag-inprogress-text: #ffffff;
+  --tag-cc-bg: rgba(168, 85, 247, 0.18);
+  --tag-cc-text: #c4b5fd;
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 重构
- [ ] 测试
- [ ] 其他

## 变更概述

修复深色模式下工作区多处浅色背景未跟随主题的问题。

## 背景/问题

Closes #245。深色模式下部分区域仍使用硬编码浅色，导致左侧任务卡、工作区顶部状态行、底部输入区域等位置出现明显漏白，破坏深色主题一致性。

## 变更内容

- 将左侧任务卡状态背景/边框从硬编码浅色改为 `var(...)` 与 `color-mix(...)`，随深色主题自动切换。
- 将工作区顶部任务状态行背景从 `#FFFFFF` 改为 `var(--surface)`，元信息颜色改为 `var(--text-muted)`。
- 将底部输入区域背景从硬编码浅色改为 `var(--background)`，输入框背景改为 `var(--surface)`。
- 补齐 `.dark` 下的成功/警告/危险/信息与任务标签 token，避免深色模式下徽章仍使用浅色方案。

## 日志/验证证据

```
D:\Desktop\230\MiQi> git fetch origin --prune
D:\Desktop\230\MiQi> git rebase origin/develop
Successfully rebased and updated refs/heads/fix/issue-245-dark-mode-colors.

D:\Desktop\230\MiQi> git diff --check origin/develop...HEAD
# 无输出，检查通过

D:\Desktop\230\MiQi\apps\desktop> npm.cmd run typecheck
> miqi-desktop@0.5.0 typecheck
> npm run typecheck:node && npm run typecheck:web
> tsc --noEmit -p tsconfig.node.json
> tsc --noEmit -p tsconfig.web.json
# 通过

D:\Desktop\230\MiQi\apps\desktop> npm.cmd run build
> miqi-desktop@0.5.0 build
> electron-vite build
built in 310ms
built in 223ms
built in 5.49s
# 通过；仅有 Radix 包 "use client" 被忽略的既有打包警告
```

## 测试情况

- 已执行 `git diff --check origin/develop...HEAD`，通过。
- 已执行 `npm.cmd run typecheck`，通过。
- 已执行 `npm.cmd run build`，通过。
- 已基于最新 `origin/develop` rebase，无代码冲突。
- 已本地启动 `npm.cmd run dev`，确认 MiQi 使用 `D:\Desktop\230\MiQi` 当前分支。

## 截图

重点看以下位置：

1. 左侧任务列表卡片：PENDING / COMPLETED / REVIEW / CC 卡片不再是白底，随深色主题变为深色表面与轻微状态色。
2. 工作区顶部任务状态行：标题、IN PROGRESS、Updated 信息所在横条不再是白底。
3. 底部输入区域：输入区背景和输入框不再是白底，和深色聊天背景保持一致层级。
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/f387fa19-5b87-4484-ade9-1c2e2c6d8e56" />
<img width="247" height="118" alt="image" src="https://github.com/user-attachments/assets/ca8379d3-df5f-4e54-a825-9fa1011cc5c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat and session status colors to adapt consistently across light and dark themes.
  * Refined dark-mode status indicators, tags, approval warnings, and chat bubbles for improved visual consistency.
  * Restyled the appearance theme selector as a clearer segmented control with improved active and inactive states.
  * Added accessibility state indicators to theme selection buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->