### PR TITLE
fix: hide HTML document injection text in chat — add missing Document: prefix

### DIFF
--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -50,5 +50,6 @@ export default defineConfig({
     command: 'python -m http.server 3458 --directory out/renderer',
     url: 'http://localhost:3458',
     reuseExistingServer: true,
+    timeout: 180_000,  // macOS CI can be slow to start
   },
 });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -125,6 +125,7 @@ const FILE_BLOCK_RES = [
   /\[([^\]:]+):\s*(?:binary file|scanned PDF)[^\]]*\]/g,
   /--- Document: ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,
   /--- ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,   // legacy: client-side inject before fix
+  /\[Uploaded: ([^\]]+?)\s*[—\-].*?\]/g,                // backend fallback when parse returns empty
 ];
 
 interface FileChip {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3537,11 +3537,13 @@ function MessageBubble({
                   </div>
                 );
               })}
-            {isUser && (!msg.attachments || msg.attachments.length === 0) && (() => {
+            {/* Always clean injected document text from content — shown as chips only when attachments are missing */}
+            {isUser && (() => {
               const { cleanContent, chips } = extractFileChips(msg.content);
-              if (chips.length === 0) return null;
-              // Store clean content for the bubble below
+              // Always store cleaned content so the bubble renders without injected text
               (msg as any).__cleanContent = cleanContent;
+              // Only show historical chips when there are no real attachments (avoids duplicates)
+              if (chips.length === 0 || (msg.attachments && msg.attachments.length > 0)) return null;
               return chips.map((chip, i) => (
                 <div
                   key={`hist-${i}`}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -125,7 +125,7 @@ const FILE_BLOCK_RES = [
   /\[([^\]:]+):\s*(?:binary file|scanned PDF)[^\]]*\]/g,
   /--- Document: ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,
   /--- ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,   // legacy: client-side inject before fix
-  /\[Uploaded: ([^\]]+?)\s*[—\-].*?\]/g,                // backend fallback when parse returns empty
+  /\[Uploaded: ([^\]]+?)\s+[—\-]\s+use\s+pdf_read[^\]]*\]/g,  // backend fallback when parse returns empty
 ];
 
 interface FileChip {
@@ -3591,7 +3591,7 @@ function MessageBubble({
               ) : msg.role === 'assistant' ? (
                 <MarkdownContent content={msg.content} />
               ) : (
-                renderContent((msg as any).__cleanContent || msg.content)
+                renderContent((msg as any).__cleanContent ?? msg.content)
               )}
             </ErrorBoundary>
             </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -124,6 +124,7 @@ const FILE_BLOCK_RES = [
   /\[File: ([^\]]+)\]\n```\n[\s\S]*?\n```/g,
   /\[([^\]:]+):\s*(?:binary file|scanned PDF)[^\]]*\]/g,
   /--- Document: ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,
+  /--- ([^\n]+) ---\n[\s\S]*?\n--- End of \1 ---/g,   // legacy: client-side inject before fix
 ];
 
 interface FileChip {
@@ -1343,7 +1344,7 @@ export function ChatConsole({
           }
 
           if (extracted && extracted.trim()) {
-            content += `\n\n--- ${att.name} ---\n${extracted.slice(0, 50000)}\n--- End of ${att.name} ---`;
+            content += `\n\n--- Document: ${att.name} ---\n${extracted.slice(0, 50000)}\n--- End of ${att.name} ---`;
           } else if (ext === 'pdf') {
             content += `\n\n[${att.name}: scanned PDF — OCR will be attempted by the server]`;
           } else {


### PR DESCRIPTION
## 类型
- [x] 🐛 修复

## 变更概述
上传的 HTML/PDF 文件内容在聊天中直接显示全文，而非提取为彩色 chips。根因是客户端注入格式与后端不匹配、extractFileChips 条件错误、后端 fallback 未被捕获。

## 背景/问题
- 后端注入格式：`--- Document: name ---\n...\n--- End of name ---`
- 客户端注入格式：`--- name ---\n...\n--- End of name ---`（缺 `Document:` 前缀）
- `extractFileChips` 只在无附件时运行，但上传文件就是附件，条件永远为假
- 后端 `[Uploaded: ...]` fallback 无 regex 匹配

## 变更内容
- 客户端注入格式改为 `--- Document: name ---` 与后端一致
- FILE_BLOCK_RES 新增向后兼容正则 + `[Uploaded: ...]` 正则
- extractFileChips 始终运行以设置 `__cleanContent`

## 日志/验证证据
```
$ tsc --noEmit -p tsconfig.web.json
0 new errors
```

## 测试情况
- TypeScript 编译通过
- 文档注入文本被正确提取为 chips
- `[Uploaded: ...]` 不再显示为裸文本

## 截图
（纯修复，HTML 文档上传后显示为 chip 而非全文）

Closes #478