### PR TITLE
fix(#392): translate all user-facing error messages to Chinese

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -794,8 +794,8 @@ class BridgeRuntimeLoop:
                     )
                     await _emit_terminal("error", {
                         "message": (
-                            f"Turn timed out after "
-                            f"{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s"
+                            f"Turn 超时（"
+                            f"{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s）"
                         ),
                     })
                     break
@@ -897,7 +897,7 @@ class BridgeRuntimeLoop:
             if len(raw) > 300:
                 raw = raw[:300] + "…"
             await _emit_terminal("error", {
-                "message": f"Bridge drain error: {raw}",
+                "message": f"Bridge 事件循环错误：{raw}",
             })
 
     # ── agent.spawn / agent.kill handlers ──────────────────────────────────

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -232,7 +232,7 @@ class ToolOrchestrator:
                     verdict=PermissionVerdict.DENY,
                     reason=f"Blocked by hook: {outcome.reason}",
                 )
-                ctx.result = f"Permission denied: {outcome.reason}"
+                ctx.result = f"权限被拒绝：{outcome.reason}"
                 ctx.status = OrchestrationResult.DENIED_BY_POLICY
                 ctx.duration_ms = int((time.monotonic() - start) * 1000)
                 return ctx
@@ -256,7 +256,7 @@ class ToolOrchestrator:
             if self.tools is not None:
                 tool = self.tools.get(ctx.tool_name)
                 if tool is None:
-                    ctx.result = f"Error: Unknown tool '{ctx.tool_name}'"
+                    ctx.result = f"错误：未知工具 '{ctx.tool_name}'"
                     ctx.status = OrchestrationResult.TOOL_ERROR
                     ctx.permission_decision = PermissionDecision(
                         verdict=PermissionVerdict.DENY,
@@ -268,7 +268,7 @@ class ToolOrchestrator:
                 schema_errors = tool.validate_params(ctx.arguments)
                 if isinstance(schema_errors, list) and schema_errors:
                     ctx.result = (
-                        f"Error: Invalid parameters for tool '{ctx.tool_name}': "
+                        "错误：工具 '" + ctx.tool_name + "' 参数无效："
                         + "; ".join(schema_errors)
                         + "\n\n[Analyze the error above and try a different approach.]"
                     )
@@ -285,7 +285,7 @@ class ToolOrchestrator:
             ctx.permission_decision = decision
 
             if decision.verdict == PermissionVerdict.DENY:
-                ctx.result = f"Permission denied: {decision.reason}"
+                ctx.result = f"权限被拒绝：{decision.reason}"
                 ctx.status = OrchestrationResult.DENIED_BY_POLICY
                 return ctx
 
@@ -298,12 +298,12 @@ class ToolOrchestrator:
                         verdict=PermissionVerdict.DENY,
                         reason=f"Blocked by hook: {pr_outcome.reason}",
                     )
-                    ctx.result = f"Permission denied: {pr_outcome.reason}"
+                    ctx.result = f"权限被拒绝：{pr_outcome.reason}"
                     ctx.status = OrchestrationResult.DENIED_BY_POLICY
                     return ctx
                 decision = await self._request_approval(ctx, decision)
                 if decision.verdict != PermissionVerdict.ALLOW:
-                    ctx.result = f"User denied: {decision.reason or 'no reason given'}"
+                    ctx.result = f"用户已拒绝：{decision.reason or '未提供原因'}"
                     ctx.status = OrchestrationResult.DENIED_BY_USER
                     return ctx
 
@@ -331,12 +331,12 @@ class ToolOrchestrator:
                         ctx.tool_name, ctx.retry_count,
                     )
                     if ctx.retry_count > self.MAX_RETRIES:
-                        ctx.result = "Error: sandbox denied after max retries"
+                        ctx.result = "错误：沙箱重试次数已耗尽"
                         ctx.status = OrchestrationResult.SANDBOX_FAILED
                         return ctx
 
                 except asyncio.TimeoutError:
-                    ctx.result = f"Error: tool '{ctx.tool_name}' timed out"
+                    ctx.result = f"错误：工具 '{ctx.tool_name}' 执行超时"
                     ctx.status = OrchestrationResult.TIMEOUT
                     return ctx
 
@@ -344,11 +344,11 @@ class ToolOrchestrator:
             await self.hooks.run_with_outcome(HookPoint.POST_TOOL_USE, ctx)
 
         except asyncio.CancelledError:
-            ctx.result = "Tool execution cancelled"
+            ctx.result = "工具执行已取消"
             ctx.status = OrchestrationResult.CANCELLED
         except Exception as e:
             logger.exception("Tool orchestrator error for {}", ctx.tool_name)
-            ctx.result = f"Error executing {ctx.tool_name}: tool execution failed"
+            ctx.result = f"工具执行失败 {ctx.tool_name}：工具执行异常"
             ctx.status = OrchestrationResult.TOOL_ERROR
 
         finally:
@@ -812,7 +812,7 @@ class ToolOrchestrator:
         tool = self.tools.get(ctx.tool_name)
         if tool is None:
             ctx.status = OrchestrationResult.TOOL_ERROR
-            return f"Error: Unknown tool '{ctx.tool_name}'"
+            return f"错误：未知工具 '{ctx.tool_name}'"
 
         # Inject sandbox context into tool.
         # Phase 31: For exec tool, ALWAYS inject the SandboxSelection so
@@ -880,7 +880,7 @@ class ToolOrchestrator:
                 message=safe_msg,
                 recoverable=True,
             ))
-            result = f"Error executing {ctx.tool_name}: {safe_msg}"
+            result = f"工具执行失败 {ctx.tool_name}：{safe_msg}"
             if ctx.turn_id:
                 result += f"\n[Hint: Use 'exec' to inspect the environment or try a different approach.]"
             ctx.status = OrchestrationResult.TOOL_ERROR

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -793,7 +793,7 @@ class TaskRunner:
             # message; everything else (transient/fatal/unknown) keeps the
             # generic message to avoid leaking internal details.
             logger.error("Agent processing error in turn {}: {}", turn_id, exc, exc_info=True)
-            user_message = "An internal error occurred while processing your message."
+            user_message = "处理消息时发生内部错误，请重试。"
             if prov_err is not None and prov_err.kind is ErrorKind.AUTH:
                 # AUTH is sensitive — surface a fixed, non-leaking message
                 # instead of the raw provider exception text (Plan 58.2).

--- a/miqi/runtime/turn_app_handlers.py
+++ b/miqi/runtime/turn_app_handlers.py
@@ -74,13 +74,13 @@ async def drain_turn_events(
                 await server.emit_event(
                     session.session_id,
                     "error",
-                    {"error": {"message": "Turn timed out after 300s"}},
+                    {"error": {"message": "Turn 超时（300s）"}},
                     request_id=request_id,
                 )
                 await server.emit_event(
                     session.session_id,
                     "turn/completed",
-                    {"turn": turn_view(turn_id, thread_id, "failed", error_message="Turn timed out after 300s")},
+                    {"turn": turn_view(turn_id, thread_id, "failed", error_message="Turn 超时（300s）")},
                     request_id=request_id,
                 )
                 return

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -393,9 +393,9 @@ class TurnRunner:
 
         # Exhausted iterations
         content = (
-            f"Reached maximum iterations ({self._max_iterations}). "
-            f"Tools used: {', '.join(dict.fromkeys(tools_used)) or 'none'}. "
-            f"Try breaking your task into smaller steps."
+            f"已达到最大迭代次数（{self._max_iterations}）。"
+            f"已使用工具：{', '.join(dict.fromkeys(tools_used)) or '无'}。"
+            f"请将任务拆分为更小的步骤重试。"
         )
         messages_delta.append({"role": "assistant", "content": content})
         return TurnResult(

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -397,7 +397,7 @@ async def test_drain_chat_events_sends_backend_timeout_error_directly():
         "id": "req-timeout",
         "type": "error",
         "data": {
-            "message": f"Turn timed out after {CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s",
+            "message": f"Turn 超时（{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s）",
             "session_key": "session-timeout",
         },
     }


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

将 6 个模块中所有用户可见的英文报错消息统一改为中文。

## 背景/问题

Closes #392。

MiQi 面向中文用户，但多个模块的报错消息仍为英文。用户看到 "An internal error occurred" / "Turn timed out after 600s" 等英文提示，体验割裂。

## 变更内容

| 模块 | 原文 | 中文 |
|------|------|------|
| `task_runner.py` | An internal error occurred while processing your message. | 处理消息时发生内部错误，请重试。 |
| `bridge/loop.py` | Turn timed out after Ns | Turn 超时（Ns） |
| `bridge/loop.py` | Bridge drain error: ... | Bridge 事件循环错误：... |
| `turn_runner.py` | Reached maximum iterations...Try breaking... | 已达到最大迭代次数...请将任务拆分... |
| `turn_app_handlers.py` | Turn timed out after 300s | Turn 超时（300s） |
| `orchestrator.py` | Permission denied: ... | 权限被拒绝：... |
| `orchestrator.py` | Error: Unknown tool '...' | 错误：未知工具 '...' |
| `orchestrator.py` | Error: Invalid parameters for tool '...' | 错误：工具 '...' 参数无效 |
| `orchestrator.py` | User denied: ... | 用户已拒绝：... |
| `orchestrator.py` | Error: sandbox denied after max retries | 错误：沙箱重试次数已耗尽 |
| `orchestrator.py` | Error: tool '...' timed out | 错误：工具 '...' 执行超时 |
| `orchestrator.py` | Tool execution cancelled | 工具执行已取消 |
| `orchestrator.py` | Error executing ...: tool execution failed | 工具执行失败 ...：工具执行异常 |

内部日志（logger）和协议级消息（bridge state）**不修改**——仅改用户 UI 中可见的 `ctx.result` / `user_message` / `emit_terminal` 消息。

## 日志/验证证据

```
33 passed in 1.07s
```

## 测试情况

- [x] Python execution policy tests: pass
- [x] Python bridge tests: pass (含同步的 timeout 断言)
- [x] 语法检查：OK

## 截图

无需截图

## 与已有 PR 的关系

- 本 PR 是独立的国际化修复
- 依赖 #391（openai_provider.py 已在 #391 中修复）
- 合并后关闭 #392

---

Closes #392