### PR TITLE
fix(runtime): add missing loguru import in context_runtime and model_client

### DIFF
--- a/miqi/kun_runtime/model_client.py
+++ b/miqi/kun_runtime/model_client.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
+from loguru import logger
+
 from miqi.providers.base import LLMProvider
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/miqi/runtime/context_runtime.py
+++ b/miqi/runtime/context_runtime.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Awaitable
 
+from loguru import logger
+
 from miqi.execution.hook_runtime import (
     HookPoint,
     HookRuntime,


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #382：`context_runtime.py` 和 `model_client.py` 缺少 `from loguru import logger`，导致长对话触发 `trim_for_model` 时抛出 `NameError`。

## 背景/问题

commit `fa73385d`（#291）新增 `trim_for_model` 方法时使用了 `logger.warning()` 和 `logger.info()`，但遗漏了 loguru 导入。当对话 token 数超过模型上限 80% 触发 pre-send context guard 时，`NameError` 向上传播到 `task_runner.py` 的 `except Exception` 块，用户看到通用错误，对话无法继续。

## 变更内容

- `miqi/runtime/context_runtime.py`: 在 `from __future__` 之后添加 `from loguru import logger`
- `miqi/kun_runtime/model_client.py`: 同上

两个文件各 +1 行，共 4 insertions。

## 日志/验证证据

```
修复前（NameError）：
miqi.runtime.task_runner:_handle_user_message:788 | Agent processing error in turn xxx: name 'logger' is not defined

修复后（logger 正常输出）：
miqi.runtime.context_runtime:trim_for_model:328 | Pre-send guard: estimated 743184 tokens exceeds 102400 limit for deepseek-v4-pro (model max=128000); trimming oldest turns
miqi.runtime.context_runtime:trim_for_model:357 | Pre-send guard: messages 61 -> 3 (est tokens 715675 -> 715592)
```

## 测试情况

- [x] pytest tests/runtime/test_context_runtime.py: 10/10 全部通过
- [x] 代码级验证：under-limit 不裁剪、system+last user 保留、无孤儿 tool 消息、连续 tool 完整

## 截图

无需截图。