### PR TITLE
feat(feedback): add in-app feedback submission to Feishu Bitable with auto log collection

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -37,6 +37,7 @@ import {
   ThreadNameSetInput,
   TurnStartInput,
   TurnInterruptInput,
+  FeedbackSubmitInput,
 } from '../../shared/ipc';
 import type { WslCheckResult, WslStatsResult } from '../../shared/ipc';
 
@@ -1479,7 +1480,8 @@ for m in ("pydantic", "httpx", "loguru"):
 
   // -- Feedback --------------------------------------------------------------
   ipcMain.handle(IPC.FEEDBACK_SUBMIT, async (_event, payload: unknown) => {
-    return bridge.send('feedback:submit', payload as Record<string, unknown>);
+    const input = FeedbackSubmitInput.parse(payload);
+    return bridge.send('feedback:submit', input as unknown as Record<string, unknown>);
   });
 
   ipcMain.handle(IPC.FEEDBACK_LIST, async (_event, payload: unknown) => {

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1477,6 +1477,15 @@ for m in ("pydantic", "httpx", "loguru"):
     return bridge.sendSafe('plugins.toggle', { name, enabled });
   });
 
+  // -- Feedback --------------------------------------------------------------
+  ipcMain.handle(IPC.FEEDBACK_SUBMIT, async (_event, payload: unknown) => {
+    return bridge.send('feedback:submit', payload as Record<string, unknown>);
+  });
+
+  ipcMain.handle(IPC.FEEDBACK_LIST, async (_event, payload: unknown) => {
+    return bridge.sendSafe('feedback:list', payload as Record<string, unknown>);
+  });
+
   // -- Threads (Phase 36+) --------------------------------------------------
   // thread/start is a simple request-response method (not streaming).
   // Do NOT pass an onEvent callback — it would put the bridge in streaming

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -495,6 +495,7 @@ const api = {
       content: string;
       contact?: string;
       app_version?: string;
+      screenshots?: string[];
     }): Promise<FeedbackSubmitResult> =>
       ipcRenderer.invoke(IPC.FEEDBACK_SUBMIT, params),
     list: (params?: { limit?: number }): Promise<FeedbackListResult> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -62,6 +62,9 @@ import type {
   TurnStartResult,
   TurnInterruptResult,
   SandboxSetEnabledResult,
+  FeedbackEntry,
+  FeedbackListResult,
+  FeedbackSubmitResult,
 } from '../shared/ipc';
 
 // ---------------------------------------------------------------------------
@@ -482,6 +485,20 @@ const api = {
         turn_id: turnId,
         session_key: sessionKey,
       }),
+  },
+
+  // -- Feedback ---------------------------------------------------------------
+  feedback: {
+    submit: (params: {
+      category: string;
+      title: string;
+      content: string;
+      contact?: string;
+      app_version?: string;
+    }): Promise<FeedbackSubmitResult> =>
+      ipcRenderer.invoke(IPC.FEEDBACK_SUBMIT, params),
+    list: (params?: { limit?: number }): Promise<FeedbackListResult> =>
+      ipcRenderer.invoke(IPC.FEEDBACK_LIST, params ?? {}),
   },
 };
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,6 @@
+import type { z } from 'zod';
 import { contextBridge, ipcRenderer } from 'electron';
-import { IPC, IPC_EVENTS } from '../shared/ipc';
+import { IPC, IPC_EVENTS, FeedbackSubmitInput } from '../shared/ipc';
 import type {
   RuntimeStatus,
   SessionInfo,
@@ -66,6 +67,8 @@ import type {
   FeedbackListResult,
   FeedbackSubmitResult,
 } from '../shared/ipc';
+
+type FeedbackSubmitInputType = z.infer<typeof FeedbackSubmitInput>;
 
 // ---------------------------------------------------------------------------
 // Typed API exposed to the renderer via contextBridge
@@ -489,14 +492,7 @@ const api = {
 
   // -- Feedback ---------------------------------------------------------------
   feedback: {
-    submit: (params: {
-      category: string;
-      title: string;
-      content: string;
-      contact?: string;
-      app_version?: string;
-      screenshots?: string[];
-    }): Promise<FeedbackSubmitResult> =>
+    submit: (params: FeedbackSubmitInputType): Promise<FeedbackSubmitResult> =>
       ipcRenderer.invoke(IPC.FEEDBACK_SUBMIT, params),
     list: (params?: { limit?: number }): Promise<FeedbackListResult> =>
       ipcRenderer.invoke(IPC.FEEDBACK_LIST, params ?? {}),

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -188,7 +188,7 @@ function SubmitModal({
     setSubmitting(true);
     setError(null);
     try {
-      await window.miqi.feedback.submit({
+      const result = await window.miqi.feedback.submit({
         category,
         title: title.trim(),
         content: content.trim(),
@@ -197,6 +197,12 @@ function SubmitModal({
           typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev',
         screenshots: screenshots.map((s) => s.dataUrl),
       });
+      // The bridge always returns ok=true for successful submissions.  An
+      // unexpected payload (e.g. from an older backend) is treated as a
+      // failure rather than silently marking success.
+      if (!result || result.ok !== true) {
+        throw new Error('提交未确认（后端返回 ok=false）');
+      }
       setSuccess(true);
       setTimeout(() => {
         onSubmitted();

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -86,15 +86,15 @@ function SubmitModal({
 
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
-  // Close on Escape
+  // Close on Escape — but only when not actively submitting
   useEffect(() => {
     if (success) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape' && !submitting) onClose();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onClose, success]);
+  }, [onClose, submitting, success]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {
@@ -121,24 +121,40 @@ function SubmitModal({
   const addFiles = useCallback(
     async (files: FileList | File[]) => {
       const list = Array.from(files);
-      const remaining = MAX_SCREENSHOTS - screenshots.length;
-      if (remaining <= 0) {
-        setError(`最多 ${MAX_SCREENSHOTS} 张截图`);
-        return;
-      }
-      const accepted = list.slice(0, remaining);
       setError(null);
       try {
-        const decoded = await Promise.all(accepted.map(readFileAsDataUrl));
-        setScreenshots((prev) => [...prev, ...decoded]);
-        if (list.length > remaining) {
-          setError(`仅添加了前 ${remaining} 张，已达 ${MAX_SCREENSHOTS} 张上限`);
+        // Pre-decode all files (catching per-file errors so one bad file
+        // doesn't drop the whole batch); then commit against the LATEST
+        // state to enforce MAX_SCREENSHOTS under concurrent pastes/drops.
+        const results = await Promise.allSettled(list.map(readFileAsDataUrl));
+        const accepted: ScreenshotFile[] = [];
+        for (const r of results) {
+          if (r.status === 'fulfilled') accepted.push(r.value);
         }
+        if (accepted.length < results.length) {
+          const rejected = results.length - accepted.length;
+          setError(
+            `${rejected} 个文件未添加（不支持的类型或超过 10MB）`,
+          );
+        }
+        setScreenshots((prev) => {
+          const cap = Math.max(0, MAX_SCREENSHOTS - prev.length);
+          if (cap === 0) {
+            setError(`最多 ${MAX_SCREENSHOTS} 张截图`);
+            return prev;
+          }
+          if (accepted.length > cap) {
+            setError(
+              `仅添加了前 ${cap} 张，已达 ${MAX_SCREENSHOTS} 张上限`,
+            );
+          }
+          return [...prev, ...accepted.slice(0, cap)];
+        });
       } catch (e: any) {
         setError(e?.message || '处理图片失败');
       }
     },
-    [screenshots.length],
+    [],
   );
 
   // Paste from clipboard (Ctrl+V) when modal is open
@@ -196,7 +212,9 @@ function SubmitModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={onClose}
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
     >
       <div
         onClick={(e) => e.stopPropagation()}
@@ -206,8 +224,11 @@ function SubmitModal({
         <div className="flex items-center justify-between mb-5">
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
-            onClick={onClose}
-            className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)]"
+            onClick={() => {
+              if (!submitting) onClose();
+            }}
+            disabled={submitting}
+            className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"
           >
             <X size={18} />
           </button>

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -1,0 +1,362 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  MessageSquare,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Bug,
+  HelpCircle,
+  Lightbulb,
+  FileText,
+  X,
+  Loader2,
+  CheckCircle,
+  AlertTriangle,
+} from 'lucide-react';
+import { cn } from '../../lib/utils';
+import type { FeedbackEntry, FeedbackSubmitResult } from '../../../shared/ipc';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const CATEGORY_OPTIONS = [
+  { value: 'bug', label: '🐛 缺陷报告', icon: Bug },
+  { value: 'question', label: '❓ 使用问题', icon: HelpCircle },
+  { value: 'suggestion', label: '💡 功能建议', icon: Lightbulb },
+  { value: 'other', label: '📝 其他', icon: FileText },
+] as const;
+
+const CATEGORY_LABELS: Record<string, string> = {
+  bug: '缺陷报告',
+  question: '使用问题',
+  suggestion: '功能建议',
+  other: '其他',
+};
+
+const CATEGORY_ICONS: Record<string, typeof Bug> = {
+  bug: Bug,
+  question: HelpCircle,
+  suggestion: Lightbulb,
+  other: FileText,
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function relativeTime(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const diff = now.getTime() - d.getTime();
+  if (diff < 60_000) return '刚刚';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`;
+  if (diff < 2 * 86_400_000) return '昨天';
+  return d.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' });
+}
+
+// ─── Submit Modal ────────────────────────────────────────────────────────────
+
+function SubmitModal({
+  onClose,
+  onSubmitted,
+}: {
+  onClose: () => void;
+  onSubmitted: () => void;
+}) {
+  const [category, setCategory] = useState('bug');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [contact, setContact] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await window.miqi.feedback.submit({
+        category,
+        title: title.trim(),
+        content: content.trim(),
+        contact: contact.trim() || undefined,
+        app_version:
+          typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev',
+      });
+      setSuccess(true);
+      setTimeout(() => {
+        onSubmitted();
+        onClose();
+      }, 1500);
+    } catch (e: any) {
+      setError(e?.message || '提交失败，请重试');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-lg font-semibold">提交反馈</h3>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)]"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {success ? (
+          <div className="flex flex-col items-center gap-3 py-8">
+            <CheckCircle size={40} className="text-green-400" />
+            <p className="text-sm font-medium">提交成功！</p>
+            <p className="text-xs text-[var(--muted-foreground)]">
+              日志已自动附加并发送到飞书
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Category */}
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
+                类别
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                {CATEGORY_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => setCategory(opt.value)}
+                    className={cn(
+                      'flex items-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors',
+                      category === opt.value
+                        ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
+                        : 'border-[var(--border)] hover:bg-[var(--muted)]/10'
+                    )}
+                  >
+                    <opt.icon size={15} />
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Title */}
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
+                标题
+              </label>
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="简要描述你的问题或建议"
+                maxLength={200}
+                className="w-full px-3 py-2 text-sm bg-[var(--muted)]/10 rounded-md border border-[var(--border)]
+                           outline-none focus:border-[var(--accent)]"
+              />
+            </div>
+
+            {/* Content */}
+            <div className="mb-4">
+              <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
+                详细描述
+              </label>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="请详细描述你的问题或建议..."
+                rows={5}
+                maxLength={10000}
+                className="w-full px-3 py-2 text-sm bg-[var(--muted)]/10 rounded-md border border-[var(--border)]
+                           outline-none focus:border-[var(--accent)] resize-none"
+              />
+            </div>
+
+            {/* Contact (optional) */}
+            <div className="mb-5">
+              <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
+                联系方式（选填）
+              </label>
+              <input
+                value={contact}
+                onChange={(e) => setContact(e.target.value)}
+                placeholder="邮箱或飞书账号，方便我们联系你"
+                maxLength={200}
+                className="w-full px-3 py-2 text-sm bg-[var(--muted)]/10 rounded-md border border-[var(--border)]
+                           outline-none focus:border-[var(--accent)]"
+              />
+            </div>
+
+            {error && (
+              <div className="flex items-center gap-2 mb-4 p-2.5 rounded-md bg-red-500/10 border border-red-500/20">
+                <AlertTriangle size={14} className="text-red-400 shrink-0" />
+                <p className="text-xs text-red-400">{error}</p>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={onClose}
+                disabled={submitting}
+                className="px-4 py-2 text-sm rounded-md border border-[var(--border)] hover:bg-[var(--muted)]/30 disabled:opacity-50"
+              >
+                取消
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+                className={cn(
+                  'flex items-center gap-2 px-4 py-2 text-sm rounded-md transition-colors',
+                  canSubmit
+                    ? 'bg-[var(--accent)] text-white hover:opacity-90'
+                    : 'bg-[var(--muted)]/20 text-[var(--muted-foreground)] cursor-not-allowed'
+                )}
+              >
+                {submitting ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    提交中...
+                  </>
+                ) : (
+                  '提交'
+                )}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── FeedbackPage ────────────────────────────────────────────────────────────
+
+export function FeedbackPage() {
+  const [entries, setEntries] = useState<FeedbackEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await window.miqi.feedback.list({ limit: 50 });
+      setEntries(res?.entries ?? []);
+    } catch {
+      setError('加载反馈记录失败');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-5 py-3 border-b border-[var(--border)] shrink-0">
+        <MessageSquare size={18} className="text-[var(--muted-foreground)]" />
+        <h2 className="text-lg font-semibold flex-1">用户反馈</h2>
+        <button
+          onClick={() => setShowSubmitModal(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md
+                     bg-[var(--accent)]/10 hover:bg-[var(--accent)]/20 text-[var(--accent)] transition-colors"
+        >
+          <Plus size={15} />
+          提交反馈
+        </button>
+        <button
+          onClick={load}
+          className="p-1.5 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)]"
+          title="刷新"
+        >
+          <RefreshCw size={15} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {loading && entries.length === 0 ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 size={20} className="animate-spin text-[var(--muted-foreground)]" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center gap-2 py-12 text-center">
+            <AlertTriangle size={24} className="text-[var(--muted-foreground)] opacity-40" />
+            <p className="text-sm text-[var(--muted-foreground)]">{error}</p>
+            <button
+              onClick={load}
+              className="text-xs text-[var(--accent)] hover:underline mt-1"
+            >
+              重试
+            </button>
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-16 text-center">
+            <MessageSquare size={28} className="text-[var(--muted-foreground)] opacity-30" />
+            <p className="text-sm text-[var(--muted-foreground)]">暂无反馈记录</p>
+            <p className="text-xs text-[var(--muted-foreground)] opacity-60">
+              提交反馈将自动附加日志并发送到飞书
+            </p>
+            <button
+              onClick={() => setShowSubmitModal(true)}
+              className="flex items-center gap-1.5 mt-2 px-4 py-2 text-sm rounded-md
+                         bg-[var(--accent)]/10 hover:bg-[var(--accent)]/20 text-[var(--accent)]"
+            >
+              <Plus size={15} />
+              提交第一条反馈
+            </button>
+          </div>
+        ) : (
+          <div className="divide-y divide-[var(--border)]">
+            {entries.map((entry) => {
+              const Icon = CATEGORY_ICONS[entry.category] || FileText;
+              return (
+                <div
+                  key={entry.id}
+                  className="px-5 py-3.5 hover:bg-[var(--muted)]/5 transition-colors"
+                >
+                  <div className="flex items-start gap-3">
+                    <Icon size={16} className="mt-0.5 text-[var(--muted-foreground)] shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-[var(--muted)]/10 text-[var(--muted-foreground)]">
+                          {CATEGORY_LABELS[entry.category] || entry.category}
+                        </span>
+                        <span className="text-sm font-medium truncate">{entry.title}</span>
+                      </div>
+                      <p className="text-xs text-[var(--muted-foreground)] line-clamp-2 mb-1.5">
+                        {entry.content}
+                      </p>
+                      <div className="flex items-center gap-2 text-[11px] text-[var(--muted-foreground)]">
+                        <span>{relativeTime(entry.created_at)}</span>
+                        {entry.contact && <span>· {entry.contact}</span>}
+                        {entry.app_version && <span>· v{entry.app_version}</span>}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Submit modal */}
+      {showSubmitModal && (
+        <SubmitModal
+          onClose={() => setShowSubmitModal(false)}
+          onSubmitted={load}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -72,6 +72,16 @@ function SubmitModal({
 
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
+  // Close on Escape
+  useEffect(() => {
+    if (success) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose, success]);
+
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
@@ -98,8 +108,14 @@ function SubmitModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
+      >
         {/* Header */}
         <div className="flex items-center justify-between mb-5">
           <h3 className="text-lg font-semibold">提交反馈</h3>

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   MessageSquare,
   Plus,
@@ -12,11 +12,22 @@ import {
   Loader2,
   CheckCircle,
   AlertTriangle,
+  ImagePlus,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import type { FeedbackEntry, FeedbackSubmitResult } from '../../../shared/ipc';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
+
+const MAX_SCREENSHOTS = 5;
+const MAX_SCREENSHOT_BYTES = 10 * 1024 * 1024; // 10 MB per image
+const ALLOWED_MIME_PREFIX = 'image/';
+
+interface ScreenshotFile {
+  dataUrl: string;
+  name: string;
+  size: number;
+}
 
 const CATEGORY_OPTIONS = [
   { value: 'bug', label: '🐛 缺陷报告', icon: Bug },
@@ -69,6 +80,9 @@ function SubmitModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [screenshots, setScreenshots] = useState<ScreenshotFile[]>([]);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
@@ -82,6 +96,77 @@ function SubmitModal({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [onClose, success]);
 
+  const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
+    new Promise((resolve, reject) => {
+      if (!file.type.startsWith(ALLOWED_MIME_PREFIX)) {
+        reject(new Error(`不支持的文件类型: ${file.type || '未知'}`));
+        return;
+      }
+      if (file.size > MAX_SCREENSHOT_BYTES) {
+        reject(new Error(`${file.name} 超过 10MB 限制`));
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        resolve({
+          dataUrl: String(reader.result),
+          name: file.name,
+          size: file.size,
+        });
+      };
+      reader.onerror = () => reject(new Error('读取文件失败'));
+      reader.readAsDataURL(file);
+    });
+
+  const addFiles = useCallback(
+    async (files: FileList | File[]) => {
+      const list = Array.from(files);
+      const remaining = MAX_SCREENSHOTS - screenshots.length;
+      if (remaining <= 0) {
+        setError(`最多 ${MAX_SCREENSHOTS} 张截图`);
+        return;
+      }
+      const accepted = list.slice(0, remaining);
+      setError(null);
+      try {
+        const decoded = await Promise.all(accepted.map(readFileAsDataUrl));
+        setScreenshots((prev) => [...prev, ...decoded]);
+        if (list.length > remaining) {
+          setError(`仅添加了前 ${remaining} 张，已达 ${MAX_SCREENSHOTS} 张上限`);
+        }
+      } catch (e: any) {
+        setError(e?.message || '处理图片失败');
+      }
+    },
+    [screenshots.length],
+  );
+
+  // Paste from clipboard (Ctrl+V) when modal is open
+  useEffect(() => {
+    if (success) return;
+    const onPaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const imageFiles: File[] = [];
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].type.startsWith(ALLOWED_MIME_PREFIX)) {
+          const f = items[i].getAsFile();
+          if (f) imageFiles.push(f);
+        }
+      }
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        addFiles(imageFiles);
+      }
+    };
+    window.addEventListener('paste', onPaste);
+    return () => window.removeEventListener('paste', onPaste);
+  }, [addFiles, success]);
+
+  const removeScreenshot = (idx: number) => {
+    setScreenshots((prev) => prev.filter((_, i) => i !== idx));
+  };
+
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
@@ -94,6 +179,7 @@ function SubmitModal({
         contact: contact.trim() || undefined,
         app_version:
           typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev',
+        screenshots: screenshots.map((s) => s.dataUrl),
       });
       setSuccess(true);
       setTimeout(() => {
@@ -193,7 +279,7 @@ function SubmitModal({
             </div>
 
             {/* Contact (optional) */}
-            <div className="mb-5">
+            <div className="mb-4">
               <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
                 联系方式（选填）
               </label>
@@ -205,6 +291,88 @@ function SubmitModal({
                 className="w-full px-3 py-2 text-sm bg-[var(--muted)]/10 rounded-md border border-[var(--border)]
                            outline-none focus:border-[var(--accent)]"
               />
+            </div>
+
+            {/* Screenshots */}
+            <div className="mb-4">
+              <label className="flex items-center justify-between text-xs font-medium text-[var(--muted-foreground)] mb-1.5">
+                <span>截图（选填，可拖入 / 粘贴 / 点击上传）</span>
+                <span className="text-[10px] opacity-70">
+                  {screenshots.length}/{MAX_SCREENSHOTS}
+                </span>
+              </label>
+
+              <div
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  setDragOver(false);
+                  if (e.dataTransfer?.files?.length) {
+                    addFiles(e.dataTransfer.files);
+                  }
+                }}
+                onClick={() => fileInputRef.current?.click()}
+                className={cn(
+                  'flex flex-col items-center justify-center gap-1.5 py-4 px-3 rounded-md border border-dashed cursor-pointer transition-colors',
+                  dragOver
+                    ? 'border-[var(--accent)] bg-[var(--accent)]/5'
+                    : 'border-[var(--border)] hover:border-[var(--accent)]/50 hover:bg-[var(--muted)]/5',
+                )}
+              >
+                <ImagePlus size={20} className="text-[var(--muted-foreground)]" />
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  拖入图片 / 粘贴 (Ctrl+V) / 点击选择
+                </p>
+                <p className="text-[10px] text-[var(--muted-foreground)] opacity-70">
+                  支持 PNG / JPG / GIF / WebP，单张 ≤ 10MB
+                </p>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  className="hidden"
+                  onChange={(e) => {
+                    if (e.target.files?.length) addFiles(e.target.files);
+                    e.target.value = '';
+                  }}
+                />
+              </div>
+
+              {screenshots.length > 0 && (
+                <div className="grid grid-cols-3 gap-2 mt-2">
+                  {screenshots.map((s, idx) => (
+                    <div
+                      key={idx}
+                      className="relative group rounded-md overflow-hidden border border-[var(--border)] aspect-video bg-[var(--muted)]/10"
+                    >
+                      <img
+                        src={s.dataUrl}
+                        alt={s.name}
+                        className="w-full h-full object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeScreenshot(idx);
+                        }}
+                        className="absolute top-1 right-1 p-1 rounded-full bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+                        title="移除"
+                      >
+                        <X size={12} />
+                      </button>
+                      <div className="absolute bottom-0 left-0 right-0 px-1.5 py-0.5 bg-black/60 text-[10px] text-white truncate">
+                        {(s.size / 1024).toFixed(0)} KB
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
             {error && (

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -37,6 +37,7 @@ import AgentPanel from '../agents/AgentPanel';
 import { PermissionsPage } from '../permissions/PermissionsPage';
 import { PluginMarket } from '../plugins/PluginMarket';
 import WslStatusPage from '../wsl/WslStatusPage';
+import { FeedbackPage } from '../feedback/FeedbackPage';
 
 export type SettingsTab =
   | 'general'
@@ -56,7 +57,8 @@ export type SettingsTab =
   | 'wsl'
   | 'logs'
   | 'archived'
-  | 'docs';
+  | 'docs'
+  | 'feedback';
 
 // ---- Helpers ----
 function getNestedStr(obj: Record<string, unknown>, ...keys: string[]): string {
@@ -1133,6 +1135,7 @@ export function SettingsPage({ onReopenSetup, tab = 'general' }: { onReopenSetup
             { value: 'logs', label: '日志' },
             { value: 'archived', label: '已归档' },
             { value: 'docs', label: '文档' },
+            { value: 'feedback', label: '反馈' },
           ].map((tab) => (
             <Tabs.Trigger
               key={tab.value}
@@ -1202,6 +1205,9 @@ export function SettingsPage({ onReopenSetup, tab = 'general' }: { onReopenSetup
         </Tabs.Content>
         <Tabs.Content value="docs" className="flex-1 min-h-0 flex flex-col">
           <DocsTab />
+        </Tabs.Content>
+        <Tabs.Content value="feedback" className="flex-1 overflow-y-auto">
+          <FeedbackPage />
         </Tabs.Content>
       </Tabs.Root>
     </div>

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -132,6 +132,8 @@ export const IPC = {
   PLUGINS_INSTALL: 'plugins:install',
   PLUGINS_UNINSTALL: 'plugins:uninstall',
   PLUGINS_TOGGLE: 'plugins:toggle',
+  FEEDBACK_SUBMIT: 'feedback:submit',
+  FEEDBACK_LIST: 'feedback:list',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -970,4 +972,38 @@ export interface SandboxSetEnabledResult {
   destroyed?: number;
   already?: boolean;
   initializing?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Feedback schemas
+// ---------------------------------------------------------------------------
+
+export const FeedbackSubmitInput = z.object({
+  category: z.enum(['bug', 'question', 'suggestion', 'other']),
+  title: z.string().min(1).max(200),
+  content: z.string().min(1).max(10000),
+  contact: z.string().max(200).optional(),
+  app_version: z.string().max(50).optional(),
+});
+
+export interface FeedbackEntry {
+  id: string;
+  category: 'bug' | 'question' | 'suggestion' | 'other';
+  title: string;
+  content: string;
+  contact: string;
+  app_version: string;
+  os: string;
+  python_version: string;
+  feishu_record_id: string;
+  created_at: string;
+}
+
+export interface FeedbackListResult {
+  entries: FeedbackEntry[];
+}
+
+export interface FeedbackSubmitResult {
+  ok: boolean;
+  record_id: string;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -984,6 +984,7 @@ export const FeedbackSubmitInput = z.object({
   content: z.string().min(1).max(10000),
   contact: z.string().max(200).optional(),
   app_version: z.string().max(50).optional(),
+  screenshots: z.array(z.string()).max(5).optional(),
 });
 
 export interface FeedbackEntry {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -978,13 +978,36 @@ export interface SandboxSetEnabledResult {
 // Feedback schemas
 // ---------------------------------------------------------------------------
 
+// Per-screenshot validator: must be a `data:image/<mime>;base64,<...>`
+// URL whose decoded byte size is within the documented 10 MB limit.
+// Mirrors the server-side check in miqi/runtime/feedback_handlers.py
+// _decode_data_url so oversized/malformed payloads are rejected at the
+// IPC boundary before they reach the bridge.
+const MAX_DATA_URL_BYTES = 10 * 1024 * 1024;
+const dataUrlScreenshot = z
+  .string()
+  .refine(
+    (s) => s.startsWith('data:image/') && s.includes(';base64,'),
+    'Screenshot must be a base64-encoded data URL with image MIME type',
+  )
+  .refine(
+    (s) => {
+      const comma = s.indexOf(',');
+      if (comma < 0) return false;
+      const b64 = s.slice(comma + 1);
+      // base64 inflates ~4/3, so 14 MB encoded → ~10.5 MB decoded
+      return b64.length * 3 <= MAX_DATA_URL_BYTES * 4 + 4;
+    },
+    'Screenshot exceeds 10 MB limit',
+  );
+
 export const FeedbackSubmitInput = z.object({
   category: z.enum(['bug', 'question', 'suggestion', 'other']),
   title: z.string().min(1).max(200),
   content: z.string().min(1).max(10000),
   contact: z.string().max(200).optional(),
   app_version: z.string().max(50).optional(),
-  screenshots: z.array(z.string()).max(5).optional(),
+  screenshots: z.array(dataUrlScreenshot).max(5).optional(),
 });
 
 export interface FeedbackEntry {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1008,6 +1008,8 @@ export const FeedbackSubmitInput = z.object({
   contact: z.string().max(200).optional(),
   app_version: z.string().max(50).optional(),
   screenshots: z.array(dataUrlScreenshot).max(5).optional(),
+  prompt_used: z.string().max(10000).optional(),
+  repro_frequency: z.string().max(200).optional(),
 });
 
 export interface FeedbackEntry {

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -152,4 +152,41 @@ test.describe('Feedback Page E2E', () => {
     // At minimum, the modal must still be visible (no crash)
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible({ timeout: 2000 });
   });
+
+  test('screenshot drop zone accepts files and shows thumbnails', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    // Drop zone hint visible
+    await expect(page.getByText('拖入图片 / 粘贴 (Ctrl+V) / 点击选择')).toBeVisible();
+
+    // Counter starts at 0/5
+    await expect(page.getByText('0/5')).toBeVisible();
+
+    // Upload a small PNG via the hidden file input (scoped to the modal)
+    const tinyPng = Buffer.from(
+      '89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489' +
+      '0000000D49444154789C636000000000050001A5F645400000000049454E44AE426082',
+      'hex',
+    );
+    const fileInput = page
+      .locator('div.bg-\\[var\\(--surface\\)\\]')
+      .locator('input[type="file"]');
+    await fileInput.setInputFiles({
+      name: 'test.png',
+      mimeType: 'image/png',
+      buffer: tinyPng,
+    });
+
+    // Counter updates to 1/5
+    await expect(page.getByText('1/5')).toBeVisible({ timeout: 3_000 });
+    // Thumbnail renders
+    await expect(page.locator('img[alt="test.png"]')).toBeVisible();
+  });
 });

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * E2E: Feedback Page (用户反馈 tab)
+ *
+ * Validates the in-app feedback submission flow:
+ * - Navigate to Settings → 反馈 tab
+ * - Verify empty state (no entries yet)
+ * - Open submit modal, fill form, submit
+ * - Verify the entry appears in the list
+ * - Verify success message and modal dismiss
+ * - Verify Escape key closes the modal
+ *
+ * Note: This test does NOT verify the Feishu Bitable API call — that
+ * requires real credentials.  We mock feedback.submit() to capture the
+ * payload, then verify it has the right shape.
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts --project=electron feedback.spec.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+/** Helper: navigate from current page to Settings → 反馈 tab. */
+async function openFeedbackTab(page: Page) {
+  const settingsLink = page.getByTestId('nav-system-settings');
+  await expect(settingsLink).toBeVisible({ timeout: 10_000 });
+  await settingsLink.click();
+
+  // Settings page renders a "通用" tab heading
+  await expect(page.getByText('通用').first()).toBeVisible({ timeout: 10_000 });
+
+  const feedbackTab = page.getByRole('tab', { name: '反馈' });
+  await expect(feedbackTab).toBeVisible({ timeout: 5_000 });
+  await feedbackTab.click();
+
+  // FeedbackPage header is rendered
+  await expect(page.getByText('用户反馈')).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe('Feedback Page E2E', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 120_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test('feedback tab loads with empty state', async () => {
+    await openFeedbackTab(page);
+
+    // Empty state should show (button "提交第一条反馈" is visible)
+    await expect(page.getByText('提交反馈将自动附加日志并发送到飞书')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByRole('button', { name: /提交第一条反馈/ })).toBeVisible();
+  });
+
+  test('submit modal opens and validates form', async () => {
+    await openFeedbackTab(page);
+
+    // Click "提交反馈" header button (NOT the "提交第一条反馈" empty-state one)
+    // Use exact match to disambiguate.
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await expect(headerBtn).toBeVisible({ timeout: 5_000 });
+    await headerBtn.click();
+
+    // Modal heading
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    // Submit button should be disabled (title/content empty)
+    const submitButton = page
+      .locator('div.bg-\\[var\\(--surface\\)\\]')
+      .getByRole('button', { name: '提交', exact: true });
+    await expect(submitButton).toBeDisabled();
+
+    // Fill title and content
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E 测试标题');
+    await page
+      .getByPlaceholder('请详细描述你的问题或建议...')
+      .fill('E2E 测试内容 - 验证表单收集');
+
+    // Submit button should now be enabled
+    await expect(submitButton).toBeEnabled();
+  });
+
+  test('Escape key closes the submit modal', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    // Press Escape
+    await page.keyboard.press('Escape');
+
+    // Modal heading should no longer be visible
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test('submit feedback shows validation error when disabled', async () => {
+    // E2E test config has feedback disabled by default, so a real submit
+    // surfaces the FEEDBACK_DISABLED error.  This verifies the modal handles
+    // errors gracefully.  Full success flow requires enabling feedback in
+    // the test config and is covered by the Python unit tests + the manual
+    // E2E verification (see PR description).
+    await openFeedbackTab(page);
+
+    // Open modal
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+
+    // Fill form with valid data
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E test title');
+    await page
+      .getByPlaceholder('请详细描述你的问题或建议...')
+      .fill('E2E test content - verifying the form submission path.');
+
+    // Submit
+    const submitButton = page
+      .locator('div.bg-\\[var\\(--surface\\)\\]')
+      .getByRole('button', { name: '提交', exact: true });
+    await submitButton.click();
+
+    // Either success (if feedback enabled) or error message should appear
+    const successOrError = await Promise.race([
+      page.getByText('提交成功！').waitFor({ timeout: 5000 }).then(() => 'success').catch(() => null),
+      page.locator('.bg-red-500\\/10, [class*="red"]').waitFor({ timeout: 5000 }).then(() => 'error').catch(() => null),
+    ]).catch(() => null);
+
+    // At minimum, the modal must still be visible (no crash)
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible({ timeout: 2000 });
+  });
+});

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -167,13 +167,98 @@ test.describe('Feedback Page E2E', () => {
   });
 
   test('submit feedback via mocked bridge shows success entry', async () => {
-    // Skip: the renderer captures `window.miqi.feedback` via contextBridge
-    // which freezes the API surface, so direct property replacement in
-    // page.evaluate() doesn't intercept calls.  A full success-path E2E
-    // requires enabling feedback in the test config (mock IPC at the
-    // main-process level) — covered by Python unit tests + manual
-    // verification documented in PR description.
-    test.skip(true, 'success-path requires main-process IPC mock; see PR description');
+    // The renderer reaches the bridge via the IPC pipeline, so we patch
+    // window.miqi.feedback.submit/list with deterministic stubs BEFORE
+    // the FeedbackPage mounts.  Since the renderer captures the API via
+    // contextBridge (which freezes the surface), we instead drive the
+    // bridge directly from the page's ipcRenderer by patching the
+    // window-level function that the FeedbackPage component reads.
+    //
+    // Implementation: the renderer reads `window.miqi.feedback` lazily on
+    // each call, so replacing it at runtime works for our test scope.
+    await page.addInitScript(() => {
+      (window as any).__capturedSubmits = [];
+      const origSubmit = (window as any).miqi?.feedback?.submit;
+      const origList = (window as any).miqi?.feedback?.list;
+      // Wrap submit so calls are captured but only if mocking succeeds
+      if ((window as any).miqi?.feedback) {
+        (window as any).miqi.feedback.submit = async (params: any) => {
+          (window as any).__capturedSubmits.push(params);
+          return { ok: true, record_id: 'mock_record_xyz' };
+        };
+        (window as any).miqi.feedback.list = async () => {
+          const subs = (window as any).__capturedSubmits;
+          return {
+            entries: subs.map((s: any, i: number) => ({
+              id: `mock_${i}`,
+              category: s.category,
+              title: s.title,
+              content: s.content,
+              contact: s.contact || '',
+              app_version: s.app_version || 'dev',
+              os: 'Windows 11 (test)',
+              python_version: '3.12',
+              feishu_record_id: 'mock_record_xyz',
+              created_at: new Date().toISOString(),
+            })),
+          };
+        };
+      }
+      // Mark success if either path worked
+      (window as any).__mockApplied = !!(window as any).miqi?.feedback;
+    });
+
+    await openFeedbackTab(page);
+
+    // Open modal
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await page.getByRole('heading', { name: '提交反馈' }).waitFor();
+
+    // Fill form
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E mock submission');
+    await page
+      .getByPlaceholder('请详细描述你的问题或建议...')
+      .fill('Mocked success-path content for E2E.');
+    await page.getByPlaceholder('邮箱或飞书账号，方便我们联系你').fill('e2e@test.com');
+
+    // Submit
+    const submitButton = page
+      .locator('div.bg-\\[var\\(--surface\\)\\]')
+      .getByRole('button', { name: '提交', exact: true });
+    await submitButton.click();
+
+    // Wait briefly for either success or FEEDBACK_DISABLED (mock may have failed to apply)
+    await page.waitForTimeout(2_000);
+
+    // Verify the renderer either:
+    // (a) Called the mock — captured payload is non-empty, OR
+    // (b) Hit FEEDBACK_DISABLED — full chain ran end-to-end
+    const captured = await page.evaluate(() => (window as any).__capturedSubmits);
+    const mockApplied = await page.evaluate(() => !!(window as any).__mockApplied);
+    const errorBox = page.locator('[class*="bg-red-500"]');
+    const errorVisible = await errorBox.isVisible().catch(() => false);
+
+    if (mockApplied && captured.length > 0) {
+      // Mock path: success message visible
+      await expect(page.getByText('提交成功！')).toBeVisible({ timeout: 3_000 });
+      expect(captured[0].title).toBe('E2E mock submission');
+      expect(captured[0].content).toContain('Mocked success-path');
+      expect(captured[0].contact).toBe('e2e@test.com');
+    } else {
+      // contextBridge froze the surface — confirm real backend was reached.
+      // When feedback is disabled by default, we observe FEEDBACK_DISABLED
+      // which proves the IPC → bridge → handler chain is wired correctly.
+      await expect(errorBox).toBeVisible({ timeout: 5_000 });
+      await expect(errorBox).toContainText('反馈功能未启用');
+      console.log(
+        '[e2e] contextBridge froze window.miqi.feedback; ' +
+          'mock path skipped but real IPC chain verified via FEEDBACK_DISABLED.',
+      );
+    }
   });
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -166,57 +166,52 @@ test.describe('Feedback Page E2E', () => {
     await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible();
   });
 
-  test('submit feedback via mocked bridge shows success entry', async () => {
-    // The renderer reaches the bridge via the IPC pipeline, so we patch
-    // window.miqi.feedback.submit/list with deterministic stubs BEFORE
-    // the FeedbackPage mounts.  Since the renderer captures the API via
-    // contextBridge (which freezes the surface), we instead drive the
-    // bridge directly from the page's ipcRenderer by patching the
-    // window-level function that the FeedbackPage component reads.
-    //
-    // Implementation: the renderer reads `window.miqi.feedback` lazily on
-    // each call, so replacing it at runtime works for our test scope.
-    await page.addInitScript(() => {
-      (window as any).__capturedSubmits = [];
-      const origSubmit = (window as any).miqi?.feedback?.submit;
-      const origList = (window as any).miqi?.feedback?.list;
-      // Wrap submit so calls are captured but only if mocking succeeds
-      if ((window as any).miqi?.feedback) {
-        (window as any).miqi.feedback.submit = async (params: any) => {
-          (window as any).__capturedSubmits.push(params);
-          return { ok: true, record_id: 'mock_record_xyz' };
+  test('submit feedback via mocked main-process IPC shows success entry', async () => {
+    // contextBridge freezes window.miqi.feedback in the renderer, so
+    // addInitScript-based mocks are no-ops.  Patch the IPC handler in
+    // the main process instead via electronApp.evaluate — this captures
+    // the actual params flowing through the full IPC pipeline and lets
+    // us assert against a deterministic success path.
+    await electronApp.evaluate(async ({ ipcMain: ipc }) => {
+      // Use the IPC channel string literals directly — Playwright's eval
+      // context is ESM sandboxed and can't import the compiled CJS IPC
+      // module.  These strings are stable and match apps/desktop/src/shared/ipc.ts
+      const FEEDBACK_SUBMIT = 'feedback:submit';
+      const FEEDBACK_LIST = 'feedback:list';
+      const box = ((global as any).__capturedSubmits = []);
+      ipc.removeHandler(FEEDBACK_SUBMIT);
+      ipc.handle(FEEDBACK_SUBMIT, async (_e: unknown, params: any) => {
+        box.push(params);
+        return { ok: true, record_id: 'mock_record_xyz' };
+      });
+      ipc.removeHandler(FEEDBACK_LIST);
+      ipc.handle(FEEDBACK_LIST, async () => {
+        return {
+          entries: box.map((s: any, i: number) => ({
+            id: `mock_${i}`,
+            category: s.category,
+            title: s.title,
+            content: s.content,
+            contact: s.contact || '',
+            app_version: s.app_version || 'dev',
+            os: 'Windows 11 (test)',
+            python_version: '3.12',
+            feishu_record_id: 'mock_record_xyz',
+            created_at: new Date().toISOString(),
+          })),
         };
-        (window as any).miqi.feedback.list = async () => {
-          const subs = (window as any).__capturedSubmits;
-          return {
-            entries: subs.map((s: any, i: number) => ({
-              id: `mock_${i}`,
-              category: s.category,
-              title: s.title,
-              content: s.content,
-              contact: s.contact || '',
-              app_version: s.app_version || 'dev',
-              os: 'Windows 11 (test)',
-              python_version: '3.12',
-              feishu_record_id: 'mock_record_xyz',
-              created_at: new Date().toISOString(),
-            })),
-          };
-        };
-      }
-      // Mark success if either path worked
-      (window as any).__mockApplied = !!(window as any).miqi?.feedback;
+      });
     });
 
     await openFeedbackTab(page);
 
-    // Open modal
     const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
       name: '提交反馈',
       exact: true,
     });
+    await expect(headerBtn).toBeVisible({ timeout: 5_000 });
     await headerBtn.click();
-    await page.getByRole('heading', { name: '提交反馈' }).waitFor();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
 
     // Fill form
     await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E mock submission');
@@ -231,35 +226,27 @@ test.describe('Feedback Page E2E', () => {
       .getByRole('button', { name: '提交', exact: true });
     await submitButton.click();
 
-    // Wait briefly for either success or FEEDBACK_DISABLED (mock may have failed to apply)
-    await page.waitForTimeout(2_000);
+    // Deterministic success: success toast appears
+    await expect(page.getByText('提交成功！')).toBeVisible({ timeout: 5_000 });
 
-    // Verify the renderer either:
-    // (a) Called the mock — captured payload is non-empty, OR
-    // (b) Hit FEEDBACK_DISABLED — full chain ran end-to-end
-    const captured = await page.evaluate(() => (window as any).__capturedSubmits);
-    const mockApplied = await page.evaluate(() => !!(window as any).__mockApplied);
-    const errorBox = page.locator('[class*="bg-red-500"]');
-    const errorVisible = await errorBox.isVisible().catch(() => false);
+    // After modal auto-closes, list refreshes and shows the new entry
+    await expect(page.getByText('E2E mock submission')).toBeVisible({ timeout: 5_000 });
 
-    if (mockApplied && captured.length > 0) {
-      // Mock path: success message visible
-      await expect(page.getByText('提交成功！')).toBeVisible({ timeout: 3_000 });
-      expect(captured[0].title).toBe('E2E mock submission');
-      expect(captured[0].content).toContain('Mocked success-path');
-      expect(captured[0].contact).toBe('e2e@test.com');
-    } else {
-      // contextBridge froze the surface — confirm real backend was reached.
-      // When feedback is disabled by default, we observe FEEDBACK_DISABLED
-      // which proves the IPC → bridge → handler chain is wired correctly.
-      await expect(errorBox).toBeVisible({ timeout: 5_000 });
-      await expect(errorBox).toContainText('反馈功能未启用');
-      console.log(
-        '[e2e] contextBridge froze window.miqi.feedback; ' +
-          'mock path skipped but real IPC chain verified via FEEDBACK_DISABLED.',
-      );
-    }
-  });
+    // Verify the captured payload went through the IPC pipeline
+    const captured = await electronApp.evaluate(async () => {
+      const box = (global as any).__capturedSubmits ?? [];
+      return box.map((s: any) => ({
+        title: s.title,
+        content: s.content,
+        contact: s.contact,
+        category: s.category,
+      }));
+    });
+    expect(captured).toHaveLength(1);
+    expect(captured[0].title).toBe('E2E mock submission');
+    expect(captured[0].content).toContain('Mocked success-path');
+    expect(captured[0].contact).toBe('e2e@test.com');
+  });;
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {
     await openFeedbackTab(page);

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -56,6 +56,16 @@ test.describe('Feedback Page E2E', () => {
     await closeElectronApp(electronApp, miqiHome);
   });
 
+  // Reset modal between tests so the backdrop doesn't intercept clicks
+  // in subsequent tests that call openFeedbackTab().
+  test.afterEach(async () => {
+    const modalHeading = page.getByRole('heading', { name: '提交反馈' });
+    if (await modalHeading.isVisible().catch(() => false)) {
+      await page.keyboard.press('Escape');
+      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+    }
+  });
+
   test('feedback tab loads with empty state', async () => {
     await openFeedbackTab(page);
 
@@ -143,14 +153,22 @@ test.describe('Feedback Page E2E', () => {
       .getByRole('button', { name: '提交', exact: true });
     await submitButton.click();
 
-    // Either success (if feedback enabled) or error message should appear
+    // Either success (if feedback enabled) or error message should appear.
+    // We must observe one of them — silent no-op is a test failure.
     const successOrError = await Promise.race([
-      page.getByText('提交成功！').waitFor({ timeout: 5000 }).then(() => 'success').catch(() => null),
-      page.locator('.bg-red-500\\/10, [class*="red"]').waitFor({ timeout: 5000 }).then(() => 'error').catch(() => null),
+      page
+        .getByText('提交成功！')
+        .waitFor({ timeout: 5000 })
+        .then(() => 'success' as const)
+        .catch(() => null),
+      page
+        .locator('[class*="bg-red-500"]')
+        .waitFor({ timeout: 5000 })
+        .then(() => 'error' as const)
+        .catch(() => null),
     ]).catch(() => null);
 
-    // At minimum, the modal must still be visible (no crash)
-    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible({ timeout: 2000 });
+    expect(successOrError).not.toBeNull();
   });
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -153,22 +153,27 @@ test.describe('Feedback Page E2E', () => {
       .getByRole('button', { name: '提交', exact: true });
     await submitButton.click();
 
-    // Either success (if feedback enabled) or error message should appear.
-    // We must observe one of them — silent no-op is a test failure.
-    const successOrError = await Promise.race([
-      page
-        .getByText('提交成功！')
-        .waitFor({ timeout: 5000 })
-        .then(() => 'success' as const)
-        .catch(() => null),
-      page
-        .locator('[class*="bg-red-500"]')
-        .waitFor({ timeout: 5000 })
-        .then(() => 'error' as const)
-        .catch(() => null),
-    ]).catch(() => null);
+    // Feedback is disabled by default in E2E config → specific error must appear.
+    // Assert the FEEDBACK_DISABLED message is shown and "提交成功！" is absent.
+    const errorBox = page.locator('[class*="bg-red-500"]');
+    await expect(errorBox).toBeVisible({ timeout: 5_000 });
+    await expect(errorBox).toContainText('反馈功能未启用');
+    await expect(page.getByText('提交成功！')).not.toBeVisible();
+    // Modal stays open so the user can correct and retry
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+    // Close modal so afterEach Escape doesn't double-press
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible();
+  });
 
-    expect(successOrError).not.toBeNull();
+  test('submit feedback via mocked bridge shows success entry', async () => {
+    // Skip: the renderer captures `window.miqi.feedback` via contextBridge
+    // which freezes the API surface, so direct property replacement in
+    // page.evaluate() doesn't intercept calls.  A full success-path E2E
+    // requires enabling feedback in the test config (mock IPC at the
+    // main-process level) — covered by Python unit tests + manual
+    // verification documented in PR description.
+    test.skip(true, 'success-path requires main-process IPC mock; see PR description');
   });
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -246,6 +246,15 @@ export async function launchElectronApp(): Promise<ElectronFixture> {
     ? JSON.parse(readFileSync(destConfigPath, 'utf-8'))
     : {};
   config.approvals = { ...config.approvals, bypass_all: true };
+  // ── E2E: always disable feedback channel so tests don't hit real Feishu ──
+  // Each test that needs feedback enabled can opt in by patching the config
+  // after launchElectronApp.  Default OFF keeps the disabled-error path
+  // verifiable for the E2E suite.
+  config.channels = {
+    ...config.channels,
+    feishu: { ...(config.channels?.feishu ?? {}), enabled: false },
+    feedback: { enabled: false, bitableAppToken: '', bitableTableId: '' },
+  };
   writeFileSync(destConfigPath, JSON.stringify(config, null, 2));
 
   // Delete ELECTRON_RUN_AS_NODE inherited from Electron-based IDEs

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -504,7 +504,15 @@ class BridgeRuntimeLoop:
         self._app_server.register_method("experience:toggle", experience_toggle_handler)
         self._app_server.register_method("experience:search", experience_search_handler)
 
-        # Register Phase 35.8: diagnostic handlers
+        # Register Phase 35.8: feedback handlers
+        from miqi.runtime.feedback_handlers import (
+            feedback_list_handler,
+            feedback_submit_handler,
+        )
+        self._app_server.register_method("feedback:submit", feedback_submit_handler)
+        self._app_server.register_method("feedback:list", feedback_list_handler)
+
+        # Register Phase 35.9: diagnostic handlers
         from miqi.runtime.diagnostic_handlers import python_check_handler
         self._app_server.register_method("python.check", python_check_handler, spec=protocol_specs.PYTHON_CHECK)
 

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -158,6 +158,14 @@ class FeishuChannelConfig(Base):
     require_mention_in_groups: bool = True  # If true, only respond when @mentioned in group chats
 
 
+class FeedbackConfig(Base):
+    """User feedback collection configuration (submit to Feishu Bitable)."""
+
+    enabled: bool = False
+    bitable_app_token: str = ""   # Bitable app_token (from URL "base/xxx")
+    bitable_table_id: str = ""    # Bitable table id (from URL "?table=tblxxx")
+
+
 class ChannelsConfig(Base):
     """Configuration for chat channels."""
 
@@ -165,6 +173,7 @@ class ChannelsConfig(Base):
     send_tool_hints: bool = False  # stream tool-call hints (e.g. read_file("…"))
     send_queue_notifications: bool = True  # Notify users about their position in the task queue
     feishu: FeishuChannelConfig = Field(default_factory=FeishuChannelConfig)
+    feedback: FeedbackConfig = Field(default_factory=FeedbackConfig)
 
 
 class FallbackChainEntry(Base):

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -159,9 +159,14 @@ class FeishuChannelConfig(Base):
 
 
 class FeedbackConfig(Base):
-    """User feedback collection configuration (submit to Feishu Bitable)."""
+    """User feedback collection configuration (submit to Feishu Bitable).
 
-    enabled: bool = False
+    Default is enabled=True so the Settings → 反馈 tab is functional
+    out-of-the-box.  Users fill in the bitable_app_token /
+    bitable_table_id from their Feishu Bitable URL to enable submission.
+    """
+
+    enabled: bool = True
     bitable_app_token: str = ""   # Bitable app_token (from URL "base/xxx")
     bitable_table_id: str = ""    # Bitable table id (from URL "?table=tblxxx")
 

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -77,26 +77,25 @@ def _collect_all_logs(log_dir: Path) -> str:
 
     combined = "\n\n".join(parts)
     # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 100k bytes,
-    # not 100k chars (Chinese characters can be 3+ bytes each).  The truncation
-    # marker is reserved up front so the result never exceeds the byte cap.
-    total_bytes = len(combined.encode("utf-8"))
+    # not 100k chars (Chinese characters can be 3+ bytes each).  Encode once,
+    # then slice the tail bytes directly to avoid repeatedly re-encoding.
+    encoded = combined.encode("utf-8")
+    total_bytes = len(encoded)
     if total_bytes > 100_000:
-        # Truncate from the head, keeping the tail (most recent log entries).
-        # Marker placeholder is filled in last, so its exact length is reserved.
-        marker_template = "...(总日志超出 NNN 字节, 已截断)\n"
-        cap = 100_000
-        truncated_tail = combined
-        while len(truncated_tail.encode("utf-8")) + len(marker_template.encode("utf-8")) > cap:
-            truncated_tail = truncated_tail[len(truncated_tail) // 10:]
-        dropped = total_bytes - len(truncated_tail.encode("utf-8"))
-        marker = marker_template.replace("NNN", str(dropped))
-        # If the marker itself pushed us over, drop more bytes from the tail
-        final_bytes = (marker + truncated_tail).encode("utf-8")
-        if len(final_bytes) > cap:
-            excess = len(final_bytes) - cap
-            # truncate the kept tail further to fit the marker
-            truncated_tail = truncated_tail.encode("utf-8")[:-excess].decode("utf-8", errors="ignore")
-        return marker + truncated_tail
+        # Reserve 100 bytes for the marker text (incl. the digit count).
+        keep_bytes = 100_000 - 100
+        retained = encoded[-keep_bytes:].decode("utf-8", errors="ignore")
+        retained_bytes = len(retained.encode("utf-8"))
+        dropped = total_bytes - retained_bytes
+        marker = f"...(总日志超出 {dropped} 字节，已截断)\n"
+        # If the marker pushed us over (rare; depends on dropped digit count),
+        # trim the tail further to fit exactly within the cap.
+        candidate = marker + retained
+        if len(candidate.encode("utf-8")) > 100_000:
+            excess = len(candidate.encode("utf-8")) - 100_000
+            retained = retained.encode("utf-8")[:-excess].decode("utf-8", errors="ignore")
+            return marker + retained
+        return candidate
     return combined
 
 

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -325,6 +325,8 @@ async def feedback_submit_handler(
     content = str(params.get("content", "")).strip()
     contact = str(params.get("contact", "")).strip()
     app_version = str(params.get("app_version", "unknown"))
+    prompt_used = str(params.get("prompt_used", "")).strip()
+    repro_frequency = str(params.get("repro_frequency", "")).strip()
     screenshots_raw = params.get("screenshots") or []
     if not isinstance(screenshots_raw, list):
         screenshots_raw = []
@@ -375,13 +377,15 @@ async def feedback_submit_handler(
     fields: dict[str, Any] = {
         "类别": category,
         "标题": title,
-        "详细描述": content,
+        "详细描述（复现步骤，期望行为，实际行为等）": content,
         "联系方式": contact,
         "应用版本": app_version,
         "操作系统": os_str,
         "Python版本": sys_info["python_version"],
-        "日志内容": log_content,
+        "日志内容（设置界面日志栏目-复制日志）": log_content,
         "提交时间": now_iso,
+        "使用的提示词": prompt_used,
+        "复现频率": repro_frequency,
     }
 
     # 5. Send to Feishu — get token first, then upload screenshots, then add record
@@ -416,7 +420,7 @@ async def feedback_submit_handler(
                     parent_node=fb_cfg.bitable_app_token,
                 )
                 file_tokens.append({"file_token": file_token})
-            fields["截图"] = file_tokens
+            fields["附件"] = file_tokens
 
         # 5b. Add the Bitable record (with attachment references)
         record_id = _add_bitable_record(

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -46,24 +46,31 @@ def _ensure_memory_dir() -> None:
 
 
 def _collect_all_logs(log_dir: Path) -> str:
-    """Read all .log and .jsonl files from workspace/logs/ and return
-    concatenated text.  Individual files are capped at 1 MB (tail end).
-    The combined payload is capped at 100,000 UTF-8 bytes to fit within
-    Feishu Bitable text-field limits (per official docs)."""
+    """Read every file under workspace/logs/ recursively (relative path
+    shown for nested files) and return concatenated text.
+
+    Individual files are capped at 1 MB (tail end).  The combined payload
+    is capped at 100,000 UTF-8 bytes to fit within Feishu Bitable
+    text-field limits (per official docs).
+    """
     if not log_dir.exists():
         return "[日志目录不存在]"
 
     parts: list[str] = []
-    for pattern in ("*.log", "*.jsonl"):
-        for f in sorted(log_dir.glob(pattern)):
-            try:
-                content = f.read_text(encoding="utf-8", errors="replace")
-                max_chars = 1_000_000
-                if len(content) > max_chars:
-                    content = f"...(截断 {len(content) - max_chars} 字符)\n{content[-max_chars:]}"
-                parts.append(f"=== {f.name} ===\n{content}")
-            except Exception as exc:
-                parts.append(f"=== {f.name} === [读取失败: {exc}]")
+    # Recursive walk: catches nested logs and any extension (binary-safe
+    # via errors='replace' below).
+    for f in sorted(log_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        try:
+            content = f.read_text(encoding="utf-8", errors="replace")
+            max_chars = 1_000_000
+            if len(content) > max_chars:
+                content = f"...(截断 {len(content) - max_chars} 字符)\n{content[-max_chars:]}"
+            rel = f.relative_to(log_dir)
+            parts.append(f"=== {rel} ===\n{content}")
+        except Exception as exc:
+            parts.append(f"=== {f.name} === [读取失败: {exc}]")
 
     if not parts:
         return "[无日志文件]"
@@ -144,11 +151,15 @@ def _upload_attachment(
     filename: str,
     content_type: str,
     data: bytes,
+    parent_node: str,
 ) -> str:
     """Upload an attachment to Feishu Drive and return the file_token.
 
     Used for Bitable attachment fields: the record references the file_token
     rather than embedding the bytes inline.
+
+    `parent_node` MUST be the target Bitable's app_token — empty strings
+    cause the upload to fail before the record is created.
     """
     resp = requests.post(
         "https://open.feishu.cn/open-apis/drive/v1/medias/upload_all",
@@ -156,7 +167,7 @@ def _upload_attachment(
         data={
             "file_name": filename,
             "parent_type": "bitable_file",
-            "parent_node": "",
+            "parent_node": parent_node,
             "size": str(len(data)),
         },
         files={"file": (filename, data, content_type)},
@@ -398,7 +409,11 @@ async def feedback_submit_handler(
                     )
                 logger.info("Uploading screenshot {} ({} bytes)", idx + 1, len(raw))
                 file_token = _upload_attachment(
-                    token, filename=filename, content_type=mime, data=raw,
+                    token,
+                    filename=filename,
+                    content_type=mime,
+                    data=raw,
+                    parent_node=fb_cfg.bitable_app_token,
                 )
                 file_tokens.append({"file_token": file_token})
             fields["截图"] = file_tokens

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -1,0 +1,308 @@
+"""Feedback handlers for AppServer dispatch.
+
+Submits user feedback + collected logs to Feishu Bitable and stores
+a local backup in memory/FEEDBACK.jsonl.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+from loguru import logger
+
+from miqi.runtime.app_server import AppServerError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_workspace_path() -> Path:
+    """Resolve workspace path from bridge state config."""
+    import miqi.bridge.server as bridge_module
+
+    state = getattr(bridge_module, "_state", None)
+    if state is None:
+        raise AppServerError("Bridge state not available", code="INTERNAL")
+    config = state.load_config()
+    return config.workspace_path
+
+
+def _get_feedback_file() -> Path:
+    """Return path to local feedback backup JSONL file."""
+    return _get_workspace_path() / "memory" / "FEEDBACK.jsonl"
+
+
+def _ensure_memory_dir() -> None:
+    """Ensure the memory directory exists."""
+    memory_dir = _get_workspace_path() / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _collect_all_logs(log_dir: Path) -> str:
+    """Read all .log and .jsonl files from workspace/logs/ and return
+    concatenated text.  Individual files are capped at 1 MB (tail end)."""
+    if not log_dir.exists():
+        return "[日志目录不存在]"
+
+    parts: list[str] = []
+    for pattern in ("*.log", "*.jsonl"):
+        for f in sorted(log_dir.glob(pattern)):
+            try:
+                content = f.read_text(encoding="utf-8", errors="replace")
+                max_chars = 1_000_000
+                if len(content) > max_chars:
+                    content = f"...(截断 {len(content) - max_chars} 字符)\n{content[-max_chars:]}"
+                parts.append(f"=== {f.name} ===\n{content}")
+            except Exception as exc:
+                parts.append(f"=== {f.name} === [读取失败: {exc}]")
+
+    if not parts:
+        return "[无日志文件]"
+    return "\n\n".join(parts)
+
+
+def _collect_system_info() -> dict[str, str]:
+    """Collect basic system / environment info."""
+    info: dict[str, str] = {
+        "os": platform.system(),
+        "os_version": platform.release(),
+        "machine": platform.machine(),
+        "python_version": sys.version.split()[0],
+    }
+    # Try WSL check
+    try:
+        import subprocess
+        r = subprocess.run(
+            ["wsl", "--list", "--verbose"],
+            capture_output=True, text=True, timeout=5,  # noqa: S603
+        )
+        info["wsl_status"] = r.stdout.strip() or "[未安装或无权限]"
+    except Exception:
+        info["wsl_status"] = "[检测失败]"
+    return info
+
+
+def _get_tenant_access_token(app_id: str, app_secret: str) -> str:
+    """Obtain a Feishu tenant_access_token via app_id/app_secret."""
+    resp = requests.post(
+        "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+        json={"app_id": app_id, "app_secret": app_secret},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    code = body.get("code", -1)
+    if code != 0:
+        msg = body.get("msg", "unknown error")
+        raise AppServerError(
+            f"获取飞书 tenant_access_token 失败: {msg} (code={code})",
+            code="FEISHU_AUTH_ERROR",
+        )
+    token = body.get("tenant_access_token", "")
+    if not token:
+        raise AppServerError(
+            "飞书返回的 tenant_access_token 为空", code="FEISHU_AUTH_ERROR",
+        )
+    return token
+
+
+def _add_bitable_record(
+    token: str,
+    app_token: str,
+    table_id: str,
+    fields: dict[str, Any],
+) -> str:
+    """Add one record to a Feishu Bitable and return the record_id."""
+    resp = requests.post(
+        f"https://open.feishu.cn/open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json={"fields": fields},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    code = body.get("code", -1)
+    if code != 0:
+        msg = body.get("msg", "unknown error")
+        raise AppServerError(
+            f"写入飞书多维表格失败: {msg} (code={code})",
+            code="FEISHU_BITABLE_ERROR",
+        )
+    record = body.get("data", {}).get("record", {})
+    record_id = record.get("record_id", "")
+    logger.info("Feedback submitted to Feishu Bitable, record_id={}", record_id)
+    return record_id
+
+
+def _save_local_backup(entry: dict[str, Any]) -> None:
+    """Append one feedback entry to the local backup JSONL file."""
+    _ensure_memory_dir()
+    feedback_file = _get_feedback_file()
+    try:
+        with feedback_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        logger.warning("Failed to write local feedback backup: {}", exc)
+
+
+def _append_feedback(entry: dict[str, Any]) -> None:
+    """Backward-compat alias for _save_local_backup."""
+    _save_local_backup(entry)
+
+
+def _read_local_backups() -> list[dict[str, Any]]:
+    """Read all local feedback backup entries (newest first)."""
+    feedback_file = _get_feedback_file()
+    if not feedback_file.exists():
+        return []
+
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in feedback_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    except Exception as exc:
+        logger.warning("Failed to read local feedback backups: {}", exc)
+        return []
+
+    entries.sort(key=lambda e: e.get("created_at", ""), reverse=True)
+    return entries
+
+
+def _read_local_feedbacks() -> list[dict[str, Any]]:
+    """Backward-compat alias for _read_local_backups."""
+    return _read_local_backups()
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+async def feedback_submit_handler(
+    request_id: str,
+    params: dict[str, Any],
+    client_id: str,
+    session_id: str | None,
+    registry: Any,
+) -> dict[str, Any]:
+    """Submit user feedback + collected logs to Feishu Bitable."""
+    category = str(params.get("category", "other"))
+    title = str(params.get("title", "")).strip()
+    content = str(params.get("content", "")).strip()
+    contact = str(params.get("contact", "")).strip()
+    app_version = str(params.get("app_version", "unknown"))
+
+    if not title:
+        raise AppServerError("反馈标题不能为空", code="INVALID_PARAMS")
+    if not content:
+        raise AppServerError("反馈内容不能为空", code="INVALID_PARAMS")
+
+    workspace = _get_workspace_path()
+    log_dir = workspace / "logs"
+
+    # 1. Collect all logs
+    logger.info("feedback:submit — collecting logs from {}", log_dir)
+    log_content = _collect_all_logs(log_dir)
+
+    # 2. Collect system info
+    sys_info = _collect_system_info()
+    os_str = f"{sys_info['os']} {sys_info['os_version']} ({sys_info['machine']})"
+
+    # 3. Get Feishu config
+    import miqi.bridge.server as bridge_module
+
+    state = getattr(bridge_module, "_state", None)
+    if state is None:
+        raise AppServerError("Bridge state not available", code="INTERNAL")
+    config = state.load_config()
+    fb_cfg = config.channels.feedback
+
+    if not fb_cfg.enabled:
+        raise AppServerError("反馈功能未启用，请在配置中开启", code="FEEDBACK_DISABLED")
+
+    app_id = config.channels.feishu.app_id
+    app_secret = config.channels.feishu.app_secret
+    if not app_id or not app_secret:
+        raise AppServerError(
+            "飞书 App ID / App Secret 未配置", code="FEISHU_NOT_CONFIGURED",
+        )
+    if not fb_cfg.bitable_app_token or not fb_cfg.bitable_table_id:
+        raise AppServerError(
+            "飞书多维表格 app_token / table_id 未配置", code="BITABLE_NOT_CONFIGURED",
+        )
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # 4. Build Bitable fields
+    fields: dict[str, Any] = {
+        "类别": category,
+        "标题": title,
+        "详细描述": content,
+        "联系方式": contact,
+        "应用版本": app_version,
+        "操作系统": os_str,
+        "Python版本": sys_info["python_version"],
+        "日志内容": log_content,
+        "提交时间": now_iso,
+    }
+
+    # 5. Send to Feishu
+    try:
+        token = _get_tenant_access_token(app_id, app_secret)
+        record_id = _add_bitable_record(
+            token, fb_cfg.bitable_app_token, fb_cfg.bitable_table_id, fields,
+        )
+    except AppServerError:
+        raise
+    except Exception as exc:
+        logger.exception("feedback:submit — Feishu API error")
+        raise AppServerError(
+            f"提交到飞书失败: {exc}", code="FEISHU_API_ERROR",
+        ) from exc
+
+    # 6. Local backup (strip log content to avoid huge local file)
+    local_entry = {
+        "id": f"fbk_{int(datetime.now(timezone.utc).timestamp() * 1000)}",
+        "category": category,
+        "title": title,
+        "content": content,
+        "contact": contact,
+        "app_version": app_version,
+        "os": os_str,
+        "python_version": sys_info["python_version"],
+        "feishu_record_id": record_id,
+        "created_at": now_iso,
+    }
+    _save_local_backup(local_entry)
+
+    return {"result": {"ok": True, "record_id": record_id}}
+
+
+async def feedback_list_handler(
+    request_id: str,
+    params: dict[str, Any],
+    client_id: str,
+    session_id: str | None,
+    registry: Any,
+) -> dict[str, Any]:
+    """List local feedback backups."""
+    limit = int(params.get("limit", 50))
+    entries = _read_local_backups()
+    if limit > 0 and len(entries) > limit:
+        entries = entries[:limit]
+    return {"result": {"entries": entries}}

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -47,7 +47,9 @@ def _ensure_memory_dir() -> None:
 
 def _collect_all_logs(log_dir: Path) -> str:
     """Read all .log and .jsonl files from workspace/logs/ and return
-    concatenated text.  Individual files are capped at 1 MB (tail end)."""
+    concatenated text.  Individual files are capped at 1 MB (tail end).
+    The combined payload is capped at 100,000 characters to fit within
+    Feishu Bitable text-field limits (per official docs)."""
     if not log_dir.exists():
         return "[日志目录不存在]"
 
@@ -65,7 +67,12 @@ def _collect_all_logs(log_dir: Path) -> str:
 
     if not parts:
         return "[无日志文件]"
-    return "\n\n".join(parts)
+
+    combined = "\n\n".join(parts)
+    total_cap = 100_000
+    if len(combined) > total_cap:
+        return f"...(总日志超出 {len(combined) - total_cap} 字符，已截断)\n{combined[-total_cap:]}"
+    return combined
 
 
 def _collect_system_info() -> dict[str, str]:
@@ -201,7 +208,9 @@ async def feedback_submit_handler(
     registry: Any,
 ) -> dict[str, Any]:
     """Submit user feedback + collected logs to Feishu Bitable."""
-    category = str(params.get("category", "other"))
+    raw_category = str(params.get("category", "other"))
+    allowed_categories = {"bug", "question", "suggestion", "other"}
+    category = raw_category if raw_category in allowed_categories else "other"
     title = str(params.get("title", "")).strip()
     content = str(params.get("content", "")).strip()
     contact = str(params.get("contact", "")).strip()
@@ -301,7 +310,7 @@ async def feedback_list_handler(
     registry: Any,
 ) -> dict[str, Any]:
     """List local feedback backups."""
-    limit = int(params.get("limit", 50))
+    limit = int(params.get("limit") or 50)
     entries = _read_local_backups()
     if limit > 0 and len(entries) > limit:
         entries = entries[:limit]

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -127,6 +127,69 @@ def _get_tenant_access_token(app_id: str, app_secret: str) -> str:
     return token
 
 
+def _upload_attachment(
+    token: str,
+    *,
+    filename: str,
+    content_type: str,
+    data: bytes,
+) -> str:
+    """Upload an attachment to Feishu Drive and return the file_token.
+
+    Used for Bitable attachment fields: the record references the file_token
+    rather than embedding the bytes inline.
+    """
+    resp = requests.post(
+        "https://open.feishu.cn/open-apis/drive/v1/medias/upload_all",
+        headers={"Authorization": f"Bearer {token}"},
+        data={
+            "file_name": filename,
+            "parent_type": "bitable_file",
+            "parent_node": "",
+            "size": str(len(data)),
+        },
+        files={"file": (filename, data, content_type)},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    code = body.get("code", -1)
+    if code != 0:
+        msg = body.get("msg", "unknown error")
+        raise AppServerError(
+            f"上传截图失败: {msg} (code={code})", code="FEISHU_UPLOAD_ERROR",
+        )
+    file_token = body.get("data", {}).get("file_token", "")
+    if not file_token:
+        raise AppServerError(
+            "上传截图返回的 file_token 为空", code="FEISHU_UPLOAD_ERROR",
+        )
+    return file_token
+
+
+def _decode_data_url(data_url: str) -> tuple[str, str, bytes]:
+    """Decode a `data:<mime>;base64,<...>` URL to (mime, filename, bytes)."""
+    if not data_url.startswith("data:"):
+        raise AppServerError(
+            "截图格式错误（期望 data URL）", code="INVALID_PARAMS",
+        )
+    try:
+        header, b64 = data_url.split(",", 1)
+        mime = header.split(";", 1)[0].split(":", 1)[1]
+        import base64
+        raw = base64.b64decode(b64)
+    except Exception as exc:
+        raise AppServerError(
+            f"截图 base64 解码失败: {exc}", code="INVALID_PARAMS",
+        ) from exc
+    ext_map = {
+        "image/png": "png", "image/jpeg": "jpg", "image/jpg": "jpg",
+        "image/gif": "gif", "image/webp": "webp", "image/bmp": "bmp",
+    }
+    ext = ext_map.get(mime, "png")
+    return mime, f"screenshot.{ext}", raw
+
+
 def _add_bitable_record(
     token: str,
     app_token: str,
@@ -222,6 +285,10 @@ async def feedback_submit_handler(
     content = str(params.get("content", "")).strip()
     contact = str(params.get("contact", "")).strip()
     app_version = str(params.get("app_version", "unknown"))
+    screenshots_raw = params.get("screenshots") or []
+    if not isinstance(screenshots_raw, list):
+        screenshots_raw = []
+    screenshots = [str(s) for s in screenshots_raw if s][:5]  # cap at 5
 
     if not title:
         raise AppServerError("反馈标题不能为空", code="INVALID_PARAMS")
@@ -277,9 +344,37 @@ async def feedback_submit_handler(
         "提交时间": now_iso,
     }
 
-    # 5. Send to Feishu
+    # 5. Send to Feishu — get token first, then upload screenshots, then add record
     try:
         token = _get_tenant_access_token(app_id, app_secret)
+
+        # 5a. Upload each screenshot to get file_token references
+        if screenshots:
+            file_tokens: list[dict[str, str]] = []
+            for idx, data_url in enumerate(screenshots):
+                try:
+                    mime, filename, raw = _decode_data_url(data_url)
+                except AppServerError:
+                    raise
+                except Exception as exc:
+                    raise AppServerError(
+                        f"截图 {idx + 1} 处理失败: {exc}",
+                        code="INVALID_PARAMS",
+                    ) from exc
+                # 10 MB cap per image
+                if len(raw) > 10 * 1024 * 1024:
+                    raise AppServerError(
+                        f"截图 {idx + 1} 超过 10MB 限制",
+                        code="FILE_TOO_LARGE",
+                    )
+                logger.info("Uploading screenshot {} ({} bytes)", idx + 1, len(raw))
+                file_token = _upload_attachment(
+                    token, filename=filename, content_type=mime, data=raw,
+                )
+                file_tokens.append({"file_token": file_token})
+            fields["截图"] = file_tokens
+
+        # 5b. Add the Bitable record (with attachment references)
         record_id = _add_bitable_record(
             token, fb_cfg.bitable_app_token, fb_cfg.bitable_table_id, fields,
         )

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -48,7 +48,7 @@ def _ensure_memory_dir() -> None:
 def _collect_all_logs(log_dir: Path) -> str:
     """Read all .log and .jsonl files from workspace/logs/ and return
     concatenated text.  Individual files are capped at 1 MB (tail end).
-    The combined payload is capped at 100,000 characters to fit within
+    The combined payload is capped at 100,000 UTF-8 bytes to fit within
     Feishu Bitable text-field limits (per official docs)."""
     if not log_dir.exists():
         return "[日志目录不存在]"
@@ -69,9 +69,16 @@ def _collect_all_logs(log_dir: Path) -> str:
         return "[无日志文件]"
 
     combined = "\n\n".join(parts)
-    total_cap = 100_000
-    if len(combined) > total_cap:
-        return f"...(总日志超出 {len(combined) - total_cap} 字符，已截断)\n{combined[-total_cap:]}"
+    # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 100k bytes,
+    # not 100k chars (Chinese characters can be 3+ bytes each).
+    total_bytes = len(combined.encode("utf-8"))
+    if total_bytes > 100_000:
+        # Truncate from the head, keeping the tail (most recent log entries)
+        truncated_tail = combined
+        while len(truncated_tail.encode("utf-8")) > 100_000:
+            truncated_tail = truncated_tail[len(truncated_tail) // 10:]
+        dropped = total_bytes - len(truncated_tail.encode("utf-8"))
+        return f"...(总日志超出 {dropped} 字节，已截断)\n{truncated_tail}"
     return combined
 
 

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -70,15 +70,26 @@ def _collect_all_logs(log_dir: Path) -> str:
 
     combined = "\n\n".join(parts)
     # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 100k bytes,
-    # not 100k chars (Chinese characters can be 3+ bytes each).
+    # not 100k chars (Chinese characters can be 3+ bytes each).  The truncation
+    # marker is reserved up front so the result never exceeds the byte cap.
     total_bytes = len(combined.encode("utf-8"))
     if total_bytes > 100_000:
-        # Truncate from the head, keeping the tail (most recent log entries)
+        # Truncate from the head, keeping the tail (most recent log entries).
+        # Marker placeholder is filled in last, so its exact length is reserved.
+        marker_template = "...(总日志超出 NNN 字节, 已截断)\n"
+        cap = 100_000
         truncated_tail = combined
-        while len(truncated_tail.encode("utf-8")) > 100_000:
+        while len(truncated_tail.encode("utf-8")) + len(marker_template.encode("utf-8")) > cap:
             truncated_tail = truncated_tail[len(truncated_tail) // 10:]
         dropped = total_bytes - len(truncated_tail.encode("utf-8"))
-        return f"...(总日志超出 {dropped} 字节，已截断)\n{truncated_tail}"
+        marker = marker_template.replace("NNN", str(dropped))
+        # If the marker itself pushed us over, drop more bytes from the tail
+        final_bytes = (marker + truncated_tail).encode("utf-8")
+        if len(final_bytes) > cap:
+            excess = len(final_bytes) - cap
+            # truncate the kept tail further to fit the marker
+            truncated_tail = truncated_tail.encode("utf-8")[:-excess].decode("utf-8", errors="ignore")
+        return marker + truncated_tail
     return combined
 
 
@@ -168,19 +179,37 @@ def _upload_attachment(
 
 
 def _decode_data_url(data_url: str) -> tuple[str, str, bytes]:
-    """Decode a `data:<mime>;base64,<...>` URL to (mime, filename, bytes)."""
+    """Decode a `data:<mime>;base64,<...>` URL to (mime, filename, bytes).
+
+    Validates the encoded b64 section's size BEFORE decoding to bound memory
+    usage — a malicious caller could otherwise send a multi-GB data URL.
+    """
     if not data_url.startswith("data:"):
         raise AppServerError(
-            "截图格式错误（期望 data URL）", code="INVALID_PARAMS",
+            "Screenshot format error (expected data URL)", code="INVALID_PARAMS",
         )
     try:
         header, b64 = data_url.split(",", 1)
         mime = header.split(";", 1)[0].split(":", 1)[1]
-        import base64
-        raw = base64.b64decode(b64)
     except Exception as exc:
         raise AppServerError(
-            f"截图 base64 解码失败: {exc}", code="INVALID_PARAMS",
+            f"Screenshot header parse failed: {exc}", code="INVALID_PARAMS",
+        ) from exc
+
+    # Bound the encoded size before decoding.  base64 inflates by ~4/3, so
+    # 14 MB encoded gives at most ~10.5 MB decoded — leave a small buffer.
+    if len(b64) > 14 * 1024 * 1024:
+        raise AppServerError(
+            "Screenshot exceeds 10MB limit (encoded)",
+            code="FILE_TOO_LARGE",
+        )
+
+    import base64
+    try:
+        raw = base64.b64decode(b64, validate=True)
+    except Exception as exc:
+        raise AppServerError(
+            f"Screenshot base64 decode failed: {exc}", code="INVALID_PARAMS",
         ) from exc
     ext_map = {
         "image/png": "png", "image/jpeg": "jpg", "image/jpg": "jpg",
@@ -412,7 +441,23 @@ async def feedback_list_handler(
     registry: Any,
 ) -> dict[str, Any]:
     """List local feedback backups."""
-    limit = int(params.get("limit") or 50)
+    # Validate and clamp limit.  Accept int, treat None/0/non-positive as
+    # "no limit" (return all).  Clamp to a sane upper bound to bound work.
+    raw_limit = params.get("limit")
+    if raw_limit is None or raw_limit == 0:
+        limit = 0  # 0 = no limit
+    else:
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            raise AppServerError(
+                f"Invalid limit value: {raw_limit!r}", code="INVALID_PARAMS",
+            )
+    if limit < 0:
+        limit = 0
+    if limit > 200:
+        limit = 200
+
     entries = _read_local_backups()
     if limit > 0 and len(entries) > limit:
         entries = entries[:limit]

--- a/tests/bridge/test_phase35_control_plane_audit.py
+++ b/tests/bridge/test_phase35_control_plane_audit.py
@@ -309,8 +309,9 @@ def test_phase35_runtime_bridge_state_imports_audit():
     #   (2 imports: _get_experience_store + _cleanup_experience_store)
     # - memory_handlers.py: needs state for workspace/config (Phase 35.7)
     # - cron_handlers.py: needs state for get_data_dir() (Phase 35.6)
+    # - feedback_handlers.py: needs state for workspace + config (Phase 78 feedback)
     # Phase 38.5: config_handlers.py migrated to get_bridge_state(registry) + shared helpers.
-    expected_remaining = 6  # files with at least 1 import
+    expected_remaining = 7  # files with at least 1 import
     assert len(imports) == expected_remaining, (
         f"Expected {expected_remaining} runtime files with bridge.server imports, "
         f"got {len(imports)}: {list(imports.keys())}. "
@@ -319,8 +320,8 @@ def test_phase35_runtime_bridge_state_imports_audit():
     )
 
     total_imports = sum(imports.values())
-    assert total_imports == 12, (
-        f"Expected 12 total bridge.server imports in runtime/, "
+    assert total_imports == 14, (
+        f"Expected 14 total bridge.server imports in runtime/, "
         f"got {total_imports}. Update this test if the count changed."
     )
 

--- a/tests/bridge/test_phase69_core_contract_audit.py
+++ b/tests/bridge/test_phase69_core_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan69_reduces_legacy_method_count():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 154  # +1 for providers.activate
+        assert len(catalog["methods"]) == 156  # +2 for feedback:submit, feedback:list
         assert len(typed) >= 44
         assert len(legacy) <= 109
     finally:

--- a/tests/bridge/test_phase70_plugin_skill_contract_audit.py
+++ b/tests/bridge/test_phase70_plugin_skill_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan70_plugin_skill_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 154
+        assert len(catalog["methods"]) == 156  # +2 for feedback:submit, feedback:list
         assert len(typed) >= 56
         assert len(legacy) <= 97
     finally:

--- a/tests/bridge/test_phase71_session_contract_audit.py
+++ b/tests/bridge/test_phase71_session_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan71_session_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 154
+        assert len(catalog["methods"]) == 156  # +2 for feedback:submit, feedback:list
         assert len(typed) >= 65
         assert len(legacy) <= 88
     finally:

--- a/tests/bridge/test_phase72_thread_contract_audit.py
+++ b/tests/bridge/test_phase72_thread_contract_audit.py
@@ -54,8 +54,8 @@ async def test_plan72_primary_thread_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 154
+        assert len(catalog["methods"]) == 156  # +2 for feedback:submit, feedback:list
         assert len(typed) >= 83
-        assert len(legacy) <= 71
+        assert len(legacy) <= 73
     finally:
         await loop.app_server.stop()

--- a/tests/fixtures/protocol/app_protocol_snapshot.v1.json
+++ b/tests/fixtures/protocol/app_protocol_snapshot.v1.json
@@ -1067,6 +1067,36 @@
         "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
         "emits": [],
         "eventSchemas": {},
+        "method": "feedback:list",
+        "paramsSchema": {
+          "type": "object"
+        },
+        "resultSchema": {
+          "type": "object"
+        },
+        "scope": "session",
+        "stability": "legacy"
+      },
+      {
+        "deprecatedBy": null,
+        "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
+        "emits": [],
+        "eventSchemas": {},
+        "method": "feedback:submit",
+        "paramsSchema": {
+          "type": "object"
+        },
+        "resultSchema": {
+          "type": "object"
+        },
+        "scope": "session",
+        "stability": "legacy"
+      },
+      {
+        "deprecatedBy": null,
+        "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
+        "emits": [],
+        "eventSchemas": {},
         "method": "files.accept",
         "paramsSchema": {
           "type": "object"
@@ -5310,8 +5340,8 @@
     "source": "miqi.runtime.export_app_protocol_ts.render_typescript_contract"
   },
   "methodCounts": {
-    "legacy": 71,
-    "total": 154,
+    "legacy": 73,
+    "total": 156,
     "typed": 83
   },
   "schemaVersion": 1

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -535,7 +535,7 @@ def test_decode_data_url_rejects_invalid_base64():
 async def test_feedback_submit_uploads_screenshots_and_creates_record(
     _bridge_state_isolated,
 ):
-    """Submit with one screenshot: upload should be called once, record includes 截图 field."""
+    """Submit with one screenshot: upload should be called once, record includes 附件 field."""
     from miqi.runtime.feedback_handlers import feedback_submit_handler
     import base64
 
@@ -576,15 +576,15 @@ async def test_feedback_submit_uploads_screenshots_and_creates_record(
     # Check that file_token reference was passed to add_record
     call_kwargs = add_record.call_args
     fields = call_kwargs.args[3]  # 4th positional arg is fields dict
-    assert "截图" in fields
-    assert fields["截图"] == [{"file_token": "file_tok_1"}]
+    assert "附件" in fields
+    assert fields["附件"] == [{"file_token": "file_tok_1"}]
 
 
 @pytest.mark.asyncio
 async def test_feedback_submit_without_screenshots_skips_upload(
     _bridge_state_isolated,
 ):
-    """No screenshots → no upload call, no 截图 field in record."""
+    """No screenshots → no upload call, no 附件 field in record."""
     from miqi.runtime.feedback_handlers import feedback_submit_handler
 
     workspace = _make_workspace()
@@ -609,7 +609,7 @@ async def test_feedback_submit_without_screenshots_skips_upload(
 
     upload.assert_not_called()
     fields = add_record.call_args.args[3]
-    assert "截图" not in fields
+    assert "附件" not in fields
 
 
 @pytest.mark.asyncio
@@ -711,4 +711,4 @@ async def test_feedback_submit_caps_screenshots_at_5(_bridge_state_isolated):
 
     assert upload.call_count == 5
     fields = add_record.call_args.args[3]
-    assert len(fields["截图"]) == 5
+    assert len(fields["附件"]) == 5

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -385,3 +385,188 @@ def test_backward_compat_aliases_exist(tmp_path):
         result = _read_local_feedbacks()
         assert len(result) == 1
         assert result[0]["id"] == "a"
+
+
+# ── Screenshot upload tests ──────────────────────────────────────────────────
+
+
+def test_decode_data_url_extracts_mime_filename_and_bytes():
+    """Round-trip: build a tiny PNG data URL, decode it."""
+    import base64
+    from miqi.runtime.feedback_handlers import _decode_data_url
+
+    # 1x1 transparent PNG
+    png_bytes = bytes.fromhex(
+        "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489"
+        "0000000D49444154789C636000000000050001A5F645400000000049454E44AE426082"
+    )
+    data_url = "data:image/png;base64," + base64.b64encode(png_bytes).decode("ascii")
+
+    mime, filename, raw = _decode_data_url(data_url)
+    assert mime == "image/png"
+    assert filename.endswith(".png")
+    assert raw == png_bytes
+
+
+def test_decode_data_url_rejects_invalid_format():
+    from miqi.runtime.feedback_handlers import _decode_data_url
+
+    with pytest.raises(AppServerError, match="data URL"):
+        _decode_data_url("not-a-data-url")
+
+
+def test_decode_data_url_rejects_invalid_base64():
+    from miqi.runtime.feedback_handlers import _decode_data_url
+
+    with pytest.raises(AppServerError, match="base64"):
+        _decode_data_url("data:image/png;base64,!!!not-valid-base64!!!")
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_uploads_screenshots_and_creates_record(
+    _bridge_state_isolated,
+):
+    """Submit with one screenshot: upload should be called once, record includes 截图 field."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+    import base64
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    # 1x1 PNG
+    png_bytes = bytes.fromhex(
+        "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489"
+        "0000000D49444154789C636000000000050001A5F645400000000049454E44AE426082"
+    )
+    data_url = "data:image/png;base64," + base64.b64encode(png_bytes).decode("ascii")
+
+    with patch(
+        "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,
+    ), patch(
+        "miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="tok",
+    ), patch(
+        "miqi.runtime.feedback_handlers._upload_attachment", return_value="file_tok_1",
+    ) as upload, patch(
+        "miqi.runtime.feedback_handlers._add_bitable_record", return_value="rec_1",
+    ) as add_record:
+        result = await feedback_submit_handler(
+            "req-1",
+            {
+                "title": "with screenshot",
+                "content": "see attached image",
+                "screenshots": [data_url],
+            },
+            "client-1", None, registry,
+        )
+
+    assert result["result"]["record_id"] == "rec_1"
+    upload.assert_called_once()
+    # Check that file_token reference was passed to add_record
+    call_kwargs = add_record.call_args
+    fields = call_kwargs.args[3]  # 4th positional arg is fields dict
+    assert "截图" in fields
+    assert fields["截图"] == [{"file_token": "file_tok_1"}]
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_without_screenshots_skips_upload(
+    _bridge_state_isolated,
+):
+    """No screenshots → no upload call, no 截图 field in record."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch(
+        "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,
+    ), patch(
+        "miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="tok",
+    ), patch(
+        "miqi.runtime.feedback_handlers._upload_attachment",
+    ) as upload, patch(
+        "miqi.runtime.feedback_handlers._add_bitable_record", return_value="rec_2",
+    ) as add_record:
+        await feedback_submit_handler(
+            "req-1", {"title": "no shots", "content": "just text"},
+            "client-1", None, registry,
+        )
+
+    upload.assert_not_called()
+    fields = add_record.call_args.args[3]
+    assert "截图" not in fields
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_rejects_oversized_screenshot(_bridge_state_isolated):
+    """Screenshot > 10MB must be rejected."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    # Construct a data URL whose decoded bytes exceed 10 MB
+    import base64
+    big_png = b"\x89PNG" + b"\x00" * (11 * 1024 * 1024)
+    data_url = "data:image/png;base64," + base64.b64encode(big_png).decode("ascii")
+
+    with patch(
+        "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,
+    ), patch(
+        "miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="tok",
+    ):
+        with pytest.raises(AppServerError, match="10MB"):
+            await feedback_submit_handler(
+                "req-1",
+                {"title": "big", "content": "x", "screenshots": [data_url]},
+                "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_caps_screenshots_at_5(_bridge_state_isolated):
+    """More than 5 screenshots → only first 5 are uploaded."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+    import base64
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    png_bytes = bytes.fromhex(
+        "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C489"
+        "0000000D49444154789C636000000000050001A5F645400000000049454E44AE426082"
+    )
+    data_url = "data:image/png;base64," + base64.b64encode(png_bytes).decode("ascii")
+    screenshots = [data_url] * 7  # 7 > cap of 5
+
+    with patch(
+        "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,
+    ), patch(
+        "miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="tok",
+    ), patch(
+        "miqi.runtime.feedback_handlers._upload_attachment",
+        side_effect=[f"file_tok_{i}" for i in range(5)],
+    ) as upload, patch(
+        "miqi.runtime.feedback_handlers._add_bitable_record", return_value="rec_3",
+    ) as add_record:
+        await feedback_submit_handler(
+            "req-1",
+            {"title": "many shots", "content": "x", "screenshots": screenshots},
+            "client-1", None, registry,
+        )
+
+    assert upload.call_count == 5
+    fields = add_record.call_args.args[3]
+    assert len(fields["截图"]) == 5

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -1,0 +1,368 @@
+"""Tests for feedback handlers."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from miqi.runtime.app_server import AppServerError, ClientSessionRegistry
+
+
+@pytest.fixture
+def _bridge_state_isolated():
+    """Save original bridge_module._state, then restore after the test.
+
+    Other test files rely on ``_state`` being initialized to the real
+    ``BridgeState()`` instance that ``miqi.bridge.server`` sets at
+    module-import time.  Setting ``_state = None`` here would break them
+    when tests are run together.  Use this fixture to safely mutate
+    ``_state`` during a feedback test and restore it on teardown.
+    """
+    import miqi.bridge.server as bridge_module
+    original = getattr(bridge_module, "_state", None)
+    yield bridge_module
+    bridge_module._state = original
+
+
+def _make_workspace() -> Path:
+    """Create a fresh temp workspace with memory/ and logs/ subdirs."""
+    tmpdir = tempfile.mkdtemp(prefix="miqi-test-feedback-")
+    workspace = Path(tmpdir)
+    (workspace / "memory").mkdir(parents=True, exist_ok=True)
+    (workspace / "logs").mkdir(parents=True, exist_ok=True)
+    (workspace / "logs" / "test.log").write_text("[INFO] test log line\n")
+    return workspace
+
+
+def _make_mock_state(
+    workspace: Path,
+    *,
+    enabled: bool = True,
+    bitable_app_token: str = "test_app_token",
+    bitable_table_id: str = "tbl_test",
+    app_id: str = "cli_test",
+    app_secret: str = "test_secret",
+) -> MagicMock:
+    """Build a mock BridgeState with feedback config pointing at ``workspace``."""
+    from miqi.config.schema import Config
+
+    state = MagicMock()
+    cfg = Config()
+    cfg.agents.defaults.workspace = str(workspace)
+    cfg.channels.feedback.enabled = enabled
+    cfg.channels.feedback.bitable_app_token = bitable_app_token
+    cfg.channels.feedback.bitable_table_id = bitable_table_id
+    cfg.channels.feishu.app_id = app_id
+    cfg.channels.feishu.app_secret = app_secret
+    state.load_config.return_value = cfg
+    return state
+
+
+# ── feedback:list tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_returns_entries():
+    """feedback:list returns entries array (empty when no feedback submitted)."""
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        result = await feedback_list_handler("req-1", {}, "client-1", None, registry)
+        assert "entries" in result["result"]
+        assert isinstance(result["result"]["entries"], list)
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_respects_limit():
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        result = await feedback_list_handler("req-1", {"limit": 5}, "client-1", None, registry)
+        assert "entries" in result["result"]
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_handles_null_limit():
+    """params.get('limit', 50) crashes on explicit null; use params.get('limit') or 50."""
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        # Should not raise TypeError
+        result = await feedback_list_handler("req-1", {"limit": None}, "client-1", None, registry)
+        assert "entries" in result["result"]
+
+
+# ── feedback:submit validation tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_requires_title(_bridge_state_isolated):
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with pytest.raises(AppServerError, match="标题不能为空"):
+            await feedback_submit_handler(
+                "req-1", {"content": "some content"}, "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_requires_content(_bridge_state_isolated):
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with pytest.raises(AppServerError, match="内容不能为空"):
+            await feedback_submit_handler(
+                "req-1", {"title": "some title"}, "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_rejects_when_disabled(_bridge_state_isolated):
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace, enabled=False)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with pytest.raises(AppServerError, match="未启用"):
+            await feedback_submit_handler(
+                "req-1", {"title": "test", "content": "test content"}, "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_rejects_when_no_feishu_credentials(_bridge_state_isolated):
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace, app_id="", app_secret="")
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with pytest.raises(AppServerError, match="未配置"):
+            await feedback_submit_handler(
+                "req-1", {"title": "test", "content": "test content"}, "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_rejects_when_no_bitable_config(_bridge_state_isolated):
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace, bitable_app_token="", bitable_table_id="")
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with pytest.raises(AppServerError, match="未配置"):
+            await feedback_submit_handler(
+                "req-1", {"title": "test", "content": "test content"}, "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_invalid_category_falls_back_to_other(_bridge_state_isolated):
+    """Unknown category values should fall back to 'other' instead of being passed through."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace), \
+         patch("miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="mock_token"), \
+         patch("miqi.runtime.feedback_handlers._add_bitable_record", return_value="rec_123") as mock_add:
+        await feedback_submit_handler(
+            "req-1",
+            {"title": "test", "content": "test content", "category": "INVALID"},
+            "client-1", None, registry,
+        )
+        fields = mock_add.call_args[0][3]
+        assert fields["类别"] == "other"
+
+
+# ── Helper function tests ────────────────────────────────────────────────────
+
+
+def test_collect_all_logs_empty_dir(tmp_path):
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    result = _collect_all_logs(log_dir)
+    assert "无日志文件" in result
+
+
+def test_collect_all_logs_reads_log_files(tmp_path):
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "test.log").write_text("[INFO] line1\n[WARN] line2\n")
+    result = _collect_all_logs(log_dir)
+    assert "test.log" in result
+    assert "line1" in result
+
+
+def test_collect_all_logs_nonexistent_dir():
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    result = _collect_all_logs(Path("/nonexistent/path/12345"))
+    assert "日志目录不存在" in result
+
+
+def test_collect_all_logs_caps_combined_payload_at_100k(tmp_path):
+    """Combined log content must be capped at 100k chars for Bitable text-field limit."""
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "big.log").write_text("x" * 200_000)
+    result = _collect_all_logs(log_dir)
+    assert len(result) <= 100_200  # 100k + truncation marker overhead
+
+
+def test_collect_system_info():
+    from miqi.runtime.feedback_handlers import _collect_system_info
+    info = _collect_system_info()
+    assert "os" in info
+    assert "python_version" in info
+    assert "machine" in info
+
+
+def test_read_local_backups_empty(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        result = handlers._read_local_backups()
+        assert result == []
+
+
+def test_read_local_backups_returns_newest_first(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    entries = [
+        {"id": "1", "title": "old", "created_at": "2026-01-01T00:00:00Z"},
+        {"id": "2", "title": "new", "created_at": "2026-07-01T00:00:00Z"},
+    ]
+    feedback_file.write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n"
+    )
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        result = handlers._read_local_backups()
+        assert len(result) == 2
+        assert result[0]["id"] == "2"
+        assert result[1]["id"] == "1"
+
+
+def test_read_local_backups_skips_blank_lines(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    feedback_file.write_text(
+        '{"id": "1", "title": "test", "created_at": "2026-01-01T00:00:00Z"}\n\n\n'
+    )
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        result = handlers._read_local_backups()
+        assert len(result) == 1
+
+
+def test_read_local_backups_skips_invalid_json(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    feedback_file.write_text(
+        '{"id": "1", "title": "good", "created_at": "2026-01-01T00:00:00Z"}\n'
+        'not valid json\n'
+        '{"id": "2", "title": "also good", "created_at": "2026-01-02T00:00:00Z"}\n'
+    )
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        result = handlers._read_local_backups()
+        assert len(result) == 2
+
+
+def test_save_local_backup_creates_file(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        with patch.object(handlers, '_ensure_memory_dir'):
+            handlers._save_local_backup({"id": "1", "title": "test"})
+    lines = feedback_file.read_text().strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["id"] == "1"
+
+
+def test_save_local_backup_appends_to_existing(tmp_path):
+    import miqi.runtime.feedback_handlers as handlers
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    feedback_file.write_text('{"id": "1", "title": "first"}\n')
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        with patch.object(handlers, '_ensure_memory_dir'):
+            handlers._save_local_backup({"id": "2", "title": "second"})
+    lines = feedback_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+
+
+def test_backward_compat_aliases_exist(tmp_path):
+    """Verify _append_feedback and _read_local_feedbacks aliases are callable."""
+    import miqi.runtime.feedback_handlers as handlers
+    from miqi.runtime.feedback_handlers import _append_feedback, _read_local_feedbacks
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    feedback_file = memory_dir / "FEEDBACK.jsonl"
+    with patch.object(handlers, '_get_feedback_file', return_value=feedback_file):
+        with patch.object(handlers, '_ensure_memory_dir'):
+            _append_feedback({"id": "a", "title": "via alias"})
+        result = _read_local_feedbacks()
+        assert len(result) == 1
+        assert result[0]["id"] == "a"

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -251,14 +251,31 @@ def test_collect_all_logs_nonexistent_dir():
     assert "日志目录不存在" in result
 
 
-def test_collect_all_logs_caps_combined_payload_at_100k(tmp_path):
-    """Combined log content must be capped at 100k chars for Bitable text-field limit."""
+def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
+    """Combined log payload must be capped at 100k UTF-8 bytes for Bitable text-field.
+
+    Feishu Bitable's text-field limit is 100k bytes (not chars).  Chinese
+    characters are 3+ bytes each in UTF-8, so a naive 100k-char cap can
+    still exceed the byte limit.  Verify the cap is enforced in bytes.
+    """
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    (log_dir / "big.log").write_text("x" * 200_000)
+    # 200k chars of multi-byte content (each char is ~3 bytes UTF-8)
+    (log_dir / "big.log").write_text("中" * 200_000)
     result = _collect_all_logs(log_dir)
-    assert len(result) <= 100_200  # 100k + truncation marker overhead
+    assert len(result.encode("utf-8")) <= 100_200  # 100k + marker overhead
+
+
+def test_collect_all_logs_keeps_small_payloads_intact(tmp_path):
+    """Payloads under 100k bytes pass through without the truncation marker."""
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "small.log").write_text("line1\nline2\n")
+    result = _collect_all_logs(log_dir)
+    assert "已截断" not in result
+    assert "small.log" in result
 
 
 def test_collect_system_info():

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -85,6 +85,98 @@ async def test_feedback_list_returns_entries():
 
 @pytest.mark.asyncio
 async def test_feedback_list_respects_limit():
+    """With 7 backups and limit=3, only the newest 3 are returned."""
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+    import miqi.runtime.feedback_handlers as handlers
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+    feedback_file = workspace / "memory" / "FEEDBACK.jsonl"
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with patch.object(handlers, "_get_feedback_file", return_value=feedback_file):
+            # Write 7 backups, oldest first
+            entries = [
+                {"id": str(i), "title": f"item-{i}", "created_at": f"2026-01-{i:02d}T00:00:00Z"}
+                for i in range(1, 8)
+            ]
+            with feedback_file.open("w", encoding="utf-8") as f:
+                for e in entries:
+                    f.write(json.dumps(e) + "\n")
+
+            result = await feedback_list_handler(
+                "req-1", {"limit": 3}, "client-1", None, registry,
+            )
+    assert len(result["result"]["entries"]) == 3
+    # Newest first (item-7, item-6, item-5)
+    assert result["result"]["entries"][0]["id"] == "7"
+    assert result["result"]["entries"][1]["id"] == "6"
+    assert result["result"]["entries"][2]["id"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_limit_zero_returns_all():
+    """limit=0 (or null/None) means no limit — return everything."""
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+    import miqi.runtime.feedback_handlers as handlers
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+    feedback_file = workspace / "memory" / "FEEDBACK.jsonl"
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with patch.object(handlers, "_get_feedback_file", return_value=feedback_file):
+            entries = [
+                {"id": str(i), "title": f"item-{i}", "created_at": "2026-01-01T00:00:00Z"}
+                for i in range(1, 8)
+            ]
+            with feedback_file.open("w", encoding="utf-8") as f:
+                for e in entries:
+                    f.write(json.dumps(e) + "\n")
+
+            for raw_limit in (None, 0, "0"):
+                result = await feedback_list_handler(
+                    "req-1", {"limit": raw_limit}, "client-1", None, registry,
+                )
+                assert len(result["result"]["entries"]) == 7
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_limit_clamps_to_max():
+    """limit > 200 is clamped to 200 to bound work."""
+    from miqi.runtime.feedback_handlers import feedback_list_handler
+    import miqi.runtime.feedback_handlers as handlers
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+    feedback_file = workspace / "memory" / "FEEDBACK.jsonl"
+
+    with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
+        with patch.object(handlers, "_get_feedback_file", return_value=feedback_file):
+            entries = [
+                {"id": str(i), "title": f"item-{i}", "created_at": "2026-01-01T00:00:00Z"}
+                for i in range(1, 4)
+            ]
+            with feedback_file.open("w", encoding="utf-8") as f:
+                for e in entries:
+                    f.write(json.dumps(e) + "\n")
+
+            result = await feedback_list_handler(
+                "req-1", {"limit": 999}, "client-1", None, registry,
+            )
+            # 3 entries available, all returned
+            assert len(result["result"]["entries"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_feedback_list_rejects_malformed_limit():
+    """Non-integer limit raises AppServerError."""
     from miqi.runtime.feedback_handlers import feedback_list_handler
 
     workspace = _make_workspace()
@@ -93,8 +185,10 @@ async def test_feedback_list_respects_limit():
     registry.bridge_context["state"] = state
 
     with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
-        result = await feedback_list_handler("req-1", {"limit": 5}, "client-1", None, registry)
-        assert "entries" in result["result"]
+        with pytest.raises(AppServerError, match="Invalid limit"):
+            await feedback_list_handler(
+                "req-1", {"limit": "not-a-number"}, "client-1", None, registry,
+            )
 
 
 @pytest.mark.asyncio
@@ -264,9 +358,12 @@ def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
     # 200k ASCII chars -> ~200k bytes UTF-8 (1 byte each)
     (log_dir / "big.log").write_text("a" * 200_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
-    # The cap truncates iteratively until the result fits within 100k bytes
-    # plus a small marker overhead
-    assert len(result.encode("utf-8")) <= 100_300
+    # Result must be at most exactly 100,000 bytes
+    assert len(result.encode("utf-8")) <= 100_000, (
+        f"Expected <= 100k bytes, got {len(result.encode('utf-8'))}"
+    )
+    # And it must include the truncation marker
+    assert "已截断" in result
 
 
 def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
@@ -277,7 +374,18 @@ def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
     # 50k CJK chars = ~150k bytes UTF-8, exceeds 100k byte cap
     (log_dir / "cjk.log").write_text("中" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
-    assert len(result.encode("utf-8")) <= 100_300
+    assert len(result.encode("utf-8")) <= 100_000
+
+
+def test_collect_all_logs_byte_cap_exact_100k_bytes(tmp_path):
+    """Edge case: payload just over 100k bytes should be trimmed to exactly fit."""
+    from miqi.runtime.feedback_handlers import _collect_all_logs
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    # 110k ASCII chars = 110k bytes, just over the cap
+    (log_dir / "edge.log").write_text("x" * 110_000, encoding="utf-8")
+    result = _collect_all_logs(log_dir)
+    assert len(result.encode("utf-8")) <= 100_000
 
 
 def test_collect_system_info():
@@ -505,7 +613,7 @@ async def test_feedback_submit_without_screenshots_skips_upload(
 
 @pytest.mark.asyncio
 async def test_feedback_submit_rejects_oversized_screenshot(_bridge_state_isolated):
-    """Screenshot > 10MB must be rejected."""
+    """Screenshot > 10MB must be rejected (after base64 encoding)."""
     from miqi.runtime.feedback_handlers import feedback_submit_handler
 
     workspace = _make_workspace()
@@ -518,6 +626,34 @@ async def test_feedback_submit_rejects_oversized_screenshot(_bridge_state_isolat
     import base64
     big_png = b"\x89PNG" + b"\x00" * (11 * 1024 * 1024)
     data_url = "data:image/png;base64," + base64.b64encode(big_png).decode("ascii")
+
+    with patch(
+        "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,
+    ), patch(
+        "miqi.runtime.feedback_handlers._get_tenant_access_token", return_value="tok",
+    ):
+        with pytest.raises(AppServerError, match="10MB"):
+            await feedback_submit_handler(
+                "req-1",
+                {"title": "big", "content": "x", "screenshots": [data_url]},
+                "client-1", None, registry,
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_submit_rejects_oversized_encoded_data_url(_bridge_state_isolated):
+    """Data URL with encoded b64 section > 14MB is rejected BEFORE base64 decode."""
+    from miqi.runtime.feedback_handlers import feedback_submit_handler
+
+    workspace = _make_workspace()
+    state = _make_mock_state(workspace)
+    _bridge_state_isolated._state = state
+    registry = ClientSessionRegistry()
+    registry.bridge_context["state"] = state
+
+    # 15MB of base64 — would decode to ~11MB but we reject before decoding.
+    big_b64 = "A" * (15 * 1024 * 1024)
+    data_url = f"data:image/png;base64,{big_b64}"
 
     with patch(
         "miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace,

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -159,9 +159,10 @@ async def test_feedback_list_limit_clamps_to_max():
 
     with patch("miqi.runtime.feedback_handlers._get_workspace_path", return_value=workspace):
         with patch.object(handlers, "_get_feedback_file", return_value=feedback_file):
+            # Create 201 entries so the clamp has something to clamp down.
             entries = [
                 {"id": str(i), "title": f"item-{i}", "created_at": "2026-01-01T00:00:00Z"}
-                for i in range(1, 4)
+                for i in range(1, 202)
             ]
             with feedback_file.open("w", encoding="utf-8") as f:
                 for e in entries:
@@ -170,8 +171,8 @@ async def test_feedback_list_limit_clamps_to_max():
             result = await feedback_list_handler(
                 "req-1", {"limit": 999}, "client-1", None, registry,
             )
-            # 3 entries available, all returned
-            assert len(result["result"]["entries"]) == 3
+            # Clamped to 200 even though 201 entries exist and limit=999
+            assert len(result["result"]["entries"]) == 200
 
 
 @pytest.mark.asyncio
@@ -613,7 +614,12 @@ async def test_feedback_submit_without_screenshots_skips_upload(
 
 @pytest.mark.asyncio
 async def test_feedback_submit_rejects_oversized_screenshot(_bridge_state_isolated):
-    """Screenshot > 10MB must be rejected (after base64 encoding)."""
+    """Screenshot > 10MB decoded must be rejected by the decoded-size check.
+
+    Construct exactly 10*1024*1024 + 1 decoded bytes.  The b64 encoded form
+    is ~13.4 MB — well below the 14 MB pre-decode guard, so this exercises
+    the post-decode rejection branch.
+    """
     from miqi.runtime.feedback_handlers import feedback_submit_handler
 
     workspace = _make_workspace()
@@ -622,9 +628,9 @@ async def test_feedback_submit_rejects_oversized_screenshot(_bridge_state_isolat
     registry = ClientSessionRegistry()
     registry.bridge_context["state"] = state
 
-    # Construct a data URL whose decoded bytes exceed 10 MB
     import base64
-    big_png = b"\x89PNG" + b"\x00" * (11 * 1024 * 1024)
+    over_limit_bytes = 10 * 1024 * 1024 + 1
+    big_png = b"\x89PNG" + b"\x00" * over_limit_bytes
     data_url = "data:image/png;base64," + base64.b64encode(big_png).decode("ascii")
 
     with patch(

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -261,21 +261,23 @@ def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 200k chars of multi-byte content (each char is ~3 bytes UTF-8)
-    (log_dir / "big.log").write_text("中" * 200_000)
+    # 200k ASCII chars -> ~200k bytes UTF-8 (1 byte each)
+    (log_dir / "big.log").write_text("a" * 200_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
-    assert len(result.encode("utf-8")) <= 100_200  # 100k + marker overhead
+    # The cap truncates iteratively until the result fits within 100k bytes
+    # plus a small marker overhead
+    assert len(result.encode("utf-8")) <= 100_300
 
 
-def test_collect_all_logs_keeps_small_payloads_intact(tmp_path):
-    """Payloads under 100k bytes pass through without the truncation marker."""
+def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
+    """Multi-byte chars (CJK, 3 bytes/char in UTF-8) must be byte-capped, not char-capped."""
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    (log_dir / "small.log").write_text("line1\nline2\n")
+    # 50k CJK chars = ~150k bytes UTF-8, exceeds 100k byte cap
+    (log_dir / "cjk.log").write_text("中" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
-    assert "已截断" not in result
-    assert "small.log" in result
+    assert len(result.encode("utf-8")) <= 100_300
 
 
 def test_collect_system_info():


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

增加应用内反馈入口，用户填写反馈表单后自动收集运行日志并提交到飞书多维表格（Bitable），支持附截图。

## 背景/问题

MiQi Desktop 目前没有应用内收集普通用户问题/反馈的机制，所有问题只能通过 GitHub Issues 提交。普通用户需要一个低门槛的在应用内提交反馈的方式，并且自动附带日志和环境信息方便排查。

## 变更内容

| 操作 | 文件 |
|------|------|
| 修改 | miqi/config/schema.py（新增 FeedbackConfig） |
| 新建 | miqi/runtime/feedback_handlers.py（feedback:submit + feedback:list） |
| 修改 | miqi/bridge/loop.py（注册 handler） |
| 修改 | apps/desktop/src/shared/ipc.ts（IPC 通道 + Zod schema + TS 类型） |
| 修改 | apps/desktop/src/preload/index.ts（暴露 window.miqi.feedback） |
| 修改 | apps/desktop/src/main/ipc/index.ts（Zod 校验 + IPC handler） |
| 新建 | apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx |
| 修改 | apps/desktop/src/renderer/features/settings/SettingsPage.tsx（注册「反馈」标签页） |
| 新建 | tests/runtime/test_feedback_handlers.py |
| 新建 | apps/desktop/tests/e2e/feedback.spec.ts |
| 修改 | tests/fixtures/protocol/app_protocol_snapshot.v1.json（重新生成） |

**功能要点**：

- **后端**： 自动读取  下全部日志（100k UTF-8 字节截断），收集系统信息（OS / Python / 应用版本），调用飞书 Bitable API 写入记录，本地  保留备份； 读取本地历史
- **截图**：单次最多 5 张，单张 ≤ 10MB，支持拖入 / 粘贴 (Ctrl+V) / 点击选择；后端通过  上传到飞书 Drive，file_token 写入记录的「截图」附件字段
- **UX**：Escape / 背景点击 / 关闭按钮关闭模态框，提交中禁用；类别 / 标题 / 描述必填，联系方式选填；空状态显示「提交第一条反馈」入口

## 日志/验证证据

```
tests/runtime/test_feedback_handlers.py::test_feedback_list_returns_entries PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_list_respects_limit PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_list_limit_zero_returns_all PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_list_limit_clamps_to_max PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_list_rejects_malformed_limit PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_list_handles_null_limit PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_requires_title PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_requires_content PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_rejects_when_disabled PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_rejects_when_no_feishu_credentials PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_rejects_when_no_bitable_config PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_invalid_category_falls_back_to_other PASSED
tests/runtime/test_feedback_handlers.py::test_collect_all_logs_caps_combined_payload_at_100k_bytes PASSED
tests/runtime/test_feedback_handlers.py::test_collect_all_logs_byte_cap_handles_multibyte_chars PASSED
tests/runtime/test_feedback_handlers.py::test_collect_all_logs_byte_cap_exact_100k_bytes PASSED
tests/runtime/test_feedback_handlers.py::test_collect_system_info PASSED
tests/runtime/test_feedback_handlers.py::test_read_local_backups_empty PASSED
tests/runtime/test_feedback_handlers.py::test_read_local_backups_returns_newest_first PASSED
tests/runtime/test_feedback_handlers.py::test_read_local_backups_skips_blank_lines PASSED
tests/runtime/test_feedback_handlers.py::test_read_local_backups_skips_invalid_json PASSED
tests/runtime/test_feedback_handlers.py::test_save_local_backup_creates_file PASSED
tests/runtime/test_feedback_handlers.py::test_save_local_backup_appends_to_existing PASSED
tests/runtime/test_feedback_handlers.py::test_backward_compat_aliases_exist PASSED
tests/runtime/test_feedback_handlers.py::test_decode_data_url_extracts_mime_filename_and_bytes PASSED
tests/runtime/test_feedback_handlers.py::test_decode_data_url_rejects_invalid_format PASSED
tests/runtime/test_feedback_handlers.py::test_decode_data_url_rejects_invalid_base64 PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_uploads_screenshots_and_creates_record PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_without_screenshots_skips_upload PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_rejects_oversized_screenshot PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_rejects_oversized_encoded_data_url PASSED
tests/runtime/test_feedback_handlers.py::test_feedback_submit_caps_screenshots_at_5 PASSED
============================= 34 passed in 2.59s ==============================
```

E2E 真实验证（开发环境手动执行）：成功写入飞书 Bitable 记录 `recvpwoapeql5D`，9 个字段全部填充，日志内容截断到 100k 字节以内。

## 测试情况

- Python 单元测试：34/34 pass
- Playwright E2E：5/5 pass（feedback tab 加载、空状态、模态框表单校验、Escape 关闭、错误状态、截图上传）
- 真实飞书 Bitable 端到端写入验证通过
- 之前 PR #308 的 9 项 CI 检查 + CodeRabbit 全部通过

## 截图
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/462156d3-439a-4d53-b1d5-1a4f3f237bc7" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/b25199f2-7455-454f-9b3b-5ef59646e8fe" />
<img width="1884" height="914" alt="image" src="https://github.com/user-attachments/assets/21d85ef0-29cf-46c2-ac5c-4e47f4eed680" />


Closes #307