### PR TITLE
fix(desktop): remove displayCount from IntersectionObserver effect deps

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -172,7 +172,7 @@ export function Sidebar({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
+  }, [filteredSessions.length]);
 
   return (
     <div


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
从 Sidebar IntersectionObserver effect 依赖数组中移除冗余的 `displayCount`。

## 背景
`setDisplayCount` 已使用函数式更新 (`prev => ...`)，不需要捕获 `displayCount`。放在 deps 里导致每次翻页 disconnect + 重建 observer——在高视口下会级联加载所有页，违背懒加载初衷。

## 变更
- `apps/desktop/src/renderer/components/Sidebar.tsx:175` — deps 从 `[filteredSessions.length, displayCount]` 改为 `[filteredSessions.length]`

## 测试
`npm test` — 99 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)