### PR TITLE
fix(#516): file_tool 拒绝访问 host 全局 workspace 路径（memory/、skills/）

### DIFF
--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re as _re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
 from miqi.agent.tools.filesystem import (
@@ -274,11 +274,13 @@ class ApplyPatchTool(Tool):
         allowed_dir: Path | None = None,
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
+        shared_roots: Iterable[Path] | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
+        self._shared_roots = list(shared_roots or [])
 
     @property
     def name(self) -> str:
@@ -336,7 +338,9 @@ class ApplyPatchTool(Tool):
         path = file_patch.path
 
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-            sandbox_path = _resolve_sandbox_path(path, self._workspace, sandbox)
+            sandbox_path = _resolve_sandbox_path(
+                path, self._workspace, sandbox, extra_roots=self._shared_roots
+            )
             _log.info("apply_patch [sandbox]: %s → %s", path, sandbox_path)
 
             try:

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -11,7 +11,7 @@ import json as _json
 import logging
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
 
@@ -243,19 +243,31 @@ def _sandbox_to_host_path(sandbox_path: str, workspace: Path | None, sandbox) ->
 
 
 
-def _canonicalize_wsl_mnt_path(mnt_path: str, workspace: Path | None) -> str:
+def _canonicalize_wsl_mnt_path(
+    mnt_path: str,
+    workspace: Path | None,
+    extra_roots: Iterable[Path] | None = None,
+) -> str:
     """Canonicalize a /mnt/<drive>/... path and verify workspace containment.
 
     Converts to host path, resolves ``..`` traversal, checks the resolved
-    path stays within *workspace*, and returns the canonical /mnt/ path.
-    Raises PermissionError if the path escapes the workspace (issue #474).
+    path stays within *workspace* (or within any of the ``extra_roots``),
+    and returns the canonical /mnt/ path.  Raises PermissionError if the
+    path escapes every legal root (issue #474).
+
+    ``extra_roots`` lets callers broaden the whitelist beyond the per-session
+    workspace to host-global shared roots (issue #516) such as
+    ``~/.miqi/workspace/memory`` and ``~/.miqi/workspace/skills`` — the
+    directories the system prompt legitimately directs the agent to read and
+    write.  A path under another session's ``sessions/<other>/files`` is never
+    in any root, so per-session isolation is preserved.
 
     Returns *mnt_path* unchanged for non-/mnt/ paths or when no workspace
     is configured.
     """
     import re as _re
 
-    if workspace is None:
+    if workspace is None and not extra_roots:
         return mnt_path
 
     m = _re.match(r"^/mnt/([a-z])/(.+)$", mnt_path)
@@ -289,13 +301,31 @@ def _canonicalize_wsl_mnt_path(mnt_path: str, workspace: Path | None) -> str:
             f"Cannot canonicalize path '{host_str}': resolution failed"
         )
 
-    ws_resolved = workspace.resolve()
-    try:
-        resolved.relative_to(ws_resolved)
-    except ValueError:
+    # Build the list of legal roots: the per-session workspace plus any
+    # host-global shared roots (issue #516).  A path is accepted if it lives
+    # under ANY of them; only a path under none is rejected.  This keeps the
+    # default single-root behavior (extra_roots empty) identical to before.
+    roots: list[Path] = []
+    if workspace is not None:
+        roots.append(workspace.resolve())
+    if extra_roots:
+        for r in extra_roots:
+            try:
+                roots.append(Path(r).resolve())
+            except Exception:
+                _log.debug("_canonicalize_wsl_mnt_path: skipping unresolvable extra root %r", r)
+
+    for root in roots:
+        try:
+            resolved.relative_to(root)
+            break  # contained in this root — accept
+        except ValueError:
+            continue
+    else:
+        roots_str = ", ".join(str(r) for r in roots) if roots else "<none>"
         raise PermissionError(
             f"Path '{host_str}' (normalized: '{normalized}') resolves to '{resolved}' "
-            f"which is outside the workspace '{ws_resolved}'"
+            f"which is outside all legal roots [{roots_str}]"
         )
 
     resolved_str = str(resolved).replace("\\", "/")
@@ -349,7 +379,12 @@ def _get_session_workspace(base_workspace: Path | None, sandbox) -> Path | None:
     return session_ws
 
 
-def _resolve_sandbox_path(path: str, workspace: Path | None, sandbox) -> str:
+def _resolve_sandbox_path(
+    path: str,
+    workspace: Path | None,
+    sandbox,
+    extra_roots: Iterable[Path] | None = None,
+) -> str:
     """Resolve a path for use inside the sandbox.
 
     Returns a Linux-style absolute path inside the sandbox filesystem.
@@ -368,7 +403,7 @@ def _resolve_sandbox_path(path: str, workspace: Path | None, sandbox) -> str:
         # WSL sandbox: use /mnt/ for direct host filesystem access (issue #474)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             result = f"/mnt/{drive}/{rest}"
-            result = _canonicalize_wsl_mnt_path(result, workspace)
+            result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots)
             _log.debug("Sandbox path: %s → %s (WSL /mnt/ direct)", original_path, result)
             return result
         # If the workspace matches this drive, compute relative path
@@ -397,7 +432,7 @@ def _resolve_sandbox_path(path: str, workspace: Path | None, sandbox) -> str:
                 drive = ws_match.group(1).lower()
                 ws_rest = ws_match.group(2).rstrip("/")
                 result = f"/mnt/{drive}/{ws_rest}/{path}"
-                result = _canonicalize_wsl_mnt_path(result, workspace)
+                result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots)
                 _log.debug("Sandbox path: %s → %s (WSL relative /mnt/)", original_path, result)
                 return result
         # Compute the correct sandbox base path.
@@ -422,7 +457,7 @@ def _resolve_sandbox_path(path: str, workspace: Path | None, sandbox) -> str:
         if ws_str[1:2] == ":":
             # WSL sandbox: /mnt/ paths already access host filesystem directly (issue #474)
             if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-                result = _canonicalize_wsl_mnt_path(path, workspace)
+                result = _canonicalize_wsl_mnt_path(path, workspace, extra_roots)
                 _log.debug("Sandbox path: %s → %s (WSL /mnt/ keep)", original_path, result)
                 return result
             drive = ws_str[0].lower()
@@ -557,10 +592,12 @@ class ReadFileTool(Tool):
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
         sandbox_manager=None,
+        shared_roots: Iterable[Path] | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
+        self._shared_roots = list(shared_roots or [])
 
     @property
     def name(self) -> str:
@@ -589,7 +626,9 @@ class ReadFileTool(Tool):
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
-            sandbox_path = _resolve_sandbox_path(path, session_ws, sandbox)
+            sandbox_path = _resolve_sandbox_path(
+                path, session_ws, sandbox, extra_roots=self._shared_roots
+            )
             _log.info("read_file [sandbox]: %s → %s", path, sandbox_path)
             try:
                 exists = await _sandbox_file_exists(sandbox, sandbox_path)
@@ -632,11 +671,13 @@ class WriteFileTool(Tool):
         allowed_dir: Path | None = None,
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
+        shared_roots: Iterable[Path] | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
+        self._shared_roots = list(shared_roots or [])
 
     @property
     def name(self) -> str:
@@ -676,7 +717,9 @@ class WriteFileTool(Tool):
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
-            sandbox_path = _resolve_sandbox_path(path, session_ws, sandbox)
+            sandbox_path = _resolve_sandbox_path(
+                path, session_ws, sandbox, extra_roots=self._shared_roots
+            )
             _log.info("write_file [sandbox]: %s → %s", path, sandbox_path)
             try:
                 await _sandbox_write_file(sandbox, sandbox_path, content)
@@ -739,11 +782,13 @@ class EditFileTool(Tool):
         allowed_dir: Path | None = None,
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
+        shared_roots: Iterable[Path] | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
+        self._shared_roots = list(shared_roots or [])
 
     @property
     def name(self) -> str:
@@ -780,7 +825,9 @@ class EditFileTool(Tool):
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
-            sandbox_path = _resolve_sandbox_path(path, session_ws, sandbox)
+            sandbox_path = _resolve_sandbox_path(
+                path, session_ws, sandbox, extra_roots=self._shared_roots
+            )
             _log.info("edit_file [sandbox]: %s → %s", path, sandbox_path)
             try:
                 exists = await _sandbox_file_exists(sandbox, sandbox_path)
@@ -894,10 +941,12 @@ class ListDirTool(Tool):
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
         sandbox_manager=None,
+        shared_roots: Iterable[Path] | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
+        self._shared_roots = list(shared_roots or [])
 
     @property
     def name(self) -> str:
@@ -926,7 +975,9 @@ class ListDirTool(Tool):
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
-            sandbox_path = _resolve_sandbox_path(path, session_ws, sandbox)
+            sandbox_path = _resolve_sandbox_path(
+                path, session_ws, sandbox, extra_roots=self._shared_roots
+            )
             _log.info("list_dir [sandbox]: %s → %s", path, sandbox_path)
             try:
                 exists = await _sandbox_dir_exists(sandbox, sandbox_path)

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -84,6 +84,18 @@ def create_runtime_tool_registry(
     if _work_dir is not None:
         _write_workspace = _work_dir
 
+    # Host-global shared roots the system prompt legitimately directs the
+    # agent to read/write (issue #516): memory/ (MEMORY.md, LTM_SNAPSHOT, …)
+    # and skills/ (<name>/SKILL.md).  These live outside the per-session
+    # files dir, so without them the WSL sandbox containment check wrongly
+    # rejects memory/skill paths.  Per-session isolation is unaffected: only
+    # these two global dirs are whitelisted, never another session's files.
+    _shared_roots: list[Path] = []
+    for _sub in ("memory", "skills"):
+        _shared_dir = workspace / _sub
+        _shared_dir.mkdir(parents=True, exist_ok=True)
+        _shared_roots.append(_shared_dir)
+
     # Resolve config sections
     tools_cfg = getattr(config, "tools", None)
     restrict_to_workspace = getattr(tools_cfg, "restrict_to_workspace", False) if tools_cfg is not None else False
@@ -110,13 +122,14 @@ def create_runtime_tool_registry(
 
     # 1. Filesystem tools
     for cls in (ReadFileTool, ListDirTool):
-        registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm))
+        registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm, shared_roots=_shared_roots))
     registry.register(
         WriteFileTool(
             workspace=_write_workspace,
             allowed_dir=allowed_dir,
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
+            shared_roots=_shared_roots,
         )
     )
     registry.register(
@@ -125,6 +138,7 @@ def create_runtime_tool_registry(
             allowed_dir=allowed_dir,
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
+            shared_roots=_shared_roots,
         )
     )
     registry.register(
@@ -133,6 +147,7 @@ def create_runtime_tool_registry(
             allowed_dir=allowed_dir,
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
+            shared_roots=_shared_roots,
         )
     )
 

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -108,6 +108,67 @@ class TestCanonicalizeWslMntPath:
         result = _canonicalize_wsl_mnt_path(_as_mnt_path(ws), ws)
         assert result.endswith("/sub")
 
+    # ── issue #516: multi-root whitelist (host-global memory/ & skills/) ──
+
+    def test_extra_root_none_preserves_single_root_behavior(self, tmp_path):
+        """extra_roots=None must behave exactly like the old single-root path."""
+        ws = tmp_path / "sub"
+        ws.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        # Within workspace: accepted
+        assert "readme.md" in _canonicalize_wsl_mnt_path(
+            _as_mnt_path(ws, "readme.md"), ws, extra_roots=None
+        )
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_extra_root_allows_host_global_path(self, tmp_path):
+        """A path inside an extra root is accepted even when outside the
+        per-session workspace (issue #516: memory/MEMORY.md, skills/...)."""
+        session_ws = tmp_path / "sessions" / "abc" / "files"
+        session_ws.mkdir(parents=True)
+        host_memory = tmp_path / "memory"
+        host_memory.mkdir()
+        result = _canonicalize_wsl_mnt_path(
+            _as_mnt_path(host_memory, "MEMORY.md"),
+            session_ws,
+            extra_roots=[host_memory],
+        )
+        assert "MEMORY.md" in result
+        assert "memory" in result
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_extra_root_does_not_open_other_session_dir(self, tmp_path):
+        """A path under ANOTHER session's files dir must still be rejected —
+        per-session isolation is preserved (the #490/#505 red line)."""
+        session_ws = tmp_path / "sessions" / "abc" / "files"
+        session_ws.mkdir(parents=True)
+        host_memory = tmp_path / "memory"
+        host_memory.mkdir()
+        host_skills = tmp_path / "skills"
+        host_skills.mkdir()
+        other_session = tmp_path / "sessions" / "other" / "files"
+        other_session.mkdir(parents=True)
+        with pytest.raises(PermissionError, match="outside"):
+            _canonicalize_wsl_mnt_path(
+                _as_mnt_path(other_session, "secret.md"),
+                session_ws,
+                extra_roots=[host_memory, host_skills],
+            )
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_extra_root_traversal_into_outside_still_rejected(self, tmp_path):
+        """A path that resolves outside every root via `..` is still rejected,
+        even when extra_roots are configured."""
+        session_ws = tmp_path / "sessions" / "abc" / "files"
+        session_ws.mkdir(parents=True)
+        host_memory = tmp_path / "memory"
+        host_memory.mkdir()
+        # From inside memory, traverse up via .. into an unrelated dir.
+        mnt = _as_mnt_path(host_memory, "..", "evil.txt")
+        with pytest.raises(PermissionError, match="outside"):
+            _canonicalize_wsl_mnt_path(mnt, session_ws, extra_roots=[host_memory])
+
 
 # ── _resolve_sandbox_path ────────────────────────────────────────────────
 
@@ -195,6 +256,37 @@ class TestResolveSandboxPathWSL:
         sb = _make_wsl_sandbox()
         result = _resolve_sandbox_path("temp.txt", session_ws, sb)
         assert result.endswith("/sessions/abc123/files/temp.txt")
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_wsl_host_global_path_via_extra_roots(self, tmp_path):
+        """issue #516: a host-global path (memory/) outside the per-session
+        workspace is accepted by _resolve_sandbox_path when shared_roots are
+        passed, while a foreign session's dir is still rejected."""
+        session_ws = tmp_path / "sessions" / "abc" / "files"
+        session_ws.mkdir(parents=True)
+        host_memory = tmp_path / "memory"
+        host_memory.mkdir()
+        other_session = tmp_path / "sessions" / "other" / "files"
+        other_session.mkdir(parents=True)
+        sb = _make_wsl_sandbox()
+
+        # host-global memory path accepted
+        ok = _resolve_sandbox_path(
+            str(host_memory / "MEMORY.md"),
+            session_ws,
+            sb,
+            extra_roots=[host_memory],
+        )
+        assert "MEMORY.md" in ok
+
+        # foreign session path still rejected
+        with pytest.raises(PermissionError, match="outside"):
+            _resolve_sandbox_path(
+                str(other_session / "secret.md"),
+                session_ws,
+                sb,
+                extra_roots=[host_memory],
+            )
 
 
 # ── _sandbox_to_host_path ────────────────────────────────────────────────


### PR DESCRIPTION
Closes #516

## 类型

- [x] 🐛 Bug 修复

## 变更概述

WSL 沙箱下 file_tool 误拒 host 全局 workspace 路径（memory/、skills/）：把 `_canonicalize_wsl_mnt_path` 的单根 containment 校验改成多根白名单，额外放行 host 全局的 `memory/`、`skills/`，per-session 隔离不变。

## 背景/问题

**现象：** Windows 11 + WSL 沙箱、`session_workspace_enabled=True`、`restrict_to_workspace=True` 下，AI 调 `read_file`/`write_file`/`edit_file`/`apply_patch` 去读写 host 全局 workspace 里的共享目录（system prompt 引导它写的 `~/.miqi/workspace/memory/MEMORY.md`、`~/.miqi/workspace/skills/<name>/SKILL.md`）时，被 `_canonicalize_wsl_mnt_path` 误判越界抛 `PermissionError`，模型常因此撞墙、乱答。sijie-Z 在 #516 下补充 `memory/MEMORY.md` 命中同一 bug。

**根因：** WSL 路径上每个文件工具先算 `session_ws = workspace/sessions/<safe_key>/files`（per-session 隔离目录），再把它当**唯一**合法根传给 `_canonicalize_wsl_mnt_path`。host 全局路径不在该 per-session 子目录下 → `resolved.relative_to(ws_resolved)` 失败 → `PermissionError`。调用链：`WriteFileTool/EditFileTool/ReadFileTool/ApplyPatchTool.execute`（WSL 分支）→ `_resolve_sandbox_path(path, session_ws)` → `_canonicalize_wsl_mnt_path(result, workspace=session_ws)` → 越界拒绝。

**影响：** AI 无法用文件工具读写长期记忆 / workspace skills，触发 hallucinate。`memory` 工具本身直写 text、不走沙箱，不受影响。

## 变更内容

- `miqi/agent/tools/filesystem.py` `_canonicalize_wsl_mnt_path` 新增 `extra_roots` 参数：落 `workspace` **或** 任一 `extra_root` 内即放行，全部越界才拒；错误信息列出所有合法根。`extra_roots=None` 行为与今天完全一致（向后兼容）。
- `_resolve_sandbox_path` 同步加 `extra_roots` 并在 3 处调用点透传。
- `ReadFileTool/ListDirTool/WriteFileTool/EditFileTool` `__init__` 加 `shared_roots`，WSL 分支调用 `_resolve_sandbox_path(..., extra_roots=self._shared_roots)`。
- `miqi/agent/tools/apply_patch.py` `ApplyPatchTool` 同样加 `shared_roots` 并透传。
- `miqi/runtime/tool_registry_factory.py` 用全局 `workspace` 下的 `memory/`、`skills/` 构造 `_shared_roots`（幂等 mkdir），注入五个文件工具。

**不破隔离（守住 #490/#505 红线）：** 不碰 bwrap per-session bind、不碰 `_get_session_workspace`、不碰 `*ro_bind`。`extra_roots` 只放行全局共享的 `memory`/`skills`（本就跨 session 共享，符合设计意图）；别的 session 的 `sessions/<other>/files` 不在任何 session 的 `extra_roots` 里 → 仍被拒 → 不串。

## 日志/验证证据

```
修复后 registry 端到端构建校验（本机 Windows）：
write_file shared_roots: ['memory', 'skills']
apply_patch shared_roots: ['memory', 'skills']
per-session write_workspace: sessions\desktop_test\files
memory exists: True skills exists: True

单测 tests/sandbox/test_wsl_sandbox_path_mapping.py（含 WSL containment Windows-gated 用例）：
test_extra_root_none_preserves_single_root_behavior PASSED
test_extra_root_allows_host_global_path PASSED
test_extra_root_does_not_open_other_session_dir PASSED   # 别 session 的 files 仍被拒
test_extra_root_traversal_into_outside_still_rejected PASSED
test_wsl_host_global_path_via_extra_roots PASSED
============================= 25 passed in 0.19s ==============================

广覆盖回归：pytest tests/ -q -m "not sandbox and not wsl" → 2601 passed, 19 skipped
```

## 测试情况

- `pytest tests/sandbox/test_wsl_sandbox_path_mapping.py -v`：25 passed（含 5 个新增，全绿，旧用例不回归）。
- `pytest tests/test_session_workspace.py tests/agent/tools/test_apply_patch.py tests/execution/test_file_mutation_approval.py tests/sandbox/ -q`：82 passed。
- `pytest tests/ -q -m "not sandbox and not wsl"`：2601 passed, 19 skipped，无回归。
- 依赖 CI 的 `wsl-sandbox` job（`-m "wsl"`）在真 WSL 环境复跑 Windows-gated containment 用例。

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/53ecbb90-d69a-4826-a2a0-30de646fc302" />
<img width="389" height="111" alt="image" src="https://github.com/user-attachments/assets/49f82535-4f4e-4ba8-aeb3-7d184fd92bd6" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
