### PR TITLE
fix(runtime): add maxsize=4096 to event queue to prevent unbounded growth

### DIFF
--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -89,8 +89,11 @@ class RuntimeSession:
         available through next_event(). This includes tool-call-begin/end,
         sub-agent-spawned/completed, turn-start/complete, and error events.
         """
-        # Shared event queue — services push into it, consumers read from it
-        events: asyncio.Queue[Any] = asyncio.Queue()
+        # Shared event queue — services push into it, consumers read from it.
+        # 4096 maxsize provides backpressure: a runaway agent that floods
+        # events (e.g. thousands of tool calls) will block at put() instead
+        # of growing the queue unboundedly (#328).
+        events: asyncio.Queue[Any] = asyncio.Queue(maxsize=4096)
 
         services = RuntimeServices.from_config(
             config=config,


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

给 `RuntimeSession` 的事件队列添加 `maxsize=4096`，防止无限事件堆积。

## 背景/问题

`session.py` 中 `asyncio.Queue()` 无 `maxsize` 参数——队列无上限，`put()` 永不阻塞。所有 `event_sink` 回调通过 `RuntimeEventEmitter.emit()` 调用 `await self._events.put(event)`，但没有任何流量控制。长 turn 产生大量事件时（如 500 次工具调用 = 1000+ 对 ToolCallBegin/ToolCallEnd），事件在队列中无界堆积。

4096 足够容纳任何正常 turn（500 次迭代 × ~8 个事件/迭代），同时防止失控的 agent loop 无限增长内存。

## 变更内容

`miqi/runtime/session.py` — `asyncio.Queue()` → `asyncio.Queue(maxsize=4096)`。

## 日志/验证证据

修复前：`events: asyncio.Queue[Any] = asyncio.Queue()` — 无上限。
修复后：`events: asyncio.Queue[Any] = asyncio.Queue(maxsize=4096)` — 提供背压。

## 测试情况

- 改动仅添加 maxsize 参数，不影响任何事件语义
- 4096 远大于正常情况下的最大事件数，不会引入不必要的阻塞

## 截图

无需截图（无 UI 变更）
