### PR TITLE
fix(#387): defer hot reload restart instead of silently skipping when pending requests exist

### DIFF
--- a/apps/desktop/src/main/bridge.test.ts
+++ b/apps/desktop/src/main/bridge.test.ts
@@ -768,8 +768,9 @@ describe('BridgeManager lifecycle', () => {
 
     (bridge as any).handleFileChange('test.py');
 
-    // Should have logged about skipping, not restarted
-    expect(logs.some((l: string) => l.includes('Skipping restart'))).toBe(true);
+    // Should have deferred restart (not skipped silently — #387)
+    expect(logs.some((l: string) => l.includes('Deferring restart'))).toBe(true);
+    expect((bridge as any).deferredRestart).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -179,6 +179,7 @@ export class BridgeManager extends EventEmitter {
   private reloadCooldown: number = 1000; // 1 second cooldown between reloads
   private reloadTimer: ReturnType<typeof setTimeout> | null = null;
   private restartInProgress: boolean = false;
+  private deferredRestart: boolean = false;
   private initialized: boolean = false;
   private clientId: string = 'miqi-desktop';
   private stoppingPromise: Promise<void> | null = null;
@@ -299,6 +300,9 @@ export class BridgeManager extends EventEmitter {
                     pending.resolve(resp.data);
                   }
                 }
+                // After resolving a terminal event, check if a deferred
+                // restart was requested by the file watcher (#387).
+                this._checkDeferredRestart();
                 // Terminal: skip bridge-event
                 return;
               }
@@ -662,9 +666,13 @@ export class BridgeManager extends EventEmitter {
       return;
     }
 
-    // Don't restart if there are active requests — avoid killing sessions
+    // Defer restart if there are active requests — avoid killing sessions.
+    // The restart will be triggered when the last pending request completes.
     if (this.pending.size > 0) {
-      this.addLog(`[Hot Reload] Skipping restart — ${this.pending.size} pending request(s)`);
+      this.addLog(
+        `[Hot Reload] Deferring restart due to ${this.pending.size} pending request(s)`,
+      );
+      this.deferredRestart = true;
       return;
     }
 
@@ -679,6 +687,17 @@ export class BridgeManager extends EventEmitter {
         this.addLog(`[Hot Reload] Restart error: ${err}`);
       });
     }, 500);
+  }
+
+  /** Trigger a deferred restart after pending requests complete (#387). */
+  private _checkDeferredRestart(): void {
+    if (!this.deferredRestart) return;
+    // Only fire when all pending requests have settled
+    if (this.pending.size > 0) return;
+    this.deferredRestart = false;
+    this.addLog('[Hot Reload] Triggering deferred restart after pending requests completed');
+    // Use handleFileChange's debounce + restart flow
+    this.handleFileChange('(deferred)');
   }
 
   private async restart(): Promise<void> {


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

Hot Reload 在 pending request 期间跳过文件变更后**永久丢弃**该变更，改为标记 `deferredRestart` 标志位，等 pending 请求完成后自动触发延迟重启。

## 背景/问题

Closes #387。

### 复现步骤

1. 文件 A 变更 → Hot Reload 重启 bridge ✅
2. 用户在 bridge 重启后立即发消息（chat.send 进行中）
3. 文件 B 变更 → `pending.size > 0` → 旧逻辑：`return`（**永丢**）
4. bridge 运行新版 A + 旧版 B → `NameError`

### 实际日志

```
14:27:35  Detected change: runtime\task_runner.py      → 重启 ✅
14:27:51  Detected change: providers\__init__.py       → pending > 0 → 跳过 ❌
14:27:53  chat.send → NameError: name 'logger' is not defined
```

## 变更内容

新增 `deferredRestart: boolean` 标志位 + `_checkDeferredRestart()` 方法。

**流程对比：**

```
Before:  变更检测 → pending? → return（永丢）
After:   变更检测 → pending? → deferredRestart=true → return
          终端事件 → _checkDeferredRestart() → 触发延迟重启
```

### 改动点

| 位置 | 变更 |
|------|------|
| `bridge.ts:174` | 新增 `deferredRestart: boolean = false` |
| `bridge.ts:660-665` | `handleFileChange`: pending 时设 `deferredRestart=true` 而非静默 return |
| `bridge.ts:296` | 终端事件处理后调 `_checkDeferredRestart()` |
| `bridge.ts:686-695` | 新增 `_checkDeferredRestart()`: 检查标志位 + pending 清空时触发重启 |

## 日志/验证证据

```
Python tests:
============================= 50 passed in 1.56s ==============================

TypeScript web typecheck: clean (0 errors)
TypeScript node typecheck: 2 pre-existing bridge.ts errors (lines 890,904 — `timeout` used before assigned, same on develop)
```

## 测试情况

- [x] Python execution policy tests: 34/34 pass
- [x] Python bridge tests: 16/16 pass
- [x] TypeScript web typecheck: clean
- [x] TypeScript node typecheck: 0 new errors (2 pre-existing)
- [ ] 手动复现：编辑 2 个 Python 文件，在第一个重启后立即发消息 → 确认第二个文件变更被延迟重启捕获

## 截图

无需截图（纯 backend bridge 逻辑）

## 与已有 PR 的关系

- 本 PR 是独立的 Hot Reload bug fix
- 与 #388（Plan mode）、#389（CodeRabbit review）、#391（first-token timeout）无依赖关系
- 合并后关闭 #387