### PR TITLE
fix(runtime): move subscribe() after TURN_IN_PROGRESS check to prevent subscription leak

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -659,9 +659,6 @@ class BridgeRuntimeLoop:
         # Submit the user message
         await runtime.submit(UserMessage(content=content, thread_id=thread_id))
 
-        # Subscribe client to session events so emit_event delivers to the sink
-        self._app_server.subscribe(client_id, runtime_id)
-
         # Reject duplicate turns for the same session: cancelling the old
         # drain task leaves abandoned sandbox creation running (WSL
         # subprocesses don't respond to asyncio cancellation), which
@@ -675,6 +672,11 @@ class BridgeRuntimeLoop:
                 "A turn is already in progress for this session",
                 code="TURN_IN_PROGRESS",
             )
+
+        # Subscribe client to session events so emit_event delivers to the sink.
+        # Must happen AFTER the TURN_IN_PROGRESS check to avoid leaking a
+        # subscription when the duplicate-turn error is raised (#326).
+        self._app_server.subscribe(client_id, runtime_id)
 
         # Spawn background drain task
         app_server = self._app_server


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

将 subscribe() 调用移到 TURN_IN_PROGRESS 检查之后，防止重复 turn 被拒绝时泄漏订阅。

## 背景/问题

chat.send handler 中 subscribe(client_id, runtime_id) 在先（loop.py:663），TURN_IN_PROGRESS 检查在后（loop.py:670-676）。当快速连续发送导致重复 turn 被拒绝时，异常被 app_server.py:355 的 except AppServerError 捕获并返回错误信封——没有任何路径调用 unsubscribe()，AppServer._subscriptions 中残留该 client_id 的订阅。

## 变更内容

miqi/bridge/loop.py — 将 self._app_server.subscribe(client_id, runtime_id) 从 TURN_IN_PROGRESS 检查之前移到之后。仅 2 块代码互换位置。

## 日志/验证证据

```
修复前: subscribe() at line 663, TURN_IN_PROGRESS check at line 670
       异常路径 (app_server.py:355 catch AppServerError) 无 unsubscribe
修复后: subscribe() at line 677, 仅在 TURN_IN_PROGRESS 检查通过后执行
```

## 测试情况

- 改动为纯顺序调整，不添加新逻辑
- TURN_IN_PROGRESS 抛出时不再产生泄漏的订阅
- 正常 turn 流程不受影响

## 截图

无需截图（无 UI 变更）

Fixes #326