### PR TITLE
fix(desktop): resolve WSL /mnt/ paths and handle files.accept errors gracefully

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -86,6 +86,13 @@ function getConfigPath(): string {
  *  root.  Absolute paths outside the workspace are rejected.
  */
 function resolveWorkspacePath(raw: string): string {
+  // Convert WSL /mnt/<drive>/ paths to Windows <drive>:\ paths
+  // (e.g. /mnt/c/Users/... -> C:\Users\...)
+  const mntMatch = raw.match(/^\/mnt\/([a-zA-Z])\/?(.*)$/);
+  if (mntMatch) {
+    return mntMatch[1].toUpperCase() + ':\\' + mntMatch[2];
+  }
+
   const SANDBOX_WS = '/home/miqi/workspace';
   let normalised = raw;
   if (normalised === SANDBOX_WS) {
@@ -1230,7 +1237,11 @@ for m in ("pydantic", "httpx", "loguru"):
 
   ipcMain.handle(IPC.FILES_ACCEPT, async (_event, payload: unknown) => {
     const p = payload as { path: string; session_key?: string };
-    return bridge.send('files.accept', p as Record<string, unknown>);
+    try {
+      return await bridge.send('files.accept', p as Record<string, unknown>);
+    } catch (err: any) {
+      return { accepted: false, path: p.path, error: err?.message ?? String(err) };
+    }
   });
 
   // -- WSL helpers (async — must not block the Electron main thread) -----


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #448：`resolveWorkspacePath` 支持 WSL `/mnt/<drive>/...` 路径转换，`files.accept` 错误时优雅降级。

## 背景/问题

Agent 在 WSL 沙箱中将文件写入 workspace 之外的路径（如通过 `/mnt/c/Users/.../Desktop/` 写到 Windows 桌面）时，两个操作均失败：

1. `files:openExternal` — `resolveWorkspacePath` 不认识 `/mnt/c/` 格式，路径越界检查抛出 `Path outside workspace`
2. `files:accept` — bridge 重启后 session 授权失效，`bridge.send` 抛异常导致 IPC handler 崩溃，agent 反复重试

## 变更内容

- `apps/desktop/src/main/ipc/index.ts`:
  - `resolveWorkspacePath`: 函数开头增加 `/mnt/<drive>/...` → `<drive>:\...` 的转换逻辑
  - `files.accept`: 用 try/catch 包裹 `bridge.send`，失败时返回 `{ accepted: false, path, error }` 而非抛异常

1 文件，+12 / -1 行。

## 日志/验证证据

```
TypeScript 编译: 无错误
WSL 路径转换测试: 8/8 全部通过
  PASS: /mnt/c/Users/test/Desktop/file.md -> C:\Users/test/Desktop/file.md
  PASS: /mnt/d/projects/code -> D:\projects/code
  PASS: /mnt/c -> C:\
  PASS: /mnt/C/Users/test -> C:\Users/test
  PASS: /mnt/z/foo/bar.txt -> Z:\foo/bar.txt
  PASS: /home/miqi/workspace/file.md -> fallthrough (non-mnt path)
  PASS: C:\Users\test\file.md -> fallthrough (already Windows path)
  PASS: /home/miqi/workspace -> fallthrough (sandbox path)
vitest: 7 files, 99/99 全部通过，无回归
```

## 测试情况

- [x] TypeScript 编译通过
- [x] vitest: 99/99 全部通过
- [x] WSL 路径转换 8 个用例全部通过
- [ ] 手动测试：对 agent 说"在桌面创建 test.txt"验证文件能正常打开

## 截图

无需截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
