### PR TITLE
fix(runtime): move subscribe() after TURN_IN_PROGRESS check to prevent subscription leak

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -651,9 +651,6 @@ class BridgeRuntimeLoop:
         # Submit the user message
         await runtime.submit(UserMessage(content=content, thread_id=thread_id))
 
-        # Subscribe client to session events so emit_event delivers to the sink
-        self._app_server.subscribe(client_id, runtime_id)
-
         # Reject duplicate turns for the same session: cancelling the old
         # drain task leaves abandoned sandbox creation running (WSL
         # subprocesses don't respond to asyncio cancellation), which
@@ -667,6 +664,11 @@ class BridgeRuntimeLoop:
                 "A turn is already in progress for this session",
                 code="TURN_IN_PROGRESS",
             )
+
+        # Subscribe client to session events so emit_event delivers to the sink.
+        # Must happen AFTER the TURN_IN_PROGRESS check to avoid leaking a
+        # subscription when the duplicate-turn error is raised (#326).
+        self._app_server.subscribe(client_id, runtime_id)
 
         # Spawn background drain task
         app_server = self._app_server


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

将 `subscribe()` 调用移到 `TURN_IN_PROGRESS` 检查之后，防止重复 turn 被拒绝时泄漏订阅。

## 背景/问题

`chat.send` handler 中 `subscribe(client_id, runtime_id)` 在先（`loop.py:655`），`TURN_IN_PROGRESS` 检查在后（`loop.py:662-669`）。当快速连续发送导致重复 turn 被拒绝时，异常路径没有调用 `unsubscribe()`，`AppServer._subscriptions` 中残留该 client_id 的订阅。

## 变更内容

`miqi/bridge/loop.py` — 将 `self._app_server.subscribe(client_id, runtime_id)` 从 LINE 655 移到 `TURN_IN_PROGRESS` 检查之后的 LINE 668。

## 日志/验证证据

修复前：subscribe() 在 LINE 655，异常路径（`app_server.py:355` catch `AppServerError`）无 unsubscribe 调用。
修复后：subscribe() 在 LINE 668，仅在 TURN_IN_PROGRESS 检查通过后执行。

## 测试情况

- 改动为顺序调整，不增加新逻辑，对正常流程无影响
- TURN_IN_PROGRESS 触发时不再产生订阅

## 截图

无需截图（无 UI 变更）
