### PR TITLE
ci: use RELEASE_TOKEN (PAT) to bypass main branch protection for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
 
       - name: Detect new release


### PR DESCRIPTION
## Problem
semantic-release 在 `@semantic-release/git` 的 prepare 阶段需要 `git push --tags HEAD:main` 来回写版本号变更，但 `main` 分支开启了分支保护（require pull request reviews），`GITHUB_TOKEN` 无权直接 push。

## Fix
将 workflow 中的 `GITHUB_TOKEN` 替换为 `RELEASE_TOKEN`（一个 repo-scoped PAT）。repo owner 是 admin，`enforce_admins` 为 false，因此 admin PAT 的 push 可以绕过分支保护。

## Changes
- `.github/workflows/release.yml`: `secrets.GITHUB_TOKEN` → `secrets.RELEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)