### PR TITLE
fix: use RELEASE_TOKEN to bypass main branch protection for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
 
       - name: Detect new release


### PR DESCRIPTION
## Problem

semantic-release 的 `@semantic-release/git` 插件在 prepare 阶段需要 `git push --tags HEAD:main` 回写版本号变更，但 main 开启了 branch protection（require ≥1 PR review），`GITHUB_TOKEN` 无权直接 push。

失败记录：https://github.com/14790897/MiQi/actions/runs/30065239413

## Fix

将 `GITHUB_TOKEN` 替换为 `RELEASE_TOKEN`（repo-scoped PAT）。admin 的 PAT push 可以绕过 `enforce_admins: false` 的分支保护。

🤖 Generated with [Claude Code](https://claude.com/claude-code)