### PR TITLE
fix(runtime): clean up AppServer._subscriptions when a session is deleted

### DIFF
--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -263,6 +263,13 @@ async def sessions_delete_handler(
     # Success if runtime was stopped (session may not have been on disk)
     deleted = runtime_was_active or disk_deleted
 
+    # Clean up AppServer event subscriptions for the deleted session.
+    # stop_session() cleans _sessions/_client_sessions/_session_clients but
+    # _subscriptions lives on AppServer — clean it here (#327).
+    app_server = getattr(registry, "bridge_context", {}).get("app_server")
+    if app_server is not None and hasattr(app_server, "_subscriptions"):
+        app_server._subscriptions.pop(sid, None)
+
     logger.info(
         "sessions.delete: {} (key={}, client={})",
         "deleted" if deleted else "not found",


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

sessions.delete handler 在删除 session 时同步清理 AppServer._subscriptions。

## 背景/问题

sessions.delete 调用 registry.stop_session(sid) 清理了 _sessions、_client_sessions、_session_clients、_last_activity。但 _subscriptions 是 AppServer 的属性（app_server.py:272），ClientSessionRegistry.stop_session() 没有它的引用。删除 session 后 _subscriptions[sid] 永久残留。

## 变更内容

miqi/runtime/session_handlers.py — 在 sessions_delete_handler 末尾通过 registry.bridge_context.app_server._subscriptions.pop(sid, None) 清理。

## 日志/验证证据

```
修复前: stop_session() 清理 4 个映射，遗漏 _subscriptions
修复后: sessions_delete_handler 额外清理 app_server._subscriptions[sid]
       pop(sid, None) — 即使 key 不存在也不会抛异常
```

## 测试情况

- 新增 7 行清理逻辑，无副作用
- pop(sid, None) 安全——key 不存在时静默返回 None

## 截图

无需截图（无 UI 变更）

Fixes #327