### PR TITLE
fix(desktop): remove displayCount from IntersectionObserver effect deps

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -172,7 +172,7 @@ export function Sidebar({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
+  }, [filteredSessions.length]);
 
   return (
     <div


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
IntersectionObserver useEffect deps 中移除多余的 displayCount。

## 背景
setDisplayCount 已用函数式更新 (prev => ...)，闭包里不需要 displayCount。放在 deps 里导致每次翻页 disconnect + 重建 observer。

## 变更
`Sidebar.tsx:175` — `[filteredSessions.length, displayCount]` → `[filteredSessions.length]`

## 测试
`npm test` — 99 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)