### PR TITLE
fix: raise default max_tool_iterations from 100 to 500

### DIFF
--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -181,7 +181,7 @@ class AgentDefaults(Base):
     model: str = "anthropic/claude-opus-4-5"
     max_tokens: int = 8192
     temperature: float = 0.1
-    max_tool_iterations: int = 100
+    max_tool_iterations: int = 500
     memory_window: int = 100
     reflect_after_tool_calls: bool = True
     # Maximum characters kept per tool result in the live prompt.


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

将 `max_tool_iterations` 默认值从 100 提高到 500。

## 背景/问题

Issue #316：DeepSeek v4-pro 等模型在复杂任务中单轮可能调用 200+ 次工具（web_search → exec → write_file → plan_update 循环），100 次上限导致任务频繁被 "Reached maximum iterations (100)" 错误中断。

## 变更内容

`miqi/config/schema.py`：`max_tool_iterations: int = 100` → `500`

## 测试情况

- [x] Python 语法检查通过
- [x] 配置加载验证：`load_config()` 正确读取 500

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the default maximum number of tool iterations from 100 to 500, allowing longer-running agent tasks to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->