### PR TITLE
fix(desktop): remove displayCount from IntersectionObserver effect deps

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -172,7 +172,7 @@ export function Sidebar({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
+  }, [filteredSessions.length]);
 
   return (
     <div


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
从 Sidebar 的 IntersectionObserver useEffect 依赖数组中移除多余的 `displayCount`。

## 背景/问题
`setDisplayCount` 已使用函数式更新模式 (`prev => ...`)，不需要从闭包中捕获 `displayCount`。放在依赖数组里会导致每次翻页时 disconnect + 重建 observer — 在高视口下会级联加载所有页，违背懒加载的初衷。

## 变更内容
- `apps/desktop/src/renderer/components/Sidebar.tsx` 第 175 行：`[filteredSessions.length, displayCount]` → `[filteredSessions.length]`

## 日志/验证证据
```
（前端渲染层优化，无后端日志输出。
修改前后用户视觉行为一致，仅减少了 observer 重建次数。）
```

## 测试情况
`npm test` — 99 passed, no regressions.

## 截图
无需截图