### PR TITLE
fix: replace hardcoded /tmp with tempfile.gettempdir() (refs #388 code review)

### DIFF
--- a/tests/execution/test_execution_policy.py
+++ b/tests/execution/test_execution_policy.py
@@ -350,11 +350,12 @@ class TestPlanModeCapabilityConstraints:
         """Plan mode system prompt uses read-only analysis language."""
         from miqi.runtime.turn_context import TurnContext
         from pathlib import Path
+        import tempfile
 
         tc = TurnContext(
             turn_id="test",
             thread_id="t1",
-            workspace=Path("/tmp"),
+            workspace=Path(tempfile.gettempdir()),
             model="m",
             agent_metadata=FakeAgentMetadata(),
             provider=None,


### PR DESCRIPTION
## 类型

- [x] ♻️ 重构（CodeRabbit review fix）

## 变更概述

修复 #388 CodeRabbit review 中发现的 `/tmp` 硬编码问题：用 `tempfile.gettempdir()` 替代。

## 背景/问题

CodeRabbit 在 #388 中标记了 `tests/execution/test_execution_policy.py:357` 的 `Path("/tmp")` 为 S108（不安全临时文件使用）。

## 变更内容

- `test_plan_system_prompt_references_readonly_analysis`: `Path("/tmp")` → `Path(tempfile.gettempdir())`

## 日志/验证证据

```
1 passed in 0.11s
```

## 测试情况

- [x] `test_plan_system_prompt_references_readonly_analysis` — PASS

## 截图

无需截图

---

Refs: #388