### PR TITLE
fix(runtime): trim complete turns in trim_for_model to preserve message structure

### DIFF
--- a/miqi/runtime/context_runtime.py
+++ b/miqi/runtime/context_runtime.py
@@ -309,12 +309,13 @@ class ContextRuntime:
         """Hard-trim messages to fit within the model's input token limit.
 
         This is the LAST-RESORT safety net — it runs right before the
-        provider call and discards the oldest assistant+tool pairs until
-        the estimated token count is under 80% of the model's maximum.
+        provider call and discards the oldest complete turns
+        (user→assistant→tool(s)) until the estimated token count is
+        under 80% of the model's maximum.
 
-        Always keeps the system prompt (index 0 if role=='system') and at
-        least the last user message. Returns messages unchanged when they
-        already fit.
+        Always keeps the system prompt (index 0 if role=='system'),
+        one extra message after it, and the last message.  Returns
+        messages unchanged when they already fit.
         """
         max_input = self._resolve_model_max_input(model)
         hard_limit = int(max_input * self._CONTEXT_SAFETY_FACTOR)
@@ -325,7 +326,7 @@ class ContextRuntime:
 
         logger.warning(
             "Pre-send guard: estimated {} tokens exceeds {} limit for {} "
-            "(model max={}); trimming oldest pairs",
+            "(model max={}); trimming oldest turns",
             est, hard_limit, model, max_input,
         )
 
@@ -338,18 +339,27 @@ class ContextRuntime:
             if est <= hard_limit:
                 break
 
-            # Find the oldest cuttable message pair: assistant [+ tool(s)]
+            # Find the oldest complete turn to remove.  A turn starts
+            # with 'user'.  We skip any leading 'assistant' or 'tool'
+            # messages whose corresponding user message sits inside the
+            # protected head area.
             cut_start = None
             for i in range(head_protect, len(work) - 1):
                 role = work[i].get("role")
-                if role in ("assistant", "tool"):
+                if role == "user":
                     cut_start = i
                     break
             if cut_start is None:
                 break
 
-            # Collect a single message to drop
-            removed = work.pop(cut_start)
+            # Remove user + all following messages until the next user
+            # (i.e. one complete user→assistant→tool(s) turn).
+            # Always keep the last message as the most-recent user prompt.
+            work.pop(cut_start)  # remove user
+            while cut_start < len(work) - 1:
+                if work[cut_start].get("role") == "user":
+                    break  # next turn starts here — stop
+                work.pop(cut_start)  # remove assistant / tool
 
         est_after = self.estimate_tokens(work)
         logger.info(


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #383：`trim_for_model` 裁剪时改为以完整 turn（user→assistant→tool(s)）为单位删除，保持 API 消息结构完整性，消除 `tool` 孤儿导致的 400 错误。

## 背景/问题

`trim_for_model`（#291 引入）在超长对话触发裁剪时逐条删除消息，不保持 assistant+tool 的配对关系。当删除一个带 `tool_calls` 的 `assistant` 消息时，后续 `tool` 消息失去前置 `assistant`，API 返回 400：

```
Messages with role 'tool' must be a response to a preceding message with 'tool_calls'
```

## 变更内容

- `miqi/runtime/context_runtime.py`: `trim_for_model` 裁剪逻辑重写
  - 扫描目标从 `role in ("assistant", "tool")` 改为 `role == "user"`（定位完整 turn 起点）
  - 删除方式从单条 `pop` 改为移除 user + 循环移除其后所有 assistant/tool 直到下个 user
  - 始终保留最后一条消息 + protected head（system + 1 extra）
  - docstring 和日志措辞同步："pairs" → "turns"

1 文件，+20 / -10 行。

## 日志/验证证据

```
修复前（API 400 错误）：
miqi.runtime.context_runtime:trim_for_model:328 | Pre-send guard: messages 61 -> 3 (est tokens 715675 -> 715592)
openai.BadRequestError: Error code: 400 - Messages with role 'tool' must be a response to a preceding message with 'tool_calls'

修复后（4 个场景全部通过）：
Test 1 PASS: under-limit messages unchanged (4 msgs)
Test 2 PASS: system and last user preserved (4 msgs)
Test 3 PASS: no orphan tool messages (7 msgs)
Test 4 PASS: consecutive tool messages kept intact, tool ids: ['1', '2']
All tests passed!
```

## 测试情况

- [x] pytest tests/runtime/test_context_runtime.py: 10/10 全部通过，无回归
- [x] 手工验证 4 场景：不超限不裁剪、system+last user 保留、无孤儿 tool、连续 tool 完整

## 截图

无需截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)