### PR TITLE
fix(desktop): filter exec lifecycle events from chat.send drain loop

### DIFF
--- a/apps/desktop/src/renderer/features/chat/progressUtils.ts
+++ b/apps/desktop/src/renderer/features/chat/progressUtils.ts
@@ -35,12 +35,12 @@ export function extractProgressMessage(
 
   // Exec lifecycle events are internal plumbing. Rendering them as progress
   // rows makes completed commands look like they are still spinning.
-  if (/^ExecCommand(?:Begin|End)Event$/.test(eventName)) {
+  if (/^ExecCommand(?:Begin|End|OutputDelta)Event$/.test(eventName)) {
     return null;
   }
 
   // Exec delta events are streamed inline — skip rendering as standalone rows.
-  if (eventName.includes('outputDelta') || eventName.includes('commandExecution')) {
+  if (eventName.toLowerCase().includes('outputdelta') || eventName.toLowerCase().includes('commandexecution')) {
     return null;
   }
 

--- a/apps/desktop/src/renderer/features/chat/progressUtils.ts
+++ b/apps/desktop/src/renderer/features/chat/progressUtils.ts
@@ -24,7 +24,7 @@ export function extractProgressMessage(
 
   // 1) Direct text is the happy path
   if (payload.text && payload.text.trim()) {
-    if (/^ExecCommand(?:Begin|End)Event$/.test(payload.text.trim())) {
+    if (/^ExecCommand(?:Begin|End|OutputDelta)Event$/i.test(payload.text.trim())) {
       return null;
     }
     return { message: payload.text, role: 'progress' };

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -744,6 +744,9 @@ class BridgeRuntimeLoop:
                 AgentReasoningEvent,
                 ApprovalResolvedEvent,
                 ErrorEvent,
+                ExecCommandBeginEvent,
+                ExecCommandEndEvent,
+                ExecCommandOutputDeltaEvent,
                 ToolCallBeginEvent,
                 ToolCallEndEvent,
                 TurnAbortedEvent,
@@ -803,6 +806,9 @@ class BridgeRuntimeLoop:
                     AgentReasoningEvent,       # model reasoning; no user-visible rendering target yet
                     TurnStartedEvent,          # turn lifecycle; not chat content
                     ApprovalResolvedEvent,     # approval lifecycle; not chat content
+                    ExecCommandBeginEvent,     # exec lifecycle; rendered via ToolCallBeginEvent
+                    ExecCommandEndEvent,       # exec lifecycle; rendered via ToolCallEndEvent
+                    ExecCommandOutputDeltaEvent,  # exec delta; streamed inline, not standalone rows
                 )):
                     continue
 

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -799,6 +799,17 @@ class BridgeRuntimeLoop:
                         })
                     break
 
+                # Exec output deltas: forward with the top-level shape that
+                # ChatConsole.tsx expects (stream / delta / tool_call_id)
+                # so inline terminal output updates in real time.
+                if isinstance(event, ExecCommandOutputDeltaEvent):
+                    await _emit("progress", {
+                        "stream": event.stream,
+                        "delta": event.delta,
+                        "tool_call_id": event.tool_call_id,
+                    })
+                    continue
+
                 # Internal runtime events that should never appear in
                 # the chat message stream.  See Issue #35.
                 if isinstance(event, (
@@ -808,7 +819,6 @@ class BridgeRuntimeLoop:
                     ApprovalResolvedEvent,     # approval lifecycle; not chat content
                     ExecCommandBeginEvent,     # exec lifecycle; rendered via ToolCallBeginEvent
                     ExecCommandEndEvent,       # exec lifecycle; rendered via ToolCallEndEvent
-                    ExecCommandOutputDeltaEvent,  # exec delta; streamed inline, not standalone rows
                 )):
                     continue
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 ExecCommandOutputDeltaEvent 泛滥 workbench 的问题 — chat.send 路径未过滤 exec 生命周期事件（#287 回归修复）。

## 背景/问题

PR #287 修复了 `turn/start` 路径中的 exec delta 泛滥，但 ChatConsole 实际使用的是 `chat.send` 路径，该路径的 Python `_drain_chat_events()` 未对 exec 生命周期事件做过滤。

**两个泄漏点：**

1. `_drain_chat_events()` 中 `ExecCommandOutputDeltaEvent` 落入 catch-all `else` 分支，以 `{event: "ExecCommandOutputDeltaEvent", data: {...}}` 形式作为 `"progress"` 发出
2. `progressUtils.extractProgressMessage()` 中 `includes("outputDelta")` **区分大小写**，`"outputDelta"` ≠ `"OutputDelta"`（大写 O）

## 变更内容

- **Python**: `_drain_chat_events()` 中单独处理 `ExecCommandOutputDeltaEvent`，用 `stream`/`delta`/`tool_call_id` 顶层字段转发给 ChatConsole；过滤 `ExecCommandBeginEvent`、`ExecCommandEndEvent`
- **TypeScript**: `extractProgressMessage()` 的 outputDelta/commandExecution 检查改为 `.toLowerCase().includes(...)`（大小写不敏感）
- **TypeScript**: 将 `OutputDelta` 加入 ExecCommand 正则显式过滤中（包含 direct-text guard，使用 `/i` 标志）

## 日志/验证证据

```
 ✓ progressUtils.test.ts (18 tests)
 ✓ test_exec_events.py exec delta tests (10 tests)
```

## 测试情况

- [x] `progressUtils.test.ts` — 18 tests，包含 outputDelta/commandExecution 过滤测试
- [x] `test_exec_events.py` — 10 exec delta tests（adapter + delta emit）

## 截图

无需截图（纯后端逻辑修复，不影响 UI 布局）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)