### PR TITLE
fix(desktop): use normalized.eventType in secondary handler instead of raw resp.type

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -438,10 +438,13 @@ export class BridgeManager extends EventEmitter {
           const normalized = normalizeBridgeMessage(resp);
           const pending = normalized.requestId ? this.pending.get(normalized.requestId) : undefined;
 
-          if (!pending && resp.type && resp.data) {
+          if (!pending && normalized.eventType && resp.data) {
             // Orphan event (e.g. subagent_result after main agent finished)
             // Forward to all renderer windows so late events are not dropped.
-            const eventKey = `CHAT_${resp.type.toUpperCase()}`;
+            // Use normalized.eventType (not raw resp.type) so events sent via
+            // the "event" field are handled correctly — consistent with the
+            // primary handler (#335).
+            const eventKey = `CHAT_${normalized.eventType.toUpperCase()}`;
             const channel = IPC_EVENTS[eventKey as keyof typeof IPC_EVENTS];
             if (channel) {
               const allWindows = BrowserWindow.getAllWindows();


### PR DESCRIPTION
- [x] 🐛 Bug 修复

## 变更概述

次级 line handler（孤儿事件转发）改用 normalizeBridgeMessage 归一化后的 eventType。

## 背景/问题

normalizeBridgeMessage（bridge.ts:74-78）归一化了 type 和 event 两个字段。主 handler（bridge.ts:260）正确使用归一化的 resp.eventType，但次级 handler 直接使用 raw resp.type。如果 Python 桥使用 event 字段发射事件，主 handler 正确处理而次级 handler 静默丢弃孤儿事件。

## 变更内容

apps/desktop/src/main/bridge.ts — resp.type -> normalized.eventType（2 处：条件判断 + key 构造）。

## 日志/验证证据

```
修复前: secondary handler 使用 raw resp.type
修复后: secondary handler 使用 normalized.eventType（= resp.type || resp.event）
```


## 测试情况

- 归一化结果等价于 resp.type || resp.event，不会遗漏
- 与主 handler 保持一致性

## 截图

无需截图（无 UI 变更）

Fixes #335
