### PR TITLE
fix: translate remaining English UI strings to Chinese

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -938,7 +938,7 @@ export function ChatConsole({
     label: string;
   }
   const [threads, setThreads] = useState<ThreadTab[]>([
-    { threadId: 'main', agentType: 'main', label: 'Main' },
+    { threadId: 'main', agentType: 'main', label: '主线程' },
   ]);
   const [activeThreadId, setActiveThreadId] = useState('main');
 
@@ -1260,7 +1260,7 @@ export function ChatConsole({
   const handleDeleteSession = useCallback(async () => {
     const key = currentSessionRef.current;
     if (!key) return;
-    if (!window.confirm('Delete this conversation? This cannot be undone.')) return;
+    if (!window.confirm('确定删除此对话？此操作不可撤销。')) return;
     try {
       await window.miqi.sessions.delete(key);
     } catch {
@@ -1423,10 +1423,10 @@ export function ChatConsole({
       const elapsed = Date.now() - lastEventAt;
       if (elapsed >= NO_PROGRESS_STRONG_MS) {
         appendWatchdogMsg(
-          '⚠️ No response from backend for 60s. You can abort and check runtime logs.'
+          '⚠️ 后端 60s 无响应，可中止并检查运行日志。'
         );
       } else if (elapsed >= NO_PROGRESS_WARN_MS) {
-        appendWatchdogMsg('⏳ Still waiting for backend response…');
+        appendWatchdogMsg('⏳ 正在等待后端响应…');
       }
     }, 5_000); // check every 5s
 
@@ -1736,7 +1736,7 @@ export function ChatConsole({
         cleanupListeners();
         return;
       }
-      const errMsg = sanitizeUiMessage(e?.message ?? String(e ?? 'Unknown error'));
+      const errMsg = sanitizeUiMessage(e?.message ?? String(e ?? '未知错误'));
       if (isProviderConfigurationProblem(errMsg, e?.code)) {
         setMessages((prev) => [...prev, createProviderConfigMessage(errMsg)]);
       } else if (e?.code) {
@@ -2258,7 +2258,7 @@ export function ChatConsole({
                     await window.miqi.sessions.delete(sessionKey);
                     handleNewSession();
                   } catch (e) {
-                    console.error('Delete failed:', e);
+                    console.error('删除失败:', e);
                   }
                 },
               },
@@ -3024,7 +3024,7 @@ export function ChatConsole({
                     title="Revert to HEAD (undo changes)"
                   >
                     <Undo2 size={12} className={reverting ? 'animate-spin' : ''} />
-                    {reverting ? 'Reverting...' : 'Revert'}
+                    {reverting ? '正在还原…' : '还原'}
                   </button>
                 )}
                 <button
@@ -3090,8 +3090,8 @@ export function ChatConsole({
                 <div className="flex items-center justify-center h-48">
                   <span className="text-sm" style={{ color: 'var(--text-faint)' }}>
                     {diffFile.original_content === null && diffFile.current_content === null
-                      ? 'No snapshot available — file was not modified in this session'
-                      : 'No changes detected'}
+                      ? '无快照可用 — 此文件未在本会话中修改'
+                      : '未检测到变更'}
                   </span>
                 </div>
               )}
@@ -3261,7 +3261,7 @@ function TrackedFileCard({
                 color: isOfficeFile ? 'var(--text-faint)' : 'var(--warning)',
                 opacity: isOfficeFile ? 0.55 : 1,
               }}
-              title={'Diff is not available for Office binary files'}
+              title={'Office 二进制文件不支持差异对比'}
             >
               <GitCompare size={10} />
               Diff
@@ -3727,7 +3727,7 @@ function MarkdownContent({ content }: { content: string }) {
                   color: 'var(--text-muted)',
                 }}
               >
-                {copiedCode === code ? 'Copied' : 'Copy'}
+                {copiedCode === code ? '已复制' : '复制'}
               </button>
               {code}
             </code>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3021,7 +3021,7 @@ export function ChatConsole({
                       color: reverting ? 'var(--text-faint)' : 'var(--danger)',
                       border: '1px solid var(--danger)',
                     }}
-                    title="Revert to HEAD (undo changes)"
+                    title="还原到 HEAD（撤销所有改动）"
                   >
                     <Undo2 size={12} className={reverting ? 'animate-spin' : ''} />
                     {reverting ? '正在还原…' : '还原'}
@@ -3261,7 +3261,7 @@ function TrackedFileCard({
                 color: isOfficeFile ? 'var(--text-faint)' : 'var(--warning)',
                 opacity: isOfficeFile ? 0.55 : 1,
               }}
-              title={'Office 二进制文件不支持差异对比'}
+              title={isOfficeFile ? 'Office 二进制文件不支持差异对比' : '查看差异'}
             >
               <GitCompare size={10} />
               Diff

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -57,7 +57,7 @@ const SOURCE_LABELS: Record<string, string> = {
 };
 
 function fmtAuthors(authors: string[], max = 4): string {
-  if (!authors.length) return 'Unknown';
+  if (!authors.length) return '未知';
   const shown = authors.slice(0, max);
   const suffix = authors.length > max ? ` et al. (${authors.length})` : '';
   return shown.join(', ') + suffix;
@@ -95,7 +95,7 @@ function PaperCard({
 }) {
   const [showAbstract, setShowAbstract] = useState(false);
   const hasAbstract = paper.abstract?.trim().length > 10;
-  const sourceLabel = SOURCE_LABELS[paper.source ?? ''] || paper.source || 'Unknown';
+  const sourceLabel = SOURCE_LABELS[paper.source ?? ''] || paper.source || '未知';
   const hasPdf = !!(paper.open_access_pdf_url || paper.is_open_access);
 
   return (
@@ -118,7 +118,7 @@ function PaperCard({
               className="inline mr-1.5 shrink-0"
               style={{ color: 'var(--text-muted)' }}
             />
-            {paper.title || 'Untitled'}
+            {paper.title || '无标题'}
           </h4>
           {paper.year && (
             <span
@@ -227,7 +227,7 @@ function PaperCard({
             ) : (
               <Download size={12} />
             )}
-            {isDownloading ? 'Downloading...' : 'Download PDF'}
+            {isDownloading ? '下载中…' : '下载 PDF'}
           </button>
         )}
       </div>
@@ -278,7 +278,7 @@ export default function PaperSearchResult({
         className="flex items-center gap-2 mb-2 text-[11px]"
         style={{ color: 'var(--text-muted)' }}
       >
-        <span>{data.query ? `Results for "${data.query}"` : 'Search results'}</span>
+        <span>{data.query ? `Results for "${data.query}"` : '搜索结果'}</span>
         {data.total != null && (
           <span style={{ color: 'var(--text-faint)' }}>
             · {data.total} found · showing {items.length}

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -278,7 +278,7 @@ export default function PaperSearchResult({
         className="flex items-center gap-2 mb-2 text-[11px]"
         style={{ color: 'var(--text-muted)' }}
       >
-        <span>{data.query ? `Results for "${data.query}"` : '搜索结果'}</span>
+        <span>{data.query ? `"${data.query}"的搜索结果` : '搜索结果'}</span>
         {data.total != null && (
           <span style={{ color: 'var(--text-faint)' }}>
             · {data.total} found · showing {items.length}

--- a/apps/desktop/src/renderer/features/chat/progressUtils.ts
+++ b/apps/desktop/src/renderer/features/chat/progressUtils.ts
@@ -50,7 +50,7 @@ export function extractProgressMessage(
       data.error?.message ??
       data.reason ??
       payload.text ??
-      `${eventName || 'Error'}`;
+      `${eventName || '错误'}`;
     if (msg) return { message: String(msg), role: 'error' };
   }
 


### PR DESCRIPTION
## 背景/问题

ChatConsole、PaperSearch 等组件仍有英文 UI 字符串，用户体验不一致。

Closes #431

## 变更内容

3 文件，17 处变更：

| 文件 | 内容 |
|------|------|
| ChatConsole.tsx | 后端等待/超时/删除确认/错误提示/还原/差异对比/复制按钮 → 中文 |
| PaperSearchResult.tsx | 下载/标题/作者/数据源/搜索 → 中文 |
| progressUtils.ts | 错误标识 → 中文 |

## 日志/验证证据

```
热重载验证通过
```

## 测试情况

- [x] 发消息等 15s 确认提示变为中文
- [x] 右键删除确认弹窗中文
- [x] 复制按钮显示中文

## 截图

无需截图