### PR TITLE
fix(#490): inject cross-thread session context on thread switch

### DIFF
--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -319,6 +319,63 @@ class HistoryRuntime:
             messages.append(msg)
         return messages
 
+    # ── Session-level cross-thread context (Issue #490) ─────────────────
+
+    async def get_session_thread_ids(self) -> list[str]:
+        """Return all distinct thread IDs in this session.
+
+        Used for cross-thread context injection so that threads within the
+        same session can share conversation history awareness.
+        """
+        db = self._conn
+        cursor = await db.execute(
+            """SELECT DISTINCT thread_id FROM runtime_history_items
+               WHERE session_id = ?
+               ORDER BY thread_id""",
+            (self.session_id,),
+        )
+        rows = await cursor.fetchall()
+        return [row["thread_id"] for row in rows]
+
+    async def load_session_context(
+        self,
+        exclude_thread_id: str,
+        *,
+        max_messages_per_thread: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Load recent messages from other threads as session context.
+
+        Returns a list of provider-compatible message dicts from threads
+        other than *exclude_thread_id*, limited to
+        *max_messages_per_thread* most recent items per thread.
+
+        Used by TaskRunner to inject cross-thread awareness when starting
+        a new turn in a thread that has no (or limited) history of its own.
+        """
+        thread_ids = await self.get_session_thread_ids()
+        other_thread_ids = [t for t in thread_ids if t != exclude_thread_id]
+        if not other_thread_ids:
+            return []
+
+        context_messages: list[dict[str, Any]] = []
+        for tid in other_thread_ids:
+            items = await self.load_items(tid)
+            if not items:
+                continue
+            # Take the most recent messages, limited
+            recent = items[-max_messages_per_thread:]
+            for item in recent:
+                msg: dict[str, Any] = {
+                    "role": item.role,
+                    "content": item.content,
+                }
+                msg.update(item.payload.get("message_fields", {}))
+                # Attach metadata so downstream consumers know the source
+                msg["_miqi_cross_thread_id"] = tid
+                context_messages.append(msg)
+
+        return context_messages
+
     # ── Phase 36: delete turn items for rollback ───────────────────────
 
     async def delete_turn_items(self, thread_id: str, turn_ids: list[str]) -> int:

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -342,12 +342,19 @@ class HistoryRuntime:
         exclude_thread_id: str,
         *,
         max_messages_per_thread: int = 5,
+        max_total_messages: int = 20,
+        max_threads: int = 5,
     ) -> list[dict[str, Any]]:
         """Load recent messages from other threads as session context.
 
         Returns a list of provider-compatible message dicts from threads
         other than *exclude_thread_id*, limited to
-        *max_messages_per_thread* most recent items per thread.
+        *max_messages_per_thread* most recent items per thread and
+        *max_total_messages* total across all threads.
+
+        *max_threads* bounds how many sibling threads are queried
+        (newest first) to prevent unbounded SQLite reads in large
+        sessions.
 
         Used by TaskRunner to inject cross-thread awareness when starting
         a new turn in a thread that has no (or limited) history of its own.
@@ -356,6 +363,11 @@ class HistoryRuntime:
         other_thread_ids = [t for t in thread_ids if t != exclude_thread_id]
         if not other_thread_ids:
             return []
+
+        # Bound number of threads queried (newest first; thread_id ordering
+        # is a reasonable stand-in for creation order in the absence of a
+        # dedicated created_at column on threads).
+        other_thread_ids = other_thread_ids[-max_threads:]
 
         context_messages: list[dict[str, Any]] = []
         for tid in other_thread_ids:
@@ -373,6 +385,10 @@ class HistoryRuntime:
                 # Attach metadata so downstream consumers know the source
                 msg["_miqi_cross_thread_id"] = tid
                 context_messages.append(msg)
+
+        # Enforce total message budget
+        if len(context_messages) > max_total_messages:
+            context_messages = context_messages[-max_total_messages:]
 
         return context_messages
 

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -983,12 +983,17 @@ class TaskRunner:
 
 def _format_cross_thread_context(
     session_context: list[dict[str, Any]],
+    *,
+    max_total_chars: int = 3000,
 ) -> str:
     """Format cross-thread session context as a system prompt block.
 
     Groups messages by source thread and produces a structured summary
     block that the LLM can use as background awareness of the broader
     session conversation.
+
+    *max_total_chars* caps the output to prevent cross-thread context
+    from consuming excessive prompt budget.
     """
     if not session_context:
         return ""
@@ -996,7 +1001,7 @@ def _format_cross_thread_context(
     # Group messages by their source thread id
     thread_groups: dict[str, list[dict[str, Any]]] = {}
     for msg in session_context:
-        tid = msg.pop("_miqi_cross_thread_id", "__unknown__")
+        tid = msg.get("_miqi_cross_thread_id", "__unknown__")
         thread_groups.setdefault(tid, []).append(msg)
 
     lines: list[str] = []
@@ -1026,7 +1031,10 @@ def _format_cross_thread_context(
         "保持对话的自然流畅。"
     )
 
-    return "\n".join(lines)
+    result = "\n".join(lines)
+    if len(result) > max_total_chars:
+        result = result[:max_total_chars] + "\n…[跨线程上下文已截断]"
+    return result
 
 
 _ROLE_LABEL_MAP: dict[str, str] = {

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -549,6 +549,34 @@ class TaskRunner:
             else:
                 history = []
 
+            # Issue #490: inject cross-thread session context so threads
+            # within the same session share conversation awareness.
+            if history_runtime is not None:
+                try:
+                    session_context = await history_runtime.load_session_context(
+                        exclude_thread_id=thread_id,
+                        max_messages_per_thread=5,
+                    )
+                    if session_context:
+                        context_block = _format_cross_thread_context(
+                            session_context
+                        )
+                        effective_system_prompt = (
+                            context_block + "\n\n" + effective_system_prompt
+                        )
+                        logger.info(
+                            "Injected cross-thread session context: "
+                            "%d messages from %d other thread(s)",
+                            len(session_context),
+                            len({m.get("_miqi_cross_thread_id", "")
+                                 for m in session_context}),
+                        )
+                except Exception:
+                    logger.warning(
+                        "Failed to load cross-thread session context",
+                        exc_info=True,
+                    )
+
             # Phase 24: record turn start in ledger
             if ledger is not None:
                 await ledger.append_item(
@@ -948,3 +976,63 @@ class TaskRunner:
             reason=f"Unknown thread action: {cmd.action}",
             recoverable=False,
         ))
+
+
+# ── Cross-thread context formatting (Issue #490) ────────────────────────
+
+
+def _format_cross_thread_context(
+    session_context: list[dict[str, Any]],
+) -> str:
+    """Format cross-thread session context as a system prompt block.
+
+    Groups messages by source thread and produces a structured summary
+    block that the LLM can use as background awareness of the broader
+    session conversation.
+    """
+    if not session_context:
+        return ""
+
+    # Group messages by their source thread id
+    thread_groups: dict[str, list[dict[str, Any]]] = {}
+    for msg in session_context:
+        tid = msg.pop("_miqi_cross_thread_id", "__unknown__")
+        thread_groups.setdefault(tid, []).append(msg)
+
+    lines: list[str] = []
+    lines.append("【跨线程会话上下文】")
+    lines.append(
+        "以下是同一会话中其他对话线程的近期内容，供你理解会话背景时参考："
+    )
+    lines.append("")
+
+    for i, (tid, messages) in enumerate(thread_groups.items(), start=1):
+        # Use a short label for each thread
+        short_id = tid[:8] if len(tid) > 8 else tid
+        lines.append(f"--- 线程 {i} ({short_id}…) ---")
+        for msg in messages:
+            role_label = _ROLE_LABEL_MAP.get(msg.get("role", ""), msg.get("role", "unknown"))
+            content = msg.get("content", "")
+            # Truncate very long messages to keep context compact
+            if len(content) > 500:
+                content = content[:500] + "…[已截断]"
+            lines.append(f"{role_label}: {content}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        "请结合以上跨线程上下文理解用户的背景和偏好，"
+        "但不要在当前回答中主动提及'其他线程'或上下文来源，"
+        "保持对话的自然流畅。"
+    )
+
+    return "\n".join(lines)
+
+
+_ROLE_LABEL_MAP: dict[str, str] = {
+    "user": "👤 用户",
+    "assistant": "🤖 助手",
+    "system": "📋 系统",
+    "tool": "🔧 工具",
+    "developer": "💻 开发者",
+}


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
在 TaskRunner 中注入跨线程会话上下文，使同一 session 下的不同 thread 能够共享对话背景信息。

## 背景/问题
同一 session 内切换 thread 后，新 thread 无法获取之前线程的对话历史，导致上下文丢失。用户在 thread A 中建立的背景信息（如偏好设置），在切换到 thread B 后 AI 完全无法感知。

根因：HistoryRuntime.load_messages(thread_id) 只加载当前 thread 的消息，SQL 查询按 session_id + thread_id 双重过滤。切换 thread 后 history 为空，且缺少跨线程上下文注入机制。

## 变更内容
1. **HistoryRuntime 新增方法：**
   - `get_session_thread_ids()` — 枚举 session 内所有 thread ID
   - `load_session_context(exclude_thread_id, max_messages_per_thread=5, max_total_messages=20, max_threads=5)` — 加载其他 thread 的最近消息，含多层预算上限

2. **TaskRunner 注入逻辑：**
   - 在加载当前 thread history 后，调用 `load_session_context()` 获取其他 thread 的近期消息
   - 通过 `_format_cross_thread_context(max_total_chars=3000)` 格式化为【跨线程会话上下文】system prompt 块
   - 上下文块按线程分组，中文角色标签，长消息截断（500字符），总输出不超过3000字符

## 日志/验证证据
```
$ pytest tests/runtime/test_history_runtime.py tests/runtime/test_runtime_task_runner.py \
    tests/runtime/test_task_runner_history_integration.py tests/runtime/test_turn_runner.py \
    tests/runtime/test_context_runtime.py -v -q
65 passed in 4.31s

$ pytest tests/runtime/ --ignore=tests/runtime/test_thread_export_import.py -q
1157 passed, 4 skipped in 62.79s

$ python -c "import py_compile; py_compile.compile('miqi/runtime/history_runtime.py', doraise=True); py_compile.compile('miqi/runtime/task_runner.py', doraise=True); print('OK')"
OK
```

## 测试情况
- ✅ Python 语法检查通过（两个文件均编译通过）
- ✅ 现有测试全部通过：**1157 passed, 4 skipped**（pytest tests/runtime/）
- ✅ 核心模块测试通过：test_history_runtime (13), test_context_runtime (10), test_turn_runner (7), test_task_runner 相关 (42)

## 截图
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/678e7a9b-f36d-497c-84a2-91ac14b33555" />

Closes #490