### PR TITLE
feat(#484): add 13 new file format parsers (CSV/JSON/XML/YAML/ENV/LOG/SQL/INI/TOML/HTACCESS/SH/TXT/RTF)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -80,7 +80,7 @@ interface Attachment {
   parseError?: string;
 }
 
-const DOCUMENT_SUFFIXES_RE = /\.(docx|doc|pptx|ppt|xlsx|xls|pdf|odt|odp|ods|md|markdown|mdown|html|htm)$/i;
+const DOCUMENT_SUFFIXES_RE = /\.(docx|doc|pptx|ppt|xlsx|xls|pdf|odt|odp|ods|md|markdown|mdown|html|htm|csv|json|xml|yaml|yml|env|log|sql|ini|toml|htaccess|sh|bash|txt|text|rtf)$/i;
 
 function getDocCategory(name: string): { label: string; color: string; bg: string } {
   const ext = name.split('.').pop()?.toLowerCase() ?? '';
@@ -97,6 +97,22 @@ function getDocCategory(name: string): { label: string; color: string; bg: strin
     mdown: { label: 'MD', color: '#a855f7', bg: 'rgba(168,85,247,0.12)' },
     html: { label: 'HTML', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
     htm: { label: 'HTML', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
+    csv: { label: 'CSV', color: '#10b981', bg: 'rgba(16,185,129,0.12)' },
+    json: { label: 'JSON', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
+    xml: { label: 'XML', color: '#6366f1', bg: 'rgba(99,102,241,0.12)' },
+    yaml: { label: 'YAML', color: '#06b6d4', bg: 'rgba(6,182,212,0.12)' },
+    yml: { label: 'YAML', color: '#06b6d4', bg: 'rgba(6,182,212,0.12)' },
+    env: { label: 'ENV', color: '#84cc16', bg: 'rgba(132,204,22,0.12)' },
+    log: { label: 'LOG', color: '#64748b', bg: 'rgba(100,116,139,0.12)' },
+    sql: { label: 'SQL', color: '#0ea5e9', bg: 'rgba(14,165,233,0.12)' },
+    ini: { label: 'INI', color: '#8b5cf6', bg: 'rgba(139,92,246,0.12)' },
+    toml: { label: 'TOML', color: '#e11d48', bg: 'rgba(225,29,72,0.12)' },
+    htaccess: { label: 'HTA', color: '#d946ef', bg: 'rgba(217,70,239,0.12)' },
+    sh: { label: 'SH', color: '#14b8a6', bg: 'rgba(20,184,166,0.12)' },
+    bash: { label: 'SH', color: '#14b8a6', bg: 'rgba(20,184,166,0.12)' },
+    txt: { label: 'TXT', color: '#6b7280', bg: 'rgba(107,114,128,0.12)' },
+    text: { label: 'TXT', color: '#6b7280', bg: 'rgba(107,114,128,0.12)' },
+    rtf: { label: 'RTF', color: '#ec4899', bg: 'rgba(236,72,153,0.12)' },
     odt: { label: 'DOC', color: '#3b82f6', bg: 'rgba(59,130,246,0.12)' },
     odp: { label: 'PPT', color: '#f97316', bg: 'rgba(249,115,22,0.12)' },
     ods: { label: 'XLS', color: '#22c55e', bg: 'rgba(34,197,94,0.12)' },
@@ -213,7 +229,7 @@ interface TrackedFile {
 
 const OFFICE_FILE_RE = /\.(docx|xlsx|pptx|ppt|xls|doc|odt|odp|ods)$/i;
 const PDF_FILE_RE = /\.pdf$/i;
-const TEXT_SUFFIXES_RE = /\.(md|markdown|mdown|txt|csv|json|yaml|yml|xml|log)$/i;
+const TEXT_SUFFIXES_RE = /\.(md|markdown|mdown|txt|text|csv|json|yaml|yml|xml|log|env|sql|ini|toml|htaccess|sh|bash|rtf)$/i;
 const OFFICE_FILE_RE_LEGACY = /\.(docx|xlsx|pptx|ppt)$/i;
 
 /** Extract text from a PDF buffer by parsing BT/ET text blocks.
@@ -1212,9 +1228,9 @@ export function ChatConsole({
         reader.onload = () => {
           const base64 = (reader.result as string).split(',')[1];
           const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
-          // PDF/MD/text parse instantly client-side → done; Office needs server → pending
-          const isOffice = /^(docx|doc|pptx|ppt|xlsx|xls|odt|odp|ods)$/i.test(ext);
-          const parseStatus: Attachment['status'] = isOffice ? 'pending' : 'done';
+          // PDF/MD/text parse instantly client-side → done; Office/RTF needs server → pending
+          const isServerParsed = /^(docx|doc|pptx|ppt|xlsx|xls|odt|odp|ods|rtf)$/i.test(ext);
+          const parseStatus: Attachment['status'] = isServerParsed ? 'pending' : 'done';
 
           setAttachments((prev) => [
             ...prev,
@@ -1337,14 +1353,12 @@ export function ChatConsole({
 
           if (ext === 'pdf') {
             extracted = extractPdfText(raw.buffer);
-          } else if (ext === 'md' || ext === 'markdown' || ext === 'mdown' || ext === 'txt' || ext === 'html' || ext === 'htm') {
-            extracted = new TextDecoder().decode(raw);
           } else if (
-            ext === 'csv' ||
-            ext === 'json' ||
-            ext === 'yaml' ||
-            ext === 'yml' ||
-            ext === 'xml'
+            ext === 'md' || ext === 'markdown' || ext === 'mdown' || ext === 'txt' || ext === 'text' ||
+            ext === 'html' || ext === 'htm' || ext === 'csv' || ext === 'json' ||
+            ext === 'yaml' || ext === 'yml' || ext === 'xml' || ext === 'env' ||
+            ext === 'log' || ext === 'sql' || ext === 'ini' || ext === 'toml' ||
+            ext === 'htaccess' || ext === 'sh' || ext === 'bash'
           ) {
             extracted = new TextDecoder().decode(raw);
           }
@@ -1956,8 +1970,8 @@ export function ChatConsole({
         reader.onload = () => {
           const base64 = (reader.result as string).split(',')[1];
           const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
-          const isOffice = /^(docx|doc|pptx|ppt|xlsx|xls|odt|odp|ods)$/i.test(ext);
-          const parseStatus: Attachment['status'] = isOffice ? 'pending' : 'done';
+          const isServerParsed = /^(docx|doc|pptx|ppt|xlsx|xls|odt|odp|ods|rtf)$/i.test(ext);
+          const parseStatus: Attachment['status'] = isServerParsed ? 'pending' : 'done';
           setAttachments((prev) => [
             ...prev,
             {
@@ -2128,7 +2142,7 @@ export function ChatConsole({
         ref={fileInputRef}
         type="file"
         multiple
-        accept="image/*,text/*,.md,.markdown,.mdown,.txt,.py,.ts,.js,.json,.csv,.yaml,.yml,.toml,.pdf,.docx,.pptx,.xlsx,.doc,.ppt,.xls,.odt,.odp,.ods,.html,.htm"
+        accept="image/*,text/*,.md,.markdown,.mdown,.txt,.text,.py,.ts,.js,.json,.csv,.yaml,.yml,.toml,.xml,.env,.log,.sql,.ini,.htaccess,.sh,.bash,.rtf,.pdf,.docx,.pptx,.xlsx,.doc,.ppt,.xls,.odt,.odp,.ods,.html,.htm"
         className="hidden"
         onChange={handleFileChange}
       />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2497,7 +2497,7 @@ export function ChatConsole({
                             if (ext === 'pdf') {
                               previewText = extractPdfText(raw.buffer);
                             } else if (
-                              /^(md|markdown|mdown|txt|csv|json|ya?ml|xml|py|ts|js|log|html|htm)$/i.test(ext)
+                              /^(md|markdown|mdown|txt|text|csv|json|ya?ml|xml|py|ts|js|log|html|htm|env|sql|ini|toml|htaccess|sh|bash)$/i.test(ext)
                             ) {
                               previewText = new TextDecoder().decode(raw);
                             } else {

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -58,7 +58,7 @@ def parse_document(
         dict with keys: text, page_count, size_bytes, mime_type, ocr_used,
                         parse_ms, charts (if extract_charts=True)
     """
-    suffix = file_path.suffix.lower()
+    suffix = _get_suffix(file_path)
     if suffix in _PDF_SUFFIXES:
         return _parse_pdf(file_path, max_chars=max_chars, force_ocr=force_ocr,
                           extract_charts=extract_charts)
@@ -104,32 +104,51 @@ def parse_document(
 
 def is_supported_document(path: Path | str) -> bool:
     """Check if the file path is a supported document format."""
-    suffix = Path(path).suffix.lower()
+    suffix = _get_suffix(path)
     return suffix in _ALL_DOCUMENT_SUFFIXES
 
 
 def get_document_category(path: Path | str) -> str:
     """Get the document category (pdf, word, ppt, excel, markdown, unknown)."""
-    suffix = Path(path).suffix.lower()
-    if suffix in _PDF_SUFFIXES: return "pdf"
-    if suffix in _DOCX_SUFFIXES: return "word"
-    if suffix in _PPTX_SUFFIXES: return "ppt"
-    if suffix in _XLSX_SUFFIXES: return "excel"
-    if suffix in _MD_SUFFIXES: return "markdown"
-    if suffix in _HTML_SUFFIXES: return "html"
-    if suffix in _CSV_SUFFIXES: return "csv"
-    if suffix in _JSON_SUFFIXES: return "json"
-    if suffix in _XML_FILE_SUFFIXES: return "xml"
-    if suffix in _YAML_SUFFIXES: return "yaml"
-    if suffix in _ENV_SUFFIXES: return "env"
-    if suffix in _LOG_SUFFIXES: return "log"
-    if suffix in _SQL_SUFFIXES: return "sql"
-    if suffix in _INI_SUFFIXES: return "ini"
-    if suffix in _TOML_SUFFIXES: return "toml"
-    if suffix in _HTACCESS_SUFFIXES: return "htaccess"
-    if suffix in _SH_SUFFIXES: return "sh"
-    if suffix in _TXT_SUFFIXES: return "txt"
-    if suffix in _RTF_SUFFIXES: return "rtf"
+    suffix = _get_suffix(path)
+    if suffix in _PDF_SUFFIXES:
+        return "pdf"
+    if suffix in _DOCX_SUFFIXES:
+        return "word"
+    if suffix in _PPTX_SUFFIXES:
+        return "ppt"
+    if suffix in _XLSX_SUFFIXES:
+        return "excel"
+    if suffix in _MD_SUFFIXES:
+        return "markdown"
+    if suffix in _HTML_SUFFIXES:
+        return "html"
+    if suffix in _CSV_SUFFIXES:
+        return "csv"
+    if suffix in _JSON_SUFFIXES:
+        return "json"
+    if suffix in _XML_FILE_SUFFIXES:
+        return "xml"
+    if suffix in _YAML_SUFFIXES:
+        return "yaml"
+    if suffix in _ENV_SUFFIXES:
+        return "env"
+    if suffix in _LOG_SUFFIXES:
+        return "log"
+    if suffix in _SQL_SUFFIXES:
+        return "sql"
+    if suffix in _INI_SUFFIXES:
+        return "ini"
+    if suffix in _TOML_SUFFIXES:
+        return "toml"
+    if suffix in _HTACCESS_SUFFIXES:
+        return "htaccess"
+    if suffix in _SH_SUFFIXES:
+        return "sh"
+    if suffix in _TXT_SUFFIXES:
+        return "txt"
+    if suffix in _RTF_SUFFIXES:
+        return "rtf"
     return "unknown"
 
 
@@ -164,6 +183,26 @@ _ALL_DOCUMENT_SUFFIXES = (
     _HTACCESS_SUFFIXES | _SH_SUFFIXES | _TXT_SUFFIXES |
     _RTF_SUFFIXES
 )
+
+
+# ── Suffix normalization ──────────────────────────────────────────────────
+
+def _get_suffix(file_path: Path | str) -> str:
+    """Normalize suffix for dotfiles where Path.suffix returns empty.
+
+    Path(".env").suffix == ""  → _get_suffix(".env") == ".env"
+    Path(".htaccess").suffix == ""  → _get_suffix(".htaccess") == ".htaccess"
+    Path("test.csv").suffix == ".csv"  → unchanged.
+    """
+    p = Path(file_path)
+    suffix = p.suffix.lower()
+    if suffix:
+        return suffix
+    # Dotfile: name IS the suffix (e.g., ".env", ".htaccess")
+    name = p.name.lower()
+    if name.startswith("."):
+        return name
+    return ""
 
 
 # ── MIME types ─────────────────────────────────────────────────────────────
@@ -846,7 +885,7 @@ def _parse_csv(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str,
     t0 = time.perf_counter()
     try:
         raw = file_path.read_text(encoding="utf-8", errors="replace")
-        reader = _csv_mod.reader(raw.splitlines())
+        reader = _csv_mod.reader(io.StringIO(raw, newline=""))
         rows = list(reader)
         if not rows:
             return _make_text_result(file_path, raw, max_chars, t0, "text/csv")
@@ -989,17 +1028,23 @@ def _parse_rtf(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str,
     t0 = time.perf_counter()
     try:
         raw = file_path.read_text(encoding="utf-8", errors="replace")
-        # Strip RTF control words (\\rtf1, \\b, \\i, \\par, etc.)
-        # Remove \\ followed by word chars (control words) and optional space
-        text = re.sub(r"\\[a-zA-Z]+\s?", " ", raw)
+        # Decode RTF Unicode escapes (\uN with ANSI fallback) before stripping markup.
+        # \u233?  → é (U+00E9, decimal 233, fallback ?)
+        text = re.sub(
+            r"\\u(-?\d+)\s*\??",
+            lambda m: chr(int(m.group(1)) % 0x10000) if 0 < int(m.group(1)) <= 0x10FFFF else m.group(0),
+            raw,
+        )
+        # Decode \'xx hex byte escapes (code-page dependent; basic ASCII/Latin-1 pass-through)
+        text = re.sub(r"\\\'([0-9a-fA-F]{2})", lambda m: chr(int(m.group(1), 16)), text)
+        # Strip remaining RTF control words (rtf1, b, i, par, etc.)
+        text = re.sub(r"\\[a-zA-Z]+\s?", " ", text)
         # Remove { and }
         text = text.replace("{", "").replace("}", "")
-        # Remove \\'xx hex escapes
-        text = re.sub(r"\\\'[0-9a-fA-F]{2}", " ", text)
         # Normalize whitespace
         text = re.sub(r"\s+", " ", text).strip()
-        if len(text) < 50:
-            # Fallback: RTF parsing failed, return raw
+        if len(text.strip()) < 5:
+            # Fallback: RTF parsing produced too little text, return raw
             text = raw
     except Exception as exc:
         logger.warning(f"RTF parsing failed: {exc}")

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -995,7 +995,7 @@ def _parse_rtf(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str,
         # Remove { and }
         text = text.replace("{", "").replace("}", "")
         # Remove \\'xx hex escapes
-        text = re.sub(r"\\\\'[0-9a-fA-F]{2}", " ", text)
+        text = re.sub(r"\\\'[0-9a-fA-F]{2}", " ", text)
         # Normalize whitespace
         text = re.sub(r"\s+", " ", text).strip()
         if len(text) < 50:

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -72,6 +72,32 @@ def parse_document(
         return _parse_markdown(file_path, max_chars=max_chars)
     elif suffix in _HTML_SUFFIXES:
         return _parse_html(file_path, max_chars=max_chars)
+    elif suffix in _CSV_SUFFIXES:
+        return _parse_csv(file_path, max_chars=max_chars)
+    elif suffix in _JSON_SUFFIXES:
+        return _parse_json(file_path, max_chars=max_chars)
+    elif suffix in _XML_FILE_SUFFIXES:
+        return _parse_xml_file(file_path, max_chars=max_chars)
+    elif suffix in _YAML_SUFFIXES:
+        return _parse_yaml(file_path, max_chars=max_chars)
+    elif suffix in _ENV_SUFFIXES:
+        return _parse_env(file_path, max_chars=max_chars)
+    elif suffix in _LOG_SUFFIXES:
+        return _parse_log(file_path, max_chars=max_chars)
+    elif suffix in _SQL_SUFFIXES:
+        return _parse_sql(file_path, max_chars=max_chars)
+    elif suffix in _INI_SUFFIXES:
+        return _parse_ini(file_path, max_chars=max_chars)
+    elif suffix in _TOML_SUFFIXES:
+        return _parse_toml(file_path, max_chars=max_chars)
+    elif suffix in _HTACCESS_SUFFIXES:
+        return _parse_htaccess(file_path, max_chars=max_chars)
+    elif suffix in _SH_SUFFIXES:
+        return _parse_sh(file_path, max_chars=max_chars)
+    elif suffix in _TXT_SUFFIXES:
+        return _parse_txt(file_path, max_chars=max_chars)
+    elif suffix in _RTF_SUFFIXES:
+        return _parse_rtf(file_path, max_chars=max_chars)
     else:
         raise ValueError(f"Unsupported document format: {suffix}")
 
@@ -91,6 +117,19 @@ def get_document_category(path: Path | str) -> str:
     if suffix in _XLSX_SUFFIXES: return "excel"
     if suffix in _MD_SUFFIXES: return "markdown"
     if suffix in _HTML_SUFFIXES: return "html"
+    if suffix in _CSV_SUFFIXES: return "csv"
+    if suffix in _JSON_SUFFIXES: return "json"
+    if suffix in _XML_FILE_SUFFIXES: return "xml"
+    if suffix in _YAML_SUFFIXES: return "yaml"
+    if suffix in _ENV_SUFFIXES: return "env"
+    if suffix in _LOG_SUFFIXES: return "log"
+    if suffix in _SQL_SUFFIXES: return "sql"
+    if suffix in _INI_SUFFIXES: return "ini"
+    if suffix in _TOML_SUFFIXES: return "toml"
+    if suffix in _HTACCESS_SUFFIXES: return "htaccess"
+    if suffix in _SH_SUFFIXES: return "sh"
+    if suffix in _TXT_SUFFIXES: return "txt"
+    if suffix in _RTF_SUFFIXES: return "rtf"
     return "unknown"
 
 
@@ -102,10 +141,28 @@ _PPTX_SUFFIXES = {".pptx", ".ppt", ".odp"}
 _XLSX_SUFFIXES = {".xlsx", ".xls", ".ods"}
 _MD_SUFFIXES = {".md", ".markdown", ".mdown"}
 _HTML_SUFFIXES = {".html", ".htm"}
+_CSV_SUFFIXES = {".csv"}
+_JSON_SUFFIXES = {".json"}
+_XML_FILE_SUFFIXES = {".xml"}
+_YAML_SUFFIXES = {".yaml", ".yml"}
+_ENV_SUFFIXES = {".env"}
+_LOG_SUFFIXES = {".log"}
+_SQL_SUFFIXES = {".sql"}
+_INI_SUFFIXES = {".ini"}
+_TOML_SUFFIXES = {".toml"}
+_HTACCESS_SUFFIXES = {".htaccess"}
+_SH_SUFFIXES = {".sh", ".bash"}
+_TXT_SUFFIXES = {".txt", ".text"}
+_RTF_SUFFIXES = {".rtf"}
 
 _ALL_DOCUMENT_SUFFIXES = (
     _PDF_SUFFIXES | _DOCX_SUFFIXES | _PPTX_SUFFIXES |
-    _XLSX_SUFFIXES | _MD_SUFFIXES | _HTML_SUFFIXES
+    _XLSX_SUFFIXES | _MD_SUFFIXES | _HTML_SUFFIXES |
+    _CSV_SUFFIXES | _JSON_SUFFIXES | _XML_FILE_SUFFIXES |
+    _YAML_SUFFIXES | _ENV_SUFFIXES | _LOG_SUFFIXES |
+    _SQL_SUFFIXES | _INI_SUFFIXES | _TOML_SUFFIXES |
+    _HTACCESS_SUFFIXES | _SH_SUFFIXES | _TXT_SUFFIXES |
+    _RTF_SUFFIXES
 )
 
 
@@ -124,6 +181,22 @@ _SUFFIX_TO_MIME: dict[str, str] = {
     ".ods": "application/vnd.oasis.opendocument.spreadsheet",
     ".html": "text/html",
     ".htm": "text/html",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".xml": "application/xml",
+    ".yaml": "text/yaml",
+    ".yml": "text/yaml",
+    ".env": "text/plain",
+    ".log": "text/plain",
+    ".sql": "text/x-sql",
+    ".ini": "text/plain",
+    ".toml": "text/plain",
+    ".htaccess": "text/plain",
+    ".sh": "text/x-shellscript",
+    ".bash": "text/x-shellscript",
+    ".txt": "text/plain",
+    ".text": "text/plain",
+    ".rtf": "text/rtf",
 }
 
 
@@ -760,6 +833,195 @@ def _parse_html(file_path: Path, max_chars: int = 50000) -> dict:
         "page_count": 1,
         "size_bytes": file_path.stat().st_size,
         "mime_type": "text/html",
+        "ocr_used": False,
+        "parse_ms": round((time.perf_counter() - t0) * 1000),
+    }
+
+
+# ── CSV Parser ────────────────────────────────────────────────────────────
+
+def _parse_csv(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Extract and format CSV data as readable text."""
+    import csv as _csv_mod
+    t0 = time.perf_counter()
+    try:
+        raw = file_path.read_text(encoding="utf-8", errors="replace")
+        reader = _csv_mod.reader(raw.splitlines())
+        rows = list(reader)
+        if not rows:
+            return _make_text_result(file_path, raw, max_chars, t0, "text/csv")
+        # Format as table-like text
+        lines = []
+        headers = rows[0] if rows else []
+        if headers:
+            lines.append(" | ".join(str(h) for h in headers))
+            lines.append("-" * 40)
+        for row in rows[1:101]:  # max 100 data rows
+            lines.append(" | ".join(str(c) for c in row))
+        if len(rows) > 101:
+            lines.append(f"... ({len(rows) - 101} more rows)")
+        text = "\n".join(lines)
+    except Exception as exc:
+        logger.warning(f"CSV parsing failed: {exc}, falling back to raw text")
+        raw = file_path.read_text(encoding="utf-8", errors="replace")
+        text = raw
+    return _make_text_result(file_path, text, max_chars, t0, "text/csv")
+
+
+# ── JSON Parser ───────────────────────────────────────────────────────────
+
+def _parse_json(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Extract and format JSON data as readable text."""
+    import json as _json_mod
+    t0 = time.perf_counter()
+    try:
+        raw = file_path.read_text(encoding="utf-8", errors="replace")
+        data = _json_mod.loads(raw)
+        text = _json_mod.dumps(data, ensure_ascii=False, indent=2)
+    except Exception as exc:
+        logger.warning(f"JSON parsing failed: {exc}, falling back to raw text")
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, text, max_chars, t0, "application/json")
+
+
+# ── XML File Parser ───────────────────────────────────────────────────────
+
+def _parse_xml_file(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Extract text from XML files via lxml or plain-text fallback."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    if _HAS_LXML_HTML:
+        try:
+            doc = _lxml_html.document_fromstring(raw)
+            text = " ".join(doc.itertext())
+            text = re.sub(r"\s+", " ", text).strip()
+            return _make_text_result(file_path, text, max_chars, t0, "application/xml")
+        except Exception as exc:
+            logger.warning(f"lxml XML parsing failed: {exc}, falling back to raw text")
+    return _make_text_result(file_path, raw, max_chars, t0, "application/xml")
+
+
+# ── YAML Parser ───────────────────────────────────────────────────────────
+
+def _parse_yaml(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read YAML file as plain text (structure preservation)."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/yaml")
+
+
+# ── ENV Parser ────────────────────────────────────────────────────────────
+
+def _parse_env(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read .env file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── LOG Parser ────────────────────────────────────────────────────────────
+
+def _parse_log(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read log file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── SQL Parser ────────────────────────────────────────────────────────────
+
+def _parse_sql(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read SQL file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/x-sql")
+
+
+# ── INI Parser ────────────────────────────────────────────────────────────
+
+def _parse_ini(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read INI file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── TOML Parser ───────────────────────────────────────────────────────────
+
+def _parse_toml(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read TOML file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── HTACCESS Parser ───────────────────────────────────────────────────────
+
+def _parse_htaccess(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read .htaccess file as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── Shell Script Parser ───────────────────────────────────────────────────
+
+def _parse_sh(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read shell script as plain text."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/x-shellscript")
+
+
+# ── TXT Parser ────────────────────────────────────────────────────────────
+
+def _parse_txt(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Read plain text file."""
+    t0 = time.perf_counter()
+    raw = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, raw, max_chars, t0, "text/plain")
+
+
+# ── RTF Parser ────────────────────────────────────────────────────────────
+
+def _parse_rtf(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Extract text from RTF files by stripping RTF markup."""
+    t0 = time.perf_counter()
+    try:
+        raw = file_path.read_text(encoding="utf-8", errors="replace")
+        # Strip RTF control words (\\rtf1, \\b, \\i, \\par, etc.)
+        # Remove \\ followed by word chars (control words) and optional space
+        text = re.sub(r"\\[a-zA-Z]+\s?", " ", raw)
+        # Remove { and }
+        text = text.replace("{", "").replace("}", "")
+        # Remove \\'xx hex escapes
+        text = re.sub(r"\\\\'[0-9a-fA-F]{2}", " ", text)
+        # Normalize whitespace
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 50:
+            # Fallback: RTF parsing failed, return raw
+            text = raw
+    except Exception as exc:
+        logger.warning(f"RTF parsing failed: {exc}")
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    return _make_text_result(file_path, text, max_chars, t0, "text/rtf")
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────
+
+def _make_text_result(
+    file_path: Path,
+    text: str,
+    max_chars: int,
+    t0: float,
+    mime_type: str = "text/plain",
+) -> dict[str, Any]:
+    """Build a standard result dict for text-based parsers."""
+    return {
+        "text": text[:max_chars],
+        "page_count": 1,
+        "size_bytes": file_path.stat().st_size,
+        "mime_type": mime_type,
         "ocr_used": False,
         "parse_ms": round((time.perf_counter() - t0) * 1000),
     }


### PR DESCRIPTION
## 类型

- [x] 新功能 (feat)
- [ ] 修复 (fix)
- [ ] 重构
- [ ] 文档
- [ ] CI / 构建

## 变更概述

扩展 MiQi 文件解析能力，新增 **13 种文件格式**支持：CSV、JSON、XML、YAML、ENV、LOG、SQL、INI、TOML、HTACCESS、SH、TXT、RTF。每种格式有独立的颜色标识，切换对话时通过 extractFileChips() 自动隐藏注入文本。

## 背景/问题

当前仅支持 PDF/DOCX/PPTX/XLSX/MD/HTML 6 种格式，用户反馈需要解析更多常见文件格式（配置类、脚本类、日志类、文档类）。见 #484。

## 变更内容

### 服务端 (`miqi/documents/document_parser.py`)
- 新增 13 种格式的 suffix set 和 parser 函数：
  - `_parse_csv`: 表格格式化（提取 header + 100 行数据）
  - `_parse_json`: JSON pretty-print
  - `_parse_xml_file`: lxml 文本提取，无 lxml 时 raw text fallback
  - `_parse_rtf`: 去除 RTF markup（\\控制字、{}、\\'xx 转义）
  - `_parse_yaml/_parse_env/_parse_log/_parse_sql/_parse_ini/_parse_toml/_parse_htaccess/_parse_sh/_parse_txt`: 纯文本读取
- 通用 helper `_make_text_result()` 复用
- 更新 `_ALL_DOCUMENT_SUFFIXES`、`get_document_category()`、`_SUFFIX_TO_MIME`

### 客户端 (`ChatConsole.tsx`)
- **13 种新颜色**：CSV#10b981(翠绿) JSON#f59e0b(琥珀) XML#6366f1(靛蓝) YAML#06b6d4(青色) ENV#84cc16(柠绿) LOG#64748b(灰蓝) SQL#0ea5e9(天蓝) INI#8b5cf6(紫罗兰) TOML#e11d48(玫红) HTACCESS#d946ef(品红) SH#14b8a6(蓝绿) TXT#6b7280(灰色) RTF#ec4899(粉红)
- 更新 `DOCUMENT_SUFFIXES_RE`、`TEXT_SUFFIXES_RE`、文件选择器 `accept`
- `handleSend` 客户端解码并入所有文本格式
- RTF 标记为 server-parsed（pending 状态，类似 Office 文档）
- 已有的 `extractFileChips()` 自动剥离 `--- Document: name ---` 格式的注入文本

## 日志/验证证据
```
$ uv run python -m pytest tests/bridge/ -x -q
225 passed in 22.16s

所有 16 个新 suffix 通过 is_supported_document() 和 get_document_category() 验证
13 种 parser 手动测试全部通过（提取文本正确）
```

## 测试情况

- [x] 225 个 bridge 测试全部通过
- [x] 手动验证 13 种 parser 正确提取文本
- [x] `is_supported_document()` 和 `get_document_category()` 正确识别所有新格式

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/5cc3889c-2658-4250-88ef-9ad940a943ed" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/792becec-0f4e-4401-bf1a-a50ad9f098b3" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/7ca82e01-a575-4301-947d-efd46f10a195" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/a3da23e0-7ce0-411e-83bb-755f72753451" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/043e083c-3bb0-4433-972e-326fd5e3c8c5" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/24d3a8da-2948-4e72-b077-71cd3cb97da0" />


Closes #484