### PR TITLE
fix(desktop): report actual error in line handler catch block instead of misleading non-JSON

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -340,8 +340,9 @@ export class BridgeManager extends EventEmitter {
           } else {
             pending.resolve(resp.result);
           }
-        } catch {
-          this.addLog(`[Bridge] Ignoring non-JSON stdout line: ${line}`);
+        } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          this.addLog(`[Bridge] Error processing stdout line: ${errMsg} — raw: ${line}`);
         }
       });
 


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

主 line handler 的 catch 块改为记录真正的错误信息，而非总是声称"非 JSON 行"。

## 背景/问题

`bridge.ts:343-344`：catch 块始终打印 `"Ignoring non-JSON stdout line: ${line}"`。实际上该行可能是完全合法的 JSON——错误可能源自 `onEvent` 回调抛异常。这让维护者排查完全错误的方向。

## 变更内容

`apps/desktop/src/main/bridge.ts` — catch 块记录 `Error processing stdout line: <errMsg> — raw: <line>`，区分 JSON 解析失败、onEvent 回调异常等不同原因。

## 日志/验证证据

修复前：`[Bridge] Ignoring non-JSON stdout line: {"type":"final",...}`（误导——实际是合法 JSON）
修复后：`[Bridge] Error processing stdout line: <real error> — raw: {"type":"final",...}`

## 测试情况

- catch 块逻辑不变，仅日志内容改进
- 不影响正常 flow

## 截图

无需截图（无 UI 变更）
