### PR TITLE
fix(desktop): remove displayCount from IntersectionObserver effect deps

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -172,7 +172,7 @@ export function Sidebar({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
+  }, [filteredSessions.length]);
 
   return (
     <div


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复
## 变更概述
从 Sidebar IntersectionObserver effect 的依赖数组中移除 displayCount，消除每次翻页都重建 observer 的问题。
## 背景
setDisplayCount 已经使用函数式更新模式 (prev => ...)，不需要从闭包捕获 displayCount。放在 deps 里会导致每次翻页 disconnect + 重建 observer，在 tall viewports 会级联加载所有页，违背懒加载初衷。
## 变更
- apps/desktop/src/renderer/components/Sidebar.tsx:175 — 移除 displayCount 依赖
## 测试
npm test — 99 passed, no regressions
🤖 Generated with [Claude Code](https://claude.com/claude-code)