### PR TITLE
fix(ui): bypass island auto-dismiss + sessionStorage defaults (#285)

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -122,6 +122,13 @@ function AppShell() {
     setActiveNav('settings');
   };
 
+  // Listen for navigation event from Banner/TopBar
+  useEffect(() => {
+    const handler = () => openApprovalSettings();
+    window.addEventListener('miqi:navigate:approvals', handler);
+    return () => window.removeEventListener('miqi:navigate:approvals', handler);
+  }, []);
+
   // Loading state
   if (needsSetup === null) {
     return (
@@ -224,8 +231,8 @@ function AppShell() {
         <ApprovalProvider>
           {/* Full-height flex column */}
           <div className="flex flex-col h-screen" style={{ background: 'var(--background)' }}>
-            <TopBar onOpenApprovals={openApprovalSettings} />
-            <ApprovalBypassBanner onOpenApprovals={openApprovalSettings} />
+            <TopBar />
+            <ApprovalBypassBanner />
             {/* Body row */}
             <div className="flex flex-1 overflow-hidden">
               <Sidebar

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -231,8 +231,8 @@ function AppShell() {
         <ApprovalProvider>
           {/* Full-height flex column */}
           <div className="flex flex-col h-screen" style={{ background: 'var(--background)' }}>
-            <TopBar />
-            <ApprovalBypassBanner />
+            <TopBar onNavigateSettings={openApprovalSettings} />
+            <ApprovalBypassBanner onNavigateSettings={openApprovalSettings} />
             {/* Body row */}
             <div className="flex flex-1 overflow-hidden">
               <Sidebar

--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -8,9 +8,25 @@ export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSetting
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const handler = () => {
-      sessionStorage.setItem(SESSION_KEY, 'true');
-      setVisible(true);
+    const handler = async () => {
+      try {
+        const cfg = await window.miqi.config.get();
+        const a = (cfg as any)?.approvals ?? {};
+        const on = !!(
+          a.bypassAll ||
+          a.bypassCommandApproval ||
+          a.bypassFileWriteApproval ||
+          a.bypassToolConfirmation ||
+          a.bypassNetworkApproval
+        );
+        if (on) {
+          sessionStorage.setItem(SESSION_KEY, 'true');
+          setVisible(true);
+        } else {
+          sessionStorage.removeItem(SESSION_KEY);
+          setVisible(false);
+        }
+      } catch { /* bridge busy, keep current state */ }
     };
     window.addEventListener('miqi:approval-bypass-updated', handler);
     return () => window.removeEventListener('miqi:approval-bypass-updated', handler);

--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -6,9 +6,8 @@ export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSetting
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ enabled: boolean }>).detail;
-      if (detail?.enabled) {
+    const handler = () => {
+      if (sessionStorage.getItem('miqi:bypass:enabled') === 'true') {
         setVisible(true);
       } else {
         setVisible(false);
@@ -20,7 +19,6 @@ export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSetting
 
   const dismiss = useCallback(() => setVisible(false), []);
 
-  // Auto-dismiss after 3 seconds
   useEffect(() => {
     if (!visible) return;
     const t = setTimeout(dismiss, 3000);
@@ -41,24 +39,18 @@ export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSetting
       }}
     >
       <AlertTriangle size={14} className="shrink-0" />
-      <span className="min-w-0 truncate font-medium">
-        审批绕过已开启，本次会话的部分操作会直接放行。
-      </span>
+      <span className="min-w-0 truncate font-medium">审批绕过已开启，本次会话的部分操作会直接放行。</span>
       <button
         type="button"
         onClick={() => { onNavigateSettings(); dismiss(); }}
         className="shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold transition-colors hover:bg-[rgba(124,45,18,0.08)]"
-      >
-        查看设置
-      </button>
+      >查看设置</button>
       <button
         type="button"
         onClick={dismiss}
         className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full hover:bg-[rgba(124,45,18,0.12)] transition-colors"
         title="关闭提醒"
-      >
-        <X size={13} />
-      </button>
+      ><X size={13} /></button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -4,24 +4,22 @@ import { cn } from '../lib/utils';
 
 const SESSION_KEY = 'miqi:bypass:enabled';
 
-export function ApprovalBypassBanner() {
-  const [visible, setVisible] = useState(() => sessionStorage.getItem(SESSION_KEY) === 'true');
+export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSettings: () => void }) {
+  const [visible, setVisible] = useState(false);
 
-  const show = useCallback(() => {
-    sessionStorage.setItem(SESSION_KEY, 'true');
-    setVisible(true);
+  useEffect(() => {
+    const handler = () => {
+      sessionStorage.setItem(SESSION_KEY, 'true');
+      setVisible(true);
+    };
+    window.addEventListener('miqi:approval-bypass-updated', handler);
+    return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
   }, []);
 
   const dismiss = useCallback(() => {
     sessionStorage.removeItem(SESSION_KEY);
     setVisible(false);
   }, []);
-
-  useEffect(() => {
-    const handler = () => show();
-    window.addEventListener('miqi:approval-bypass-updated', handler);
-    return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
-  }, [show]);
 
   // Auto-dismiss after 3 seconds
   useEffect(() => {
@@ -49,10 +47,7 @@ export function ApprovalBypassBanner() {
       </span>
       <button
         type="button"
-        onClick={() => {
-          window.dispatchEvent(new Event('miqi:navigate:approvals'));
-          dismiss();
-        }}
+        onClick={() => { onNavigateSettings(); dismiss(); }}
         className="shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold transition-colors hover:bg-[rgba(124,45,18,0.08)]"
       >
         查看设置

--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -2,40 +2,23 @@ import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import { cn } from '../lib/utils';
 
-const SESSION_KEY = 'miqi:bypass:enabled';
-
 export function ApprovalBypassBanner({ onNavigateSettings }: { onNavigateSettings: () => void }) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const handler = async () => {
-      try {
-        const cfg = await window.miqi.config.get();
-        const a = (cfg as any)?.approvals ?? {};
-        const on = !!(
-          a.bypassAll ||
-          a.bypassCommandApproval ||
-          a.bypassFileWriteApproval ||
-          a.bypassToolConfirmation ||
-          a.bypassNetworkApproval
-        );
-        if (on) {
-          sessionStorage.setItem(SESSION_KEY, 'true');
-          setVisible(true);
-        } else {
-          sessionStorage.removeItem(SESSION_KEY);
-          setVisible(false);
-        }
-      } catch { /* bridge busy, keep current state */ }
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ enabled: boolean }>).detail;
+      if (detail?.enabled) {
+        setVisible(true);
+      } else {
+        setVisible(false);
+      }
     };
     window.addEventListener('miqi:approval-bypass-updated', handler);
     return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
   }, []);
 
-  const dismiss = useCallback(() => {
-    sessionStorage.removeItem(SESSION_KEY);
-    setVisible(false);
-  }, []);
+  const dismiss = useCallback(() => setVisible(false), []);
 
   // Auto-dismiss after 3 seconds
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
+++ b/apps/desktop/src/renderer/components/ApprovalBypassBanner.tsx
@@ -1,58 +1,42 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
+import { cn } from '../lib/utils';
 
-interface ApprovalBypassStatus {
-  bypassAll?: boolean;
-  bypassCommandApproval?: boolean;
-  bypassFileWriteApproval?: boolean;
-  bypassToolConfirmation?: boolean;
-  bypassNetworkApproval?: boolean;
-}
+const SESSION_KEY = 'miqi:bypass:enabled';
 
-function hasApprovalBypass(config: Record<string, unknown>): boolean {
-  const approvals = (config.approvals ?? {}) as ApprovalBypassStatus;
+export function ApprovalBypassBanner() {
+  const [visible, setVisible] = useState(() => sessionStorage.getItem(SESSION_KEY) === 'true');
 
-  return Boolean(
-    approvals.bypassAll ||
-      approvals.bypassCommandApproval ||
-      approvals.bypassFileWriteApproval ||
-      approvals.bypassToolConfirmation ||
-      approvals.bypassNetworkApproval
-  );
-}
+  const show = useCallback(() => {
+    sessionStorage.setItem(SESSION_KEY, 'true');
+    setVisible(true);
+  }, []);
 
-export function ApprovalBypassBanner({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
-  const [enabled, setEnabled] = useState(false);
-  const [dismissed, setDismissed] = useState(false);
-
-  const load = useCallback(async () => {
-    if (!(window as any).miqi?.config?.get) {
-      setEnabled(false);
-      return;
-    }
-    try {
-      const config = await window.miqi.config.get();
-      setEnabled(hasApprovalBypass(config));
-    } catch {
-      setEnabled(false);
-    }
+  const dismiss = useCallback(() => {
+    sessionStorage.removeItem(SESSION_KEY);
+    setVisible(false);
   }, []);
 
   useEffect(() => {
-    load();
-    window.addEventListener('miqi:approval-bypass-updated', load);
-    return () => window.removeEventListener('miqi:approval-bypass-updated', load);
-  }, [load]);
+    const handler = () => show();
+    window.addEventListener('miqi:approval-bypass-updated', handler);
+    return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
+  }, [show]);
 
+  // Auto-dismiss after 3 seconds
   useEffect(() => {
-    if (!enabled) setDismissed(false);
-  }, [enabled]);
-
-  if (!enabled || dismissed) return null;
+    if (!visible) return;
+    const t = setTimeout(dismiss, 3000);
+    return () => clearTimeout(t);
+  }, [visible, dismiss]);
 
   return (
     <div
-      className="approval-bypass-island fixed left-1/2 top-12 z-50 flex max-w-[min(720px,calc(100vw-24px))] items-center gap-2 rounded-full border px-3 py-2 text-xs backdrop-blur"
+      className={cn(
+        'approval-bypass-island fixed left-1/2 top-12 z-50 flex max-w-[min(720px,calc(100vw-24px))] items-center gap-2 rounded-full border px-3 py-2 text-xs backdrop-blur',
+        'transition-all duration-300',
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none',
+      )}
       style={{
         background: 'color-mix(in srgb, var(--approval-warning-bg) 92%, white)',
         borderColor: 'var(--approval-warning-border)',
@@ -65,14 +49,17 @@ export function ApprovalBypassBanner({ onOpenApprovals }: { onOpenApprovals?: ()
       </span>
       <button
         type="button"
-        onClick={onOpenApprovals}
+        onClick={() => {
+          window.dispatchEvent(new Event('miqi:navigate:approvals'));
+          dismiss();
+        }}
         className="shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold transition-colors hover:bg-[rgba(124,45,18,0.08)]"
       >
         查看设置
       </button>
       <button
         type="button"
-        onClick={() => setDismissed(true)}
+        onClick={dismiss}
         className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full hover:bg-[rgba(124,45,18,0.12)] transition-colors"
         title="关闭提醒"
       >

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -4,84 +4,20 @@ import { AlertTriangle, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { MiQiLogo } from './MiQiLogo';
 
-interface ApprovalBypassStatus {
-  bypassAll?: boolean;
-  bypassCommandApproval?: boolean;
-  bypassFileWriteApproval?: boolean;
-  bypassToolConfirmation?: boolean;
-  bypassNetworkApproval?: boolean;
-}
-
-function isBypassEnabled(status: ApprovalBypassStatus | null): boolean {
-  if (!status) return false;
-  return Boolean(
-    status.bypassAll ||
-    status.bypassCommandApproval ||
-    status.bypassFileWriteApproval ||
-    status.bypassToolConfirmation ||
-    status.bypassNetworkApproval
-  );
-}
-
-function getBypassLabel(status: ApprovalBypassStatus | null): string {
-  if (status?.bypassAll) return '全部绕过';
-  return '绕过';
-}
-
-function getBypassTitle(status: ApprovalBypassStatus | null): string {
-  if (status?.bypassAll) return '所有审批类别已启用绕过';
-  const labels: string[] = [];
-  if (status?.bypassCommandApproval) labels.push('命令审批');
-  if (status?.bypassFileWriteApproval) labels.push('文件写入审批');
-  if (status?.bypassToolConfirmation) labels.push('工具确认');
-  if (status?.bypassNetworkApproval) labels.push('网络审批');
-  return labels.length > 0
-    ? `已绕过: ${labels.join('、')}`
-    : '打开审批设置';
-}
-
-export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
+export function TopBar() {
   const { status } = useRuntime();
-  const [approvalBypass, setApprovalBypass] = useState<ApprovalBypassStatus | null>(null);
+  const [bypassEnabled, setBypassEnabled] = useState(
+    () => sessionStorage.getItem('miqi:bypass:enabled') === 'true'
+  );
+
+  useEffect(() => {
+    const handler = () => setBypassEnabled(true);
+    window.addEventListener('miqi:approval-bypass-updated', handler);
+    return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
+  }, []);
 
   const isRunning = status.state === 'running';
   const isStarting = status.state === 'starting' || status.state === 'stopping';
-  const bypassEnabled = isBypassEnabled(approvalBypass);
-
-  useEffect(() => {
-    let cancelled = false;
-    let inFlight = false; // debounce guard: don't pile up requests when bridge is slow
-
-    const loadApprovalBypass = async () => {
-      if (inFlight) return; // skip if previous request still pending
-      if (!(window as any).miqi?.config?.get) {
-        if (!cancelled) setApprovalBypass(null);
-        return;
-      }
-      inFlight = true;
-      try {
-        const cfg = await window.miqi.config.get();
-        const approvals = (cfg.approvals ?? {}) as ApprovalBypassStatus;
-        if (!cancelled) {
-          setApprovalBypass(approvals);
-        }
-      } catch {
-        // Keep the last known good state — bridge may be temporarily busy
-        // Don't clear approvalBypass; a null here cascades into false
-        // "runtime not started" UI.  See PR #xxx.
-      } finally {
-        inFlight = false;
-      }
-    };
-    loadApprovalBypass();
-    window.addEventListener('miqi:approval-bypass-updated', loadApprovalBypass);
-    const timer = window.setInterval(loadApprovalBypass, 30_000);
-    return () => {
-      cancelled = true;
-      window.removeEventListener('miqi:approval-bypass-updated', loadApprovalBypass);
-      window.clearInterval(timer);
-    };
-  }, []);
 
   return (
     <div
@@ -109,7 +45,7 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
         {bypassEnabled && (
           <button
             type="button"
-            onClick={onOpenApprovals}
+            onClick={() => window.dispatchEvent(new Event('miqi:navigate:approvals'))}
             className={cn(
               'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold',
               'transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]'
@@ -117,13 +53,12 @@ export function TopBar({ onOpenApprovals }: { onOpenApprovals?: () => void }) {
             style={{
               background: 'var(--approval-warning-pill-bg)',
               color: 'var(--approval-warning-pill-text)',
-              border: '1px solid var(--approval-warning-border)',
             }}
-            title={getBypassTitle(approvalBypass)}
-            aria-label={getBypassTitle(approvalBypass)}
+            title="审批绕过已开启"
+            aria-label="审批绕过已开启"
           >
             <AlertTriangle size={11} className="shrink-0" />
-            <span className="whitespace-nowrap">{getBypassLabel(approvalBypass)}</span>
+            <span className="whitespace-nowrap">绕过</span>
           </button>
         )}
         {/* Sync state */}

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -4,11 +4,9 @@ import { AlertTriangle, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { MiQiLogo } from './MiQiLogo';
 
-export function TopBar() {
+export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void }) {
   const { status } = useRuntime();
-  const [bypassEnabled, setBypassEnabled] = useState(
-    () => sessionStorage.getItem('miqi:bypass:enabled') === 'true'
-  );
+  const [bypassEnabled, setBypassEnabled] = useState(false);
 
   useEffect(() => {
     const handler = () => setBypassEnabled(true);
@@ -27,33 +25,20 @@ export function TopBar() {
         borderBottom: '1px solid var(--topbar-border)',
       }}
     >
-      {/* Left: logo text */}
       <div className="flex items-center gap-2">
-        <span
-          className="text-sm font-semibold tracking-tight"
-          style={{ color: 'var(--topbar-text)' }}
-        >
-          MiQi
-        </span>
-        <span className="text-xs font-light opacity-50" style={{ color: 'var(--topbar-text)' }}>
-          Desktop
-        </span>
+        <span className="text-sm font-semibold tracking-tight" style={{ color: 'var(--topbar-text)' }}>MiQi</span>
+        <span className="text-xs font-light opacity-50" style={{ color: 'var(--topbar-text)' }}>Desktop</span>
       </div>
-
-      {/* Center: status pills */}
       <div className="flex items-center gap-2">
         {bypassEnabled && (
           <button
             type="button"
-            onClick={() => window.dispatchEvent(new Event('miqi:navigate:approvals'))}
+            onClick={onNavigateSettings}
             className={cn(
               'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold',
               'transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]'
             )}
-            style={{
-              background: 'var(--approval-warning-pill-bg)',
-              color: 'var(--approval-warning-pill-text)',
-            }}
+            style={{ background: 'var(--approval-warning-pill-bg)', color: 'var(--approval-warning-pill-text)' }}
             title="审批绕过已开启"
             aria-label="审批绕过已开启"
           >
@@ -61,15 +46,10 @@ export function TopBar() {
             <span className="whitespace-nowrap">绕过</span>
           </button>
         )}
-        {/* Sync state */}
         <div
           className={cn('flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium')}
           style={{
-            background: isRunning
-              ? 'var(--success-bg)'
-              : isStarting
-                ? 'var(--warning-bg)'
-                : 'var(--danger-bg)',
+            background: isRunning ? 'var(--success-bg)' : isStarting ? 'var(--warning-bg)' : 'var(--danger-bg)',
             color: isRunning ? 'var(--success)' : isStarting ? 'var(--warning)' : 'var(--danger)',
           }}
         >
@@ -77,12 +57,8 @@ export function TopBar() {
           <span>{isRunning ? '已同步' : isStarting ? '同步中' : '离线'}</span>
         </div>
       </div>
-
-      {/* Right: user avatar */}
       <div className="flex items-center gap-2">
-        <span className="text-xs font-medium hidden sm:block" style={{ color: 'var(--topbar-text)' }}>
-          MiQi 智能体
-        </span>
+        <span className="text-xs font-medium hidden sm:block" style={{ color: 'var(--topbar-text)' }}>MiQi 智能体</span>
         <MiQiLogo size={28} />
       </div>
     </div>

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -10,13 +10,9 @@ export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void 
   const [pressed, setPressed] = useState(false);
 
   useEffect(() => {
-    const handler = async () => {
-      try {
-        const cfg = await window.miqi.config.get();
-        const a = (cfg as any)?.approvals ?? {};
-        const on = !!(a.bypassAll || a.bypassCommandApproval || a.bypassFileWriteApproval || a.bypassToolConfirmation || a.bypassNetworkApproval);
-        setBypassEnabled(on);
-      } catch { /* bridge may be busy */ }
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ enabled: boolean }>).detail;
+      setBypassEnabled(!!detail?.enabled);
     };
     window.addEventListener('miqi:approval-bypass-updated', handler);
     return () => window.removeEventListener('miqi:approval-bypass-updated', handler);

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRuntime } from '../contexts/RuntimeContext';
 import { AlertTriangle, RefreshCw, Loader2 } from 'lucide-react';
 import { cn } from '../lib/utils';
@@ -7,12 +7,26 @@ import { MiQiLogo } from './MiQiLogo';
 export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void }) {
   const { status } = useRuntime();
   const [bypassEnabled, setBypassEnabled] = useState(false);
+  const [pressed, setPressed] = useState(false);
 
   useEffect(() => {
-    const handler = () => setBypassEnabled(true);
+    const handler = async () => {
+      try {
+        const cfg = await window.miqi.config.get();
+        const a = (cfg as any)?.approvals ?? {};
+        const on = !!(a.bypassAll || a.bypassCommandApproval || a.bypassFileWriteApproval || a.bypassToolConfirmation || a.bypassNetworkApproval);
+        setBypassEnabled(on);
+      } catch { /* bridge may be busy */ }
+    };
     window.addEventListener('miqi:approval-bypass-updated', handler);
     return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
   }, []);
+
+  const handleClick = useCallback(() => {
+    setPressed(true);
+    setTimeout(() => setPressed(false), 600);
+    onNavigateSettings();
+  }, [onNavigateSettings]);
 
   const isRunning = status.state === 'running';
   const isStarting = status.state === 'starting' || status.state === 'stopping';
@@ -33,12 +47,18 @@ export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void 
         {bypassEnabled && (
           <button
             type="button"
-            onClick={onNavigateSettings}
+            onClick={handleClick}
             className={cn(
-              'flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold',
-              'transition-transform hover:scale-[1.02] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]'
+              'bypass-pill flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold',
+              'transition-all duration-200 hover:-translate-y-px hover:shadow-sm',
+              'focus:outline-none',
+              pressed && 'bypass-pill-pressed',
             )}
-            style={{ background: 'var(--approval-warning-pill-bg)', color: 'var(--approval-warning-pill-text)' }}
+            style={{
+              background: 'var(--approval-warning-pill-bg)',
+              color: 'var(--approval-warning-pill-text)',
+              border: '1px solid var(--approval-warning-pill-border, var(--approval-warning-border))',
+            }}
             title="审批绕过已开启"
             aria-label="审批绕过已开启"
           >

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -10,9 +10,8 @@ export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void 
   const [pressed, setPressed] = useState(false);
 
   useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ enabled: boolean }>).detail;
-      setBypassEnabled(!!detail?.enabled);
+    const handler = () => {
+      setBypassEnabled(sessionStorage.getItem('miqi:bypass:enabled') === 'true');
     };
     window.addEventListener('miqi:approval-bypass-updated', handler);
     return () => window.removeEventListener('miqi:approval-bypass-updated', handler);
@@ -28,22 +27,15 @@ export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void 
   const isStarting = status.state === 'starting' || status.state === 'stopping';
 
   return (
-    <div
-      className="flex items-center justify-between h-10 px-5 shrink-0"
-      style={{
-        background: 'var(--topbar-bg)',
-        borderBottom: '1px solid var(--topbar-border)',
-      }}
-    >
+    <div className="flex items-center justify-between h-10 px-5 shrink-0"
+      style={{ background: 'var(--topbar-bg)', borderBottom: '1px solid var(--topbar-border)' }}>
       <div className="flex items-center gap-2">
         <span className="text-sm font-semibold tracking-tight" style={{ color: 'var(--topbar-text)' }}>MiQi</span>
         <span className="text-xs font-light opacity-50" style={{ color: 'var(--topbar-text)' }}>Desktop</span>
       </div>
       <div className="flex items-center gap-2">
         {bypassEnabled && (
-          <button
-            type="button"
-            onClick={handleClick}
+          <button type="button" onClick={handleClick}
             className={cn(
               'bypass-pill flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold',
               'transition-all duration-200 hover:-translate-y-px hover:shadow-sm',
@@ -55,20 +47,16 @@ export function TopBar({ onNavigateSettings }: { onNavigateSettings: () => void 
               color: 'var(--approval-warning-pill-text)',
               border: '1px solid var(--approval-warning-pill-border, var(--approval-warning-border))',
             }}
-            title="审批绕过已开启"
-            aria-label="审批绕过已开启"
-          >
+            title="审批绕过已开启" aria-label="审批绕过已开启">
             <AlertTriangle size={11} className="shrink-0" />
             <span className="whitespace-nowrap">绕过</span>
           </button>
         )}
-        <div
-          className={cn('flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium')}
+        <div className={cn('flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium')}
           style={{
             background: isRunning ? 'var(--success-bg)' : isStarting ? 'var(--warning-bg)' : 'var(--danger-bg)',
             color: isRunning ? 'var(--success)' : isStarting ? 'var(--warning)' : 'var(--danger)',
-          }}
-        >
+          }}>
           {isStarting ? <Loader2 size={11} className="animate-spin" /> : <RefreshCw size={11} />}
           <span>{isRunning ? '已同步' : isStarting ? '同步中' : '离线'}</span>
         </div>

--- a/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
+++ b/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
@@ -294,7 +294,14 @@ export function ApprovalsPage() {
       }
       await window.miqi.config.update(update);
       setBypassSaved(key);
-      window.dispatchEvent(new Event('miqi:approval-bypass-updated'));
+      const bypassOn = !!(
+        next.bypassAll ||
+        next.bypassCommandApproval ||
+        next.bypassFileWriteApproval ||
+        next.bypassToolConfirmation ||
+        next.bypassNetworkApproval
+      );
+      window.dispatchEvent(new CustomEvent('miqi:approval-bypass-updated', { detail: { enabled: bypassOn } }));
       window.setTimeout(
         () => setBypassSaved((current) => (current === key ? null : current)),
         1800

--- a/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
+++ b/apps/desktop/src/renderer/features/approvals/ApprovalsPage.tsx
@@ -301,7 +301,8 @@ export function ApprovalsPage() {
         next.bypassToolConfirmation ||
         next.bypassNetworkApproval
       );
-      window.dispatchEvent(new CustomEvent('miqi:approval-bypass-updated', { detail: { enabled: bypassOn } }));
+      sessionStorage.setItem('miqi:bypass:enabled', bypassOn ? 'true' : '');
+      window.dispatchEvent(new Event('miqi:approval-bypass-updated'));
       window.setTimeout(
         () => setBypassSaved((current) => (current === key ? null : current)),
         1800

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -328,3 +328,13 @@ code {
     0 14px 35px rgba(124, 45, 18, 0.14),
     0 2px 10px rgba(124, 45, 18, 0.08);
 }
+
+/* Bypass pill: subtle pulse on click */
+@keyframes bypass-pill-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.5); }
+  50%  { box-shadow: 0 0 0 4px rgba(251, 146, 60, 0.15); }
+  100% { box-shadow: 0 0 0 0 rgba(251, 146, 60, 0); }
+}
+.bypass-pill-pressed {
+  animation: bypass-pill-pulse 500ms ease-out;
+}


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 变更概述

修复 #285：灵动岛 3 秒自动淡出、绕过按钮不再依赖持久化配置、默认关闭。

## 背景/问题

#285：旧配置文件中 `bypassAll: true` 持久化后，每次启动都会弹出灵动岛，即使用户已关闭审批绕过。绕过按钮的 `focus:ring-2` 光圈过大。需要改为 sessionStorage 管理状态，确保重启后不显示。

## 变更内容

### 灵动岛 (ApprovalBypassBanner)
- 使用 `sessionStorage` 代替 `config.get()` — 不读配置文件，重启即清
- 监听 `miqi:approval-bypass-updated` 事件触发显示
- **淡入淡出**: `opacity + translateY` + `transition-all duration-300`
- **3 秒自动消失**: `setTimeout(dismiss, 3000)`
- 元素常驻 DOM，hidden 时 `opacity-0 pointer-events-none`

### 绕过按钮 (TopBar)
- 同样 `sessionStorage` 判断——默认不显示
- 设置页手动打开绕过后出现
- 去掉了配置轮询和 ApprovalBypassStatus 死代码
- 点击事件改用 `window.dispatchEvent(miqi:navigate:approvals)`

### 导航 (App.tsx)
- 监听 `miqi:navigate:approvals` 事件跳转审批 tab

## 日志/验证证据
```
typecheck: PASS
build: PASS (electron-vite)
pytest tests/session/: 47 passed
```
## 测试情况

- Web typecheck: PASS
- Build: PASS
- Pytest (session tests): 47 passed
- 手动测试：重启 app 灵动岛不显示，手动开启绕过后灵动岛 3 秒淡出

## 截图

（行为变更，参考 #286 的截图）

Closes #285