### PR TITLE
fix(bridge): check sandbox initialize() return value to avoid misleading log

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -187,11 +187,10 @@ class BridgeRuntimeLoop:
                     "sandbox auto-enable: config save failed: {}", exc,
                 )
 
-        log_msg = "Sandbox manager initialized"
         try:
-            await sandbox_mgr.initialize()
+            ok = await sandbox_mgr.initialize()
         except TypeError:
-            pass  # mock in tests — initialize() is not async
+            ok = False  # mock in tests — initialize() is not async
         except Exception as exc:
             logger.warning("Sandbox manager initialization failed: {}", exc)
             if self._app_server is not None:
@@ -205,10 +204,15 @@ class BridgeRuntimeLoop:
                     pass
             return
 
-        if need_auto_enable:
-            log_msg += " (auto-enabled after first-time install)"
-
-        logger.info(log_msg)
+        if ok:
+            log_msg = "Sandbox manager initialized"
+            if need_auto_enable:
+                log_msg += " (auto-enabled after first-time install)"
+            logger.info(log_msg)
+        else:
+            logger.info(
+                "Sandbox manager not available — tools will run in RESTRICTED mode"
+            )
 
         # Notify the frontend so the settings toggle updates.
         if self._app_server is not None:
@@ -216,7 +220,7 @@ class BridgeRuntimeLoop:
                 await self._app_server.emit_client_event(
                     "desktop",
                     "sandbox.ready",
-                    {"enabled": True, "initialized": True},
+                    {"enabled": True, "initialized": ok},
                 )
             except Exception:
                 pass  # best-effort notification

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -188,9 +188,11 @@ class BridgeRuntimeLoop:
                 )
 
         try:
-            ok = await sandbox_mgr.initialize()
-        except TypeError:
-            ok = False  # mock in tests — initialize() is not async
+            res = sandbox_mgr.initialize()
+            if hasattr(res, "__await__"):
+                ok = await res
+            else:
+                ok = False  # mock in tests — initialize() is not async
         except Exception as exc:
             logger.warning("Sandbox manager initialization failed: {}", exc)
             if self._app_server is not None:
@@ -198,7 +200,7 @@ class BridgeRuntimeLoop:
                     await self._app_server.emit_client_event(
                         "desktop",
                         "sandbox.ready",
-                        {"enabled": True, "initialized": False, "error": str(exc)},
+                        {"enabled": getattr(sandbox_mgr, "enabled", True), "initialized": False, "error": str(exc)},
                     )
                 except Exception:
                     pass
@@ -220,7 +222,7 @@ class BridgeRuntimeLoop:
                 await self._app_server.emit_client_event(
                     "desktop",
                     "sandbox.ready",
-                    {"enabled": True, "initialized": ok},
+                    {"enabled": getattr(sandbox_mgr, "enabled", True), "initialized": ok},
                 )
             except Exception:
                 pass  # best-effort notification


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 `_init_sandbox_manager()` 在 bwrap 不可用时的误导性日志。

## 背景/问题

`miqi/bridge/loop.py` 的 `_init_sandbox_manager()` 调用 `sandbox_mgr.initialize()` 后未检查返回值。当 WSL 无 Linux 发行版（bwrap 不可用）时，`manager.initialize()` 返回 `False`，但 bridge 日志仍打印 "Sandbox manager initialized (auto-enabled after first-time install)"，且 `sandbox.ready` 事件的 `initialized` 字段 hardcoded 为 `True`。

这导致：
1. 用户看到 "auto-enabled" 日志以为沙箱已成功启动
2. 前端收到 `initialized: true` 的 `sandbox.ready` 事件，显示错误的状态
3. 实际上工具运行在 RESTRICTED 模式，与 UI 显示不一致

Closes #293

## 变更内容

- `miqi/bridge/loop.py`: 检查 `initialize()` 返回值，成功时保留原有日志，失败时输出明确提示；`sandbox.ready` 事件使用实际状态

## 日志/验证证据

```
# 修复前（bwrap 不可用时）
2026-07-15 Sandbox manager initialized (auto-enabled after first-time install)

# 修复后
2026-07-15 Sandbox manager not available — tools will run in RESTRICTED mode
```

## 测试情况

E2E sandbox 测试通过（sandbox-exec 8/8, sandbox-toggle 3/3），无 sandbox 环境下的降级行为验证正常。

## 截图

无需截图（纯后端日志修复）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox startup failures and timeouts, with clearer availability status.
  * Improved bridge reliability during concurrent operations and timeouts.
  * Fixed desktop Office file opening and tracked-file persistence.
  * Reduced excessive or empty execution-output updates.
  * Fixed session timestamp synchronization and handling of undefined list results.
  * Updated protocol and sandbox fallback behavior for improved reliability.

* **Release**
  * Updated the application to version 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->