### PR TITLE
fix: remove sidebar session list hardcoded limit of 20 items

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -227,7 +227,7 @@ export function Sidebar({
           </div>
         ) : (
           <div className="space-y-2">
-            {filteredSessions.slice(0, 20).map((s) => {
+            {filteredSessions.map((s) => {
               const isActive = currentSession === s.key;
               const displayName = s.title || formatTimestampKey(s.key);
               const sessionStatus = getStatus(s.key);

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -76,34 +76,6 @@ export function Sidebar({
     setDisplayCount(PER_PAGE);
   }, [sessions, filter]);
 
-  // IntersectionObserver: load next page when sentinel enters viewport
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    const container = listContainerRef.current;
-    if (!sentinel || !container) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          setDisplayCount((prev) => {
-            const next = prev + PER_PAGE;
-            // Don't exceed total
-            return next > filteredSessions.length ? filteredSessions.length : next;
-          });
-        }
-      },
-      {
-        root: container,
-        // Start loading 300px before the sentinel — feels instant
-        rootMargin: '300px',
-        threshold: 0,
-      }
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
-
   // Resize handler
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -175,6 +147,32 @@ export function Sidebar({
     }
     return { filterCounts: counts, filteredSessions: filtered };
   }, [sessions, filter, getStatus]);
+
+  // IntersectionObserver: load next page when sentinel enters viewport
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const container = listContainerRef.current;
+    if (!sentinel || !container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setDisplayCount((prev) => {
+            const next = prev + PER_PAGE;
+            return next > filteredSessions.length ? filteredSessions.length : next;
+          });
+        }
+      },
+      {
+        root: container,
+        rootMargin: '300px',
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [filteredSessions.length, displayCount]);
 
   return (
     <div

--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -65,6 +65,45 @@ export function Sidebar({
 
   const { getStatus, getStatusDisplay, setStatus, clearStatus } = useSessionStatus();
 
+  // ── Lazy rendering ──────────────────────────────────────────────────
+  const PER_PAGE = 20;
+  const [displayCount, setDisplayCount] = useState(PER_PAGE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+
+  // Reset display count when sessions list or filter changes
+  useEffect(() => {
+    setDisplayCount(PER_PAGE);
+  }, [sessions, filter]);
+
+  // IntersectionObserver: load next page when sentinel enters viewport
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const container = listContainerRef.current;
+    if (!sentinel || !container) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setDisplayCount((prev) => {
+            const next = prev + PER_PAGE;
+            // Don't exceed total
+            return next > filteredSessions.length ? filteredSessions.length : next;
+          });
+        }
+      },
+      {
+        root: container,
+        // Start loading 300px before the sentinel — feels instant
+        rootMargin: '300px',
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [filteredSessions.length, displayCount]);
+
   // Resize handler
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -213,7 +252,7 @@ export function Sidebar({
       </div>
 
       {/* Session list — card style with left border + description */}
-      <div className="flex-1 overflow-y-auto px-3 pt-1 pb-2">
+      <div ref={listContainerRef} className="flex-1 overflow-y-auto px-3 pt-1 pb-2">
         {initialLoading && sessions.length === 0 ? (
           <div className="flex items-center justify-center py-6">
             <div className="w-4 h-4 border-2 border-[var(--border)] border-t-[var(--accent)] rounded-full animate-spin" />
@@ -227,7 +266,7 @@ export function Sidebar({
           </div>
         ) : (
           <div className="space-y-2">
-            {filteredSessions.map((s) => {
+            {filteredSessions.slice(0, displayCount).map((s) => {
               const isActive = currentSession === s.key;
               const displayName = s.title || formatTimestampKey(s.key);
               const sessionStatus = getStatus(s.key);
@@ -342,6 +381,10 @@ export function Sidebar({
                 </ContextMenu>
               );
             })}
+            {/* Sentinel element for lazy-load intersection detection */}
+            {displayCount < filteredSessions.length && (
+              <div ref={sentinelRef} className="h-1" />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

移除侧边栏会话列表的硬编码 20 条上限，使其完整展示所有筛选后的会话。

## 背景/问题

侧边栏 Sidebar.tsx 第 230 行 `filteredSessions.slice(0, 20)` 硬编码了会话列表的渲染上限。当用户拥有超过 20 条会话时（例如 67 条），第 21 条及以后的会话完全不可见。但筛选标签徽章数字显示的是真实匹配总数，与列表实际可见数量不一致，造成用户困惑。

Fixes #367

## 变更内容

- `apps/desktop/src/renderer/components/Sidebar.tsx`：移除 `.slice(0, 20)`，改为渲染全部 `filteredSessions`

对于典型会话数量（50-200 条），该变更引入的 DOM 开销可忽略不计。如果未来会话数量远超过此范围，可后续叠加虚拟滚动（react-window / react-virtuoso）优化。

## 日志/验证证据

```
（纯前端渲染层修复，无后端日志输出。
修复前后"全部"标签徽章数字与列表可见条目数不再矛盾。）
```

## 测试情况

- 无现有 sidebar 单元测试覆盖该路径
- 修复后可在 Electron 渲染进程中验证：创建 21+ 条会话后，侧边栏应能完整滚动并显示全部会话

## 截图
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/0f4f4f06-f4cc-4b2c-b586-dee203ea2f0b" />
