### PR TITLE
feat: add right-click bulk delete/archive all tasks on sidebar 全部 tab

### DIFF
--- a/apps/desktop/src/renderer/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { cn } from '../lib/utils';
 import { Plus, ListChecks, Settings, Play, Clock, Eye, CheckCircle2, RotateCcw, Archive, Trash2 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
@@ -212,7 +212,7 @@ export function Sidebar({
         {FILTER_TABS.map((tab) => {
           const isActive = filter === tab.value;
           const count = filterCounts[tab.value];
-          return (
+          const tabButton = (
             <button
               key={tab.value}
               role="tab"
@@ -245,6 +245,41 @@ export function Sidebar({
               )}
             </button>
           );
+          // Right-click on the 全部 tab: bulk delete / archive all
+          if (tab.value === 'ALL') {
+            return (
+              <ContextMenu
+                key={tab.value}
+                items={[
+                  {
+                    label: '删除全部任务',
+                    icon: <Trash2 size={13} />,
+                    danger: true,
+                    onSelect: async () => {
+                      if (!window.confirm(`确认删除全部 ${count} 个任务？此操作不可撤销。`)) return;
+                      for (const s of sessions) {
+                        try { await window.miqi.sessions.delete(s.key); } catch { /* ignore */ }
+                      }
+                      loadSessions();
+                    },
+                  },
+                  {
+                    label: '归档全部任务',
+                    icon: <Archive size={13} />,
+                    onSelect: async () => {
+                      for (const s of sessions) {
+                        try { await window.miqi.sessions.archive(s.key); } catch { /* ignore */ }
+                      }
+                      loadSessions();
+                    },
+                  },
+                ]}
+              >
+                {({ onContextMenu }) => React.cloneElement(tabButton as React.ReactElement, { onContextMenu })}
+              </ContextMenu>
+            );
+          }
+          return tabButton;
         })}
         </div>
       </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -98,6 +98,40 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/**
+ * Parse embedded document content from message body so the UI shows
+ * coloured chips instead of raw injection text.  Handles three formats:
+ *   1. Client-side preview:  [File: name]\n```\n...\n```
+ *   2. Binary/scanned placeholder: [name: binary file, ...] / [name: scanned PDF ...]
+ *   3. Server-side parsed:   --- Document: name ---\n...\n--- End of name ---
+ *
+ * The LLM still receives the full content; only the display is cleaned.
+ */
+const FILE_BLOCK_RES = [
+  /\[File: ([^\]]+)\]\n```\n[\s\S]*?\n```/g,
+  /\[([^\]:]+):\s*(?:binary file|scanned PDF)[^\]]*\]/g,
+  /--- Document: ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,
+];
+
+interface FileChip {
+  name: string;
+  category: ReturnType<typeof getDocCategory>;
+}
+
+function extractFileChips(content: string): { cleanContent: string; chips: FileChip[] } {
+  const chips: FileChip[] = [];
+  let clean = content;
+  for (const re of FILE_BLOCK_RES) {
+    clean = clean.replace(re, (_full: string, name: string) => {
+      if (!chips.some(c => c.name === name)) {
+        chips.push({ name, category: getDocCategory(name) });
+      }
+      return '';
+    });
+  }
+  return { cleanContent: clean.trim(), chips };
+}
+
 interface Message {
   role: 'user' | 'assistant' | 'progress' | 'error' | 'subagent';
   content: string;
@@ -3371,6 +3405,31 @@ function MessageBubble({
                 </div>
                 );
               })}
+            {/* Historical file chips — extracted from [File: ...] blocks when attachments are missing */}
+            {isUser && (!msg.attachments || msg.attachments.length === 0) && (() => {
+              const { cleanContent, chips } = extractFileChips(msg.content);
+              if (chips.length === 0) return null;
+              // Store clean content for the bubble below
+              (msg as any).__cleanContent = cleanContent;
+              return chips.map((chip, i) => (
+                <div
+                  key={`hist-${i}`}
+                  className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                  style={{
+                    background: chip.category.bg,
+                    border: `1px solid ${chip.category.color}40`,
+                    color: chip.category.color,
+                  }}
+                >
+                  <span className="shrink-0 rounded font-bold text-[10px] px-1 py-0.5 leading-none text-white"
+                    style={{ background: chip.category.color }}>
+                    {chip.category.label}
+                  </span>
+                  <span>{chip.name}</span>
+                  <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
+                </div>
+              ));
+            })()}
 
             {/* Main bubble */}
             <div
@@ -3390,7 +3449,7 @@ function MessageBubble({
               ) : msg.role === 'assistant' ? (
                 <MarkdownContent content={msg.content} />
               ) : (
-                renderContent(msg.content)
+                renderContent((msg as any).__cleanContent || msg.content)
               )}
             </div>
 


### PR DESCRIPTION
## 背景/问题

当前只能逐个任务右键删除/归档，任务多时操作繁琐。

Closes #429

## 变更内容

在侧边栏"全部" tab 上右键弹出菜单：
- **删除全部任务** — 确认对话框 + 遍历删除
- **归档全部任务** — 遍历归档

## 日志/验证证据

```
# 热重载验证通过
# 右键"全部" tab → 弹出菜单 → 选择操作
```

## 测试情况

- [x] 右键"全部" tab 弹出菜单
- [x] 删除全部任务确认弹窗
- [x] 归档全部任务正常执行
- [x] 操作后列表自动刷新

## 截图

无需截图