### PR TITLE
ci(docs): also deploy docs on develop branch pushes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "docs/**"
       - "mkdocs.yml"


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

让文档部署 CI 同时监听 `develop` 分支，合并到 develop 即可自动构建部署。

## 背景/问题

当前 `deploy-docs.yml` 只监听 `main` 分支，文档类 PR 合并到 `develop` 后需要额外手动同步到 main 才会触发部署。文档站点 `mygithub.sixiangjia.de/MiQi` 因此可能滞后。

## 变更内容

- `.github/workflows/deploy-docs.yml`：`branches: [main]` → `branches: [main, develop]`

## 日志/验证证据

```
$ git diff
-    branches: [main]
+    branches: [main, develop]
```

## 测试情况

CI 配置文件变更，无运行时测试。语法检查通过，不影响现有 main 分支部署逻辑。

## 截图

无需截图。