### PR TITLE
fix(desktop): wrap onEvent in try/finally so resolve always runs on terminal events

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -279,9 +279,18 @@ export class BridgeManager extends EventEmitter {
                   if (resp.code) (err as Error & { code?: string }).code = resp.code;
                   pending.reject(err);
                 } else {
-                  // final / aborted: call onEvent then resolve
-                  pending.onEvent?.(resp.eventType, resp.data);
-                  pending.resolve(resp.data);
+                  // final / aborted: call onEvent then resolve.
+                  // Wrap onEvent in try/catch so a thrown error in the
+                  // callback does not skip pending.resolve (#331).
+                  try {
+                    pending.onEvent?.(resp.eventType, resp.data);
+                  } catch (onEventErr) {
+                    this.addLog(
+                      `[Bridge] onEvent threw for terminal event ${resp.eventType}: ${onEventErr}`
+                    );
+                  } finally {
+                    pending.resolve(resp.data);
+                  }
                 }
                 // Terminal: skip bridge-event
                 return;


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

终端事件（final/aborted）的 onEvent 回调用 try/catch/finally 包裹，确保 pending.resolve() 始终执行。

## 背景/问题

bridge.ts:282-284:

若 onEvent 抛出异常，resolve() 被跳过，Promise 挂起直到 inactivity 超时（720 秒），用户收到超时错误而非实际结果。

## 变更内容

apps/desktop/src/main/bridge.ts — onEvent 用 try/catch 包裹，resolve() 放入 finally。

## 日志/验证证据

```
修复前: onEvent -> throw -> catch 吞掉 -> resolve() 跳过 -> Promise 挂起
修复后: onEvent -> throw -> catch 记录 -> finally resolve() -> Promise 正常结算
```


## 测试情况

- try/catch 仅包裹 onEvent，resolve 始终在 finally 中执行
- onEvent 不抛异常时路径不变

## 截图

无需截图（无 UI 变更）

Fixes #331
