### PR TITLE
fix(#402): reverse dual-write order — JSONL before SQLite

### DIFF
--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -638,6 +638,13 @@ class TaskRunner:
                 payload_fields["input_items"] = msg.input_items
             if msg.client_user_message_id:
                 payload_fields["client_user_message_id"] = msg.client_user_message_id
+            # Issue #402: write JSONL FIRST so sessions.get (which reads
+            # JSONL) sees the message even if a crash occurs before the
+            # SQLite write completes.  The JSONL store is the legacy
+            # single-source-of-truth for session overview; SQLite is
+            # thread-scoped and recoverable from JSONL if needed.
+            await self._save_to_session_manager(
+                role="user", content=msg.content)
             if history_runtime is not None:
                 await history_runtime.append_message(
                     thread_id=thread_id,
@@ -646,10 +653,6 @@ class TaskRunner:
                     content=msg.content,
                     payload={"message_fields": payload_fields},
                 )
-            # Dual-write to legacy SessionManager JSONL so sessions.get
-            # (which reads JSONL) finds messages created via AppServer flow.
-            await self._save_to_session_manager(
-                role="user", content=msg.content)
             # Phase 24: record user message in ledger
             if ledger is not None:
                 await ledger.append_item(
@@ -702,6 +705,14 @@ class TaskRunner:
                 content = message.get("content") or ""
                 extra_fields = {k: v for k, v in message.items() if k not in ("role", "content")}
 
+                # Issue #402: write JSONL FIRST so sessions.get sees the
+                # message even if SQLite write fails later.  Forward all
+                # extra fields (tool_calls, name, tool_call_id, etc.) so
+                # the frontend can reconstruct file operations.
+                await self._save_to_session_manager(
+                    role=role, content=content, **extra_fields,
+                )
+
                 if history_runtime is not None:
                     await history_runtime.append_message(
                         thread_id=thread_id,
@@ -710,14 +721,6 @@ class TaskRunner:
                         content=content,
                         payload={"message_fields": extra_fields},
                     )
-
-                # Dual-write to legacy SessionManager (independent of history_runtime
-                # so fallback JSONL is always populated). Forward all extra fields
-                # (tool_calls, name, tool_call_id, etc.) so get_history() preserves
-                # them and the frontend can reconstruct file operations.
-                await self._save_to_session_manager(
-                    role=role, content=content, **extra_fields,
-                )
 
                 if ledger is not None:
                     await ledger.append_item(


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
反转 TaskRunner 中消息双写（SQLite + JSONL）的顺序，JSONL 先写、SQLite 后写，减少崩溃导致的数据不一致。

## 背景/问题
`TaskRunner._handle_user_message()` 将消息同时写入 SQLite（HistoryRuntime）和 JSONL（SessionManager），两个独立操作之间没有事务保证。原先 SQLite 先写、JSONL 后写，如果在两个写入之间发生崩溃，SQLite 有该消息但 JSONL 没有 → `sessions.get`（读取 JSONL）看不到该消息 → 侧边栏/会话列表不一致。

## 变更内容
- **User 消息持久化**（~L638-653）：`_save_to_session_manager`（JSONL）移到 `history_runtime.append_message`（SQLite）之前
- **Assistant 消息持久化**（~L703-723）：同上，循环内先写 JSONL、后写 SQLite

**原理**：JSONL 是 `sessions.get` / 侧边栏使用的 legacy overview 存储；SQLite 是 thread-scoped 存储。JSONL 先写确保即使崩溃，overview 路径也能看到最新数据。SQLite 缺失的消息可从 JSONL 恢复。

## 日志/验证证据
```
$ pytest tests/runtime/test_runtime_task_runner.py tests/runtime/test_task_runner_history_integration.py -v -q
35 passed in 4.15s

$ pytest tests/runtime/ --ignore=tests/runtime/test_thread_export_import.py -q
1157 passed, 4 skipped in 61.91s

$ python -c "import py_compile; py_compile.compile('miqi/runtime/task_runner.py', doraise=True); print('OK')"
OK
```

## 测试情况
- ✅ 35 个 TaskRunner + 集成测试全部通过
- ✅ 全量 runtime 测试 1157 passed, 4 skipped

## 截图
纯后端变更，无 UI 变化。

Closes #402