### PR TITLE
feat(ci): add PR title semantic consistency check

### DIFF
--- a/.github/workflows/pr-title-semantic-check.yml
+++ b/.github/workflows/pr-title-semantic-check.yml
@@ -1,0 +1,88 @@
+name: PR 标题语义检测
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check-title-semantic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const body = context.payload.pull_request.body || '';
+
+            // 去掉 HTML 注释
+            const withoutComments = body.replace(/<!--[\s\S]*?-->/g, '');
+
+            const errors = [];
+
+            // ── 1. 标题格式校验 ──
+            const validPrefixRe = /^(feat|fix|perf|refactor|docs|style|test|build|ci|chore|revert)(\(.+\))?!?: /;
+            const match = title.match(validPrefixRe);
+
+            if (!match) {
+              errors.push(
+                `❌ 标题格式不符：PR 标题必须以语义前缀开头\n` +
+                `当前标题: "${title}"\n` +
+                `正确格式: <type>(<scope>): <subject>\n` +
+                `允许前缀: feat, fix, perf, refactor, docs, style, test, build, ci, chore, revert\n` +
+                `示例: "feat(sandbox): add auto-install support", "fix(desktop): correct path encoding"`
+              );
+            }
+
+            // ── 2. 标题与 body 类型一致性校验 ──
+            if (match) {
+              const type = match[1];
+
+              // 语义映射：标题前缀 → body 勾选项标签
+              const typeToLabel = {
+                feat: '✨ 新功能',
+                fix: '🐛 Bug 修复',
+                docs: '📝 文档',
+                refactor: '♻️ 重构',
+                test: '🧪 测试',
+              };
+
+              // 这些前缀不强对应特定选项，只要求至少勾了一项
+              const softTypes = ['perf', 'style', 'build', 'ci', 'chore', 'revert'];
+
+              if (softTypes.includes(type)) {
+                const hasCheck = /- \[x\] /.test(withoutComments);
+                if (!hasCheck) {
+                  errors.push(
+                    `❌ 语义不一致：PR 标题前缀为 "${type}"，需在 body "类型" 节至少勾选一项。\n` +
+                    `当前未勾选任何类型。`
+                  );
+                }
+              } else {
+                const expectedLabel = typeToLabel[type];
+                // 用行级正则匹配勾选项（同一行内同时有 [x] 和标签文本）
+                const checkboxRe = new RegExp(`- \\[x\\] .*${escapeRe(expectedLabel)}`);
+                if (!checkboxRe.test(withoutComments)) {
+                  const checkedLines = withoutComments.match(/- \[x\] .+/g) || [];
+                  const checked = checkedLines.length > 0
+                    ? checkedLines.map(l => l.replace(/- \[x\] /, '').trim()).join('、')
+                    : '(未勾选任何类型)';
+                  errors.push(
+                    `❌ 语义不一致：PR 标题前缀为 "${type}"，应勾选 "${expectedLabel}"，` +
+                    `但实际勾选了: ${checked}。\n` +
+                    `请保持标题前缀语义与 body "类型" 勾选项一致。`
+                  );
+                }
+              }
+            }
+
+            // ── 结果 ──
+            if (errors.length > 0) {
+              core.setFailed(errors.join('\n\n'));
+            } else {
+              console.log(`✅ PR 标题格式和语义检查通过: "${title}"`);
+            }
+
+            // 辅助：转义正则特殊字符（用于 emoji 等）
+            function escapeRe(s) {
+              return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            }

--- a/.github/workflows/pr-title-semantic-check.yml
+++ b/.github/workflows/pr-title-semantic-check.yml
@@ -7,8 +7,32 @@ on:
 jobs:
   check-title-semantic:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+
     steps:
-      - uses: actions/github-script@v7
+      # ── 1. 标题格式校验（开源标准 action） ──
+      - uses: amannn/action-semantic-pull-request@v6
+        id: lint-title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            style
+            test
+            build
+            ci
+            chore
+            revert
+
+      # ── 2. 标题与 body 类型一致性校验 ──
+      - name: 检查标题前缀与 body 类型勾选项一致性
+        uses: actions/github-script@v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -17,72 +41,58 @@ jobs:
             // 去掉 HTML 注释
             const withoutComments = body.replace(/<!--[\s\S]*?-->/g, '');
 
-            const errors = [];
-
-            // ── 1. 标题格式校验 ──
-            const validPrefixRe = /^(feat|fix|perf|refactor|docs|style|test|build|ci|chore|revert)(\(.+\))?!?: /;
-            const match = title.match(validPrefixRe);
-
-            if (!match) {
-              errors.push(
-                `❌ 标题格式不符：PR 标题必须以语义前缀开头\n` +
-                `当前标题: "${title}"\n` +
-                `正确格式: <type>(<scope>): <subject>\n` +
-                `允许前缀: feat, fix, perf, refactor, docs, style, test, build, ci, chore, revert\n` +
-                `示例: "feat(sandbox): add auto-install support", "fix(desktop): correct path encoding"`
-              );
+            // 提取标题前缀 type
+            const typeMatch = title.match(/^(\w+)/);
+            if (!typeMatch) {
+              console.log('⚠️ 无法从标题提取类型前缀，跳过语义一致性检查');
+              return;
             }
 
-            // ── 2. 标题与 body 类型一致性校验 ──
-            if (match) {
-              const type = match[1];
+            const type = typeMatch[1];
 
-              // 语义映射：标题前缀 → body 勾选项标签
-              const typeToLabel = {
-                feat: '✨ 新功能',
-                fix: '🐛 Bug 修复',
-                docs: '📝 文档',
-                refactor: '♻️ 重构',
-                test: '🧪 测试',
-              };
+            // 语义映射：标题前缀 → body 勾选项标签
+            const typeToLabel = {
+              feat: '✨ 新功能',
+              fix: '🐛 Bug 修复',
+              docs: '📝 文档',
+              refactor: '♻️ 重构',
+              test: '🧪 测试',
+            };
 
-              // 这些前缀不强对应特定选项，只要求至少勾了一项
-              const softTypes = ['perf', 'style', 'build', 'ci', 'chore', 'revert'];
+            // 这些前缀不强对应特定选项，只要求至少勾了一项
+            const softTypes = ['perf', 'style', 'build', 'ci', 'chore', 'revert'];
 
-              if (softTypes.includes(type)) {
-                const hasCheck = /- \[x\] /.test(withoutComments);
-                if (!hasCheck) {
-                  errors.push(
-                    `❌ 语义不一致：PR 标题前缀为 "${type}"，需在 body "类型" 节至少勾选一项。\n` +
-                    `当前未勾选任何类型。`
-                  );
-                }
+            if (softTypes.includes(type)) {
+              const hasCheck = /- \[x\] /.test(withoutComments);
+              if (!hasCheck) {
+                core.setFailed(
+                  `❌ 语义不一致：PR 标题前缀为 "${type}"，需在 body "类型" 节至少勾选一项。\n` +
+                  `当前未勾选任何类型。`
+                );
               } else {
-                const expectedLabel = typeToLabel[type];
-                // 用行级正则匹配勾选项（同一行内同时有 [x] 和标签文本）
-                const checkboxRe = new RegExp(`- \\[x\\] .*${escapeRe(expectedLabel)}`);
-                if (!checkboxRe.test(withoutComments)) {
-                  const checkedLines = withoutComments.match(/- \[x\] .+/g) || [];
-                  const checked = checkedLines.length > 0
-                    ? checkedLines.map(l => l.replace(/- \[x\] /, '').trim()).join('、')
-                    : '(未勾选任何类型)';
-                  errors.push(
-                    `❌ 语义不一致：PR 标题前缀为 "${type}"，应勾选 "${expectedLabel}"，` +
-                    `但实际勾选了: ${checked}。\n` +
-                    `请保持标题前缀语义与 body "类型" 勾选项一致。`
-                  );
-                }
+                console.log(`✅ 语义一致性通过: "${type}" 已勾选至少一项类型`);
               }
-            }
-
-            // ── 结果 ──
-            if (errors.length > 0) {
-              core.setFailed(errors.join('\n\n'));
+            } else if (typeToLabel[type]) {
+              const expectedLabel = typeToLabel[type];
+              const checkboxRe = new RegExp(`- \\[x\\] .*${escapeRe(expectedLabel)}`);
+              if (!checkboxRe.test(withoutComments)) {
+                const checkedLines = withoutComments.match(/- \[x\] .+/g) || [];
+                const checked = checkedLines.length > 0
+                  ? checkedLines.map(l => l.replace(/- \[x\] /, '').trim()).join('、')
+                  : '(未勾选任何类型)';
+                core.setFailed(
+                  `❌ 语义不一致：PR 标题前缀为 "${type}"，应勾选 "${expectedLabel}"，` +
+                  `但实际勾选了: ${checked}。\n` +
+                  `请保持标题前缀语义与 body "类型" 勾选项一致。`
+                );
+              } else {
+                console.log(`✅ 语义一致性通过: "${type}" → "${expectedLabel}"`);
+              }
             } else {
-              console.log(`✅ PR 标题格式和语义检查通过: "${title}"`);
+              // 未知类型（理论上不会走到这里，因为 step 1 已过滤）
+              console.log(`⚠️ 未知类型前缀 "${type}"，跳过语义一致性检查`);
             }
 
-            // 辅助：转义正则特殊字符（用于 emoji 等）
             function escapeRe(s) {
               return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             }

--- a/.github/workflows/pr-title-semantic-check.yml
+++ b/.github/workflows/pr-title-semantic-check.yml
@@ -5,15 +5,13 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 jobs:
-  check-title-semantic:
+  check-title:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
 
     steps:
-      # ── 1. 标题格式校验（开源标准 action） ──
       - uses: amannn/action-semantic-pull-request@v6
-        id: lint-title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -29,70 +27,3 @@ jobs:
             ci
             chore
             revert
-
-      # ── 2. 标题与 body 类型一致性校验 ──
-      - name: 检查标题前缀与 body 类型勾选项一致性
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = context.payload.pull_request.title;
-            const body = context.payload.pull_request.body || '';
-
-            // 去掉 HTML 注释
-            const withoutComments = body.replace(/<!--[\s\S]*?-->/g, '');
-
-            // 提取标题前缀 type
-            const typeMatch = title.match(/^(\w+)/);
-            if (!typeMatch) {
-              console.log('⚠️ 无法从标题提取类型前缀，跳过语义一致性检查');
-              return;
-            }
-
-            const type = typeMatch[1];
-
-            // 语义映射：标题前缀 → body 勾选项标签
-            const typeToLabel = {
-              feat: '✨ 新功能',
-              fix: '🐛 Bug 修复',
-              docs: '📝 文档',
-              refactor: '♻️ 重构',
-              test: '🧪 测试',
-            };
-
-            // 这些前缀不强对应特定选项，只要求至少勾了一项
-            const softTypes = ['perf', 'style', 'build', 'ci', 'chore', 'revert'];
-
-            if (softTypes.includes(type)) {
-              const hasCheck = /- \[x\] /.test(withoutComments);
-              if (!hasCheck) {
-                core.setFailed(
-                  `❌ 语义不一致：PR 标题前缀为 "${type}"，需在 body "类型" 节至少勾选一项。\n` +
-                  `当前未勾选任何类型。`
-                );
-              } else {
-                console.log(`✅ 语义一致性通过: "${type}" 已勾选至少一项类型`);
-              }
-            } else if (typeToLabel[type]) {
-              const expectedLabel = typeToLabel[type];
-              const checkboxRe = new RegExp(`- \\[x\\] .*${escapeRe(expectedLabel)}`);
-              if (!checkboxRe.test(withoutComments)) {
-                const checkedLines = withoutComments.match(/- \[x\] .+/g) || [];
-                const checked = checkedLines.length > 0
-                  ? checkedLines.map(l => l.replace(/- \[x\] /, '').trim()).join('、')
-                  : '(未勾选任何类型)';
-                core.setFailed(
-                  `❌ 语义不一致：PR 标题前缀为 "${type}"，应勾选 "${expectedLabel}"，` +
-                  `但实际勾选了: ${checked}。\n` +
-                  `请保持标题前缀语义与 body "类型" 勾选项一致。`
-                );
-              } else {
-                console.log(`✅ 语义一致性通过: "${type}" → "${expectedLabel}"`);
-              }
-            } else {
-              // 未知类型（理论上不会走到这里，因为 step 1 已过滤）
-              console.log(`⚠️ 未知类型前缀 "${type}"，跳过语义一致性检查`);
-            }
-
-            function escapeRe(s) {
-              return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            }


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] ✨ 新功能
- [ ] 🐛 Bug 修复
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

新增 PR 标题语义检测 CI workflow，使用 `amannn/action-semantic-pull-request@v6` 对所有分支校验 PR 标题是否符合 Conventional Commits 格式。

## 背景/问题

现有的 `pr-title-check.yml` 仅对 `main` 分支生效，`develop` 等分支的 PR 缺少标题格式校验。

## 变更内容

- **新增** `.github/workflows/pr-title-semantic-check.yml`
  - 触发条件：所有分支的 `pull_request`（opened/edited/reopened/synchronize）
  - 使用 `amannn/action-semantic-pull-request@v6`（semantic-release 生态开源标准 action）
  - 配置类型：feat, fix, perf, refactor, docs, style, test, build, ci, chore, revert

## 日志/验证证据

```
amannn/action-semantic-pull-request@v6 — 1k+ GitHub stars，semantic-release 官方推荐
```

## 测试情况

PR 自身标题 `feat(ci): ...` 即为测试用例，CI 触发后可在 PR Checks 标签页验证。

## 截图

无需截图（纯 CI workflow 变更）。