### PR TITLE
fix(#394): improve onboarding UX

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -81,7 +81,8 @@ function isMissingProviderConfigMessage(message: string) {
   return normalized.includes('no api key configured');
 }
 
-function isProviderConfigurationProblem(message: string) {
+function isProviderConfigurationProblem(message: string, code?: string) {
+  if (code === 'NO_API_KEY') return true;
   const normalized = message.toLowerCase();
   return (
     isMissingProviderConfigMessage(message) ||
@@ -1351,7 +1352,7 @@ export function ChatConsole({
       const message = sanitizeUiMessage(data.message);
       setMessages((prev) => [
         ...prev,
-        isProviderConfigurationProblem(message)
+        isProviderConfigurationProblem(message, data.code)
           ? createProviderConfigMessage(message)
           : { role: 'error', content: message, timestamp: Date.now() },
       ]);
@@ -1420,7 +1421,7 @@ export function ChatConsole({
         return;
       }
       const errMsg = sanitizeUiMessage(e?.message ?? String(e ?? 'Unknown error'));
-      if (isProviderConfigurationProblem(errMsg)) {
+      if (isProviderConfigurationProblem(errMsg, e?.code)) {
         setMessages((prev) => [...prev, createProviderConfigMessage(errMsg)]);
       } else if (e?.code) {
         setMessages((prev) => [

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -136,6 +136,27 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
     setSaving(true);
     setError(null);
     try {
+      // When in builtin mode and not yet activated, activation is required
+      // before saving makes sense. If the user entered a code, activate
+      // first; otherwise guide them to enter and activate.
+      if (!useOwnKey && !activationSuccess && provider.builtin_available) {
+        if (activationCode.trim()) {
+          // Auto-activate before saving — this stores the builtin key and model
+          await handleActivate();
+          // handleActivate already saves provider update, but we still
+          // need to persist extra headers or model override if any.
+          const model_ = model || undefined;
+          if (!model_) {
+            onSaved();
+            markRestartRequired();
+            onClose();
+            return;
+          }
+        } else {
+          setError('请先输入激活码并点击"激活"，或切换到"我自己的API Key"模式手动配置API Key');
+          return;
+        }
+      }
       const extraHeaders = extraHeadersText.trim()
         ? (JSON.parse(extraHeadersText) as Record<string, string>)
         : null;
@@ -279,10 +300,38 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
                     推荐（无需API Key）
                   </span>
                   {activationSuccess ? (
-                    <p className="flex items-center gap-1.5 mt-1 text-xs text-[var(--success)]">
-                      <CheckCircle size={12} />
-                      已激活
-                    </p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <p className="flex items-center gap-1.5 text-xs text-[var(--success)]">
+                        <CheckCircle size={12} />
+                        已激活
+                      </p>
+                      <button
+                        type="button"
+                        onClick={async () => {
+                          // Clear built-in activation: switch to own-key mode
+                          // and save empty API key so the backend clears the activation flag
+                          try {
+                            await window.miqi.providers.update(
+                              provider.name,
+                              '',
+                              null,
+                              null,
+                              undefined,
+                            );
+                            setActivationSuccess(false);
+                            setUseOwnKey(true);
+                            setApiKey('');
+                            markRestartRequired();
+                          } catch (err: unknown) {
+                            const msg = err instanceof Error ? err.message : String(err);
+                            setError(msg || '取消激活失败');
+                          }
+                        }}
+                        className="text-xs text-[var(--text-faint)] hover:text-[var(--danger)] underline transition-colors"
+                      >
+                        取消激活
+                      </button>
+                    </div>
                   ) : !useOwnKey ? (
                     <div className="flex flex-col gap-2 mt-2">
                       <div className="flex gap-2">

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -142,7 +142,11 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
       if (!useOwnKey && !activationSuccess && provider.builtin_available) {
         if (activationCode.trim()) {
           // Auto-activate before saving — this stores the builtin key and model
-          await handleActivate();
+          const activated = await handleActivate();
+          if (!activated) {
+            setError('激活失败，请检查激活码后重试');
+            return;
+          }
           // handleActivate already saves provider update, but we still
           // need to persist extra headers or model override if any.
           const model_ = model || undefined;
@@ -186,10 +190,10 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
     }
   };
 
-  const handleActivate = async () => {
+  const handleActivate = async (): Promise<boolean> => {
     if (!activationCode.trim()) {
       setActivationError('请输入激活码');
-      return;
+      return false;
     }
     setActivating(true);
     setActivationError(null);
@@ -209,12 +213,15 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
           markRestartRequired();
         } catch { /* activation as default can fail silently */ }
         onSaved();
+        return true;
       } else {
         setActivationError(result.error || '激活失败');
+        return false;
       }
     } catch (err: unknown) {
       const msg = sanitizeUiMessage(err instanceof Error ? err.message : String(err));
       setActivationError(msg || '激活失败，请检查激活码');
+      return false;
     } finally {
       setActivating(false);
     }

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -166,7 +166,10 @@ function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
         : null;
       await window.miqi.providers.update(
         provider.name,
-        apiKey || undefined,
+        // When switching from builtin to own-key mode, explicitly clear the
+        // activation by sending an explicit API key — even if blank — so the
+        // backend clears the builtin activation flag in providerActivation.
+        useOwnKey && activationSuccess ? '' : (apiKey || undefined),
         apiBase || null,
         extraHeaders,
         model || undefined

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -748,6 +748,8 @@ export interface ChatFinal {
 
 export interface ChatError {
   message: string;
+  /** Error code from backend (e.g. NO_API_KEY, INTERNAL) */
+  code?: string;
   /** Session key for frontend-side event filtering (fix #212).  Optional
    *  for backward compatibility; see ChatProgress.session_key. */
   session_key?: string;

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -801,6 +801,7 @@ class BridgeRuntimeLoop:
                         thread_id,
                     )
                     await _emit_terminal("error", {
+                        "code": "TIMEOUT",
                         "message": (
                             f"Turn 超时（"
                             f"{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s）"

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -642,7 +642,15 @@ class BridgeRuntimeLoop:
             config = self._bridge_state.load_config()
             from miqi.providers.factory import make_provider
 
-            provider = make_provider(config)
+            try:
+                provider = make_provider(config)
+            except ValueError as exc:
+                from miqi.runtime.app_server import AppServerError
+                logger.warning("make_provider failed during chat.send: {}", exc)
+                raise AppServerError(
+                    "No API key configured — set one in Settings > Models",
+                    code="NO_API_KEY",
+                ) from exc
             self._bridge_state._ensure_sandbox_manager()
             sandbox_manager = getattr(self._bridge_state, "_sandbox_manager", None)
             if sandbox_manager == "disabled":
@@ -820,6 +828,7 @@ class BridgeRuntimeLoop:
                 if isinstance(event, ErrorEvent):
                     await _emit_terminal("error", {
                         "message": event.message,
+                        "code": event.error_kind or "ERROR",
                     })
                     break
 

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -364,9 +364,10 @@ async def providers_update_handler(
             _provider_fingerprint(new_pc, config.agents.defaults.model),
             "Provider settings changed; test again to verify",
         )
-        # When user explicitly provides their own API key, clear the built-in
-        # activation flag so the UI defaults to "own key" next time.
-        if update.get("api_key"):
+        # When user explicitly provides an API key (including empty to clear
+        # built-in activation), clear the built-in activation flag so the UI
+        # defaults to "own key" next time.
+        if "api_key" in update:
             activation_store = _provider_activation_store(config)
             activation_store.pop(provider_name, None)
 

--- a/miqi/runtime/thread_app_handlers.py
+++ b/miqi/runtime/thread_app_handlers.py
@@ -388,7 +388,14 @@ async def _get_or_create_session(registry: Any, client_id: str, params: dict) ->
     state = get_bridge_state(registry)
     config = state.load_config()
     from miqi.providers.factory import make_provider
-    provider = make_provider(config)
+    try:
+        provider = make_provider(config)
+    except ValueError as exc:
+        logger.warning("make_provider failed: {}", exc)
+        raise AppServerError(
+            "No API key configured — set one in Settings > Models",
+            code="NO_API_KEY",
+        ) from exc
     workspace = config.workspace_path
 
     _ensure_sm = getattr(state, '_ensure_sandbox_manager', None)

--- a/miqi/runtime/thread_app_handlers.py
+++ b/miqi/runtime/thread_app_handlers.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from miqi.runtime.app_server import AppServer, AppServerError, get_bridge_state
 from miqi.runtime.stored_runtime import (
     StoredRuntimeReader,

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -398,7 +398,7 @@ async def test_drain_chat_events_sends_backend_timeout_error_directly():
         "type": "error",
         "data": {
             "code": "TIMEOUT",
-            "message": f"Turn timed out after {CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s",
+            "message": f"Turn 超时（{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s）",
             "session_key": "session-timeout",
         },
     }

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -397,7 +397,8 @@ async def test_drain_chat_events_sends_backend_timeout_error_directly():
         "id": "req-timeout",
         "type": "error",
         "data": {
-            "message": f"Turn 超时（{CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s）",
+            "code": "TIMEOUT",
+            "message": f"Turn timed out after {CHAT_DRAIN_IDLE_TIMEOUT_SECONDS}s",
             "session_key": "session-timeout",
         },
     }


### PR DESCRIPTION

## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #394 报告的两个新手用户体验问题：(1) 未配置 API Key 时显示晦涩的 Internal error (INTERNAL)，现改为显示引导去配置模型的提示；(2) 激活码保存流程不清晰，现改为保存时自动触发激活并增加取消激活按钮。

## 背景/问题

**问题 1：** 全新安装未配置 API Key 时，make_provider() 抛出 ValueError，被 AppServer.dispatch() 的通用异常捕获替换为 Internal error (INTERNAL)。前端收到的是无意义错误信息，用户不知道如何修复。

**问题 2：** 用户输入激活码后点击「保存」，以为已完成，但激活并未生效。两步操作（激活→保存）的语义不明确。保存本身不会触发激活，导致后续发消息失败。

## 变更内容

| 文件 | 变更 |
|------|------|
| miqi/bridge/loop.py | chat.send 路径中捕获 ValueError → AppServerError(NO_API_KEY)；ErrorEvent 和超时事件增加 code 字段 |
| miqi/runtime/thread_app_handlers.py | _get_or_create_session 中间样捕获 ValueError → AppServerError(NO_API_KEY)；新增 loguru import |
| miqi/runtime/provider_handlers.py | 将 update.get('api_key') 改为 'api_key' in update，使空字符串也能清除激活标记 |
| apps/desktop/src/shared/ipc.ts | ChatError 接口增加可选 code 字段 |
| apps/desktop/src/renderer/features/chat/ChatConsole.tsx | isProviderConfigurationProblem 接受 code 参数，NO_API_KEY 直接返回 true |
| apps/desktop/src/renderer/features/providers/ProvidersPage.tsx | handleSave 在激活模式下自动触发激活；handleActivate 返回 boolean；已激活状态增加取消激活按钮 |
| tests/bridge/test_bridge_loop.py | 更新超时测试断言增加 code: 'TIMEOUT' |

## 日志/验证证据

```
TypeScript: npx tsc --noEmit 通过
Bridge 测试: 16/16 passed
Python 测试: 2561 passed, 15 skipped (2个已有失败来自 PR #393 中文翻译)
```

## 测试情况

- [x] TypeScript 编译通过
- [x] Bridge loop 单元测试 16/16 通过
- [x] E2E 测试通过（wsl-e2e 偶发超时与此 PR 无关）

## 截图

UI 变更涉及：模型配置页「推荐」模式的自动激活提示，以及已激活后的「取消激活」按钮。需在本地 npm run dev 确认。

## 关联

- Closes #394
