### PR TITLE
fix(desktop): add skill_manage to Task Assets file tracking

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -527,14 +527,19 @@ const _FILE_WRITE_TOOLS = [
   'pptx_write',
   'edit_docx',
   'append_xlsx',
+  'skill_manage',
 ];
 const _FILE_READ_TOOLS = ['read_file'];
 
 /** Extract a file path from a JSON-stringified tool args object.
- *  Checks common keys: path, file_path, filename. */
+ *  Checks common keys: path, file_path, filename.
+ *  For skill_manage, derives the SKILL.md path from the skill name. */
 function _extractPathFromArgs(argsStr: string): string | null {
   try {
     const args = JSON.parse(argsStr);
+    if (args.name && (args.action === 'create' || args.action === 'patch')) {
+      return `skills/${args.name}/SKILL.md`;
+    }
     return (args.path as string) || (args.file_path as string) || (args.filename as string) || null;
   } catch {
     return null;


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

将 `skill_manage` 工具纳入 Task Assets 面板的文件追踪范围，确保创建/更新 skill 时右侧面板能显示文件资产。

## 背景/问题

`skill_manage` 创建和更新 SKILL.md 文件，但 Task Assets 面板不追踪该工具的操作。用户创建 skill 后右侧面板始终显示暂无文件，缺乏操作反馈。

**根因**：`ChatConsole.tsx` 中 `_FILE_WRITE_TOOLS` 列表缺少 `skill_manage`，且 `_extractPathFromArgs` 不识别 `skill_manage` 的 `name` 参数。

**关联 Issue**：#404

## 变更内容

| 文件 | 修改 |
|------|------|
| `apps/desktop/src/renderer/features/chat/ChatConsole.tsx` | 1. `_FILE_WRITE_TOOLS` 添加 `skill_manage`<br>2. `_extractPathFromArgs`：当 `action` 为 create/patch 且存在 `name` 时，生成 `skills/{name}/SKILL.md` 路径 |

## 日志/验证证据

```
# TypeScript 类型检查通过
$ npx tsc --noEmit -p tsconfig.web.json
(无错误)

# 现有测试全部通过
$ npx vitest run tests/chatConsoleMessages.test.ts tests/progressUtils.test.ts
✓ tests/progressUtils.test.ts (18 tests) 5ms
✓ tests/chatConsoleMessages.test.ts (6 tests) 6ms
Test Files  2 passed (2)
     Tests  24 passed (24)
```

## 测试情况

- TypeScript 类型检查：✅ 通过
- chatConsoleMessages.test.ts：✅ 6 passed
- progressUtils.test.ts：✅ 18 passed

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)