### PR TITLE
test(desktop): add AI connectivity probe — fail CI fast on unreachable provider

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -136,6 +136,15 @@ jobs:
           }
           CONFEOF
 
+      - name: AI connectivity probe — fail fast if provider unreachable
+        run: |
+          xvfb-run --auto-servernum \
+            npx playwright test --config=playwright.config.ts --project=electron \
+            --grep "AI Connectivity"
+        timeout-minutes: 10
+        env:
+          PLAYWRIGHT_SKIP_WEB_SERVER: '1'
+
       - name: Run Electron E2E
         run: |
           xvfb-run --auto-servernum \
@@ -226,6 +235,14 @@ jobs:
             }
           }
           CONFEOF
+
+      - name: AI connectivity probe (macOS) — fail fast if provider unreachable
+        run: |
+          npx playwright test --config=playwright.config.ts --project=electron \
+            --grep "AI Connectivity"
+        timeout-minutes: 10
+        env:
+          PLAYWRIGHT_SKIP_WEB_SERVER: '1'
 
       - name: Run Electron E2E (macOS)
         run: |

--- a/apps/desktop/tests/e2e/ai-connectivity.spec.ts
+++ b/apps/desktop/tests/e2e/ai-connectivity.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * AI Connectivity E2E Test
+ *
+ * Verifies that the MiQi Desktop app, when launched with a valid provider
+ * configuration, can reach the configured AI model and produce a response.
+ * If the AI is unreachable (no API key, wrong base URL, network failure,
+ * provider down, etc.) this test FAILS — which causes the desktop-ci to
+ * fail immediately, surfacing the configuration problem before any other
+ * E2E steps run.
+ *
+ * Strategy: use the provider-level connectivity probe
+ * (`window.miqi.providers.list` + `window.miqi.providers.test`) instead
+ * of driving the chat UI.  This keeps the test fast and unambiguous —
+ * it's not testing the chat flow, it's testing "can the app reach AI".
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *   --config=playwright.config.ts --project=electron \
+ *   -g "AI connectivity"
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  LLM_TIMEOUT,
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+// Conservative timeout for the network round-trip — provider.test typically
+// returns within a few seconds when credentials are valid, but can hang
+// slightly longer on slow networks.  Two minutes is plenty.
+const PROBE_TIMEOUT_MS = 120_000;
+
+test.describe('AI Connectivity', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 120_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test(
+    'AI provider is reachable — desktop CI fails if disconnected',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      // Read the active provider from the bridge so we don't hard-code
+      // assumptions about which provider CI uses.
+      const probeResult = await page.evaluate(async () => {
+        const timeoutMs = 120_000;
+        const probe = async <T,>(fn: () => Promise<T>): Promise<T> => {
+          return await Promise.race([
+            fn(),
+            new Promise<T>((_, reject) =>
+              setTimeout(
+                () => reject(new Error(`Bridge probe timed out after ${timeoutMs}ms`)),
+                timeoutMs,
+              ),
+            ),
+          ]);
+        };
+
+        try {
+          const status = await probe(() => (window as any).miqi.runtime.status());
+          const listed = await probe(() => (window as any).miqi.providers.list());
+
+          const providers = (listed?.providers ?? []) as Array<{
+            name: string;
+            configured: boolean;
+            configured_model?: string;
+            api_base?: string | null;
+            verification_status?: string;
+            verification_message?: string | null;
+          }>;
+
+          const configured = providers.filter((p) => p.configured);
+          if (configured.length === 0) {
+            return {
+              ok: false,
+              stage: 'list',
+              error: 'No configured providers found in ~/.miqi/config.json',
+              runtimeState: status?.state ?? null,
+              runtimeInitialized: !!status?.initialized,
+              activeProvider: listed?.active_provider ?? null,
+              activeModel: listed?.active_model ?? null,
+              providers,
+            };
+          }
+
+          const target =
+            configured.find((p) => p.name === listed?.active_provider) ?? configured[0];
+          const model = target.configured_model ?? listed?.active_model;
+
+          const probeResp = await probe(() =>
+            (window as any).miqi.providers.test(target.name, undefined, undefined, model),
+          );
+
+          return {
+            ok: !!probeResp?.ok,
+            stage: 'test',
+            runtimeState: status?.state ?? null,
+            runtimeInitialized: !!status?.initialized,
+            activeProvider: target.name,
+            activeModel: probeResp?.model ?? model ?? null,
+            providers,
+            probeResponse: probeResp,
+          };
+        } catch (e: any) {
+          return {
+            ok: false,
+            stage: 'exception',
+            error: e?.message ?? String(e),
+            runtimeState: null,
+            runtimeInitialized: false,
+            activeProvider: null,
+            activeModel: null,
+            providers: [] as any[],
+          };
+        }
+      });
+
+      console.log('[ai-connectivity] probe result:', JSON.stringify(probeResult, null, 2));
+
+      if (!probeResult.ok) {
+        const where = probeResult.stage ?? 'unknown';
+        const detail =
+          probeResult.error ??
+          probeResult.probeResponse?.error ??
+          `provider="${probeResult.activeProvider}", model="${probeResult.activeModel}"`;
+        throw new Error(
+          `AI connectivity check failed (stage=${where}): ${detail}. ` +
+            `Check DEEEPSEEK_API_KEY / DEEEPSEEK_API_BASE / BRAVE_API_KEY ` +
+            `secrets and that providers.list returns configured providers.`,
+        );
+      }
+
+      expect(probeResult.activeProvider).toBeTruthy();
+      expect(probeResult.activeModel).toBeTruthy();
+      // Trust the bridge verdict over a UI selector — providers.test returns
+      // ok:false for any failure mode (auth, network, model not found, ...).
+      expect(probeResult.probeResponse?.ok).toBe(true);
+      console.log(
+        `[ai-connectivity] ✅ ${probeResult.activeProvider} / ${probeResult.activeModel} reachable in ${PROBE_TIMEOUT_MS}ms budget`,
+      );
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/ai-connectivity.spec.ts
+++ b/apps/desktop/tests/e2e/ai-connectivity.spec.ts
@@ -1,35 +1,42 @@
 /**
  * AI Connectivity E2E Test
  *
- * Verifies that the MiQi Desktop app, when launched with a valid provider
- * configuration, can reach the configured AI model and produce a response.
- * If the AI is unreachable (no API key, wrong base URL, network failure,
- * provider down, etc.) this test FAILS — which causes the desktop-ci to
- * fail immediately, surfacing the configuration problem before any other
- * E2E steps run.
+ * Verifies that the full chat pipeline — user input → chat.send → model
+ * inference → streaming response → UI rendering — works end-to-end.
+ * If the AI model is unreachable (no API key, wrong base URL, network
+ * failure, provider down, etc.), this test FAILS, which causes desktop-ci
+ * to halt before running the full (expensive) E2E suite.
  *
- * Strategy: use the provider-level connectivity probe
- * (`window.miqi.providers.list` + `window.miqi.providers.test`) instead
- * of driving the chat UI.  This keeps the test fast and unambiguous —
- * it's not testing the chat flow, it's testing "can the app reach AI".
+ * Strategy: drive the real chat UI via sendMessage + waitForResponseComplete
+ * (same helpers the full-electron spec uses), asking the AI for a trivial
+ * one-character reply.  This exercises EVERY layer the production user path
+ * hits:
+ *   1. Bridge readiness     — runtime.status() → running + initialized
+ *   2. Provider resolution  — which provider/model the config activates
+ *   3. chat.send IPC        — preload → main → app_server → TaskRunner
+ *   4. LLM round-trip       — HTTP call to the provider endpoint
+ *   5. Streaming delivery   — onProgress / onFinal events
+ *   6. React render         — <main> textContent stabilisation
+ *
+ * When any layer fails the test throws with a diagnostic message that
+ * pinpoints the stage, making CI failures self-documenting.
  *
  * Run: cd apps/desktop && npx playwright test \
- *   --config=playwright.config.ts --project=electron \
- *   -g "AI connectivity"
+ *      --config=playwright.config.ts --project=electron \
+ *      -g "AI connectivity"
  */
 
 import { _electron as electron, test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import {
   LLM_TIMEOUT,
+  waitForInputReady,
+  sendMessage,
+  waitForResponseComplete,
+  waitForBridgeInitialized,
   launchElectronApp,
   closeElectronApp,
 } from './helpers/electron-setup';
-
-// Conservative timeout for the network round-trip — provider.test typically
-// returns within a few seconds when credentials are valid, but can hang
-// slightly longer on slow networks.  Two minutes is plenty.
-const PROBE_TIMEOUT_MS = 120_000;
 
 test.describe('AI Connectivity', () => {
   let electronApp: ElectronApplication;
@@ -48,106 +55,81 @@ test.describe('AI Connectivity', () => {
   });
 
   test(
-    'AI provider is reachable — desktop CI fails if disconnected',
+    'full chat pipeline reaches AI — desktop CI fails if disconnected',
     { timeout: LLM_TIMEOUT },
     async () => {
-      // Read the active provider from the bridge so we don't hard-code
-      // assumptions about which provider CI uses.
-      const probeResult = await page.evaluate(async () => {
-        const timeoutMs = 120_000;
-        const probe = async <T,>(fn: () => Promise<T>): Promise<T> => {
-          return await Promise.race([
-            fn(),
-            new Promise<T>((_, reject) =>
-              setTimeout(
-                () => reject(new Error(`Bridge probe timed out after ${timeoutMs}ms`)),
-                timeoutMs,
-              ),
-            ),
-          ]);
+      // ── Phase 1: bridge readiness ─────────────────────────────
+      // waitForBridgeInitialized polls miqi.runtime.status() until
+      // state === 'running' && initialized === true.
+      await waitForBridgeInitialized(page, 30);
+      console.log('[ai-connectivity] Bridge is running + initialized');
+
+      // ── Phase 2: provider inventory ───────────────────────────
+      // providers.list reports which providers are configured and
+      // which is active.  If zero configured providers are found,
+      // the CI secrets are completely missing — fail immediately
+      // with a clear diagnostic before wasting time on chat.send.
+      const providerInfo = await page.evaluate(async () => {
+        const listed: any = await (window as any).miqi.providers.list();
+        const providers: Array<{ name: string; configured: boolean; configured_model?: string }> =
+          listed?.providers ?? [];
+        const configured = providers.filter((p) => p.configured);
+        return {
+          activeProvider: listed?.active_provider ?? null,
+          activeModel: listed?.active_model ?? null,
+          configuredCount: configured.length,
+          configuredNames: configured.map((p) => p.name),
         };
-
-        try {
-          const status = await probe(() => (window as any).miqi.runtime.status());
-          const listed = await probe(() => (window as any).miqi.providers.list());
-
-          const providers = (listed?.providers ?? []) as Array<{
-            name: string;
-            configured: boolean;
-            configured_model?: string;
-            api_base?: string | null;
-            verification_status?: string;
-            verification_message?: string | null;
-          }>;
-
-          const configured = providers.filter((p) => p.configured);
-          if (configured.length === 0) {
-            return {
-              ok: false,
-              stage: 'list',
-              error: 'No configured providers found in ~/.miqi/config.json',
-              runtimeState: status?.state ?? null,
-              runtimeInitialized: !!status?.initialized,
-              activeProvider: listed?.active_provider ?? null,
-              activeModel: listed?.active_model ?? null,
-              providers,
-            };
-          }
-
-          const target =
-            configured.find((p) => p.name === listed?.active_provider) ?? configured[0];
-          const model = target.configured_model ?? listed?.active_model;
-
-          const probeResp = await probe(() =>
-            (window as any).miqi.providers.test(target.name, undefined, undefined, model),
-          );
-
-          return {
-            ok: !!probeResp?.ok,
-            stage: 'test',
-            runtimeState: status?.state ?? null,
-            runtimeInitialized: !!status?.initialized,
-            activeProvider: target.name,
-            activeModel: probeResp?.model ?? model ?? null,
-            providers,
-            probeResponse: probeResp,
-          };
-        } catch (e: any) {
-          return {
-            ok: false,
-            stage: 'exception',
-            error: e?.message ?? String(e),
-            runtimeState: null,
-            runtimeInitialized: false,
-            activeProvider: null,
-            activeModel: null,
-            providers: [] as any[],
-          };
-        }
       });
 
-      console.log('[ai-connectivity] probe result:', JSON.stringify(probeResult, null, 2));
+      console.log(
+        '[ai-connectivity] providers.list result:',
+        JSON.stringify(providerInfo),
+      );
 
-      if (!probeResult.ok) {
-        const where = probeResult.stage ?? 'unknown';
-        const detail =
-          probeResult.error ??
-          probeResult.probeResponse?.error ??
-          `provider="${probeResult.activeProvider}", model="${probeResult.activeModel}"`;
+      if (providerInfo.configuredCount === 0) {
         throw new Error(
-          `AI connectivity check failed (stage=${where}): ${detail}. ` +
-            `Check DEEEPSEEK_API_KEY / DEEEPSEEK_API_BASE / BRAVE_API_KEY ` +
-            `secrets and that providers.list returns configured providers.`,
+          'AI connectivity check failed (stage=list): ' +
+            'No configured providers found in ~/.miqi/config.json. ' +
+            'Check DEEEPSEEK_API_KEY / DEEEPSEEK_API_BASE secrets.',
         );
       }
 
-      expect(probeResult.activeProvider).toBeTruthy();
-      expect(probeResult.activeModel).toBeTruthy();
-      // Trust the bridge verdict over a UI selector — providers.test returns
-      // ok:false for any failure mode (auth, network, model not found, ...).
-      expect(probeResult.probeResponse?.ok).toBe(true);
       console.log(
-        `[ai-connectivity] ✅ ${probeResult.activeProvider} / ${probeResult.activeModel} reachable in ${PROBE_TIMEOUT_MS}ms budget`,
+        `[ai-connectivity] Active provider: ${providerInfo.activeProvider ?? '?'}, ` +
+          `model: ${providerInfo.activeModel ?? '?'}, ` +
+          `${providerInfo.configuredCount} configured provider(s)`,
+      );
+
+      // ── Phase 3: full chat pipeline ───────────────────────────
+      // Drive the real chat UI with a minimal prompt.  This exercises:
+      //   chat.send IPC → app_server → TaskRunner → LLM HTTP call →
+      //   streaming onProgress/onFinal → React render → textContent stabilisation.
+      //
+      // Use a unique marker so we never match stale DOM text from a
+      // prior test or cross-session leak.
+      const marker = `OK_${Date.now()}`;
+      const prompt = `只回答${marker}`;
+
+      console.log(`[ai-connectivity] Sending prompt: "${prompt}"`);
+      await sendMessage(page, prompt);
+
+      // waitForResponseComplete waits for "Thinking…" to hide AND
+      // textContent to stabilise — so it covers streaming delivery
+      // AND UI rendering.
+      console.log('[ai-connectivity] Waiting for AI response…');
+      await waitForResponseComplete(page);
+
+      // Confirm the marker is visible in <main> — the final proof
+      // that the model replied AND the UI rendered it.
+      const markerEl = page.locator('main').getByText(marker, { exact: false }).first();
+      await markerEl.scrollIntoViewIfNeeded().catch(() => {});
+      await expect(markerEl).toBeVisible({ timeout: 15_000 });
+
+      console.log(
+        `[ai-connectivity] ✅ Full chat pipeline verified: ` +
+          `${providerInfo.activeProvider ?? '?'} / ${providerInfo.activeModel ?? '?'} ` +
+          `returned "${marker}"`,
       );
     },
   );


### PR DESCRIPTION
## 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [x] 🧪 测试
- [ ] 🔧 其他

## 变更概述

新增 E2E 测试 `ai-connectivity.spec.ts`，通过真实 `chat.send` → 流式返回 → UI 渲染全链路验证 AI 联通性。在上游 AI 不可达时让 desktop CI 立即失败（约 3 分钟），避免完整 E2E suite 在 credential 失效/网络故障时浪费 30 分钟。

## 背景/问题

当前 desktop-ci 的 `electron-e2e` job 直接跑完整 Playwright Electron suite（30 min 超时）。当 GitHub Secrets（`DEEEPSEEK_API_KEY` / `DEEEPSEEK_API_BASE` / `BRAVE_API_KEY`）过期、配错或上游模型临时不可用时，整套用例都会因 "Thinking…" 超时而失败，浪费 CI 分钟；同时混淆了 LLM 端到端用例故障与 PR 真实代码改动故障两个独立维度。

需要第一个快速验证：**完整的 chat.send → 模型推理 → 流式输出 → 渲染管线能走通**，desktop CI 才进入完整套件。

## 变更内容

- `apps/desktop/tests/e2e/ai-connectivity.spec.ts`（新增）
  - **Phase 1** — `waitForBridgeInitialized(page, 30)`：确认 `runtime.status()` → `running + initialized`。
  - **Phase 2** — `providers.list()` gate check：零 `configured` provider 直接抛错（secrets 完全缺失的诊断信号）。
  - **Phase 3** — `sendMessage` + `waitForResponseComplete`：真实 `chat.send` IPC → `app_server` → `TaskRunner` → LLM HTTP call → streaming `onProgress/onFinal` → React render → `textContent` stabilisation 全链路。
  - 用唯一 `Date.now()` marker 避免跨 session 污染。
  - 每个 phase 都有独立 `console.log`，CI 日志自动定位故障点。
  - 复用 `helpers/electron-setup.ts` 已有函数（`sendMessage`, `waitForResponseComplete`, `waitForBridgeInitialized`）。
- `.github/workflows/desktop-ci.yml`
  - `electron-e2e` job：在 `Run Electron E2E` 前插入 `--grep "AI Connectivity"` 步骤（`timeout-minutes: 10`）。
  - `macos-e2e` job：同样插入。

## 日志/验证证据

```
$ git log --oneline -2
a2d8a540 test(desktop): use real chat.send pipeline for AI connectivity probe
efa3a526 test(desktop): add AI connectivity probe — fail CI fast on unreachable provider
```

本环境内未执行 `npm run test:electron -- -g "AI Connectivity"`（该 worktree 不是 desktop CI 节点，且 sandbox/桥接/LLM secrets 来源不同），验证交由 desktop CI 完成。

预期 CI 日志（成功路径）：

```
[ai-connectivity] Bridge is running + initialized
[ai-connectivity] providers.list result: {"activeProvider":"siliconflow","activeModel":"deepseek-v4-pro","configuredCount":1,"configuredNames":["siliconflow"]}
[ai-connectivity] Active provider: siliconflow, model: deepseek-v4-pro, 1 configured provider(s)
[ai-connectivity] Sending prompt: "只回答OK_1750000000000"
[ai-connectivity] Waiting for AI response…
[ai-connectivity] ✅ Full chat pipeline verified: siliconflow / deepseek-v4-pro returned "OK_1750000000000"
```

预期 CI 日志（失败路径，secrets 缺失）：

```
Error: AI connectivity check failed (stage=list): No configured providers found in ~/.miqi/config.json. Check DEEEPSEEK_API_KEY / DEEEPSEEK_API_BASE secrets.
```

预期 CI 日志（失败路径，base URL 错配 / 网络不通）：

```
[ai-connectivity] Bridge is running + initialized
[ai-connectivity] providers.list result: {"activeProvider":"siliconflow",...}
[ai-connectivity] Sending prompt: "只回答OK_..."
→ waitForResponseComplete TIMEOUT — Thinking… still visible after 120s
→ test fails with timeout error
```

## 测试情况

- 仅修改 CI 工作流与新增 E2E 测试文件，未改动产品代码或第三方依赖。
- 复用 `helpers/electron-setup.ts` 的 `launchElectronApp` / `sendMessage` / `waitForResponseComplete` 等已验证函数。
- `desktop-ci.yml` YAML 结构正确：macOS job 的 `--grep-invert` 不与 `--grep "AI Connectivity"` 冲突。
- 计划在 desktop CI 上验证：
  1. secrets 正常时，本用例快速通过（< 3 min），完整 E2E 继续执行；
  2. secrets 缺失/失效时，本用例 fail（<< 10 min），不进入完整 E2E。
- 未运行：vitest（无产品代码变更）、Python tests（无 Python 改动）、docs deploy（无文档改动）。

## 截图

无需截图。