### PR TITLE
fix(desktop): decouple SectionLabel data-testid from display label

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2125,7 +2125,7 @@ export function ChatConsole({
                 {/* Written / Edited files → Active for Edit */}
                 {trackedFiles.filter((f) => f.op === 'write' || f.op === 'edit').length > 0 && (
                   <>
-                    <SectionLabel label="ACTIVE FOR EDIT" />
+                    <SectionLabel label="ACTIVE FOR EDIT" section="active-for-edit" />
                     <div className="px-3 pb-3 flex flex-col gap-2">
                       {trackedFiles
                         .filter((f) => f.op === 'write' || f.op === 'edit')
@@ -2144,7 +2144,7 @@ export function ChatConsole({
                 {/* Read files → Referenced Context */}
                 {trackedFiles.filter((f) => f.op === 'read').length > 0 && (
                   <>
-                    <SectionLabel label="REFERENCED CONTEXT" />
+                    <SectionLabel label="REFERENCED CONTEXT" section="referenced-context" />
                     <div className="px-3 pb-3 flex flex-col gap-2">
                       {trackedFiles
                         .filter((f) => f.op === 'read')
@@ -2162,7 +2162,7 @@ export function ChatConsole({
                 {/* Deleted files */}
                 {trackedFiles.filter((f) => f.op === 'delete').length > 0 && (
                   <>
-                    <SectionLabel label="DELETED" />
+                    <SectionLabel label="DELETED" section="deleted" />
                     <div className="px-3 pb-3 flex flex-col gap-2">
                       {trackedFiles
                         .filter((f) => f.op === 'delete')
@@ -2559,8 +2559,8 @@ function DiffView({ diff }: { diff: string }) {
   );
 }
 
-function SectionLabel({ label }: { label: string }) {
-  const testId = `section-label-${label.toLowerCase().replace(/\s+/g, '-')}`;
+function SectionLabel({ label, section }: { label: string; section: string }) {
+  const testId = `section-label-${section}`;
   return (
     <div
       className="px-4 pt-3 pb-1.5 text-[10px] font-semibold uppercase tracking-widest"


### PR DESCRIPTION
## 类型

- [x] bug修复

## 变更概述

`SectionLabel` 组件的 `data-testid` 是从显示文本 `label` 拼接生成的，中文化（#280）导致 testid 变化、e2e 测试失败。改为用独立的 `section` prop 生成 testid，与显示文本解耦。

## 背景/问题

PR #280 将界面改为中文时，`SectionLabel` 的 label 从 `"ACTIVE FOR EDIT"` 改为 `"编辑中"`，testid 从 `section-label-active-for-edit` 变成 `section-label-编辑中`。e2e 测试仍用旧 testid 断言，找不到元素。

根因是 #277 引入 `data-testid` 时把 testid 跟 label 文本绑死了。

## 变更内容

- `SectionLabel` 组件新增 `section` prop，testid 改为 `section-label-${section}`
- 三处调用传对应的 section 值：`active-for-edit` / `referenced-context` / `deleted`

## 日志/验证证据

```
npx tsc --noEmit  → 通过
```

## 测试情况

- [x] TypeScript 编译通过
- [ ] CI e2e 等待中

## 截图

无需截图（纯代码级 fix，UI 无变化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)