### PR TITLE
fix: semantic-release push to main blocked by branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
 
       - name: Detect new release


### PR DESCRIPTION
## Problem

semantic-release 在 `release.yml` 中跑完后需要 `git push --tags HEAD:main`，但 main 开启了 branch protection（require ≥1 PR review），`GITHUB_TOKEN` 无权直接 push，导致 `@semantic-release/git` 的 prepare 步骤失败。

最近一次失败：https://github.com/14790897/MiQi/actions/runs/30065239413/job/89394778509

## Fix

将 `GITHUB_TOKEN` 替换为 `RELEASE_TOKEN`（repo-scoped PAT）。你的账号是 repo owner/admin，`enforce_admins` 为 false，所以 admin PAT 的 push 绕过分支保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)