### PR TITLE
fix: use RELEASE_TOKEN in checkout to bypass main branch protection for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
       new_release: ${{ steps.check.outputs.new_release }}
       tag_name: ${{ steps.check.outputs.tag_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: npx semantic-release
 
       - name: Detect new release


### PR DESCRIPTION
## Problem

PR #439 把 `GITHUB_TOKEN` 换成 `RELEASE_TOKEN` 了，但 push 仍然被拒。原因：`actions/checkout@v4` 默认用 `GITHUB_TOKEN` 持久化 git 凭证，semantic-release 的 `git push` 用的是 checkout 时配置的凭证，不是环境变量里的 token。

## Fix

给 checkout 步骤加上 `token: ${{ secrets.RELEASE_TOKEN }}`，让 git push 直接用 PAT。

## Changes

- `.github/workflows/release.yml`: checkout 步骤加上 `token:` 参数

🤖 Generated with [Claude Code](https://claude.com/claude-code)