### PR TITLE
fix(sandbox): add logging for sandbox command failures

### DIFF
--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -414,14 +414,19 @@ class ExecTool(Tool):
         duration_ms = int((time.monotonic() - start) * 1000)
         exit_code = handle.returncode if handle.returncode is not None else -1
 
+        # Log sandbox command failures
+        cmd_summary = command[:200] + "…" if len(command) > 200 else command
+
         # ── Build result text ─────────────────────────────────────────
         if cancelled:
+            logger.info("Sandbox command cancelled after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output="Error: Command cancelled by user.",
                 exit_code=exit_code, duration_ms=duration_ms,
                 cancelled=True,
             )
         if timed_out:
+            logger.error("Sandbox command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output=(
                     f"Error: Command timed out after "
@@ -430,6 +435,10 @@ class ExecTool(Tool):
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
             )
+
+        if exit_code != 0:
+            cmd_short = command[:100] + "…" if len(command) > 100 else command
+            logger.warning("Sandbox command failed exit={} duration={}ms: {}", exit_code, duration_ms, cmd_short)
 
         trunc_note = ""
         if stdout_trunc or stderr_trunc:
@@ -571,6 +580,10 @@ class ExecTool(Tool):
             # Sandbox not available — fall back to direct execution
             # (e.g. during first-time install when bwrap isn't ready yet).
             # Attach a note so the AI knows it's running without isolation.
+            logger.warning(
+                "BWRAP sandbox not available for session_key={} — falling back to host execution",
+                session_key,
+            )
             result = await self._execute_direct(command, cwd, **common)
             result.output = (
                 "[sandbox not available — running on host]\n"
@@ -1035,14 +1048,19 @@ class ExecTool(Tool):
         duration_ms = int((time.monotonic() - start) * 1000)
         exit_code = process.returncode if process.returncode is not None else -1
 
+        # Log direct command failures
+        cmd_summary = command[:200] + "…" if len(command) > 200 else command
+
         # ── Build result text ─────────────────────────────────────────
         if cancelled:
+            logger.info("Direct command cancelled after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output="Error: Command cancelled by user.",
                 exit_code=exit_code, duration_ms=duration_ms,
                 cancelled=True,
             )
         if timed_out:
+            logger.error("Direct command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output=(
                     f"Error: Command timed out after "
@@ -1051,6 +1069,10 @@ class ExecTool(Tool):
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
             )
+
+        if exit_code != 0:
+            cmd_short = command[:100] + "…" if len(command) > 100 else command
+            logger.warning("Direct command failed exit={} duration={}ms: {}", exit_code, duration_ms, cmd_short)
 
         trunc_note = ""
         if stdout_trunc or stderr_trunc:


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

沙箱（bwrap）命令执行失败时缺少日志输出，无法排查问题。

## 背景/问题

当沙箱命令执行失败时（非零退出码、超时、取消、或沙箱不可用回退到主机执行），之前没有任何 loguru 日志输出。失败信息仅出现在工具返回文本中，导致：
- CI/生产环境排查困难（只能从 AI 响应文本中推断）
- 无法通过日志系统监控沙箱健康状况
- 沙箱静默回退到主机执行时没有告警

## 变更内容

修改 `miqi/agent/tools/shell.py`，在 3 个执行路径中添加日志：

1. `_execute_with_sandbox_selection` — BWRAP 沙箱不可用时回退到主机执行，添加 `logger.warning`
2. `_execute_in_sandbox` — 沙箱命令取消/超时/非零退出码，分别添加 `logger.info` / `logger.error` / `logger.warning`
3. `_execute_direct` — 主机直接执行命令取消/超时/非零退出码，同样添加对应日志

每条日志包含退出码、耗时（ms）、和命令摘要。

## 日志/验证证据

```
# 语法检查通过
python -c "import py_compile; py_compile.compile('miqi/agent/tools/shell.py', doraise=True)"
# Syntax OK
```

## 测试情况

- Python 语法编译检查通过
- 现有 pytest 测试不受影响（仅添加日志调用）
- 未引入新的 linter 警告

## 截图

无需截图
