### PR TITLE
fix(runtime): correct token estimation ratio and add pre-send context guard

### DIFF
--- a/miqi/agent/context_compressor.py
+++ b/miqi/agent/context_compressor.py
@@ -11,7 +11,7 @@ Constants tuned to match Hermes defaults:
   _MIN_SUMMARY_TOKENS   = 2000
   _SUMMARY_RATIO        = 0.20  (keep 20% of context as tail)
   _SUMMARY_TOKENS_CEILING = 12_000
-  _CHARS_PER_TOKEN      = 4
+  _CHARS_PER_TOKEN      = 2.5
   _CONTENT_MAX          = 6000  (truncate individual messages before summarising)
   _CONTENT_HEAD         = 4000
   _CONTENT_TAIL         = 1500
@@ -33,7 +33,7 @@ from miqi.agent.context_engine import ContextEngine
 _MIN_SUMMARY_TOKENS = 2000
 _SUMMARY_RATIO = 0.20
 _SUMMARY_TOKENS_CEILING = 12_000
-_CHARS_PER_TOKEN = 4
+_CHARS_PER_TOKEN = 2.5
 _CONTENT_MAX = 6_000
 _CONTENT_HEAD = 4_000
 _CONTENT_TAIL = 1_500
@@ -193,11 +193,11 @@ class ContextCompressor(ContextEngine):
         # Total budget for "tail" (recent messages we keep verbatim)
         # _SUMMARY_RATIO of (context_limit_chars / _CHARS_PER_TOKEN) — or use message count heuristic
         if self.context_limit_chars > 0:
-            total_tokens = self.context_limit_chars // _CHARS_PER_TOKEN
+            total_tokens = int(self.context_limit_chars / _CHARS_PER_TOKEN)
         else:
             # estimate from current message count
             total_chars = sum(self._msg_chars(m) for m in non_system)
-            total_tokens = total_chars // _CHARS_PER_TOKEN
+            total_tokens = int(total_chars / _CHARS_PER_TOKEN)
 
         tail_token_budget = min(
             int(total_tokens * _SUMMARY_RATIO),
@@ -252,7 +252,7 @@ class ContextCompressor(ContextEngine):
         for i in range(len(result) - 1, -1, -1):
             msg = result[i]
             chars = self._msg_chars(msg)
-            tokens_so_far += chars // _CHARS_PER_TOKEN
+            tokens_so_far += int(chars / _CHARS_PER_TOKEN)
 
             if tokens_so_far > token_budget and msg.get("role") == "tool":
                 result[i] = {
@@ -281,7 +281,7 @@ class ContextCompressor(ContextEngine):
         # Walk from the end, accumulate until budget exceeded
         split = len(messages)  # default: all goes to tail (nothing to middle)
         for i in range(len(messages) - 1, -1, -1):
-            msg_tokens = self._msg_chars(messages[i]) // _CHARS_PER_TOKEN
+            msg_tokens = int(self._msg_chars(messages[i]) / _CHARS_PER_TOKEN)
             if tokens + msg_tokens > soft_ceiling and split < len(messages):
                 break
             tokens += msg_tokens

--- a/miqi/kun_runtime/context_estimator.py
+++ b/miqi/kun_runtime/context_estimator.py
@@ -8,16 +8,16 @@ from __future__ import annotations
 
 from typing import Any
 
-# Rough heuristic: 4 characters ≈ 1 token for English text.
-# This is deliberately simple; exact token counts would require tiktoken.
-_CHARS_PER_TOKEN = 4
+# Rough heuristic: 2.5 characters ≈ 1 token for mixed content (code, JSON, CJK text).
+# Conservative estimate errs on the side of triggering compaction earlier.
+_CHARS_PER_TOKEN = 2.5
 
 
 def estimate_tokens(text: str) -> int:
     """Estimate token count for a text string."""
     if not text:
         return 0
-    return max(1, len(text) // _CHARS_PER_TOKEN)
+    return max(1, int(len(text) / _CHARS_PER_TOKEN))
 
 
 def estimate_item_tokens(item: dict[str, Any]) -> int:
@@ -76,3 +76,56 @@ def _json_str(value: Any) -> str:
         return json.dumps(value, ensure_ascii=False)
     except (TypeError, ValueError):
         return str(value)
+
+
+# Per-model maximum input tokens. Conservative defaults for models that
+# don't explicitly advertise their limit.
+_MODEL_MAX_INPUT_TOKENS: dict[str, int] = {
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4": 8_192,
+    "gpt-3.5-turbo": 16_385,
+    "o1": 200_000,
+    "o1-mini": 128_000,
+    "o3": 200_000,
+    "o3-mini": 200_000,
+    "o4-mini": 200_000,
+    "claude-3.5-sonnet": 200_000,
+    "claude-3.5-haiku": 200_000,
+    "claude-3-opus": 200_000,
+    "claude-3-haiku": 200_000,
+    "claude-3-sonnet": 200_000,
+    "claude-opus-4": 200_000,
+    "claude-opus-4-5": 200_000,
+    "claude-sonnet-4": 200_000,
+    "claude-sonnet-4-5": 200_000,
+    "claude-haiku-4-5": 200_000,
+    "deepseek-chat": 128_000,
+    "deepseek-reasoner": 128_000,
+    "gemini-2.5-flash": 1_048_576,
+    "gemini-2.5-pro": 1_048_576,
+    "gemini-2.0-flash": 1_048_576,
+    "qwen-max": 131_072,
+    "qwen-plus": 131_072,
+    "qwen-turbo": 1_000_000,
+    "kimi-k2.5": 128_000,
+    "kimi-k2": 128_000,
+    "glm-4": 128_000,
+    "minimax-m1": 1_000_000,
+}
+_CONTEXT_SAFETY_FACTOR = 0.80
+
+
+def get_model_max_input_tokens(model: str) -> int:
+    """Return the maximum input tokens for a model name (substring match)."""
+    model_lower = model.lower()
+    for key, limit in _MODEL_MAX_INPUT_TOKENS.items():
+        if key in model_lower:
+            return limit
+    return 128_000
+
+
+def get_safe_context_limit(model: str) -> int:
+    """Return the safe context limit (80% of model max) for a model."""
+    return int(get_model_max_input_tokens(model) * _CONTEXT_SAFETY_FACTOR)

--- a/miqi/kun_runtime/model_client.py
+++ b/miqi/kun_runtime/model_client.py
@@ -110,6 +110,35 @@ class MiQiModelClient:
         # Build messages
         messages = _build_messages(request)
 
+        # Phase 56: hard-trim messages before provider call so we never
+        # send a request that exceeds the model's input token limit.
+        from miqi.kun_runtime.context_estimator import (
+            estimate_tokens,
+            get_safe_context_limit,
+        )
+        model = request.model or self.model
+        safe_limit = get_safe_context_limit(model)
+        est = estimate_tokens(str(messages))
+        if est > safe_limit:
+            logger.warning(
+                "KUN pre-send guard: estimated {} tokens exceeds {} limit "
+                "for {}; trimming oldest pairs",
+                est, safe_limit, model,
+            )
+            head_protect = 1 if messages and messages[0].get("role") == "system" else 0
+            while len(messages) > head_protect + 1 and est > safe_limit:
+                head_protect = 1 if messages and messages[0].get("role") == "system" else 0
+                for i in range(head_protect, len(messages) - 1):
+                    if messages[i].get("role") in ("assistant", "tool"):
+                        messages.pop(i)
+                        break
+                else:
+                    break
+                est = estimate_tokens(str(messages))
+            logger.info(
+                "KUN pre-send guard: est tokens now {}", est,
+            )
+
         # Build tools
         tools = _build_tools(request.tools) if request.tools else None
 

--- a/miqi/runtime/context_runtime.py
+++ b/miqi/runtime/context_runtime.py
@@ -126,7 +126,7 @@ class ContextRuntime:
     # ── Phase 19: context compaction ────────────────────────────────────
 
     def estimate_tokens(self, messages: list[dict[str, Any]]) -> int:
-        """Estimate token count from messages (chars / 4 heuristic).
+        """Estimate token count from messages (chars / 2.5 heuristic).
 
         Counts content and tool_calls for each message.
         Returns at least 1.
@@ -136,7 +136,7 @@ class ContextRuntime:
             chars += len(str(message.get("content") or ""))
             if message.get("tool_calls"):
                 chars += len(str(message["tool_calls"]))
-        return max(1, chars // 4)
+        return max(1, int(chars / 2.5))
 
     async def compress_messages(
         self,
@@ -256,3 +256,116 @@ class ContextRuntime:
     ) -> bool:
         """Return True when estimated tokens exceed the configured limit."""
         return self.estimate_tokens(messages) >= token_limit
+
+    # ── Phase 56: pre-send context guard ───────────────────────────────
+
+    # Per-model maximum input tokens. Conservative defaults for models that
+    # don't explicitly advertise their limit. When the model isn't listed,
+    # we fall back to 128K — safe for most modern models.
+    _MODEL_MAX_INPUT_TOKENS: dict[str, int] = {
+        "gpt-4o": 128_000,
+        "gpt-4o-mini": 128_000,
+        "gpt-4-turbo": 128_000,
+        "gpt-4": 8_192,
+        "gpt-3.5-turbo": 16_385,
+        "o1": 200_000,
+        "o1-mini": 128_000,
+        "o3": 200_000,
+        "o3-mini": 200_000,
+        "o4-mini": 200_000,
+        "claude-3.5-sonnet": 200_000,
+        "claude-3.5-haiku": 200_000,
+        "claude-3-opus": 200_000,
+        "claude-3-haiku": 200_000,
+        "claude-3-sonnet": 200_000,
+        "claude-opus-4": 200_000,
+        "claude-opus-4-5": 200_000,
+        "claude-sonnet-4": 200_000,
+        "claude-sonnet-4-5": 200_000,
+        "claude-haiku-4-5": 200_000,
+        "deepseek-chat": 128_000,
+        "deepseek-reasoner": 128_000,
+        "gemini-2.5-flash": 1_048_576,
+        "gemini-2.5-pro": 1_048_576,
+        "gemini-2.0-flash": 1_048_576,
+        "qwen-max": 131_072,
+        "qwen-plus": 131_072,
+        "qwen-turbo": 1_000_000,
+        "kimi-k2.5": 128_000,
+        "kimi-k2": 128_000,
+        "glm-4": 128_000,
+        "minimax-m1": 1_000_000,
+    }
+
+    # Fraction of model max to use as hard limit (80% leaves headroom for
+    # the response tokens, tool definitions, and estimation error).
+    _CONTEXT_SAFETY_FACTOR = 0.80
+
+    def trim_for_model(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+    ) -> list[dict[str, Any]]:
+        """Hard-trim messages to fit within the model's input token limit.
+
+        This is the LAST-RESORT safety net — it runs right before the
+        provider call and discards the oldest assistant+tool pairs until
+        the estimated token count is under 80% of the model's maximum.
+
+        Always keeps the system prompt (index 0 if role=='system') and at
+        least the last user message. Returns messages unchanged when they
+        already fit.
+        """
+        max_input = self._resolve_model_max_input(model)
+        hard_limit = int(max_input * self._CONTEXT_SAFETY_FACTOR)
+        est = self.estimate_tokens(messages)
+
+        if est <= hard_limit:
+            return messages
+
+        logger.warning(
+            "Pre-send guard: estimated {} tokens exceeds {} limit for {} "
+            "(model max={}); trimming oldest pairs",
+            est, hard_limit, model, max_input,
+        )
+
+        work = list(messages)
+        system_idx = 0 if work and work[0].get("role") == "system" else -1
+        head_protect = max(system_idx + 1, 0) + 1  # system prompt + 1 extra
+
+        while len(work) > head_protect + 1:
+            est = self.estimate_tokens(work)
+            if est <= hard_limit:
+                break
+
+            # Find the oldest cuttable message pair: assistant [+ tool(s)]
+            cut_start = None
+            for i in range(head_protect, len(work) - 1):
+                role = work[i].get("role")
+                if role in ("assistant", "tool"):
+                    cut_start = i
+                    break
+            if cut_start is None:
+                break
+
+            # Collect a single message to drop
+            removed = work.pop(cut_start)
+
+        est_after = self.estimate_tokens(work)
+        logger.info(
+            "Pre-send guard: messages {} -> {} (est tokens {} -> {})",
+            len(messages), len(work), est, est_after,
+        )
+        return work
+
+    def _resolve_model_max_input(self, model: str) -> int:
+        """Return the maximum input tokens for a model name.
+
+        Matches by substring against the known model table, falling back
+        to 128K for models not in the table.
+        """
+        model_lower = model.lower()
+        for key, limit in self._MODEL_MAX_INPUT_TOKENS.items():
+            if key in model_lower:
+                return limit
+        return 128_000

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -508,7 +508,7 @@ class TaskRunner:
             ctx_runtime = getattr(self.services, "context_runtime", None)
             auto_limit = getattr(self.services.model_settings, "context_limit_chars", 0)
             if history_runtime is not None and ctx_runtime is not None and auto_limit:
-                token_limit = max(1, int(auto_limit) // 4)
+                token_limit = max(1, int(int(auto_limit) / 2.5))
                 if ctx_runtime.should_auto_compact(history, token_limit):
                     try:
                         compact_result = await ctx_runtime.compact_thread(

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -155,6 +155,10 @@ class TurnRunner:
             if cancel_event is not None and cancel_event.is_set():
                 raise asyncio.CancelledError("Turn cancelled via AbortTurn")
 
+            # Phase 56: hard-trim messages before provider call so we never
+            # send a request that exceeds the model's input token limit.
+            messages = self._context.trim_for_model(messages, turn.model)
+
             # Phase 20: prefer streaming. stream_chat() is a base-class
             # method on LLMProvider so every provider supports it — the
             # default wraps chat() and yields a single "completed" event.

--- a/tests/runtime/test_context_runtime.py
+++ b/tests/runtime/test_context_runtime.py
@@ -141,20 +141,20 @@ async def test_context_runtime_compact_thread_replaces_history():
 
 
 def test_context_runtime_estimate_tokens():
-    """estimate_tokens() approximates token count (chars / 4)."""
+    """estimate_tokens() approximates token count (chars / 2.5)."""
     runtime = ContextRuntime()
     msgs = [
         {"role": "user", "content": "hello world"},
         {"role": "assistant", "content": "hi"},
     ]
-    # "hello world" (11) + "hi" (2) = 13 chars → 13//4 = 3 tokens
-    assert runtime.estimate_tokens(msgs) == 3
+    # "hello world" (11) + "hi" (2) = 13 chars → int(13/2.5) = 5 tokens
+    assert runtime.estimate_tokens(msgs) == 5
 
 
 def test_context_runtime_should_auto_compact():
     """should_auto_compact() returns True when estimated tokens >= limit."""
     runtime = ContextRuntime()
-    msgs = [{"role": "user", "content": "x" * 400}]  # 400 chars → 100 tokens
+    msgs = [{"role": "user", "content": "x" * 400}]  # 400 chars → 160 tokens
     assert runtime.should_auto_compact(msgs, token_limit=50) is True
     assert runtime.should_auto_compact(msgs, token_limit=200) is False
 

--- a/tests/runtime/test_hook_lifecycle_firing.py
+++ b/tests/runtime/test_hook_lifecycle_firing.py
@@ -80,6 +80,9 @@ class _FakeContextRuntime:
     ) -> list[dict[str, Any]]:
         return [*messages, {"role": "assistant", "content": content}]
 
+    def trim_for_model(self, messages, model):
+        return messages
+
 
 class _FakeToolRuntime:
     async def execute_many(self, turn: Any, tool_calls: list[Any]) -> list[Any]:

--- a/tests/runtime/test_turn_error_propagation.py
+++ b/tests/runtime/test_turn_error_propagation.py
@@ -40,6 +40,9 @@ class _FakeContext:
     def add_tool_result(self, messages, tool_call_id, name, content):
         return [*messages, {"role": "tool", "content": content}]
 
+    def trim_for_model(self, messages, model):
+        return messages
+
 
 class _FakeEvents:
     def __init__(self):

--- a/tests/runtime/test_turn_runner.py
+++ b/tests/runtime/test_turn_runner.py
@@ -341,6 +341,9 @@ async def test_turn_runner_emits_content_deltas():
         def add_assistant_message(self, *, messages, content, tool_calls=None):
             return [*messages, {"role": "assistant", "content": content}]
 
+        def trim_for_model(self, messages, model):
+            return messages
+
     class EventCollector:
         def __init__(self):
             self.events: list = []
@@ -414,6 +417,9 @@ async def test_turn_runner_consumes_steer_queue_before_completing_final_response
 
         def add_tool_result(self, messages, tool_call_id, name, content):
             return [*messages, {"role": "tool", "content": content}]
+
+        def trim_for_model(self, messages, model):
+            return messages
 
     class FakeTools:
         async def execute_many(self, turn, tool_calls):


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复上下文超限问题：将 token 估算从 `chars/4` 改为 `chars/2.5`，并在发往 API 前增加硬截断安全网。

## 背景/问题

`chars/4` 的 token 估算对中文、代码、JSON 密集的对话严重偏低（实际 token 数可达估算的 3-5 倍），导致自动压缩从未触发。同时压缩失败后带 unbounded 历史继续执行，且没有 pre-send 校验，144 万 token 的请求直接打到 OpenAI API 被拒绝。

详见 discussion #288 和 issue #291。

## 变更内容

**第一层 — token 估算修正（`chars/4` → `chars/2.5`）**
- `miqi/runtime/context_runtime.py` — `estimate_tokens()` 改为 `int(chars / 2.5)`
- `miqi/kun_runtime/context_estimator.py` — `_CHARS_PER_TOKEN` 从 4 改为 2.5
- `miqi/agent/context_compressor.py` — `_CHARS_PER_TOKEN` 从 4 改为 2.5，所有 `// 4` 改为 `int(/ 2.5)`
- `miqi/runtime/task_runner.py` — 自动压缩触发阈值同步修正

**第二层 — 发往 API 前的硬截断安全网**
- `miqi/runtime/context_runtime.py` — 新增 `trim_for_model()` 方法，维护常见模型的 max input token 表，超 80% 阈值时裁剪最早的消息
- `miqi/runtime/turn_runner.py` — 每次 iteration 调用 `trim_for_model()` 后再发请求
- `miqi/kun_runtime/model_client.py` — KUN runtime 路径同样增加硬截断
- `miqi/kun_runtime/context_estimator.py` — 新增模型上限表和 `get_safe_context_limit()`

## 日志/验证证据

修改前，OpenAI API 返回 400：
```
openai.BadRequestError: Error code: 400 - This model's maximum context length is
1048565 tokens. However, you requested 1434177 tokens...
```

修改后，token 估算更保守，自动压缩会更早触发；即使压缩失败，硬截断也会在发 API 前裁剪超限消息。

## 测试情况

- 2167 个单元/集成测试全部通过（`uv run pytest tests/ -x -q`）
- 测试修复：更新了 4 个测试的 FakeContext mock，添加了 `trim_for_model` 桩方法；修正了 token 估算断言值