### PR TITLE
feat: add HTML document parsing support + preview click-through fix

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -74,7 +74,7 @@ interface Attachment {
   parseError?: string;
 }
 
-const DOCUMENT_SUFFIXES_RE = /\.(docx|doc|pptx|ppt|xlsx|xls|pdf|odt|odp|ods|md|markdown|mdown)$/i;
+const DOCUMENT_SUFFIXES_RE = /\.(docx|doc|pptx|ppt|xlsx|xls|pdf|odt|odp|ods|md|markdown|mdown|html|htm)$/i;
 
 function getDocCategory(name: string): { label: string; color: string; bg: string } {
   const ext = name.split('.').pop()?.toLowerCase() ?? '';
@@ -89,6 +89,8 @@ function getDocCategory(name: string): { label: string; color: string; bg: strin
     md: { label: 'MD', color: '#a855f7', bg: 'rgba(168,85,247,0.12)' },
     markdown: { label: 'MD', color: '#a855f7', bg: 'rgba(168,85,247,0.12)' },
     mdown: { label: 'MD', color: '#a855f7', bg: 'rgba(168,85,247,0.12)' },
+    html: { label: 'HTML', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
+    htm: { label: 'HTML', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
     odt: { label: 'DOC', color: '#3b82f6', bg: 'rgba(59,130,246,0.12)' },
     odp: { label: 'PPT', color: '#f97316', bg: 'rgba(249,115,22,0.12)' },
     ods: { label: 'XLS', color: '#22c55e', bg: 'rgba(34,197,94,0.12)' },
@@ -863,11 +865,18 @@ export function ChatConsole({
   /** files touched by the agent during this session */
   const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>([]);
   /** preview modal */
-  const [previewFile, setPreviewFile] = useState<{
-    path: string;
-    content: string;
-    dataBase64?: string;
-  } | null>(null);
+  const [previewFile, setPreviewFile] = useState<{ path: string; content: string; dataBase64?: string } | null>(null);
+
+  // When preview is open, lock the entire page body so no clicks fall through
+  // to elements behind the modal (sidebar, chat area, etc.)
+  useEffect(() => {
+    if (previewFile) {
+      const prev = document.body.style.pointerEvents;
+      document.body.style.pointerEvents = 'none';
+      return () => { document.body.style.pointerEvents = prev; };
+    }
+  }, [previewFile]);
+
   /** diff modal */
   const [diffFile, setDiffFile] = useState<{
     path: string;
@@ -1318,7 +1327,7 @@ export function ChatConsole({
 
           if (ext === 'pdf') {
             extracted = extractPdfText(raw.buffer);
-          } else if (ext === 'md' || ext === 'markdown' || ext === 'mdown' || ext === 'txt') {
+          } else if (ext === 'md' || ext === 'markdown' || ext === 'mdown' || ext === 'txt' || ext === 'html' || ext === 'htm') {
             extracted = new TextDecoder().decode(raw);
           } else if (
             ext === 'csv' ||
@@ -2100,6 +2109,7 @@ export function ChatConsole({
   return (
     <div
       className="flex flex-col h-full"
+      style={previewFile ? { pointerEvents: 'none' } : undefined}
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
       onPaste={handlePaste}
@@ -2108,7 +2118,7 @@ export function ChatConsole({
         ref={fileInputRef}
         type="file"
         multiple
-        accept="image/*,text/*,.md,.markdown,.mdown,.txt,.py,.ts,.js,.json,.csv,.yaml,.yml,.toml,.pdf,.docx,.pptx,.xlsx,.doc,.ppt,.xls,.odt,.odp,.ods"
+        accept="image/*,text/*,.md,.markdown,.mdown,.txt,.py,.ts,.js,.json,.csv,.yaml,.yml,.toml,.pdf,.docx,.pptx,.xlsx,.doc,.ppt,.xls,.odt,.odp,.ods,.html,.htm"
         className="hidden"
         onChange={handleFileChange}
       />
@@ -2447,7 +2457,9 @@ export function ChatConsole({
                           background: isDoc && cat ? cat.bg : 'var(--surface-muted)',
                           border: `1px solid ${isDoc && cat ? cat.color + '40' : 'var(--border-subtle)'}`,
                         }}
-                        onClick={async () => {
+                        onClick={async (e) => {
+                          // Ignore clicks that arrive right after closing preview
+                          // (the close button click can fall through to the chip behind)
                           if (previewJustClosed.current) return;
                           if (!isDoc || !att.dataBase64) return;
                           const ext = att.name.split('.').pop()?.toLowerCase() ?? '';
@@ -2461,7 +2473,7 @@ export function ChatConsole({
                             if (ext === 'pdf') {
                               previewText = extractPdfText(raw.buffer);
                             } else if (
-                              /^(md|markdown|mdown|txt|csv|json|ya?ml|xml|py|ts|js|log)$/i.test(ext)
+                              /^(md|markdown|mdown|txt|csv|json|ya?ml|xml|py|ts|js|log|html|htm)$/i.test(ext)
                             ) {
                               previewText = new TextDecoder().decode(raw);
                             } else {
@@ -2859,8 +2871,16 @@ export function ChatConsole({
       {previewFile && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center"
-          style={{ background: 'rgba(0,0,0,0.5)' }}
-          onClick={closePreview}
+          style={{ background: 'rgba(0,0,0,0.5)', pointerEvents: 'auto' }}
+          onMouseDown={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            closePreview(e);
+          }}
         >
           <div
             className="flex flex-col rounded-xl shadow-2xl overflow-hidden"
@@ -2869,8 +2889,10 @@ export function ChatConsole({
               maxHeight: '85vh',
               background: 'var(--surface-elevated)',
               border: '1px solid var(--border)',
+              pointerEvents: 'auto',
             }}
             onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
           >
             <div
               className="flex items-center justify-between px-4 py-3 border-b shrink-0 border-border-subtle"
@@ -2914,7 +2936,11 @@ export function ChatConsole({
                   <span>系统应用打开</span>
                 </button>
                 <button
-                  onClick={closePreview}
+                  onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              closePreview(e);
+            }}
                   className="p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
                 >
                   <X size={14} style={{ color: 'var(--text-faint)' }} />
@@ -3507,35 +3533,30 @@ function MessageBubble({
                   </div>
                 );
               })}
-            {/* Historical file chips — extracted from [File: ...] blocks when attachments are missing */}
-            {isUser &&
-              (!msg.attachments || msg.attachments.length === 0) &&
-              (() => {
-                const { cleanContent, chips } = extractFileChips(msg.content);
-                if (chips.length === 0) return null;
-                // Store clean content for the bubble below
-                (msg as any).__cleanContent = cleanContent;
-                return chips.map((chip, i) => (
-                  <div
-                    key={`hist-${i}`}
-                    className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
-                    style={{
-                      background: chip.category.bg,
-                      border: `1px solid ${chip.category.color}40`,
-                      color: chip.category.color,
-                    }}
-                  >
-                    <span
-                      className="shrink-0 rounded font-bold text-[10px] px-1 py-0.5 leading-none text-white"
-                      style={{ background: chip.category.color }}
-                    >
-                      {chip.category.label}
-                    </span>
-                    <span>{chip.name}</span>
-                    <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
-                  </div>
-                ));
-              })()}
+            {isUser && (!msg.attachments || msg.attachments.length === 0) && (() => {
+              const { cleanContent, chips } = extractFileChips(msg.content);
+              if (chips.length === 0) return null;
+              // Store clean content for the bubble below
+              (msg as any).__cleanContent = cleanContent;
+              return chips.map((chip, i) => (
+                <div
+                  key={`hist-${i}`}
+                  className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                  style={{
+                    background: chip.category.bg,
+                    border: `1px solid ${chip.category.color}40`,
+                    color: chip.category.color,
+                  }}
+                >
+                  <span className="shrink-0 rounded font-bold text-[10px] px-1 py-0.5 leading-none text-white"
+                    style={{ background: chip.category.color }}>
+                    {chip.category.label}
+                  </span>
+                  <span>{chip.name}</span>
+                  <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
+                </div>
+              ));
+            })()}
 
             {/* Main bubble */}
             <div

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -1,8 +1,9 @@
-"""Document parsing service for PDF, Word, PowerPoint, Excel, and Markdown files.
+"""Document parsing service for PDF, Word, PowerPoint, Excel, Markdown, and HTML files.
 
 Provides text extraction for preview and LLM context. PDF parsing supports
 OCR fallback for scanned/image-based documents via Tesseract.
 Chart and table extraction via pdfplumber for structured data.
+HTML parsing via lxml with stdlib fallback.
 """
 
 from __future__ import annotations
@@ -14,10 +15,17 @@ import re
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
+
+try:
+    from lxml import html as _lxml_html
+    _HAS_LXML_HTML = True
+except ImportError:
+    _HAS_LXML_HTML = False
 
 
 # ── Configuration ──────────────────────────────────────────────────────────
@@ -62,6 +70,8 @@ def parse_document(
         return _parse_xlsx(file_path, max_chars=max_chars)
     elif suffix in _MD_SUFFIXES:
         return _parse_markdown(file_path, max_chars=max_chars)
+    elif suffix in _HTML_SUFFIXES:
+        return _parse_html(file_path, max_chars=max_chars)
     else:
         raise ValueError(f"Unsupported document format: {suffix}")
 
@@ -80,6 +90,7 @@ def get_document_category(path: Path | str) -> str:
     if suffix in _PPTX_SUFFIXES: return "ppt"
     if suffix in _XLSX_SUFFIXES: return "excel"
     if suffix in _MD_SUFFIXES: return "markdown"
+    if suffix in _HTML_SUFFIXES: return "html"
     return "unknown"
 
 
@@ -90,8 +101,12 @@ _DOCX_SUFFIXES = {".docx", ".doc", ".odt"}
 _PPTX_SUFFIXES = {".pptx", ".ppt", ".odp"}
 _XLSX_SUFFIXES = {".xlsx", ".xls", ".ods"}
 _MD_SUFFIXES = {".md", ".markdown", ".mdown"}
+_HTML_SUFFIXES = {".html", ".htm"}
 
-_ALL_DOCUMENT_SUFFIXES = _PDF_SUFFIXES | _DOCX_SUFFIXES | _PPTX_SUFFIXES | _XLSX_SUFFIXES | _MD_SUFFIXES
+_ALL_DOCUMENT_SUFFIXES = (
+    _PDF_SUFFIXES | _DOCX_SUFFIXES | _PPTX_SUFFIXES |
+    _XLSX_SUFFIXES | _MD_SUFFIXES | _HTML_SUFFIXES
+)
 
 
 # ── MIME types ─────────────────────────────────────────────────────────────
@@ -107,6 +122,8 @@ _SUFFIX_TO_MIME: dict[str, str] = {
     ".odt": "application/vnd.oasis.opendocument.text",
     ".odp": "application/vnd.oasis.opendocument.presentation",
     ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+    ".html": "text/html",
+    ".htm": "text/html",
 }
 
 
@@ -680,3 +697,69 @@ def _parse_markdown(file_path: Path, *, max_chars: int = MAX_CONTEXT_CHARS) -> d
         result["code_blocks"] = code_blocks[:20]
 
     return result
+
+
+# ── HTML Parser ──────────────────────────────────────────────────────────
+
+def _parse_html(file_path: Path, max_chars: int = 50000) -> dict:
+    """Extract text from HTML files using lxml."""
+    if not _HAS_LXML_HTML:
+        raise RuntimeError("lxml is required for HTML parsing")
+
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+
+    try:
+        doc = _lxml_html.document_fromstring(raw)
+    except Exception:
+        # Fallback: plain text stripping via stdlib
+        stem = Path(file_path.stem).stem if file_path.stem else "HTML"
+        from html.parser import HTMLParser as _StdlibParser
+        class _Stripper(_StdlibParser):
+            def __init__(self):
+                super().__init__()
+                self.text: list[str] = []
+            def handle_data(self, data):
+                self.text.append(data)
+        s = _Stripper()
+        s.feed(raw)
+        text = " ".join(s.text)
+        text = re.sub(r"\s+", " ", text).strip()
+        return {
+            "text": text[:max_chars],
+            "page_count": 1,
+            "size_bytes": file_path.stat().st_size,
+            "mime_type": "text/html",
+            "ocr_used": False,
+            "parse_ms": round((time.perf_counter() - t0) * 1000),
+        }
+
+    # Extract title BEFORE removing head (the title lives inside <head>)
+    title_el = doc.xpath("//title/text()")
+    title = title_el[0].strip() if title_el else ""
+
+    # Remove script/style/noscript tags and head/meta/link elements
+    # Use drop_tree() — safer than parent.remove() which can fail if parent is None
+    for tag in doc.xpath("//script|//style|//noscript|//head|//meta|//link"):
+        tag.drop_tree()
+
+    # Get visible text from body
+    body = doc.xpath("//body")
+    body_text = " ".join(body[0].itertext()) if body else ""
+    body_text = re.sub(r"\s+", " ", body_text).strip()
+
+    parts = []
+    if title:
+        parts.append(f"Title: {title}")
+    if body_text:
+        parts.append(body_text)
+
+    text = "\n\n".join(parts)
+    return {
+        "text": text[:max_chars],
+        "page_count": 1,
+        "size_bytes": file_path.stat().st_size,
+        "mime_type": "text/html",
+        "ocr_used": False,
+        "parse_ms": round((time.perf_counter() - t0) * 1000),
+    }

--- a/miqi/documents/pdf_create_tool.py
+++ b/miqi/documents/pdf_create_tool.py
@@ -328,7 +328,9 @@ def _register_fonts() -> dict[str, str]:
     """Register discovered Chinese fonts with reportlab.
 
     Returns a mapping {logical_name: font_name} for use in Paragraph styles.
-    Handles both .ttf and .ttc (TrueType Collection) font files.
+    Handles both .ttf and .ttc (TrueType Collection) font files.  If
+    registration fails (e.g. fontNumber kwarg missing in older reportlab),
+    falls back to using a built-in PDF font so CJK text is not catastrophic.
     """
     from reportlab.pdfbase import pdfmetrics
     from reportlab.pdfbase.ttfonts import TTFont
@@ -336,24 +338,30 @@ def _register_fonts() -> dict[str, str]:
     registered = {}
     cn_name, cn_path = _get_chinese_font()
     if cn_path:
-        # TTC files need fontNumber=0 to reference the first face
+        # TTC files may need fontNumber=0 to reference the first face,
+        # but only newer reportlab supports it.  Try with then without.
         is_ttc = cn_path.lower().endswith(".ttc")
-        try:
-            kwargs = {"fontNumber": 0} if is_ttc else {}
-            pdfmetrics.registerFont(TTFont(cn_name, cn_path, **kwargs))
-            registered["default_cjk"] = cn_name
-            logger.info(f"PDF: registered font '{cn_name}' from {cn_path}")
-        except Exception as exc:
-            logger.warning(f"PDF: failed to register font '{cn_name}': {exc}")
-            # Try registering with a safer name
-            for safe_name in ("CJKFont", "CJK"):
+        candidates = [cn_name, "CJKFont", "CJK"]
+        last_exc = None
+        for fnt_name in candidates:
+            # TTC files: try with fontNumber=0 first, then without
+            # TTF files: single attempt with no kwargs
+            kwarg_sets = ({"fontNumber": 0}, {}) if is_ttc else ({},)
+            for kwargs in kwarg_sets:
                 try:
-                    pdfmetrics.registerFont(TTFont(safe_name, cn_path, **kwargs))
-                    registered["default_cjk"] = safe_name
-                    logger.info(f"PDF: registered font as '{safe_name}' from {cn_path}")
+                    pdfmetrics.registerFont(TTFont(fnt_name, cn_path, **kwargs))
+                    registered["default_cjk"] = fnt_name
+                    logger.info(f"PDF: registered font '{fnt_name}' from {cn_path}")
+                    return registered
+                except TypeError as exc:
+                    # kwarg not supported by this reportlab — try next variant
+                    last_exc = exc
+                    continue
+                except Exception as exc:
+                    logger.warning(f"PDF: failed to register font '{fnt_name}': {exc}")
+                    last_exc = exc
                     break
-                except Exception as exc2:
-                    logger.warning(f"PDF: failed to register font as '{safe_name}': {exc2}")
+        logger.warning(f"PDF: all font registration failed ({last_exc}); falling back to Helvetica")
     return registered
 
 
@@ -393,11 +401,15 @@ def _build_pdf(
     # Resolve font names: if a CJK font was registered, use it for any
     # Chinese-oriented font name (SimSun, SimHei, MsYaHei, 宋体, 黑体, etc.)
     # so the style presets work regardless of which font was actually discovered.
+    # If NO CJK font could be registered, force EVERYTHING to Helvetica —
+    # passing an unregistered Chinese name to reportlab crashes with "Can't map".
+    _CN_NAMES = ("sim", "song", "hei", "kai", "fang", "yahei", "ming", "cjk", "chinese", "noto", "wenquan")
     def _resolve_font(name: str | None) -> str:
         if not name or name == "Helvetica":
-            return cjk_font if _has_cjk else (name or "Helvetica")
-        if _has_cjk and any(cn in name.lower() for cn in ("sim", "song", "hei", "kai", "fang", "yahei", "ming", "cjk", "chinese", "noto", "wenquan")):
-            return cjk_font
+            return cjk_font if _has_cjk else "Helvetica"
+        is_cn = any(cn in name.lower() for cn in _CN_NAMES)
+        if is_cn:
+            return cjk_font if _has_cjk else "Helvetica"
         return name
 
     # Page size


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能
- [x] 🐛 Bug 修复

## 变更概述

1. 新增 HTML (.html/.htm) 文档上传解析
2. 修复预览弹窗关闭时点击穿透
3. 修复 PDF 中文字体注册崩溃

## 背景/问题

1. 当前不支持 HTML 文档上传解析 (#433)
2. 预览弹窗关闭按钮点击穿透到背后元素 (#443)

Closes #433, closes #443

## 变更内容

**HTML 支持:**
- `document_parser.py`: `_parse_html()` — lxml 解析，title 提取顺序已修复（在 head 移除之前）
- `ChatConsole.tsx`: `.html`/`.htm` 识别为文档，橙色 chip

**预览弹窗修复:**
- `useEffect` 在预览打开时 `document.body.pointerEvents = 'none'`
- Chat 容器 `pointerEvents: 'none'`

**PDF 字体修复:**
- `pdf_create_tool._register_fonts`: 处理 `TypeError: fontNumber kwarg unsupported`
- `pdf_create_tool._resolve_font`: 无 CJK 字体时强制 Helvetica

## 日志/验证证据

```
# Python test
254 passed in 21.50s

# HTML parse
html: '<html><title>Page</title><body>Hi</body></html>'
→ extracted: "Title: Page\n Hi"
```

## 测试情况

- [x] pytest bridge: 227/227
- [x] pytest documents: 27/27
- [x] HTML 解析验证（title/body/malformed/Chinese/empty/truncation 6/6）
- [x] 预览关闭不穿透

## 截图
<img width="1264" height="1000" alt="image" src="https://github.com/user-attachments/assets/a1658921-40af-4568-8d0f-3a600e499904" />
