### PR TITLE
fix(desktop): prevent sessions methods from timing out during sandbox init

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -757,9 +757,23 @@ export class BridgeManager extends EventEmitter {
 
     const id = randomUUID();
     const request: BridgeRequest = { id, method, params };
-    // Methods that may be slow during first-time auto-export/install
-    // (2-5 min): chat.send, thread/start, sandbox.setEnabled
-    const SLOW_METHODS = new Set(['chat.send', 'thread/start', 'sandbox.setEnabled']);
+    // Methods that may be slow during first-time auto-export/install (2-5 minutes)
+    // or while the sandbox is initializing in the background.
+    // When a request hits SLOW_METHODS, it gets the extended CHAT_SEND_TIMEOUT_MS
+    // (360s) instead of the default 30s IPC timeout to avoid sendSafe swallowing
+    // failures.  The Python side (#266) already dispatches these concurrently,
+    // so a slow method no longer blocks fast ones.
+    const SLOW_METHODS = new Set([
+      'chat.send',
+      'sandbox.setEnabled',
+      'sessions.archive',
+      'sessions.get',
+      'sessions.get_tracked_files',
+      'sessions.list',
+      'sessions.list_archived',
+      'sessions.unarchive',
+      'thread/start',
+    ]);
     const timeoutMs = options.timeoutMs ?? (
       SLOW_METHODS.has(method) ? CHAT_SEND_TIMEOUT_MS : 30_000
     );


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 变更概述

修复 sessions.list、sessions.get 等在 sandbox 后台初始化期间超时导致侧边栏历史对话消失的问题。

Closes #272。

## 背景/问题

sandbox 后台初始化（bwrap/WSL）可能需要数十秒到数分钟不等。在此期间，sessions.list / sessions.get 等方法的 30 秒超时不足以等待初始化完成，导致前端超时后侧边栏历史对话列表为空，用户误以为数据丢失。

## 变更内容

将 6 个 sessions 方法加入 SLOW_METHODS，超时从 30s 提升到 360s：

- sessions.list
- sessions.get
- sessions.archive
- sessions.unarchive
- sessions.list_archived
- sessions.get_tracked_files

只改了一个文件：apps/desktop/src/main/bridge.ts。

## 日志/验证证据
```
typecheck: PASS
build: PASS
```
## 测试情况

- 手动测试：sandbox 初始化期间侧边栏不再超时丢失历史
- 回归测试：正常情况下列表加载速度无变化

## 截图

（无 UI 变更，纯后端超时修复）
