### PR TITLE
fix: hide injected document text in chat history, show colored chips instead

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -98,6 +98,40 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/**
+ * Parse embedded document content from message body so the UI shows
+ * coloured chips instead of raw injection text.  Handles three formats:
+ *   1. Client-side preview:  [File: name]\n```\n...\n```
+ *   2. Binary/scanned placeholder: [name: binary file, ...] / [name: scanned PDF ...]
+ *   3. Server-side parsed:   --- Document: name ---\n...\n--- End of name ---
+ *
+ * The LLM still receives the full content; only the display is cleaned.
+ */
+const FILE_BLOCK_RES = [
+  /\[File: ([^\]]+)\]\n```\n[\s\S]*?\n```/g,
+  /\[([^\]:]+):\s*(?:binary file|scanned PDF)[^\]]*\]/g,
+  /--- Document: ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,
+];
+
+interface FileChip {
+  name: string;
+  category: ReturnType<typeof getDocCategory>;
+}
+
+function extractFileChips(content: string): { cleanContent: string; chips: FileChip[] } {
+  const chips: FileChip[] = [];
+  let clean = content;
+  for (const re of FILE_BLOCK_RES) {
+    clean = clean.replace(re, (_full: string, name: string) => {
+      if (!chips.some(c => c.name === name)) {
+        chips.push({ name, category: getDocCategory(name) });
+      }
+      return '';
+    });
+  }
+  return { cleanContent: clean.trim(), chips };
+}
+
 interface Message {
   role: 'user' | 'assistant' | 'progress' | 'error' | 'subagent';
   content: string;
@@ -3371,6 +3405,31 @@ function MessageBubble({
                 </div>
                 );
               })}
+            {/* Historical file chips — extracted from [File: ...] blocks when attachments are missing */}
+            {isUser && (!msg.attachments || msg.attachments.length === 0) && (() => {
+              const { cleanContent, chips } = extractFileChips(msg.content);
+              if (chips.length === 0) return null;
+              // Store clean content for the bubble below
+              (msg as any).__cleanContent = cleanContent;
+              return chips.map((chip, i) => (
+                <div
+                  key={`hist-${i}`}
+                  className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                  style={{
+                    background: chip.category.bg,
+                    border: `1px solid ${chip.category.color}40`,
+                    color: chip.category.color,
+                  }}
+                >
+                  <span className="shrink-0 rounded font-bold text-[10px] px-1 py-0.5 leading-none text-white"
+                    style={{ background: chip.category.color }}>
+                    {chip.category.label}
+                  </span>
+                  <span>{chip.name}</span>
+                  <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
+                </div>
+              ));
+            })()}
 
             {/* Main bubble */}
             <div
@@ -3390,7 +3449,7 @@ function MessageBubble({
               ) : msg.role === 'assistant' ? (
                 <MarkdownContent content={msg.content} />
               ) : (
-                renderContent(msg.content)
+                renderContent((msg as any).__cleanContent || msg.content)
               )}
             </div>
 


### PR DESCRIPTION
## 背景/问题

文件上传后，LLM 通过提示词注入获取文件内容。在当前 session 中文件显示为 chip ✅，但切换 session 再回来时，注入的文档内容以原始文本形式出现在对话框里，非常冗长。

Closes #427

## 变更内容

在渲染历史用户消息时，自动识别并提取三种文档注入格式，转为彩色 chip 显示：

| 格式 | 来源 |
|------|------|
| `[File: name]` + 代码块 | 客户端 PDF 即时提取 |
| `[name: binary file, ...]` / `[name: scanned PDF ...]` | 二进制/扫描件占位 |
| `--- Document: name ---` | 服务端深度解析结果 |

LLM 仍收到完整内容，仅 UI 隐藏。

## 日志/验证证据

```
# 本地热重载验证通过
# 切 session 后再切回，文档内容显示为彩色 chip 而非原始文本
```

## 测试情况

- [x] 手动测试：上传 PDF/DOCX/PPTX → 切 session → 切回来 → 确认 chip 显示
- [x] 热重载正常

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/46bac63c-ef0a-474f-aba3-d0141a8d1e57" />