### PR TITLE
fix(runtime,desktop): fix 7 backend bugs — subscription leaks, shutdown race, unbounded queue, dangling Promise

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -279,9 +279,18 @@ export class BridgeManager extends EventEmitter {
                   if (resp.code) (err as Error & { code?: string }).code = resp.code;
                   pending.reject(err);
                 } else {
-                  // final / aborted: call onEvent then resolve
-                  pending.onEvent?.(resp.eventType, resp.data);
-                  pending.resolve(resp.data);
+                  // final / aborted: call onEvent then resolve.
+                  // Wrap onEvent in try/catch so a thrown error in the
+                  // callback does not skip pending.resolve (#331).
+                  try {
+                    pending.onEvent?.(resp.eventType, resp.data);
+                  } catch (onEventErr) {
+                    this.addLog(
+                      `[Bridge] onEvent threw for terminal event ${resp.eventType}: ${onEventErr}`
+                    );
+                  } finally {
+                    pending.resolve(resp.data);
+                  }
                 }
                 // Terminal: skip bridge-event
                 return;
@@ -340,8 +349,9 @@ export class BridgeManager extends EventEmitter {
           } else {
             pending.resolve(resp.result);
           }
-        } catch {
-          this.addLog(`[Bridge] Ignoring non-JSON stdout line: ${line}`);
+        } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          this.addLog(`[Bridge] Error processing stdout line: ${errMsg} — raw: ${line}`);
         }
       });
 
@@ -438,10 +448,13 @@ export class BridgeManager extends EventEmitter {
           const normalized = normalizeBridgeMessage(resp);
           const pending = normalized.requestId ? this.pending.get(normalized.requestId) : undefined;
 
-          if (!pending && resp.type && resp.data) {
+          if (!pending && normalized.eventType && resp.data) {
             // Orphan event (e.g. subagent_result after main agent finished)
             // Forward to all renderer windows so late events are not dropped.
-            const eventKey = `CHAT_${resp.type.toUpperCase()}`;
+            // Use normalized.eventType (not raw resp.type) so events sent via
+            // the "event" field are handled correctly — consistent with the
+            // primary handler (#335).
+            const eventKey = `CHAT_${normalized.eventType.toUpperCase()}`;
             const channel = IPC_EVENTS[eventKey as keyof typeof IPC_EVENTS];
             if (channel) {
               const allWindows = BrowserWindow.getAllWindows();

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -651,9 +651,6 @@ class BridgeRuntimeLoop:
         # Submit the user message
         await runtime.submit(UserMessage(content=content, thread_id=thread_id))
 
-        # Subscribe client to session events so emit_event delivers to the sink
-        self._app_server.subscribe(client_id, runtime_id)
-
         # Reject duplicate turns for the same session: cancelling the old
         # drain task leaves abandoned sandbox creation running (WSL
         # subprocesses don't respond to asyncio cancellation), which
@@ -667,6 +664,11 @@ class BridgeRuntimeLoop:
                 "A turn is already in progress for this session",
                 code="TURN_IN_PROGRESS",
             )
+
+        # Subscribe client to session events so emit_event delivers to the sink.
+        # Must happen AFTER the TURN_IN_PROGRESS check to avoid leaking a
+        # subscription when the duplicate-turn error is raised (#326).
+        self._app_server.subscribe(client_id, runtime_id)
 
         # Spawn background drain task
         app_server = self._app_server

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -533,15 +533,27 @@ def _graceful_shutdown() -> None:
             loop = None
 
         if loop and loop.is_running():
-            # Phase 27.6: persistent loop running — schedule cleanup
-            asyncio.ensure_future(sandbox_mgr.destroy_all())
+            # Phase 27.6: persistent loop running — schedule cleanup.
+            # We must await the future so that destroy_all() actually
+            # runs before _clear_state_file() deletes the state file
+            # and _bridge_state is set to None (#329).
+            try:
+                loop.run_until_complete(
+                    asyncio.ensure_future(sandbox_mgr.destroy_all())
+                )
+            except Exception as destroy_exc:
+                _log(
+                    "Sandbox destroy_all failed during shutdown "
+                    f"(non-fatal): {destroy_exc}"
+                )
         else:
             # No running loop (signal/atexit after loop closed) — create one
             asyncio.run(sandbox_mgr.destroy_all())
     except Exception as exc:
         _log(f"Sandbox cleanup on shutdown failed (non-fatal): {exc}")
     finally:
-        # Always clear the state file to prevent stale entries
+        # Always clear the state file to prevent stale entries.
+        # Only do this after destroy_all() has completed (#329).
         try:
             sandbox_mgr._clear_state_file()
         except Exception:

--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -89,8 +89,11 @@ class RuntimeSession:
         available through next_event(). This includes tool-call-begin/end,
         sub-agent-spawned/completed, turn-start/complete, and error events.
         """
-        # Shared event queue — services push into it, consumers read from it
-        events: asyncio.Queue[Any] = asyncio.Queue()
+        # Shared event queue — services push into it, consumers read from it.
+        # 4096 maxsize provides backpressure: a runaway agent that floods
+        # events (e.g. thousands of tool calls) will block at put() instead
+        # of growing the queue unboundedly (#328).
+        events: asyncio.Queue[Any] = asyncio.Queue(maxsize=4096)
 
         services = RuntimeServices.from_config(
             config=config,

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -263,6 +263,13 @@ async def sessions_delete_handler(
     # Success if runtime was stopped (session may not have been on disk)
     deleted = runtime_was_active or disk_deleted
 
+    # Clean up AppServer event subscriptions for the deleted session.
+    # stop_session() cleans _sessions/_client_sessions/_session_clients but
+    # _subscriptions lives on AppServer — clean it here (#327).
+    app_server = getattr(registry, "bridge_context", {}).get("app_server")
+    if app_server is not None and hasattr(app_server, "_subscriptions"):
+        app_server._subscriptions.pop(sid, None)
+
     logger.info(
         "sessions.delete: {} (key={}, client={})",
         "deleted" if deleted else "not found",


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

修复7个后端逻辑bug：订阅泄漏、_subscriptions清理、事件队列无上限、Promise静默挂起、日志误导、handler不一致、SIGTERM下destroy_all() race。

## 背景/问题

通过源码审查确认的7个独立bug，全部位于Python backend和Electron bridge层，均不涉及UI/Renderer：

1. **#326** — `loop.py` chat.send先subscribe后检查TURN_IN_PROGRESS，异常路径泄漏订阅
2. **#327** — `sessions.delete`调用`stop_session()`清理了其他映射但遗漏`AppServer._subscriptions`
3. **#328** — `session.py`事件队列`asyncio.Queue()`无maxsize，长turn事件无界堆积
4. **#331** — `bridge.ts`终端事件onEvent抛异常时`resolve()`被跳过，Promise静默挂起
5. **#333** — `bridge.ts` catch块打印"非JSON"误导日志，实际是onEvent回调异常
6. **#335** — 次级handler使用raw `resp.type`而非归一化`eventType`，与主handler不一致
7. **#329** — `server.py` SIGTERM路径`ensure_future(destroy_all())`不await，`_clear_state_file()`在destroy完成前执行

全部改动不涉及UI，无视觉变更。

## 变更内容

| 文件 | 改动 | Issue |
|------|------|-------|
| `miqi/bridge/loop.py` | subscribe()移到TURN_IN_PROGRESS检查之后 | #326 |
| `miqi/runtime/session_handlers.py` | sessions.delete中清理`app_server._subscriptions` | #327 |
| `miqi/runtime/session.py` | `asyncio.Queue()`加`maxsize=4096` | #328 |
| `apps/desktop/src/main/bridge.ts` | 终端事件`onEvent`用try/catch/finally包裹 | #331 |
| `apps/desktop/src/main/bridge.ts` | catch块中记录真实错误信息替代误导日志 | #333 |
| `apps/desktop/src/main/bridge.ts` | 次级handler用`normalized.eventType`替代`resp.type` | #335 |
| `miqi/bridge/server.py` | SIGTERM路径`loop.run_until_complete()`同步等待destroy_all | #329 |

每个改动2-5行，相互独立，不存在交叉影响。

## 日志/验证证据

所有改动为逻辑缺陷修复，通过源码审查验证：

```
# #326 — 修复前：subscribe() at line 655, TURN_IN_PROGRESS check at line 662
# 修复后：subscribe() at line 668, after TURN_IN_PROGRESS check

# #327 — 修复前：stop_session() cleans _sessions/_client_sessions/_session_clients
# 修复后：sessions_delete_handler additionally cleans app_server._subscriptions[sid]

# #328 — 修复前：asyncio.Queue() 无上限
# 修复后：asyncio.Queue(maxsize=4096) 提供背压

# #331 — 修复前：pending.onEvent?.() at line 283, pending.resolve() at line 284
# 修复后：onEvent wrapped in try/catch with resolve in finally

# #333 — 修复前：catch logs "Ignoring non-JSON stdout line"
# 修复后：catch logs "Error processing stdout line: <msg> — raw: <line>"

# #335 — 修复前：resp.type at lines 451, 454 (次级handler)
# 修复后：normalized.eventType at lines 451, 454 (次级handler)

# #329 — 修复前：asyncio.ensure_future(sandbox_mgr.destroy_all()) at line 537, no await
# 修复后：loop.run_until_complete(...) 同步等待destroy_all完成
```

## 测试情况

- [x] Python: `uv run pytest tests/ -x -q` — 通过（无新增用例，不影响现有测试）
- [x] TypeScript: `npx tsc --noEmit` — 类型检查通过
- [x] 改动均为2-5行逻辑修复，手动review确认语义正确

## 截图

无需截图（无UI变更）
