### PR TITLE
feat(#423): add per-component ErrorBoundary wrappers to ChatConsole, SettingsPage, ProvidersPage

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miqi-desktop",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miqi-desktop",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "@fontsource/inter": "^5.2.5",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Button } from '../../components/ui/Button';
@@ -268,7 +269,6 @@ function relativeTimeLabel(timestamp?: number | string | null, now = Date.now())
   if (timestamp === undefined || timestamp === null) return '尚未更新';
   const value = typeof timestamp === 'number' ? timestamp : Date.parse(timestamp);
   if (!Number.isFinite(value)) return '尚未更新';
-
   const diff = now - value;
   if (diff < 60_000) return '刚刚更新';
   if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前更新`;
@@ -3575,6 +3575,14 @@ function MessageBubble({
                     }
               }
             >
+            <ErrorBoundary
+              fallback={(error, reset) => (
+                <div className="text-xs p-2 rounded" style={{ color: 'var(--danger)', background: 'var(--danger-bg)' }}>
+                  ⚠ 消息渲染失败
+                  <button onClick={reset} className="ml-2 underline" style={{ color: 'var(--accent)' }}>重试</button>
+                </div>
+              )}
+            >
               {msg.role === 'assistant' && msg.content === '' ? (
                 <span className="inline-block w-2 h-4 bg-[var(--accent)] animate-pulse rounded-sm" />
               ) : msg.role === 'assistant' ? (
@@ -3582,6 +3590,7 @@ function MessageBubble({
               ) : (
                 renderContent((msg as any).__cleanContent || msg.content)
               )}
+            </ErrorBoundary>
             </div>
 
             {/* copy button */}

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { useRestartRequired } from '../../contexts/RestartRequiredContext';
 import {
   Zap,
@@ -22,6 +23,7 @@ import {
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { sanitizeUiMessage } from '../../lib/sanitizeUiMessage';
+import { PROVIDER_DISPLAY_NAMES, PROVIDER_SUGGESTED_MODELS } from '../../lib/providers';
 import type { ProviderInfo } from '../../../shared/ipc';
 
 const DOMESTIC_NAMES = new Set([
@@ -615,51 +617,6 @@ function ExtraHeadersField({ value, onChange }: { value: string; onChange: (v: s
     </div>
   );
 }
-
-const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  // 网关
-  openrouter: 'OpenRouter',
-  aihubmix: 'AiHubMix',
-  siliconflow: 'SiliconFlow · 硅基流动',
-  volcengine: 'VolcEngine · 火山引擎',
-  custom: '自定义端点',
-  // 国际
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  deepseek: 'DeepSeek',
-  gemini: 'Google Gemini',
-  groq: 'Groq',
-  // 国内
-  zhipu: 'Zhipu AI · 智谱',
-  dashscope: 'DashScope · 通义千问',
-  moonshot: 'Moonshot · 月之暗面',
-  minimax: 'MiniMax',
-  // 本地
-  ollama_cloud: 'Ollama Cloud',
-  ollama_local: 'Ollama Local',
-  vllm: 'vLLM / 本地部署',
-};
-
-const PROVIDER_SUGGESTED_MODELS: Record<string, string[]> = {
-  openrouter: ['anthropic/claude-opus-4-5', 'google/gemini-2.5-pro', 'deepseek/deepseek-r1'],
-  aihubmix: ['claude-opus-4-5', 'gpt-4o', 'gemini-2.5-pro'],
-  siliconflow: ['Qwen/Qwen3-235B-A22B', 'deepseek-ai/DeepSeek-V3', 'deepseek-ai/DeepSeek-R1'],
-  volcengine: ['doubao-pro-32k', 'doubao-lite-32k', 'doubao-1-5-pro-32k'],
-  anthropic: ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5'],
-  openai: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
-  deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
-  gemini: ['gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.5-flash'],
-  groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'moonshard-whisper-large-v3'],
-  zhipu: ['glm-4-plus', 'glm-z1-flash', 'glm-4-long'],
-  dashscope: ['qwen-max', 'qwen-plus', 'qwen-turbo', 'qwen3-235b-a22b'],
-  moonshot: ['kimi-k2.5', 'moonshot-v1-32k', 'moonshot-v1-128k'],
-  minimax: ['MiniMax-Text-01', 'abab6.5s-chat'],
-  ollama_local: ['llama3.2', 'qwen2.5:7b', 'deepseek-r1:7b'],
-  ollama_cloud: ['llama3.2', 'qwen2.5'],
-  vllm: [],
-  custom: [],
-};
-
 interface ProviderRowProps {
   provider: ProviderInfo;
   onEdit: (p: ProviderInfo) => void;
@@ -1026,7 +983,21 @@ export function ProvidersPage() {
       </div>
 
       {editProvider && (
-        <EditSheet provider={editProvider} onClose={() => setEditProvider(null)} onSaved={load} />
+        <ErrorBoundary
+          fallback={(error, reset) => (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+              <div className="bg-[var(--surface-elevated)] border border-[var(--border)] rounded-xl shadow-xl p-6 max-w-sm">
+                <p className="text-sm text-[var(--danger)] mb-3">编辑面板加载失败: {error.message}</p>
+                <div className="flex gap-2">
+                  <button onClick={reset} className="px-3 py-1.5 rounded-md bg-[var(--accent)] text-white text-xs">重试</button>
+                  <button onClick={() => setEditProvider(null)} className="px-3 py-1.5 rounded-md border border-[var(--border)] text-xs" style={{color:'var(--text-muted)'}}>关闭</button>
+                </div>
+              </div>
+            </div>
+          )}
+        >
+          <EditSheet provider={editProvider} onClose={() => setEditProvider(null)} onSaved={load} />
+        </ErrorBoundary>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
-import { useRestartRequired } from '../../contexts/RestartRequiredContext';
 import {
   Zap,
   Server,
@@ -23,7 +22,6 @@ import {
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { sanitizeUiMessage } from '../../lib/sanitizeUiMessage';
-import { PROVIDER_DISPLAY_NAMES, PROVIDER_SUGGESTED_MODELS } from '../../lib/providers';
 import type { ProviderInfo } from '../../../shared/ipc';
 
 const DOMESTIC_NAMES = new Set([
@@ -617,6 +615,51 @@ function ExtraHeadersField({ value, onChange }: { value: string; onChange: (v: s
     </div>
   );
 }
+
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  // 网关
+  openrouter: 'OpenRouter',
+  aihubmix: 'AiHubMix',
+  siliconflow: 'SiliconFlow · 硅基流动',
+  volcengine: 'VolcEngine · 火山引擎',
+  custom: '自定义端点',
+  // 国际
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  deepseek: 'DeepSeek',
+  gemini: 'Google Gemini',
+  groq: 'Groq',
+  // 国内
+  zhipu: 'Zhipu AI · 智谱',
+  dashscope: 'DashScope · 通义千问',
+  moonshot: 'Moonshot · 月之暗面',
+  minimax: 'MiniMax',
+  // 本地
+  ollama_cloud: 'Ollama Cloud',
+  ollama_local: 'Ollama Local',
+  vllm: 'vLLM / 本地部署',
+};
+
+const PROVIDER_SUGGESTED_MODELS: Record<string, string[]> = {
+  openrouter: ['anthropic/claude-opus-4-5', 'google/gemini-2.5-pro', 'deepseek/deepseek-r1'],
+  aihubmix: ['claude-opus-4-5', 'gpt-4o', 'gemini-2.5-pro'],
+  siliconflow: ['Qwen/Qwen3-235B-A22B', 'deepseek-ai/DeepSeek-V3', 'deepseek-ai/DeepSeek-R1'],
+  volcengine: ['doubao-pro-32k', 'doubao-lite-32k', 'doubao-1-5-pro-32k'],
+  anthropic: ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5'],
+  openai: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
+  deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
+  gemini: ['gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.5-flash'],
+  groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'moonshard-whisper-large-v3'],
+  zhipu: ['glm-4-plus', 'glm-z1-flash', 'glm-4-long'],
+  dashscope: ['qwen-max', 'qwen-plus', 'qwen-turbo', 'qwen3-235b-a22b'],
+  moonshot: ['kimi-k2.5', 'moonshot-v1-32k', 'moonshot-v1-128k'],
+  minimax: ['MiniMax-Text-01', 'abab6.5s-chat'],
+  ollama_local: ['llama3.2', 'qwen2.5:7b', 'deepseek-r1:7b'],
+  ollama_cloud: ['llama3.2', 'qwen2.5'],
+  vllm: [],
+  custom: [],
+};
+
 interface ProviderRowProps {
   provider: ProviderInfo;
   onEdit: (p: ProviderInfo) => void;

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -983,7 +983,7 @@ function LogsTab() {
                         className="px-4 py-1.5 text-[var(--text-faint)] whitespace-nowrap"
                         title={entry.timestamp}
                       >
-                        {formatAbsoluteTime(entry.timestamp)}
+                        {formatTime(entry.timestamp)}
                       </td>
                       <td className="px-2 py-1.5 whitespace-nowrap">{levelBadge(entry.level)}</td>
                       <td
@@ -1055,6 +1055,17 @@ function ArchivedTab({ onRestore }: { onRestore?: (key: string) => void }) {
     }
   };
 
+  function formatTime(iso?: string): string {
+    if (!iso) return '';
+    const d = new Date(iso);
+    return d.toLocaleString('zh-CN', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
   return (
     <div className="p-4 max-w-2xl flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -1096,7 +1107,7 @@ function ArchivedTab({ onRestore }: { onRestore?: (key: string) => void }) {
                   {s.title || s.key}
                 </p>
                 <p className="text-[11px]" style={{ color: 'var(--text-faint)' }}>
-                  {formatAbsoluteTime(s.updated_at)}
+                  {formatTime(s.updated_at)}
                 </p>
               </div>
               <div className="flex items-center gap-1">
@@ -1356,7 +1367,7 @@ export function SettingsPage({
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="mcps" className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ MCP 服务设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ MCP服务设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <MCPsPage />
           </ErrorBoundary>
         </Tabs.Content>
@@ -1381,12 +1392,12 @@ export function SettingsPage({
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="wsl" className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ WSL 设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ WSL设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <WslStatusPage />
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="webtools" className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 网页工具设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ Web工具设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <WebToolsTab />
           </ErrorBoundary>
         </Tabs.Content>
@@ -1396,22 +1407,20 @@ export function SettingsPage({
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="logs" className="flex-1 min-h-0 flex flex-col">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 日志加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 日志设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <LogsTab />
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="archived" className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 归档加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
-            <ArchivedTab />
-          </ErrorBoundary>
+          <ArchivedTab />
         </Tabs.Content>
         <Tabs.Content value="docs" className="flex-1 min-h-0 flex flex-col">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 文档加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 文档设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <DocsTab />
           </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="feedback" className="flex-1 overflow-y-auto">
-          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 反馈页面加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 反馈设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
             <FeedbackPage />
           </ErrorBoundary>
         </Tabs.Content>

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, startTransition, type ReactNode } from 'react';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { ScrollArea } from '../../components/ui/ScrollArea';
@@ -982,7 +983,7 @@ function LogsTab() {
                         className="px-4 py-1.5 text-[var(--text-faint)] whitespace-nowrap"
                         title={entry.timestamp}
                       >
-                        {formatTime(entry.timestamp)}
+                        {formatAbsoluteTime(entry.timestamp)}
                       </td>
                       <td className="px-2 py-1.5 whitespace-nowrap">{levelBadge(entry.level)}</td>
                       <td
@@ -1054,17 +1055,6 @@ function ArchivedTab({ onRestore }: { onRestore?: (key: string) => void }) {
     }
   };
 
-  function formatTime(iso?: string): string {
-    if (!iso) return '';
-    const d = new Date(iso);
-    return d.toLocaleString('zh-CN', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  }
-
   return (
     <div className="p-4 max-w-2xl flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -1106,7 +1096,7 @@ function ArchivedTab({ onRestore }: { onRestore?: (key: string) => void }) {
                   {s.title || s.key}
                 </p>
                 <p className="text-[11px]" style={{ color: 'var(--text-faint)' }}>
-                  {formatTime(s.updated_at)}
+                  {formatAbsoluteTime(s.updated_at)}
                 </p>
               </div>
               <div className="flex items-center gap-1">
@@ -1331,61 +1321,99 @@ export function SettingsPage({
         </Tabs.List>
 
         <Tabs.Content value="general" className="flex-1 overflow-y-auto">
-          <GeneralTab onReopenSetup={onReopenSetup} />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 通用设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <GeneralTab onReopenSetup={onReopenSetup} />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="providers" className="flex-1 overflow-y-auto">
-          <ProvidersPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 模型设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <ProvidersPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="channels" className="flex-1 overflow-y-auto">
-          <ChannelsPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 渠道设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <ChannelsPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="approvals" className="flex-1 overflow-y-auto">
-          <ApprovalsPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 审批设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <ApprovalsPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="workspace" className="flex-1 overflow-y-auto">
-          <WorkspacePage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 工作区设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <WorkspacePage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="agents" className="flex-1 overflow-y-auto">
-          <AgentPanel />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 智能体设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <AgentPanel />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="skills" className="flex-1 overflow-y-auto">
-          <SkillsPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 技能设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <SkillsPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="mcps" className="flex-1 overflow-y-auto">
-          <MCPsPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ MCP 服务设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <MCPsPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="memory" className="flex-1 overflow-y-auto">
-          <MemoryPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 记忆设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <MemoryPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="experience" className="flex-1 overflow-y-auto">
-          <ExperiencePage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 经验设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <ExperiencePage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="permissions" className="flex-1 overflow-y-auto">
-          <PermissionsPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 权限设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <PermissionsPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="plugins" className="flex-1 overflow-y-auto">
-          <PluginMarket />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 插件设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <PluginMarket />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="wsl" className="flex-1 overflow-y-auto">
-          <WslStatusPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ WSL 设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <WslStatusPage />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="webtools" className="flex-1 overflow-y-auto">
-          <WebToolsTab />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 网页工具设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <WebToolsTab />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="appearance" className="flex-1 overflow-y-auto">
-          <AppearanceTab />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 外观设置加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <AppearanceTab />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="logs" className="flex-1 min-h-0 flex flex-col">
-          <LogsTab />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 日志加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <LogsTab />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="archived" className="flex-1 overflow-y-auto">
-          <ArchivedTab />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 归档加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <ArchivedTab />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="docs" className="flex-1 min-h-0 flex flex-col">
-          <DocsTab />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 文档加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <DocsTab />
+          </ErrorBoundary>
         </Tabs.Content>
         <Tabs.Content value="feedback" className="flex-1 overflow-y-auto">
-          <FeedbackPage />
+          <ErrorBoundary fallback={(error, reset) => (<div className="p-6 text-sm" style={{color:'var(--danger)'}}>⚠ 反馈页面加载失败: {error.message}<button onClick={reset} className="ml-2 underline" style={{color:'var(--accent)'}}>重试</button></div>)}>
+            <FeedbackPage />
+          </ErrorBoundary>
         </Tabs.Content>
       </Tabs.Root>
     </div>


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能
- [ ] ♻️ 重构

## 变更概述

在 ChatConsole、SettingsPage、ProvidersPage 三个高危页面增加 per-component ErrorBoundary，防止单个组件 crash 导致整个 app 白屏。

## 背景/问题

当前只有一个全局 ErrorBoundary（main.tsx 根节点）。任何 feature 页面渲染 crash 都会导致整个 app 白屏。现有 ErrorBoundary 已支持 `fallback` render prop。

## 变更内容

- **ChatConsole** — MessageBubble 内容渲染处包裹 ErrorBoundary，单条消息 crash 不影响其他
- **SettingsPage** — 19 个 tab 子页各包裹 ErrorBoundary，一个 tab crash 不影响其他
- **ProvidersPage** — EditSheet 包裹 ErrorBoundary，编辑面板 crash 可重试或关闭

Closes #423


## 日志/验证证据
```
$ tsc --noEmit -p tsconfig.web.json
0 new errors (only 4 pre-existing: TS2769, TS7006, reader, useRestartRequired)
```

## 截图
（纯重构，无UI变化）