### PR TITLE
fix(desktop): remove unnecessary displayCount dep from IntersectionObserver effect

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -172,7 +172,7 @@ export function Sidebar({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filteredSessions.length, displayCount]);
+  }, [filteredSessions.length]);
 
   return (
     <div


### PR DESCRIPTION
﻿## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

移除 IntersectionObserver useEffect 中多余的 displayCount 依赖，避免每次翻页时 observer 不必要的断开/重连。

## 背景/问题

#368 引入的 IntersectionObserver 在依赖数组中包含了 displayCount，但回调内用的是 functional updater（setDisplayCount((prev) => ...)），从未从闭包中读取 displayCount。每加载新一页 displayCount 变化，observer 就被 disconnect 再重建——纯属浪费。

Follow-up to #368。

## 变更内容

- apps/desktop/src/renderer/components/Sidebar.tsx：将 useEffect 依赖从 [filteredSessions.length, displayCount] 改为 [filteredSessions.length]

## 日志/验证证据

```
（一行依赖变更，无日志输出。
observer 不再因翻页而重建，行为无变化。）
```

## 测试情况

- 无现有单测覆盖该路径
- 逻辑上 functional updater 不依赖 displayCount，移除后不影响行为

## 截图

无需截图
