### PR TITLE
docs: fix broken CHANGELOG.md link causing mkdocs build failure

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # 更新日志
 
-完整版本更新日志请参见项目根目录的 [CHANGELOG.md](../CHANGELOG.md)。
+完整版本更新日志请参见 [GitHub 仓库 CHANGELOG.md](https://github.com/14790897/MiQi/blob/develop/CHANGELOG.md)。
 
 ## 最新更新 (2026-06)
 


### PR DESCRIPTION
## 类型

- [x] 📝 文档

## 变更概述

修复 `docs/changelog.md` 中指向 `docs/` 目录外的相对路径链接，解决 CI 构建失败。

## 背景/问题

`docs/changelog.md` 第 3 行使用了：
```markdown
[CHANGELOG.md](../CHANGELOG.md)
```

`../CHANGELOG.md` 指向 `docs/` 目录之外的文件。`mkdocs build --strict` 把无法解析的链接视为警告并在 strict 模式下终止构建。

CI 失败日志 (https://github.com/14790897/MiQi/actions/runs/30332023405)：
```
WARNING - Doc file "changelog.md" contains a link "../CHANGELOG.md", 
          but the target is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

## 变更内容

- `docs/changelog.md`：`[CHANGELOG.md](../CHANGELOG.md)` → `[GitHub 仓库 CHANGELOG.md](https://github.com/14790897/MiQi/blob/develop/CHANGELOG.md)`

## 测试情况

CI 配置文件 `--strict` 模式下不再有无法解析的链接警告。

## 截图

无需截图。