### PR TITLE
fix(desktop): wrap onEvent in try/finally so resolve always runs on terminal events

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -279,9 +279,18 @@ export class BridgeManager extends EventEmitter {
                   if (resp.code) (err as Error & { code?: string }).code = resp.code;
                   pending.reject(err);
                 } else {
-                  // final / aborted: call onEvent then resolve
-                  pending.onEvent?.(resp.eventType, resp.data);
-                  pending.resolve(resp.data);
+                  // final / aborted: call onEvent then resolve.
+                  // Wrap onEvent in try/catch so a thrown error in the
+                  // callback does not skip pending.resolve (#331).
+                  try {
+                    pending.onEvent?.(resp.eventType, resp.data);
+                  } catch (onEventErr) {
+                    this.addLog(
+                      `[Bridge] onEvent threw for terminal event ${resp.eventType}: ${onEventErr}`
+                    );
+                  } finally {
+                    pending.resolve(resp.data);
+                  }
                 }
                 // Terminal: skip bridge-event
                 return;


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

终端事件（`final`/`aborted`）的 `pending.onEvent?.()` 用 try/catch/finally 包裹，确保 `pending.resolve()` 始终执行。

## 背景/问题

`bridge.ts:282-284`：

```typescript
// final / aborted: call onEvent then resolve
pending.onEvent?.(resp.eventType, resp.data);  // line 283 — 若 throw
pending.resolve(resp.data);                     // line 284 — 永不执行
```

若 `onEvent` 回调抛出异常，控制流跳到外层 catch 块并打印误导性日志。`pending.resolve()` 永远不执行——Promise 挂起直到 inactivity 超时（720 秒）。

## 变更内容

`apps/desktop/src/main/bridge.ts` — `pending.onEvent?.()` 用 try/catch 包裹，`pending.resolve()` 放入 finally 块。

## 日志/验证证据

修复前：`onEvent` 抛异常时 resolve() 被跳过。
修复后：resolve() 在 finally 中保证执行，catch 中记录真实错误。

## 测试情况

- try/catch 仅包裹 onEvent，不影响 resolve 的正常执行路径
- 在 onEvent 不抛异常时与之前行为完全一致

## 截图

无需截图（无 UI 变更）
