### PR TITLE
ci: reduce E2E and test verbosity in CI logs

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci
 
       - name: Build renderer
-        run: npm run build
+        run: npm run build -- --logLevel warn
 
       - name: Unit tests (vitest)
         run: npm test
@@ -43,7 +43,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Mock smoke tests (Playwright)
-        run: npx playwright test --config=playwright.config.ts --project=smoke
+        run: npx playwright test --config=playwright.config.ts --project=smoke --quiet
         continue-on-error: true  # flaky in headless, don't block
 
       - name: Upload Playwright report
@@ -98,7 +98,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Build renderer
-        run: npm run build
+        run: npm run build -- --logLevel warn
 
       - name: Generate config.json
         run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -105,10 +105,10 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run WSL sandbox tests (auto-install)
-        run: uv run pytest -q -m "wsl" --tb=long -v
+        run: uv run pytest -q -m "wsl" --tb=short
 
       - name: Run WSL sandbox tests (bwrap integration)
-        run: uv run pytest -q -m "sandbox and bwrap" --tb=long -v
+        run: uv run pytest -q -m "sandbox and bwrap" --tb=short
 
   wsl-e2e:
     runs-on: windows-latest

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -38,8 +38,8 @@ export default defineConfig({
       testMatch: ['*.spec.ts'],
       timeout: 600_000,  // 10 min — pptx-generator + LLM can be slow
       use: {
-        video: 'on',
-        screenshot: 'on',
+        video: 'retain-on-failure',
+        screenshot: 'only-on-failure',
       },
     },
   ],


### PR DESCRIPTION
## 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [x] 🔧 其他

## 变更概述

减少 CI 日志中不必要的噪音，让错误信息更容易定位。

## 背景/问题

当前 CI 输出日志过大：
- Electron E2E 每个测试都录制视频和截图，产出大量 artifact
- `electron-vite build` 输出大量 `node_modules` deprecation warning
- Playwright smoke test 默认 verbose 模式
- WSL sandbox pytest 使用 `-v --tb=long` 冗长输出

日志过大导致定位失败慢、可能触发 GitHub 日志截断。

## 变更内容

| 文件 | 改动 |
|------|------|
| `playwright.config.ts` | Electron 项目: `video: 'retain-on-failure'`, `screenshot: 'only-on-failure'` |
| `desktop-ci.yml` | Build 加 `--logLevel warn`；smoke test 加 `--quiet` |
| `python-tests.yml` | WSL sandbox 测试去掉 `-v`，`--tb=long` → `--tb=short` |

行为不变，失败时完整信息仍在上传的 artifact 中可见。

## 日志/验证证据
```
git diff --stat
 .github/workflows/desktop-ci.yml   | 6 +++---
 .github/workflows/python-tests.yml | 4 ++--
 apps/desktop/playwright.config.ts  | 4 ++--
 3 files changed, 7 insertions(+), 7 deletions(-)
```

## 测试情况

- CI 自身即为验证：build + e2e + test 全部通过即确认
- 无功能变更

## 截图

（无需截图 — 仅 CI 配置变更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced test and build command output for clearer, more concise logs.
  * Updated desktop test reporting to capture screenshots and retain videos only when tests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->