### PR TITLE
fix(desktop): use normalized.eventType in secondary handler instead of raw resp.type

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -438,10 +438,13 @@ export class BridgeManager extends EventEmitter {
           const normalized = normalizeBridgeMessage(resp);
           const pending = normalized.requestId ? this.pending.get(normalized.requestId) : undefined;
 
-          if (!pending && resp.type && resp.data) {
+          if (!pending && normalized.eventType && resp.data) {
             // Orphan event (e.g. subagent_result after main agent finished)
             // Forward to all renderer windows so late events are not dropped.
-            const eventKey = `CHAT_${resp.type.toUpperCase()}`;
+            // Use normalized.eventType (not raw resp.type) so events sent via
+            // the "event" field are handled correctly — consistent with the
+            // primary handler (#335).
+            const eventKey = `CHAT_${normalized.eventType.toUpperCase()}`;
             const channel = IPC_EVENTS[eventKey as keyof typeof IPC_EVENTS];
             if (channel) {
               const allWindows = BrowserWindow.getAllWindows();


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

次级 line handler（孤儿事件转发）改用 `normalizeBridgeMessage` 归一化后的 `eventType`，与主 handler 保持一致。

## 背景/问题

主 handler（`bridge.ts:260`）使用 `normalizeBridgeMessage` 归一化后的 `resp.eventType`（同时处理 `type` 和 `event` 字段），但次级 handler（`bridge.ts:441/444`）直接使用 raw `resp.type`。如果 Python 桥使用 `"event"` 字段发射事件，主 handler 正确处理但次级 handler 会静默丢弃。

`normalizeBridgeMessage`（`bridge.ts:74-78`）正确归一化了两个字段：`eventType = resp.type || resp.event`。

## 变更内容

`apps/desktop/src/main/bridge.ts` — 次级 handler 中 `resp.type` → `normalized.eventType`。

## 日志/验证证据

修复前：`if (!pending && resp.type && resp.data)` + `CHAT_${resp.type.toUpperCase()}`
修复后：`if (!pending && normalized.eventType && resp.data)` + `CHAT_${normalized.eventType.toUpperCase()}`

## 测试情况

- 改动仅替换字段来源，逻辑不变
- 归一化结果已经包含了 `resp.type || resp.event`，不会遗漏

## 截图

无需截图（无 UI 变更）
