### PR TITLE
feat(feedback): hardcode Feishu App credentials + Bitable target as schema defaults

### DIFF
--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -161,14 +161,16 @@ class FeishuChannelConfig(Base):
 class FeedbackConfig(Base):
     """User feedback collection configuration (submit to Feishu Bitable).
 
-    Default is enabled=True so the Settings → 反馈 tab is functional
-    out-of-the-box.  Users fill in the bitable_app_token /
-    bitable_table_id from their Feishu Bitable URL to enable submission.
+    Hardcoded defaults ship with the application so that end users can
+    submit feedback with zero configuration.  The Feishu App permissions
+    are scoped to the single target Bitable table only.
     """
 
     enabled: bool = True
-    bitable_app_token: str = ""   # Bitable app_token (from URL "base/xxx")
-    bitable_table_id: str = ""    # Bitable table id (from URL "?table=tblxxx")
+    feishu_app_id: str = "cli_aaea960221b8dbea"
+    feishu_app_secret: str = "0mutMgBMlqCOH4xoR2vkTcxSFQvrRIWk"
+    bitable_app_token: str = "XdLzbs2cUaLubKsDisBcVnXknrf"
+    bitable_table_id: str = "tblXphMl4M8vjyco"
 
 
 class ChannelsConfig(Base):

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -359,13 +359,22 @@ async def feedback_submit_handler(
     if not fb_cfg.enabled:
         raise AppServerError("反馈功能未启用，请在配置中开启", code="FEEDBACK_DISABLED")
 
-    app_id = config.channels.feishu.app_id
-    app_secret = config.channels.feishu.app_secret
+    # --- Resolve credentials in order (most specific → global fallback → built-in defaults) ---
+
+    # 1. App Id / Secret: try FeedbackConfig overrides first, then channels.feishu, then schema default
+    app_id = fb_cfg.feishu_app_id or config.channels.feishu.app_id
+    app_secret = fb_cfg.feishu_app_secret or config.channels.feishu.app_secret
+
+    # 2. Bitable target: FeedbackConfig always has hardcoded defaults from schema
+    bitable_app_token = fb_cfg.bitable_app_token
+    bitable_table_id = fb_cfg.bitable_table_id
+
+    # Only fail when the resolved values are truly blank (would be a broken schema build)
     if not app_id or not app_secret:
         raise AppServerError(
             "飞书 App ID / App Secret 未配置", code="FEISHU_NOT_CONFIGURED",
         )
-    if not fb_cfg.bitable_app_token or not fb_cfg.bitable_table_id:
+    if not bitable_app_token or not bitable_table_id:
         raise AppServerError(
             "飞书多维表格 app_token / table_id 未配置", code="BITABLE_NOT_CONFIGURED",
         )
@@ -416,14 +425,14 @@ async def feedback_submit_handler(
                     filename=filename,
                     content_type=mime,
                     data=raw,
-                    parent_node=fb_cfg.bitable_app_token,
+                    parent_node=bitable_app_token,
                 )
                 file_tokens.append({"file_token": file_token})
             fields["附件"] = file_tokens
 
         # 5b. Add the Bitable record (with attachment references)
         record_id = _add_bitable_record(
-            token, fb_cfg.bitable_app_token, fb_cfg.bitable_table_id, fields,
+            token, bitable_app_token, bitable_table_id, fields,
         )
     except AppServerError:
         raise

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -268,6 +268,9 @@ async def test_feedback_submit_rejects_when_no_feishu_credentials(_bridge_state_
 
     workspace = _make_workspace()
     state = _make_mock_state(workspace, app_id="", app_secret="")
+    # Override schema default that ships with the app
+    state.load_config.return_value.channels.feedback.feishu_app_id = ""
+    state.load_config.return_value.channels.feedback.feishu_app_secret = ""
     _bridge_state_isolated._state = state
     registry = ClientSessionRegistry()
     registry.bridge_context["state"] = state
@@ -285,6 +288,9 @@ async def test_feedback_submit_rejects_when_no_bitable_config(_bridge_state_isol
 
     workspace = _make_workspace()
     state = _make_mock_state(workspace, bitable_app_token="", bitable_table_id="")
+    # Override schema default that ships with the app
+    state.load_config.return_value.channels.feedback.bitable_app_token = ""
+    state.load_config.return_value.channels.feedback.bitable_table_id = ""
     _bridge_state_isolated._state = state
     registry = ClientSessionRegistry()
     registry.bridge_context["state"] = state


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] ✨ 新功能
- [ ] 🐛 Bug 修复
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

硬编码飞书 Feedback App 凭据 + Bitable 目标到 `FeedbackConfig` schema 默认值中，终端用户零配置即可提交反馈。

## 背景/问题

之前 `FeedbackConfig` 的 `bitable_app_token` / `bitable_table_id` 默认为空字符串，用户的 `~/.miqi/config.json` 里也没有这些值，导致反馈提交流程报错 `BITABLE_NOT_CONFIGURED`。用户在飞书侧已创建专用 App（`cli_aaea960221b8dbea`），权限限定到单张 Bitable 表，blast radius 可控。

## 变更内容

| 文件 | 变更 |
|------|------|
| `miqi/config/schema.py` | `FeedbackConfig` 新增 `feishu_app_id` / `feishu_app_secret` 字段，4 个字段全部硬编码默认值；更新 docstring 说明零配置语义 |
| `miqi/runtime/feedback_handlers.py` | 凭据解析链改为 `FeedbackConfig override → channels.feishu → schema 默认值`，变量名从 `fb_cfg.bitable_*` 改为局部变量 `bitable_*`，`parent_node` 和 `_add_bitable_record` 调用同步使用局部变量 |
| `tests/runtime/test_feedback_handlers.py` | 两个 reject 测试显式覆盖 schema 默认值为空字符串后再断言 `BITABLE_NOT_CONFIGURED` / `FEISHU_NOT_CONFIGURED` |

## 日志/验证证据

```
=== 真实端到端提交 ===
Token OK
SUCCESS record_id=recvq48FI1ckdH

=== 验证写入字段完整性 ===
  Python版本: 3.12.10
  使用的提示词: 测试提示词 - 用于验证提交功能
  复现频率: 必现
  应用版本: 0.1.0
  提交时间: 2026-07-22T02:38:48.632148+00:00
  操作系统: Windows 11 (AMD64)
  日志内容（设置界面日志栏目-复制日志）: [TEST] 日志内容最多支持100k字符...
  标题: [TEST] ...
  类别: 功能建议
  联系方式: 2423580963@qq.com
  详细描述（复现步骤，期望行为，实际行为等）: ...
Total fields: 11
```

## 测试情况

- Python unit: **57/57 pass**（feedback handlers + protocol snapshot + contract audits）
- 真实 Feishu API 端到端：**`recvq48FI1ckdH`** — 新 App 11 字段全部写入成功
- E2E (mock IPC): 无变更（disabled feedback 的 mock 路径不受 schema default 影响）

🤖 Generated with [Claude Code](https://claude.com/claude-code)