### PR TITLE
fix(desktop): prevent sidebar filter overflow

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { cn } from '../lib/utils';
 import { Plus, ListChecks, Settings, Play, Clock, Eye, CheckCircle2, RotateCcw, Archive, Trash2 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { MiQiLogo } from './MiQiLogo';
 import { ContextMenu } from './ContextMenu';
 import { useSessionStatus, type SessionStatus } from '../hooks/useSessionStatus';
@@ -40,7 +41,7 @@ interface SidebarProps {
   onNewSession?: () => void;
 }
 
-const STATUS_ICONS: Record<SessionStatus, typeof Play> = {
+const STATUS_ICONS: Record<SessionStatus, LucideIcon> = {
   'IN-PROGRESS': Play,
   'PENDING': Clock,
   'REVIEW': Eye,

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -352,7 +352,7 @@ export function Sidebar({
         style={{ borderColor: 'var(--sidebar-border)' }}
       >
         <button
-          className="flex items-center gap-1.5 text-[11px] cursor-pointer transition duration-150 hover:scale-110 hover:text-[#404040] origin-left"
+          className="flex items-center gap-1.5 text-[11px] cursor-pointer transition duration-150 hover:scale-110 hover:text-[var(--text)] origin-left"
           style={{ color: 'var(--text-faint)' }}
           onClick={() => onNavChange?.('settings')}
           data-testid="nav-system-settings"

--- a/apps/desktop/src/renderer/hooks/useSessionStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionStatus.ts
@@ -67,7 +67,7 @@ export function useSessionStatus() {
         };
       case 'CC':
         return {
-          label: '旧标签',
+          label: '抄送 (旧)',
           bg: 'var(--tag-cc-bg)',
           color: 'var(--tag-cc-text)',
           cardBg: 'color-mix(in srgb, var(--surface) 75%, var(--tag-cc-bg))',


### PR DESCRIPTION
## 类型

- [x] Bug 修复
- [x] UI 改进

## 变更概述

修复 #242 中侧边栏缩窄后任务筛选标签溢出的问题，并全面优化侧边栏 UI。

## 背景/问题

Closes #242。侧边栏拖到接近 180px 最小宽度时，顶部任务筛选标签超出侧边栏边界，覆盖右侧内容区。历史版本里曾有 CC 状态入口，当前任务流主要是进行中/待审阅/已完成/待处理，继续暴露 CC 会和已完成状态混淆。同时全部 UI 字符串英文混搭，缺少统一的中文体验。

## 变更内容

### Bug 修复
- 筛选标签去框 → 下划线风格 + 数量光晕，缩窄时不溢出
- IN-PROGRESS 选中卡片深青绿边框（修复白框消失问题）
- 悬停阴影 + 微上浮，选中卡片加深阴影

### UI 优化
- 筛选标签：下划线指示 + Count 数字光晕（去掉了丑框）
- 卡片状态图标：进行中/待审阅/已完成/待处理 各有色块图标
- 时间中文化：刚刚 → N分钟前 → N小时前 → 昨天
- 标题中文化：任务、系统设置（+设置图标）
- 右键菜单：加 Play/Clock/Eye/CheckCircle2/RotateCcw/Archive 图标
- 进行中配色：深蓝 → 青绿 (teal #0F766E)，与其他状态彻底区分
- 卡片底色：增强 tint 从 88% → 75~90%

### 技术改动
- ContextMenu.tsx：新增可选 icon 字段
- useSessionStatus.ts：cardBg tint 调整
- globals.css：IN-PROGRESS 标签色改为 teal

### 冲突解决
- 与 #256 合并，对齐措辞：审阅 → 待审阅

## 日志/验证证据

```
npm run typecheck    → 通过
npm run build        → 通过 (4.2s)
pytest 82 tests      → 82 passed in 0.55s
vitest 6 tests       → 6 passed
```

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/db0a2ed5-2129-4630-a852-0fd798cc89a0" />

## 测试情况

- [x] typecheck 通过
- [x] build 通过
- [x] pytest 82 passed
- [x] 本地 UI 验证通过

Closes #242



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status icons and counts to sidebar filters.
  * Added icons to context-menu actions.
  * Added a reset-status option for sessions.
  * Improved settings and session card interactions.

* **Bug Fixes**
  * Prevented filter labels from overflowing when the sidebar is narrowed.

* **UI Improvements**
  * Refined active, hover, and selected states with clearer borders, shadows, and indicators.
  * Updated status colors and labels for improved clarity.
  * Improved light and dark theme colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->