### PR TITLE
fix(ci): skip Playwright webServer for Electron E2E projects

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -141,6 +141,8 @@ jobs:
           xvfb-run --auto-servernum \
             npx playwright test --config=playwright.config.ts --project=electron
         timeout-minutes: 30
+        env:
+          PLAYWRIGHT_SKIP_WEB_SERVER: '1'
 
       - name: Upload Playwright report (E2E)
         if: failure()
@@ -230,6 +232,8 @@ jobs:
           npx playwright test --config=playwright.config.ts --project=electron \
             --grep-invert "Sandbox Exec|session-key-mapping|PPTX Generator"
         timeout-minutes: 30
+        env:
+          PLAYWRIGHT_SKIP_WEB_SERVER: '1'
 
       - name: Upload Playwright report (macOS E2E)
         if: failure()

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -46,10 +46,12 @@ export default defineConfig({
   ],
 
   // ---- webServer (only needed by smoke project) ---------------------------
-  webServer: {
-    command: 'python -m http.server 3458 --directory out/renderer',
-    url: 'http://localhost:3458',
-    reuseExistingServer: true,
-    timeout: 180_000,  // macOS CI can be slow to start
-  },
+  webServer: process.env.PLAYWRIGHT_SKIP_WEB_SERVER === '1'
+    ? undefined
+    : {
+        command: 'python -m http.server 3458 --directory out/renderer',
+        url: 'http://localhost:3458',
+        reuseExistingServer: true,
+        timeout: 180_000,  // macOS CI can be slow to start
+      },
 });


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 macOS Electron E2E 因 webServer 超时导致失败的问题。

## 背景/问题

`playwright.config.ts` 中的 `webServer` 是全局配置，Playwright 会为**所有**项目启动它，即使只跑 `--project=electron`。这个 Python HTTP server 只服务于 `smoke` 项目（mock bridge），Electron E2E 完全不需要它。

在 Ubuntu runner 上可以正常启动，但在 **macOS ARM64 runner** 上没有 `python` 命令（只有 `python3`），导致 60 秒超时，`macos-e2e` 作业直接失败。

develop 分支虽然已有人加了 `timeout: 180_000`（延长等待），但这治标不治本——Electron 项目根本不需要等这个 server。

https://github.com/14790897/MiQi/actions/runs/30235715227/job/89883044788 — 失败的 macOS E2E 运行

## 变更内容

- `apps/desktop/playwright.config.ts`: 新增 `PLAYWRIGHT_SKIP_WEB_SERVER` 环境变量支持，设为 `1` 时完全跳过 webServer（合并了 develop 上的 `timeout: 180_000`）
- `.github/workflows/desktop-ci.yml`: `electron-e2e` 和 `macos-e2e` 作业都加上 `PLAYWRIGHT_SKIP_WEB_SERVER: '1'` 环境变量

## 日志/验证证据

```
# develop 分支 macos-e2e 成功运行（有 SKIP_WEB_SERVER 后）
https://github.com/14790897/MiQi/actions/runs/30242298713 — 全部 4 个作业通过
```

## 测试情况

- develop 分支 `macos-e2e`（首次合入时已有 SKIP_WEB_SERVER）✅ 通过
- 本地 YAML 和 TS 语法验证通过

## 截图

无需截图（CI 配置变更）
