### PR TITLE
fix(bridge): guard _log against OSError when stderr is closed during shutdown

### DIFF
--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -54,7 +54,11 @@ def _log(msg: str, level: str = "INFO") -> None:
     Also routes through loguru so that all loguru-based modules (sandbox,
     agent loop, etc.) appear in the same stream.
     """
-    print(f"[miqi-bridge] {msg}", file=sys.stderr, flush=True)
+    try:
+        print(f"[miqi-bridge] {msg}", file=sys.stderr, flush=True)
+    except OSError:
+        # stderr may be closed during shutdown on Windows / PyInstaller
+        pass
 
 
 def _init_logging() -> None:

--- a/tests/bridge/test_issue_303_log_oserror_shutdown.py
+++ b/tests/bridge/test_issue_303_log_oserror_shutdown.py
@@ -1,0 +1,115 @@
+"""Unit tests for miqi.bridge.server._log OSError handling (issue #303)."""
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class _FailingStderr:
+    """Simulates a closed/invalidated stderr on Windows/PyInstaller shutdown."""
+
+    def write(self, data: str) -> int:
+        raise OSError(22, "Invalid argument")
+
+    def flush(self) -> None:
+        raise OSError(22, "Invalid argument")
+
+
+class _FlakyStderr:
+    """Fails entirely on the first call, then recovers.
+
+    Both write() and flush() raise on the first print() call, so neither
+    can toggle a flag.  We fix this by fail() raising once, then auto-reset.
+    """
+
+    def __init__(self) -> None:
+        self._failed = False
+
+    def write(self, data: str) -> int:
+        if not self._failed:
+            self._failed = True
+            raise OSError(22, "Invalid argument")
+        return len(data)
+
+    def flush(self) -> None:
+        if not self._failed:
+            self._failed = True
+            raise OSError(22, "Invalid argument")
+
+
+def test_log_gracefully_swallows_oserror(monkeypatch) -> None:
+    """_log() should return None when sys.stderr raises OSError."""
+    from miqi.bridge.server import _log
+
+    monkeypatch.setattr(sys, "stderr", _FailingStderr())
+
+    # Must NOT raise — this is the exact scenario from issue #303
+    try:
+        _log("Bridge server stopped")
+    except OSError as exc:
+        pytest.fail(f"_log raised OSError unexpectedly: {exc}")
+
+
+def test_log_works_after_transient_oserror(monkeypatch) -> None:
+    """_log() should recover after a transient stderr failure."""
+    from miqi.bridge.server import _log
+
+    flaky = _FlakyStderr()
+    monkeypatch.setattr(sys, "stderr", flaky)
+
+    # First call should be swallowed (stderr raises, sets _failed=True)
+    _log("first call — stderr broken")
+
+    # Second call should succeed (stderr is recovered)
+    _log("second call — stderr recovered")
+    # No exception = success. _failed was set to True by the first call's
+    # write() failure, so the second call's write() and flush() both pass.
+
+
+def test_log_still_writes_to_stderr_normally() -> None:
+    """_log() writes to stderr when it's healthy (no regression)."""
+    from miqi.bridge.server import _log
+
+    buf = io.StringIO()
+    old_stderr = sys.stderr
+    try:
+        sys.stderr = buf
+        _log("healthy message")
+        output = buf.getvalue()
+        assert "healthy message" in output
+        assert "[miqi-bridge]" in output
+    finally:
+        sys.stderr = old_stderr
+
+
+def test_log_handles_broken_flush(monkeypatch) -> None:
+    """_log() should handle OSError during flush() as well."""
+
+    class _WriteOkFlushFail:
+        def write(self, data: str) -> int:
+            return len(data)
+
+        def flush(self) -> None:
+            raise OSError(22, "Invalid argument")
+
+    from miqi.bridge.server import _log
+
+    monkeypatch.setattr(sys, "stderr", _WriteOkFlushFail())
+    try:
+        _log("shutdown message")
+    except OSError as exc:
+        pytest.fail(f"_log raised OSError during flush: {exc}")
+
+
+def test_log_handles_none_stderr(monkeypatch) -> None:
+    """_log() should handle sys.stderr being None (extreme edge case)."""
+    from miqi.bridge.server import _log
+
+    monkeypatch.setattr(sys, "stderr", None)
+    try:
+        _log("message with no stderr")
+    except Exception as exc:
+        pytest.fail(f"_log raised unexpected exception: {exc}")


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复关闭 MiQi 桌面版时弹出的 OSError 异常，在 `_log()` 中添加 stderr 写入保护。

## 背景/问题

关闭 MiQi v0.7.0 exe 桌面版后弹出 "Unhandled exception in script" 错误。

**根因**：Windows 上 PyInstaller 打包后，进程退出时 `sys.stderr` 可能已被关闭/失效，`_log()` 中 `print(file=sys.stderr)` 抛出 `OSError: [Errno 22] Invalid argument`。

**影响**：用户每次关闭软件都会看到错误弹窗，影响体验。

## 变更内容

- **`miqi/bridge/server.py`**：`_log()` 函数中，将 `print(..., file=sys.stderr, flush=True)` 包裹在 `try/except OSError` 中，静默忽略关闭时 stderr 写入失败（+5/-1）
- **`tests/bridge/test_issue_303_log_oserror_shutdown.py`**：新增 5 个单元测试覆盖各种 OSError 场景

## 日志/验证证据

修复前日志：
```
File "server.py", line 57, in _log
OSError: [Errno 22] Invalid argument
```

修复后：`_log()` 调用不再抛出异常，shutdown 流程正常结束。

```
[miqi-bridge] Bridge server stopped
```

## 测试情况

新增 5 个专项单元测试全部通过：

```
tests/bridge/test_issue_303_log_oserror_shutdown.py::test_log_gracefully_swallows_oserror PASSED
tests/bridge/test_issue_303_log_oserror_shutdown.py::test_log_works_after_transient_oserror PASSED
tests/bridge/test_issue_303_log_oserror_shutdown.py::test_log_still_writes_to_stderr_normally PASSED
tests/bridge/test_issue_303_log_oserror_shutdown.py::test_log_handles_broken_flush PASSED
tests/bridge/test_issue_303_log_oserror_shutdown.py::test_log_handles_none_stderr PASSED
```

全部 227 个 bridge 测试通过，无回归：

```
tests/bridge/ ... 227 passed in 24.90s
```

## 截图

<img width="640" height="275" alt="image" src="https://github.com/user-attachments/assets/e8d44e78-e91a-4e65-829d-35fc3fa27c2e" />
已构建验证

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)