### PR TITLE
fix(#379): add first-token timeout to prevent indefinite agent turn hangs before streaming starts

### DIFF
--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -20,8 +20,9 @@ from miqi.providers.base import LLMProvider, LLMResponse, ToolCallRequest
 from miqi.providers.registry import find_by_model, find_by_name, find_gateway
 from miqi.providers.resilience import ErrorKind
 
-DEFAULT_REQUEST_TIMEOUT = 600.0
-DEFAULT_STREAM_IDLE_TIMEOUT = 60.0
+DEFAULT_REQUEST_TIMEOUT = 120.0
+DEFAULT_FIRST_TOKEN_TIMEOUT = 60.0
+DEFAULT_STREAM_IDLE_TIMEOUT = 30.0
 
 # Standard OpenAI chat-completion message keys; extras (e.g. reasoning_content) are
 # stripped for providers that reject unknown fields.
@@ -412,22 +413,35 @@ class OpenAIProvider(LLMProvider):
         usage: dict[str, int] = {}
 
         aiter = stream.__aiter__()
+        is_first = True
         while True:
             try:
-                async with asyncio.timeout(self._stream_idle_timeout):
+                timeout = DEFAULT_FIRST_TOKEN_TIMEOUT if is_first else self._stream_idle_timeout
+                async with asyncio.timeout(timeout):
                     chunk = await anext(aiter)
             except StopAsyncIteration:
                 break
             except asyncio.TimeoutError:
-                logger.warning("LLM stream idle timeout for model %s", resolved)
-                yield LLMStreamEvent(
-                    kind="completed",
-                    response=LLMResponse(
-                        content="An unexpected error occurred while processing your request.",
-                        finish_reason="error",
-                        error_kind=ErrorKind.TRANSIENT.value,
-                    ),
-                )
+                if is_first:
+                    logger.warning("LLM first-token timeout for model %s (%.0fs)", resolved, timeout)
+                    yield LLMStreamEvent(
+                        kind="completed",
+                        response=LLMResponse(
+                            content="The model did not respond within the first-token timeout. This may indicate the model is overloaded or stuck in a long reasoning phase. Please try again or use a different model.",
+                            finish_reason="error",
+                            error_kind=ErrorKind.TRANSIENT.value,
+                        ),
+                    )
+                else:
+                    logger.warning("LLM stream idle timeout for model %s", resolved)
+                    yield LLMStreamEvent(
+                        kind="completed",
+                        response=LLMResponse(
+                            content="An unexpected error occurred while processing your request.",
+                            finish_reason="error",
+                            error_kind=ErrorKind.TRANSIENT.value,
+                        ),
+                    )
                 return
             except Exception as e:
                 logger.exception("LLM streaming error for model %s", resolved)
@@ -451,6 +465,8 @@ class OpenAIProvider(LLMProvider):
                         "total_tokens": getattr(chunk.usage, "total_tokens", 0) or 0,
                     }
                 continue
+
+            is_first = False  # first real content chunk received
 
             delta = chunk.choices[0].delta
             choice_finish = chunk.choices[0].finish_reason


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

将单一的 600s request timeout 拆为三层：connection 120s / first-token 60s / stream idle 30s。模型在 60s 内不产生首个 chunk 即触发 TRANSIENT 错误，由 resilience 层自动 retry。

## 背景/问题

Closes #379。

当前 streaming provider 只有两层超时：

| 层级 | 超时 | 缺陷 |
|------|------|------|
| Request timeout | 600s | 模型卡住用户等 10 分钟 |
| Stream idle timeout | 60s | 只保护已开始的 stream，第一个 chunk 前无保护 |

**症状**：DeepSeek-v4-pro 在 Plan mode 下处理 "搜索今日要闻" 时，因 system prompt 触发长推理链，600s 内不产生任何 token → `Turn timed out after 600s`。

## 变更内容

```python
# Before
DEFAULT_REQUEST_TIMEOUT = 600.0
DEFAULT_STREAM_IDLE_TIMEOUT = 60.0

# After
DEFAULT_REQUEST_TIMEOUT = 120.0        # HTTP connection + response lifetime
DEFAULT_FIRST_TOKEN_TIMEOUT = 60.0     # first chunk deadline (NEW)
DEFAULT_STREAM_IDLE_TIMEOUT = 30.0     # per-chunk idle deadline
```

**stream_chat 循环改动**：用 `is_first` 标记切换超时值。首 chunk 用 60s，后续 chunk 用 30s。收到第一个有内容 chunk 后设 `is_first = False`。usage-only chunk（`stream_options: include_usage`）不触发切换。

超时错误类型为 `ErrorKind.TRANSIENT`，被 `resilience.with_retry(max_attempts=3)` 自动重试。

## 日志/验证证据

```
Python tests:
============================= 50 passed in 1.56s ==============================

Python syntax: compile(open('openai_provider.py').read(), ...) → OK
Python import: from miqi.providers.openai_provider import OpenAIProvider → OK
```

## 测试情况

- [x] Python execution policy tests: 34/34 pass
- [x] Python bridge tests: 16/16 pass
- [x] Python syntax check: OK
- [ ] 手动测试：DeepSeek-v4-pro + Plan mode → 60s 内报 first-token 或正常响应
- [ ] 单元测试：mock stream 不产生 chunk → 60s 后 TRANSIENT error → retry 生效

## 截图

无需截图（纯 provider 超时配置）

## 与已有 PR 的关系

- 本 PR 是独立的 streaming infrastructure 改进
- 与 #388（Plan mode prompt）、#389（CodeRabbit review）、#390（Hot Reload）无依赖关系
- 合并后关闭 #379