### PR TITLE
fix(#490): replace silent cross-thread injection with fork-thread summary

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -698,26 +698,38 @@ class BridgeRuntimeLoop:
         session_state = getattr(runtime.services, "session_state", None)
         if session_state is not None and hasattr(session_state, "active_thread_id"):
             active_tid = session_state.active_thread_id
-            if thread_id != active_tid:
-                # Only override if the active thread has history
-                history_runtime = getattr(runtime.services, "history_runtime", None)
-                if history_runtime is not None:
-                    try:
-                        existing = await history_runtime.load_messages(active_tid)
-                        if existing:
-                            thread_id = active_tid
-                    except Exception:
-                        pass
+            history_runtime = getattr(runtime.services, "history_runtime", None)
+
+            # Check whether the active thread has history — this
+            # drives the fallback decision, not ID equality.
+            active_has_history = False
+            if history_runtime is not None:
+                try:
+                    existing = await history_runtime.load_messages(active_tid)
+                    if existing:
+                        active_has_history = True
+                        thread_id = active_tid
+                except Exception:
+                    logger.warning(
+                        "Failed to load messages for active thread %s, "
+                        "treating as empty",
+                        active_tid[:8],
+                        exc_info=True,
+                    )
 
             # Fallback: when active_thread_id has no history (e.g. after
             # restart or session switch), find the most recently active
             # thread in the DB and use it instead.
-            if thread_id != active_tid:
-                history_runtime = getattr(runtime.services, "history_runtime", None)
+            if not active_has_history:
                 if history_runtime is not None:
                     try:
                         recent = await history_runtime.find_recent_thread()
                     except Exception:
+                        logger.warning(
+                            "Failed to find recent thread, keeping "
+                            "current thread_id",
+                            exc_info=True,
+                        )
                         recent = None
                     if recent is not None:
                         session_state.active_thread_id = recent

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -692,6 +692,23 @@ class BridgeRuntimeLoop:
                 sandbox_manager=sandbox_manager,
             )
 
+        # Issue #490: reuse the session's active thread so messages
+        # accumulate in one thread instead of scattering across random
+        # UUIDs the frontend sends on each turn.
+        session_state = getattr(runtime.services, "session_state", None)
+        if session_state is not None and hasattr(session_state, "active_thread_id"):
+            active_tid = session_state.active_thread_id
+            if thread_id != active_tid:
+                # Only override if the active thread has history
+                history_runtime = getattr(runtime.services, "history_runtime", None)
+                if history_runtime is not None:
+                    try:
+                        existing = await history_runtime.load_messages(active_tid)
+                        if existing:
+                            thread_id = active_tid
+                    except Exception:
+                        pass
+
         # ── Parse document attachments before submitting ────────────────
         # Extract text from uploaded documents (PDF/Office/MD) and inject
         # into the message content so the LLM can immediately understand them.

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -709,6 +709,20 @@ class BridgeRuntimeLoop:
                     except Exception:
                         pass
 
+            # Fallback: when active_thread_id has no history (e.g. after
+            # restart or session switch), find the most recently active
+            # thread in the DB and use it instead.
+            if thread_id != active_tid:
+                history_runtime = getattr(runtime.services, "history_runtime", None)
+                if history_runtime is not None:
+                    try:
+                        recent = await history_runtime.find_recent_thread()
+                    except Exception:
+                        recent = None
+                    if recent is not None:
+                        session_state.active_thread_id = recent
+                        thread_id = recent
+
         # ── Parse document attachments before submitting ────────────────
         # Extract text from uploaded documents (PDF/Office/MD) and inject
         # into the message content so the LLM can immediately understand them.

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -692,15 +692,6 @@ class BridgeRuntimeLoop:
                 sandbox_manager=sandbox_manager,
             )
 
-        # Reuse the session's active thread so messages accumulate in the
-        # same thread across turns (Issue #490 — frontend may send a new
-        # thread_id on every message).
-        session_state = getattr(runtime.services, "session_state", None)
-        if session_state is not None and hasattr(session_state, "active_thread_id"):
-            active_tid = session_state.active_thread_id
-            if thread_id != active_tid:
-                thread_id = active_tid
-
         # ── Parse document attachments before submitting ────────────────
         # Extract text from uploaded documents (PDF/Office/MD) and inject
         # into the message content so the LLM can immediately understand them.

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -692,6 +692,15 @@ class BridgeRuntimeLoop:
                 sandbox_manager=sandbox_manager,
             )
 
+        # Reuse the session's active thread so messages accumulate in the
+        # same thread across turns (Issue #490 — frontend may send a new
+        # thread_id on every message).
+        session_state = getattr(runtime.services, "session_state", None)
+        if session_state is not None and hasattr(session_state, "active_thread_id"):
+            active_tid = session_state.active_thread_id
+            if thread_id != active_tid:
+                thread_id = active_tid
+
         # ── Parse document attachments before submitting ────────────────
         # Extract text from uploaded documents (PDF/Office/MD) and inject
         # into the message content so the LLM can immediately understand them.

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -392,6 +392,29 @@ class HistoryRuntime:
 
         return context_messages
 
+    async def find_recent_thread(self) -> str | None:
+        """Return the thread_id with the most recent message in the DB.
+
+        Searches across ALL sessions (no session_id filter) so that when
+        the user restarts MiQi or switches sessions, we can recover the
+        thread they were last working on.
+
+        Returns None when the DB has no history items at all.
+        """
+        db = self._conn
+        cursor = await db.execute(
+            """SELECT thread_id, MAX(created_at) AS max_ts
+               FROM runtime_history_items
+               WHERE role IN ('user', 'assistant')
+               GROUP BY thread_id
+               ORDER BY max_ts DESC
+               LIMIT 1"""
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return row["thread_id"]
+
     # ── Phase 36: delete turn items for rollback ───────────────────────
 
     async def delete_turn_items(self, thread_id: str, turn_ids: list[str]) -> int:

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -356,6 +356,23 @@ class HistoryRuntime:
             ))
         return results
 
+    async def find_recent_thread_with_history(self) -> str | None:
+        """Return the thread_id with the most recent messages (any session).
+
+        Used after session restart to recover the active thread when the
+        session-scoped query returns empty.
+        """
+        db = self._conn
+        cursor = await db.execute(
+            """SELECT thread_id, MAX(created_at) as latest
+               FROM runtime_history_items
+               GROUP BY thread_id
+               ORDER BY latest DESC
+               LIMIT 1""",
+        )
+        row = await cursor.fetchone()
+        return row["thread_id"] if row else None
+
     # ── Session-level cross-thread context (Issue #490) ─────────────────
 
     async def get_session_thread_ids(self) -> list[str]:

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -312,12 +312,49 @@ class HistoryRuntime:
     async def load_messages(self, thread_id: str) -> list[dict[str, Any]]:
         """Return provider-compatible message dicts for a thread."""
         items = await self.load_items(thread_id)
+        # Fallback: if session-scoped query returns nothing, try
+        # loading by thread_id alone.  Covers session restart and
+        # sidebar switching where the session_id may differ but
+        # the thread (UUID) is stable.
+        if not items:
+            items = await self._load_items_by_thread(thread_id)
         messages: list[dict[str, Any]] = []
         for item in items:
             msg: dict[str, Any] = {"role": item.role, "content": item.content}
             msg.update(item.payload.get("message_fields", {}))
             messages.append(msg)
         return messages
+
+    async def _load_items_by_thread(self, thread_id: str) -> list[HistoryItem]:
+        """Load history items by thread_id alone (no session_id filter)."""
+        db = self._conn
+        cursor = await db.execute(
+            """SELECT * FROM runtime_history_items
+               WHERE thread_id = ?
+               ORDER BY created_at ASC, rowid ASC""",
+            (thread_id,),
+        )
+        rows = await cursor.fetchall()
+        results = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload_json"])
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.warning(
+                    "Skipping corrupted payload_json for item %s in thread %s: %s",
+                    row["item_id"], thread_id, exc,
+                )
+                payload = {}
+            results.append(HistoryItem(
+                item_id=row["item_id"],
+                thread_id=row["thread_id"],
+                turn_id=row["turn_id"],
+                role=row["role"],
+                content=row["content"],
+                payload=payload,
+                created_at=row["created_at"],
+            ))
+        return results
 
     # ── Session-level cross-thread context (Issue #490) ─────────────────
 

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -283,53 +283,6 @@ class HistoryRuntime:
         db = self._conn
         cursor = await db.execute(
             """SELECT * FROM runtime_history_items
-               WHERE thread_id = ? AND session_id = ?
-               ORDER BY created_at ASC, rowid ASC""",
-            (thread_id, self.session_id),
-        )
-        rows = await cursor.fetchall()
-        results = []
-        for row in rows:
-            try:
-                payload = json.loads(row["payload_json"])
-            except (json.JSONDecodeError, TypeError) as exc:
-                logger.warning(
-                    "Skipping corrupted payload_json for item %s in thread %s: %s",
-                    row["item_id"], thread_id, exc,
-                )
-                payload = {}
-            results.append(HistoryItem(
-                item_id=row["item_id"],
-                thread_id=row["thread_id"],
-                turn_id=row["turn_id"],
-                role=row["role"],
-                content=row["content"],
-                payload=payload,
-                created_at=row["created_at"],
-            ))
-        return results
-
-    async def load_messages(self, thread_id: str) -> list[dict[str, Any]]:
-        """Return provider-compatible message dicts for a thread."""
-        items = await self.load_items(thread_id)
-        # Fallback: if session-scoped query returns nothing, try
-        # loading by thread_id alone.  Covers session restart and
-        # sidebar switching where the session_id may differ but
-        # the thread (UUID) is stable.
-        if not items:
-            items = await self._load_items_by_thread(thread_id)
-        messages: list[dict[str, Any]] = []
-        for item in items:
-            msg: dict[str, Any] = {"role": item.role, "content": item.content}
-            msg.update(item.payload.get("message_fields", {}))
-            messages.append(msg)
-        return messages
-
-    async def _load_items_by_thread(self, thread_id: str) -> list[HistoryItem]:
-        """Load history items by thread_id alone (no session_id filter)."""
-        db = self._conn
-        cursor = await db.execute(
-            """SELECT * FROM runtime_history_items
                WHERE thread_id = ?
                ORDER BY created_at ASC, rowid ASC""",
             (thread_id,),
@@ -356,22 +309,15 @@ class HistoryRuntime:
             ))
         return results
 
-    async def find_recent_thread_with_history(self) -> str | None:
-        """Return the thread_id with the most recent messages (any session).
-
-        Used after session restart to recover the active thread when the
-        session-scoped query returns empty.
-        """
-        db = self._conn
-        cursor = await db.execute(
-            """SELECT thread_id, MAX(created_at) as latest
-               FROM runtime_history_items
-               GROUP BY thread_id
-               ORDER BY latest DESC
-               LIMIT 1""",
-        )
-        row = await cursor.fetchone()
-        return row["thread_id"] if row else None
+    async def load_messages(self, thread_id: str) -> list[dict[str, Any]]:
+        """Return provider-compatible message dicts for a thread."""
+        items = await self.load_items(thread_id)
+        messages: list[dict[str, Any]] = []
+        for item in items:
+            msg: dict[str, Any] = {"role": item.role, "content": item.content}
+            msg.update(item.payload.get("message_fields", {}))
+            messages.append(msg)
+        return messages
 
     # ── Session-level cross-thread context (Issue #490) ─────────────────
 

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -395,9 +395,11 @@ class HistoryRuntime:
     async def find_recent_thread(self) -> str | None:
         """Return the thread_id with the most recent message in the DB.
 
-        Searches across ALL sessions (no session_id filter) so that when
-        the user restarts MiQi or switches sessions, we can recover the
-        thread they were last working on.
+        Searches across ALL sessions (no session_id filter). This is
+        intentional: thread_id is a global UUID and must be recoverable
+        after restart when the session_id changes. The owning session
+        already has the thread in its runtime_threads table; the
+        recovery merely reconnects the new session to the same thread.
 
         Returns None when the DB has no history items at all.
         """
@@ -421,6 +423,10 @@ class HistoryRuntime:
         """Delete all history items for given turn_ids in a thread.
 
         Returns the number of deleted rows.
+
+        Thread-level operation — deletes ALL rows for the thread
+        regardless of session, matching load_items() which also
+        operates across sessions since thread_id is a global UUID.
         """
         if not turn_ids:
             return 0
@@ -428,9 +434,9 @@ class HistoryRuntime:
         db = self._conn
         cursor = await db.execute(
             f"""DELETE FROM runtime_history_items
-                WHERE session_id = ? AND thread_id = ?
+                WHERE thread_id = ?
                 AND turn_id IN ({placeholders})""",
-            (self.session_id, thread_id, *turn_ids),
+            (thread_id, *turn_ids),
         )
         await db.commit()
         return int(cursor.rowcount or 0)
@@ -469,21 +475,18 @@ class HistoryRuntime:
     ) -> None:
         """Replace all history items for a thread with compacted messages.
 
-        Deletes existing items (scoped by session_id), inserts the
-        replacement messages, and records a compaction row with full
-        audit metadata.
+        Deletes existing items for the thread (regardless of session —
+        thread_id is a global UUID), inserts the replacement messages,
+        and records a compaction row with full audit metadata.
         """
         db = self._conn
         compaction_id = str(uuid.uuid4())
-        # Wrap in transaction so DELETE+INSERT+compaction record are atomic.
-        # If the process crashes between DELETE and commit, the transaction
-        # is rolled back and no history is lost.
         await db.execute("BEGIN")
         try:
-            # Delete existing items for this thread (session-scoped)
+            # Delete existing items for this thread (thread-scoped, not session)
             await db.execute(
-                "DELETE FROM runtime_history_items WHERE thread_id = ? AND session_id = ?",
-                (thread_id, self.session_id),
+                "DELETE FROM runtime_history_items WHERE thread_id = ?",
+                (thread_id,),
             )
             # Insert replacement messages
             for msg in replacement_messages:

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -849,6 +849,8 @@ class TaskRunner:
             ))
             return
 
+        history_runtime = getattr(self.services, "history_runtime", None)
+
         if cmd.action == "new":
             try:
                 thread = await threads.create_thread(

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -546,7 +546,17 @@ class TaskRunner:
             if history_runtime is not None:
                 await history_runtime.start_turn(turn_id, thread_id=thread_id)
                 history = await history_runtime.load_messages(thread_id)
+                if not history:
+                    logger.warning(
+                        "TaskRunner: empty history for thread=%s turn=%s "
+                        "(history_runtime=%s)",
+                        thread_id[:12], turn_id,
+                        type(history_runtime).__name__,
+                    )
             else:
+                logger.warning(
+                    "TaskRunner: history_runtime is None — history will be empty"
+                )
                 history = []
 
             # Phase 24: record turn start in ledger

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -985,9 +985,9 @@ async def _inject_fork_summary(
     parent_thread_id: str,
     child_thread_id: str,
     parent_title: str,
-    max_messages: int = 3,
-    max_chars_per_msg: int = 200,
-    max_total_chars: int = 1200,
+    max_messages: int = 2,
+    max_chars_per_msg: int = 100,
+    max_total_chars: int = 500,
 ) -> None:
     """Inject parent thread context as a system message into a forked thread.
 

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -430,13 +430,6 @@ class TaskRunner:
         turn_id = msg.turn_id or str(uuid.uuid4())[:12]
         thread_id = msg.thread_id or "cli:default"
 
-        # Update session's active thread so future turns on the same
-        # session reuse this thread (Issue #490 — frontend may not
-        # track thread continuity).
-        session_state = getattr(self.services, "session_state", None)
-        if session_state is not None and hasattr(session_state, "active_thread_id"):
-            session_state.active_thread_id = thread_id
-
         # Phase 14 follow-up: register a cancel event so AbortTurn can
         # signal this specific turn to stop. Reuse existing event if a
         # previous turn on the same thread hasn't been cleaned up yet.
@@ -554,12 +547,27 @@ class TaskRunner:
                 await history_runtime.start_turn(turn_id, thread_id=thread_id)
                 history = await history_runtime.load_messages(thread_id)
                 if not history:
-                    logger.warning(
-                        "TaskRunner: empty history for thread=%s turn=%s "
-                        "(history_runtime=%s)",
-                        thread_id[:12], turn_id,
-                        type(history_runtime).__name__,
-                    )
+                    # Issue #490: after restart or session switch, the
+                    # current thread may have no messages. Try to find
+                    # the most recent thread that DOES have history.
+                    recent_tid = await history_runtime.find_recent_thread_with_history()
+                    if recent_tid and recent_tid != thread_id:
+                        history = await history_runtime.load_messages(recent_tid)
+                        if history:
+                            thread_id = recent_tid
+                            # Update session state so future turns use this thread
+                            session_state = getattr(self.services, "session_state", None)
+                            if session_state is not None and hasattr(session_state, "active_thread_id"):
+                                session_state.active_thread_id = recent_tid
+                            logger.info(
+                                "TaskRunner: recovered history from thread=%s (%d msgs)",
+                                recent_tid[:12], len(history),
+                            )
+                    if not history:
+                        logger.warning(
+                            "TaskRunner: empty history for thread=%s turn=%s",
+                            thread_id[:12], turn_id,
+                        )
             else:
                 logger.warning(
                     "TaskRunner: history_runtime is None — history will be empty"

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -430,6 +430,13 @@ class TaskRunner:
         turn_id = msg.turn_id or str(uuid.uuid4())[:12]
         thread_id = msg.thread_id or "cli:default"
 
+        # Track active thread on session state so the frontend's
+        # random thread_id UUIDs don't fragment history across
+        # multiple threads (Issue #490).
+        session_state = getattr(self.services, "session_state", None)
+        if session_state is not None and hasattr(session_state, "active_thread_id"):
+            session_state.active_thread_id = thread_id
+
         # Phase 14 follow-up: register a cancel event so AbortTurn can
         # signal this specific turn to stop. Reuse existing event if a
         # previous turn on the same thread hasn't been cleaned up yet.
@@ -546,28 +553,6 @@ class TaskRunner:
             if history_runtime is not None:
                 await history_runtime.start_turn(turn_id, thread_id=thread_id)
                 history = await history_runtime.load_messages(thread_id)
-                if not history:
-                    # Issue #490: after restart or session switch, the
-                    # current thread may have no messages. Try to find
-                    # the most recent thread that DOES have history.
-                    recent_tid = await history_runtime.find_recent_thread_with_history()
-                    if recent_tid and recent_tid != thread_id:
-                        history = await history_runtime.load_messages(recent_tid)
-                        if history:
-                            thread_id = recent_tid
-                            # Update session state so future turns use this thread
-                            session_state = getattr(self.services, "session_state", None)
-                            if session_state is not None and hasattr(session_state, "active_thread_id"):
-                                session_state.active_thread_id = recent_tid
-                            logger.info(
-                                "TaskRunner: recovered history from thread=%s (%d msgs)",
-                                recent_tid[:12], len(history),
-                            )
-                    if not history:
-                        logger.warning(
-                            "TaskRunner: empty history for thread=%s turn=%s",
-                            thread_id[:12], turn_id,
-                        )
             else:
                 logger.warning(
                     "TaskRunner: history_runtime is None — history will be empty"

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -430,6 +430,13 @@ class TaskRunner:
         turn_id = msg.turn_id or str(uuid.uuid4())[:12]
         thread_id = msg.thread_id or "cli:default"
 
+        # Update session's active thread so future turns on the same
+        # session reuse this thread (Issue #490 — frontend may not
+        # track thread continuity).
+        session_state = getattr(self.services, "session_state", None)
+        if session_state is not None and hasattr(session_state, "active_thread_id"):
+            session_state.active_thread_id = thread_id
+
         # Phase 14 follow-up: register a cancel event so AbortTurn can
         # signal this specific turn to stop. Reuse existing event if a
         # previous turn on the same thread hasn't been cleaned up yet.

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -1042,12 +1042,12 @@ async def _inject_fork_summary(
         )
 
         logger.info(
-            "Injected fork summary: parent=%s → child=%s (%d messages)",
+            "Injected fork summary: parent={} → child={} ({} messages)",
             parent_thread_id[:8], child_thread_id[:8], len(recent),
         )
     except Exception:
         logger.warning(
-            "Failed to inject fork summary for thread %s",
+            "Failed to inject fork summary for thread {}",
             parent_thread_id[:8],
             exc_info=True,
         )

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -549,34 +549,6 @@ class TaskRunner:
             else:
                 history = []
 
-            # Issue #490: inject cross-thread session context so threads
-            # within the same session share conversation awareness.
-            if history_runtime is not None:
-                try:
-                    session_context = await history_runtime.load_session_context(
-                        exclude_thread_id=thread_id,
-                        max_messages_per_thread=5,
-                    )
-                    if session_context:
-                        context_block = _format_cross_thread_context(
-                            session_context
-                        )
-                        effective_system_prompt = (
-                            context_block + "\n\n" + effective_system_prompt
-                        )
-                        logger.info(
-                            "Injected cross-thread session context: "
-                            "%d messages from %d other thread(s)",
-                            len(session_context),
-                            len({m.get("_miqi_cross_thread_id", "")
-                                 for m in session_context}),
-                        )
-                except Exception:
-                    logger.warning(
-                        "Failed to load cross-thread session context",
-                        exc_info=True,
-                    )
-
             # Phase 24: record turn start in ledger
             if ledger is not None:
                 await ledger.append_item(
@@ -953,6 +925,10 @@ class TaskRunner:
 
         if cmd.action == "fork":
             try:
+                # Fetch parent title before fork so we can label the summary
+                parent = await threads.get_thread(cmd.thread_id)
+                parent_title = parent.title if parent else "未知线程"
+
                 thread = await threads.fork_thread(
                     cmd.thread_id,
                     title=cmd.params.get("title", "Forked thread"),
@@ -964,6 +940,16 @@ class TaskRunner:
                     recoverable=False,
                 ))
                 return
+
+            # Issue #490: inject parent thread summary into forked thread
+            # so the user's existing context carries over on explicit fork.
+            await _inject_fork_summary(
+                history_runtime=history_runtime,
+                parent_thread_id=cmd.thread_id,
+                child_thread_id=thread.thread_id,
+                parent_title=parent_title,
+            )
+
             await self._events.put(ThreadCreatedEvent(
                 thread_id=thread.thread_id,
                 title=thread.title,
@@ -978,66 +964,80 @@ class TaskRunner:
         ))
 
 
-# ── Cross-thread context formatting (Issue #490) ────────────────────────
+# ── Fork-thread summary injection (Issue #490) ──────────────────────────
 
 
-def _format_cross_thread_context(
-    session_context: list[dict[str, Any]],
+async def _inject_fork_summary(
     *,
-    max_total_chars: int = 3000,
-) -> str:
-    """Format cross-thread session context as a system prompt block.
+    history_runtime: Any,
+    parent_thread_id: str,
+    child_thread_id: str,
+    parent_title: str,
+    max_messages: int = 10,
+) -> None:
+    """Inject parent thread context as a system message into a forked thread.
 
-    Groups messages by source thread and produces a structured summary
-    block that the LLM can use as background awareness of the broader
-    session conversation.
+    Called when the user explicitly forks a thread.  Loads the most recent
+    messages from the parent and prepends a structured summary so the LLM
+    in the forked thread has continuity with the original conversation.
 
-    *max_total_chars* caps the output to prevent cross-thread context
-    from consuming excessive prompt budget.
+    Silent injection is limited to explicit fork — new blank threads receive
+    no cross-thread context (see #490 design discussion).
     """
-    if not session_context:
-        return ""
+    if history_runtime is None:
+        return
 
-    # Group messages by their source thread id
-    thread_groups: dict[str, list[dict[str, Any]]] = {}
-    for msg in session_context:
-        tid = msg.get("_miqi_cross_thread_id", "__unknown__")
-        thread_groups.setdefault(tid, []).append(msg)
+    try:
+        messages = await history_runtime.load_messages(parent_thread_id)
+        if not messages:
+            return
 
-    lines: list[str] = []
-    lines.append("【跨线程会话上下文】")
-    lines.append(
-        "以下是同一会话中其他对话线程的近期内容，供你理解会话背景时参考："
-    )
-    lines.append("")
+        recent = messages[-max_messages:]
 
-    for i, (tid, messages) in enumerate(thread_groups.items(), start=1):
-        # Use a short label for each thread
-        short_id = tid[:8] if len(tid) > 8 else tid
-        lines.append(f"--- 线程 {i} ({short_id}…) ---")
-        for msg in messages:
-            role_label = _ROLE_LABEL_MAP.get(msg.get("role", ""), msg.get("role", "unknown"))
-            content = msg.get("content", "")
-            # Truncate very long messages to keep context compact
-            if len(content) > 500:
-                content = content[:500] + "…[已截断]"
-            lines.append(f"{role_label}: {content}")
+        lines: list[str] = []
+        lines.append(f"【派生对话 — 源线程：{parent_title}】")
+        lines.append(
+            "以下是从原线程继承的近期对话内容，供你理解对话背景："
+        )
         lines.append("")
 
-    lines.append("---")
-    lines.append(
-        "请结合以上跨线程上下文理解用户的背景和偏好，"
-        "但不要在当前回答中主动提及'其他线程'或上下文来源，"
-        "保持对话的自然流畅。"
-    )
+        for msg in recent:
+            role_label = _FORK_ROLE_LABEL.get(msg.get("role", ""), msg.get("role", "?"))
+            content = msg.get("content", "")
+            if len(content) > 500:
+                content = content[:500] + "…[截断]"
+            lines.append(f"{role_label}: {content}")
 
-    result = "\n".join(lines)
-    if len(result) > max_total_chars:
-        result = result[:max_total_chars] + "\n…[跨线程上下文已截断]"
-    return result
+        lines.append("")
+        lines.append("---")
+        lines.append(
+            "请基于以上背景继续对话。不要显式提及'派生'或'源线程'，"
+            "自然融入上下文即可。"
+        )
+
+        summary = "\n".join(lines)
+
+        # Write the summary as a system message into the new thread
+        await history_runtime.append_message(
+            thread_id=child_thread_id,
+            turn_id="fork-summary",
+            role="system",
+            content=summary,
+        )
+
+        logger.info(
+            "Injected fork summary: parent=%s → child=%s (%d messages)",
+            parent_thread_id[:8], child_thread_id[:8], len(recent),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to inject fork summary for thread %s",
+            parent_thread_id[:8],
+            exc_info=True,
+        )
 
 
-_ROLE_LABEL_MAP: dict[str, str] = {
+_FORK_ROLE_LABEL: dict[str, str] = {
     "user": "👤 用户",
     "assistant": "🤖 助手",
     "system": "📋 系统",

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -975,7 +975,9 @@ async def _inject_fork_summary(
     parent_thread_id: str,
     child_thread_id: str,
     parent_title: str,
-    max_messages: int = 10,
+    max_messages: int = 3,
+    max_chars_per_msg: int = 200,
+    max_total_chars: int = 1200,
 ) -> None:
     """Inject parent thread context as a system message into a forked thread.
 
@@ -1006,8 +1008,8 @@ async def _inject_fork_summary(
         for msg in recent:
             role_label = _FORK_ROLE_LABEL.get(msg.get("role", ""), msg.get("role", "?"))
             content = msg.get("content", "")
-            if len(content) > 500:
-                content = content[:500] + "…[截断]"
+            if len(content) > max_chars_per_msg:
+                content = content[:max_chars_per_msg] + "…"
             lines.append(f"{role_label}: {content}")
 
         lines.append("")
@@ -1018,6 +1020,8 @@ async def _inject_fork_summary(
         )
 
         summary = "\n".join(lines)
+        if len(summary) > max_total_chars:
+            summary = summary[:max_total_chars] + "\n…[已截断]"
 
         # Write the summary as a system message into the new thread
         await history_runtime.append_message(

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -440,14 +440,13 @@ async def test_find_recent_thread_ignores_system_messages(tmp_path):
     runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
     await runtime.initialize()
     try:
-        # Thread with only system messages should not be found
-        await runtime.append_message(
-            thread_id="sys-only", turn_id="turn-a", role="system", content="setup"
-        )
-
-        # Another thread with actual conversation
+        # Another thread with actual conversation (older)
         await runtime.append_message(
             thread_id="real", turn_id="turn-b", role="user", content="real msg"
+        )
+        # A newer system-only thread must still be ignored
+        await runtime.append_message(
+            thread_id="sys-only", turn_id="turn-a", role="system", content="setup"
         )
 
         recent = await runtime.find_recent_thread()

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -404,3 +404,90 @@ async def test_replace_messages_with_compaction_skips_missing_role(tmp_path):
         assert "unknown" in roles, f"missing-role msg should default to 'unknown', got {roles}"
     finally:
         await runtime.close()
+
+
+# ── Issue #490: find_recent_thread for session recovery ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_recent_thread_returns_most_recent_thread(tmp_path):
+    """find_recent_thread() returns the thread with the most recent message."""
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        # Thread 1: older messages
+        await runtime.append_message(
+            thread_id="t1", turn_id="turn-a", role="user", content="hello"
+        )
+        await runtime.append_message(
+            thread_id="t1", turn_id="turn-a", role="assistant", content="hi there"
+        )
+
+        # Thread 2: newer message
+        await runtime.append_message(
+            thread_id="t2", turn_id="turn-b", role="user", content="newer message"
+        )
+
+        recent = await runtime.find_recent_thread()
+        assert recent == "t2", f"Expected t2 (newest), got {recent}"
+    finally:
+        await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_find_recent_thread_ignores_system_messages(tmp_path):
+    """find_recent_thread() only considers user/assistant roles."""
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        # Thread with only system messages should not be found
+        await runtime.append_message(
+            thread_id="sys-only", turn_id="turn-a", role="system", content="setup"
+        )
+
+        # Another thread with actual conversation
+        await runtime.append_message(
+            thread_id="real", turn_id="turn-b", role="user", content="real msg"
+        )
+
+        recent = await runtime.find_recent_thread()
+        assert recent == "real", f"Expected 'real', got {recent}"
+    finally:
+        await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_find_recent_thread_returns_none_when_empty(tmp_path):
+    """find_recent_thread() returns None when there are no messages."""
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+    try:
+        recent = await runtime.find_recent_thread()
+        assert recent is None
+    finally:
+        await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_find_recent_thread_cross_session(tmp_path):
+    """find_recent_thread() finds threads from other sessions (no session_id filter)."""
+    # Write messages under session A
+    runtime_a = HistoryRuntime(tmp_path / "runtime.db", session_id="session-a")
+    await runtime_a.initialize()
+    try:
+        await runtime_a.append_message(
+            thread_id="t-a", turn_id="turn-1", role="user", content="from session A"
+        )
+    finally:
+        await runtime_a.close()
+
+    # Query from session B — should still find the thread
+    runtime_b = HistoryRuntime(tmp_path / "runtime.db", session_id="session-b")
+    await runtime_b.initialize()
+    try:
+        recent = await runtime_b.find_recent_thread()
+        assert recent == "t-a", (
+            f"Should find thread from session-a, got {recent}"
+        )
+    finally:
+        await runtime_b.close()

--- a/tests/runtime/test_runtime_task_runner.py
+++ b/tests/runtime/test_runtime_task_runner.py
@@ -492,6 +492,11 @@ async def test_thread_command_fork_unknown_parent_rejected(fake_services):
 
     events = asyncio.Queue()
     fake_services.thread_runtime = MagicMock()
+    # Fork handler now calls get_thread() first to fetch parent title;
+    # both must fail for the test to exercise the KeyError path.
+    fake_services.thread_runtime.get_thread = AsyncMock(
+        side_effect=KeyError("parent thread not found"),
+    )
     fake_services.thread_runtime.fork_thread = AsyncMock(
         side_effect=KeyError("parent thread not found"),
     )

--- a/tests/runtime/test_turn_error_propagation.py
+++ b/tests/runtime/test_turn_error_propagation.py
@@ -210,7 +210,6 @@ def error_services(fake_services):
     history = MagicMock()
     history.start_turn = AsyncMock(return_value=None)
     history.load_messages = AsyncMock(return_value=[])
-    history.find_recent_thread_with_history = AsyncMock(return_value=None)
     history.append_message = AsyncMock(return_value=None)
     history.complete_turn = AsyncMock(return_value=None)
     fake_services.history_runtime = history

--- a/tests/runtime/test_turn_error_propagation.py
+++ b/tests/runtime/test_turn_error_propagation.py
@@ -210,6 +210,7 @@ def error_services(fake_services):
     history = MagicMock()
     history.start_turn = AsyncMock(return_value=None)
     history.load_messages = AsyncMock(return_value=[])
+    history.find_recent_thread_with_history = AsyncMock(return_value=None)
     history.append_message = AsyncMock(return_value=None)
     history.complete_turn = AsyncMock(return_value=None)
     fake_services.history_runtime = history


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复 / 设计修正

## 变更概述
撤回 #500 的设计，改为 fork thread 时携带父线程摘要而非静默注入。

## 背景/问题
#500 无差别把同 session 下其他 thread 的对话 dump 进 system prompt，违反 thread 分支隔离语义。

正确设计：
- Fork thread → 用户选择"继续"→ 携带父线程上下文
- 新建空白 thread → 用户选择"新话题"→ 不注入上下文

## 变更内容
1. 移除 _handle_user_message 中的静默注入块
2. 移除 _format_cross_thread_context() 和 _ROLE_LABEL_MAP
3. 新增 _inject_fork_summary() — fork 时加载父线程最近 10 条消息，以 system message 写入新线程
4. 更新测试 mock get_thread()

## 日志/验证证据
```
$ pytest tests/runtime/ --ignore=tests/runtime/test_thread_export_import.py -q
1157 passed, 4 skipped in 58.24s
```

## 测试情况
- ✅ 41 个 TaskRunner + ThreadRuntime 测试通过
- ✅ 全量 runtime 1157 passed, 4 skipped

## 截图
纯后端变更，无 UI 变化。

Closes #490