### PR TITLE
fix(#528): 识别 402 Payment Required 为余额不足并显示账单提示

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -16,6 +16,7 @@ class ErrorKind(str, Enum):
     TRANSIENT = "transient"
     RATE_LIMIT = "rate_limit"
     AUTH = "auth"
+    PAYMENT_REQUIRED = "payment_required"
     CONTEXT_LENGTH = "context_length"
     INVALID_REQUEST = "invalid_request"
     FATAL = "fatal"
@@ -98,6 +99,10 @@ def _classify_by_message(exc: BaseException) -> ErrorKind | None:
 
     if "rate limit" in message or "too many requests" in message:
         return ErrorKind.RATE_LIMIT
+    # Issue #528: check billing/quota before AUTH — a 402 body that mentions
+    # "forbidden"-ish wording would otherwise be misread as authentication.
+    if _is_payment_required_error(exc):
+        return ErrorKind.PAYMENT_REQUIRED
     if "invalid api key" in message or "unauthorized" in message or "forbidden" in message:
         return ErrorKind.AUTH
     if _is_context_length_error(exc):
@@ -123,6 +128,33 @@ def _is_context_length_error(exc: BaseException) -> bool:
     return any(s in message for s in signals)
 
 
+# Issue #528: signal phrases across providers for 402 / balance / quota errors.
+# Distinct from AUTH — identity is accepted but the account has no
+# balance/quota, so it gets its own non-retryable kind. Covers OpenAI
+# ("exceeded your current quota"), Anthropic ("credit balance is too low"),
+# and gateway/proxy wording ("insufficient balance", "payment required").
+_PAYMENT_REQUIRED_SIGNALS = (
+    "insufficient balance",
+    "insufficient quota",
+    "payment required",
+    "payment_required",
+    "balance exceeded",
+    "quota exceeded",
+    "quota exhausted",
+    "credit exhausted",
+    "out of credits",
+    "credit balance is too low",
+    "exceeded your current quota",
+    "billing",
+)
+
+
+def _is_payment_required_error(exc: BaseException) -> bool:
+    """Detect 402/balance/quota exhaustion from message text."""
+    message = str(exc).lower()
+    return any(s in message for s in _PAYMENT_REQUIRED_SIGNALS)
+
+
 def _classify_by_status_code(exc: BaseException) -> ErrorKind | None:
     """Classify a retry error by HTTP status code."""
     code = _status_code(exc)
@@ -133,6 +165,10 @@ def _classify_by_status_code(exc: BaseException) -> ErrorKind | None:
         return ErrorKind.RATE_LIMIT
     if code in (401, 403):
         return ErrorKind.AUTH
+    if code == 402:
+        # Issue #528: Payment Required — balance/quota exhausted. Distinct
+        # from AUTH and non-retryable (retrying won't add balance).
+        return ErrorKind.PAYMENT_REQUIRED
     if code == 408 or 500 <= code < 600:
         return ErrorKind.TRANSIENT
     if code == 409:

--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -145,7 +145,11 @@ _PAYMENT_REQUIRED_SIGNALS = (
     "out of credits",
     "credit balance is too low",
     "exceeded your current quota",
-    "billing",
+    # CodeRabbit (#528): no bare "billing" — too broad. It misclassified
+    # AUTH-style messages like "Forbidden: billing access denied" as
+    # PAYMENT_REQUIRED (checked before the AUTH branch). Only balance/quota-
+    # specific phrases remain; a true 402 is still caught by the
+    # status-code layer (402 → PAYMENT_REQUIRED) regardless of wording.
 )
 
 

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -844,6 +844,11 @@ class TaskRunner:
                 # AUTH is sensitive — surface a fixed, non-leaking message
                 # instead of the raw provider exception text (Plan 58.2).
                 user_message = "模型服务认证失败，请检查 Provider 的 API Key、API Base 或当前模型配置。"
+            elif prov_err.kind is ErrorKind.PAYMENT_REQUIRED:
+                # Issue #528: 402 / balance / quota exhausted — account
+                # status, not auth. Fixed non-leaking billing hint
+                # (never the raw text), recoverable=False.
+                user_message = "模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。"
             elif prov_err.kind is ErrorKind.TRANSIENT:
                 user_message = "模型服务暂时不可用或过载，请稍后重试。"
             elif prov_err.kind in (

--- a/tests/runtime/test_turn_error_propagation.py
+++ b/tests/runtime/test_turn_error_propagation.py
@@ -464,6 +464,53 @@ async def test_task_runner_raw_auth_exception_surfaces_fixed_message(error_servi
 
 
 @pytest.mark.asyncio
+async def test_task_runner_raw_payment_required_surfaces_billing_message(error_services):
+    """Issue #528: a raw 402 error reaching the final boundary is re-classified
+    to PAYMENT_REQUIRED. It surfaces the fixed billing hint (never the raw text,
+    which may leak account details) and recoverable=False — retrying won't add
+    balance."""
+    from miqi.protocol.events import ErrorEvent
+
+    class _PaymentRequired(Exception):
+        status_code = 402
+
+    emitted, _history, ledger = await _run_turn_expect_error(
+        error_services,
+        _PaymentRequired("Insufficient balance"),
+    )
+
+    err = next(e for e in emitted if isinstance(e, ErrorEvent))
+    assert err.error_kind == "payment_required"
+    assert err.recoverable is False
+    assert err.message == "模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。"
+    assert "Insufficient balance" not in err.message
+
+    payload = _record_ledger_error_payload(ledger)
+    assert payload.get("error_kind") == "payment_required"
+    assert payload.get("recoverable") is False
+
+
+@pytest.mark.asyncio
+async def test_task_runner_raw_quota_exhausted_message_classifies_payment(error_services):
+    """Issue #528: even without an explicit 402 status, a quota-exhausted
+    message body classifies as PAYMENT_REQUIRED via the message keyword path."""
+    from miqi.protocol.events import ErrorEvent
+
+    emitted, _history, ledger = await _run_turn_expect_error(
+        error_services,
+        Exception("You exceeded your current quota, please check your plan and billing"),
+    )
+
+    err = next(e for e in emitted if isinstance(e, ErrorEvent))
+    assert err.error_kind == "payment_required"
+    assert err.recoverable is False
+    assert err.message == "模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。"
+
+    payload = _record_ledger_error_payload(ledger)
+    assert payload.get("error_kind") == "payment_required"
+
+
+@pytest.mark.asyncio
 async def test_task_runner_provider_error_fatal_keeps_generic_message(error_services):
     """A FATAL ProviderError is NOT user-actionable, so the generic message
     is kept even though error_kind is recorded."""

--- a/tests/runtime/test_turn_error_propagation.py
+++ b/tests/runtime/test_turn_error_propagation.py
@@ -474,16 +474,19 @@ async def test_task_runner_raw_payment_required_surfaces_billing_message(error_s
     class _PaymentRequired(Exception):
         status_code = 402
 
+    # Neutral body (no _PAYMENT_REQUIRED_SIGNALS match) so the
+    # classification must come from status_code == 402, not the message
+    # layer (CodeRabbit #528).
     emitted, _history, ledger = await _run_turn_expect_error(
         error_services,
-        _PaymentRequired("Insufficient balance"),
+        _PaymentRequired("upstream response"),
     )
 
     err = next(e for e in emitted if isinstance(e, ErrorEvent))
     assert err.error_kind == "payment_required"
     assert err.recoverable is False
     assert err.message == "模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。"
-    assert "Insufficient balance" not in err.message
+    assert "upstream response" not in err.message
 
     payload = _record_ledger_error_payload(ledger)
     assert payload.get("error_kind") == "payment_required"

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -99,6 +99,47 @@ def test_classify_error_auth_message() -> None:
     assert classify_error(Exception("invalid api key")) == ErrorKind.AUTH
 
 
+# ── Issue #528: 402 / balance / quota → PAYMENT_REQUIRED ───────────────────
+
+
+def test_classify_error_payment_required_status_402() -> None:
+    assert classify_error(_StatusError("Payment Required", status_code=402)) == ErrorKind.PAYMENT_REQUIRED
+
+
+@pytest.mark.parametrize("message", [
+    # OpenAI style
+    "You exceeded your current quota, please check your plan and billing details",
+    # Anthropic style
+    "Error: credit balance is too low",
+    # Gateway / proxy wording
+    "Insufficient balance",
+    "payment required",
+    "quota exceeded - top up to continue",
+    "credit exhausted",
+    "out of credits",
+    "billing: account suspended",
+    "balance exceeded the limit",
+])
+def test_classify_error_payment_required_message(message: str) -> None:
+    assert classify_error(Exception(message)) == ErrorKind.PAYMENT_REQUIRED
+
+
+def test_classify_error_payment_required_is_not_retryable() -> None:
+    """402 is non-retryable — retrying won't add balance."""
+    assert is_retryable(ErrorKind.PAYMENT_REQUIRED) is False
+    assert ProviderError(
+        kind=ErrorKind.PAYMENT_REQUIRED, message="insufficient balance"
+    ).recoverable is False
+
+
+def test_classify_error_payment_required_preferred_over_auth_wording() -> None:
+    """A 402 body that also says 'forbidden' must not be misread as AUTH —
+    billing is checked before the auth keyword branch."""
+    assert classify_error(
+        Exception("Forbidden: insufficient balance, payment required")
+    ) == ErrorKind.PAYMENT_REQUIRED
+
+
 def test_classify_error_context_length_message() -> None:
     assert classify_error(Exception("context length exceeded")) == ErrorKind.CONTEXT_LENGTH
 
@@ -158,6 +199,7 @@ def test_is_retryable() -> None:
     assert is_retryable(ErrorKind.TRANSIENT) is True
     assert is_retryable(ErrorKind.RATE_LIMIT) is True
     assert is_retryable(ErrorKind.AUTH) is False
+    assert is_retryable(ErrorKind.PAYMENT_REQUIRED) is False
     assert is_retryable(ErrorKind.CONTEXT_LENGTH) is False
     assert is_retryable(ErrorKind.INVALID_REQUEST) is False
     assert is_retryable(ErrorKind.FATAL) is False
@@ -634,6 +676,7 @@ def test_provider_error_recoverable_true_for_retryable_kinds() -> None:
 
 def test_provider_error_recoverable_false_for_non_retryable_kinds() -> None:
     assert ProviderError(kind=ErrorKind.AUTH, message="x").recoverable is False
+    assert ProviderError(kind=ErrorKind.PAYMENT_REQUIRED, message="x").recoverable is False
     assert ProviderError(kind=ErrorKind.CONTEXT_LENGTH, message="x").recoverable is False
     assert (
         ProviderError(kind=ErrorKind.INVALID_REQUEST, message="x").recoverable is False

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -103,7 +103,10 @@ def test_classify_error_auth_message() -> None:
 
 
 def test_classify_error_payment_required_status_402() -> None:
-    assert classify_error(_StatusError("Payment Required", status_code=402)) == ErrorKind.PAYMENT_REQUIRED
+    # Neutral body (no _PAYMENT_REQUIRED_SIGNALS match) so this test
+    # actually exercises the explicit status_code == 402 mapping, not the
+    # message-keyword layer (CodeRabbit #528).
+    assert classify_error(_StatusError("upstream response", status_code=402)) == ErrorKind.PAYMENT_REQUIRED
 
 
 @pytest.mark.parametrize("message", [
@@ -117,7 +120,7 @@ def test_classify_error_payment_required_status_402() -> None:
     "quota exceeded - top up to continue",
     "credit exhausted",
     "out of credits",
-    "billing: account suspended",
+    "payment required - top up your account",
     "balance exceeded the limit",
 ])
 def test_classify_error_payment_required_message(message: str) -> None:
@@ -138,6 +141,16 @@ def test_classify_error_payment_required_preferred_over_auth_wording() -> None:
     assert classify_error(
         Exception("Forbidden: insufficient balance, payment required")
     ) == ErrorKind.PAYMENT_REQUIRED
+
+
+def test_bare_billing_word_is_not_payment_required() -> None:
+    """CodeRabbit regression (#528): a bare 'billing' substring in an
+    AUTH-style message ("Forbidden: billing access denied") must NOT be
+    misclassified as PAYMENT_REQUIRED — only balance/quota-specific phrases
+    match the message layer; a bare 'billing' was removed from the signals."""
+    assert classify_error(
+        Exception("Forbidden: billing access denied")
+    ) == ErrorKind.AUTH
 
 
 def test_classify_error_context_length_message() -> None:


### PR DESCRIPTION
## 概述

修复 #528（栈式 PR，基于 #529 —— 本 PR 的 base 指向 #529 分支）。

当 API provider 返回 **402 Payment Required**（余额不足 / 额度用尽）时，前端显示通用 `处理消息时发生内部错误，请重试。` 而非账单相关提示 —— 用户无法得知真正原因是账户余额问题。

## 根因

`classify_error()` 完全不识别 402：
- **status-code 层**（`_classify_by_status_code`）：覆盖 429/401/403/408/409/400/404/413/5xx —— **缺 402**。
- **message 层**（`_classify_by_message`）：有 `rate limit`/`invalid api key` 但没有账单关键词。

于是 402 落到 `ErrorKind.FATAL` → 无消息分支命中 → 通用消息。

## 修复 —— 新增 `ErrorKind.PAYMENT_REQUIRED`

与 `AUTH` 区分：身份验证通过了，但账户没有余额/额度，所以是独立的**不可重试** kind（重试也补不出余额）。拆出来让 `FATAL` 保持纯粹（=「未知」），也避免污染 `AUTH` 的统计/分支（`if kind == ErrorKind.AUTH: refresh_api_key()` 不会在 402 上误触发）。

**分类 —— 两层任一命中即可：**
- `_classify_by_status_code`：`402 → PAYMENT_REQUIRED`
- `_classify_by_message`：覆盖各 provider 的关键词 —— OpenAI（`exceeded your current quota`）、Anthropic（`credit balance is too low`）、网关/代理文案（`insufficient balance`、`payment required`、`quota exceeded`、`billing`……）。**在 AUTH 之前检查**，避免带 `forbidden` 味道的 402 body 被误读成认证失败。

**消息映射（`task_runner`）：** 固定不泄漏的账单提示 `模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。` + `recoverable=False` —— 永不用原始 SDK 文本（可能泄露账户/租户信息），与 AUTH 同样姿势。文案避开 `sanitizeUiMessage` 替换关键字，能原样到达 UI。

## 为何栈式基于 #529

原始 402 在 `task_runner` 走的消息分支路径，依赖 **#529 提供的 ProviderError 回退管线**（非 `ProviderError` 异常经 `_classify_chain` 分类并包成 `ProviderError` 视图）。在纯 `develop` 上，旧的 `prov_err = exc if isinstance(exc, ProviderError) else None` 会把原始 402 塌缩成 `None`，`PAYMENT_REQUIRED` 分支永远不触发。所以本 PR base 指向 #529 分支；先合并 #529，再 rebase 本 PR 到 `develop`。

按讨论确定的拆分：
- **#529** 负责错误传播基础设施（完全不引用 `PAYMENT_REQUIRED`）。
- **#528** 负责完整的 `PAYMENT_REQUIRED` 功能：枚举 + 分类规则 + 消息映射 + 测试。

## 文件

- [`miqi/providers/resilience.py`](miqi/providers/resilience.py) —— `PAYMENT_REQUIRED` 枚举；`_classify_by_status_code` 加 `402`；`_classify_by_message` 加 `_is_payment_required_error` + `_PAYMENT_REQUIRED_SIGNALS`
- [`miqi/runtime/task_runner.py`](miqi/runtime/task_runner.py) —— `PAYMENT_REQUIRED` 消息分支
- [`tests/test_provider_resilience.py`](tests/test_provider_resilience.py) —— 402 status 分类 + provider 消息关键词 + 不可重试 + 优先于 AUTH；`is_retryable`/`recoverable` 枚举覆盖
- [`tests/runtime/test_turn_error_propagation.py`](tests/runtime/test_turn_error_propagation.py) —— task_runner 集成：原始 402 → 账单消息 + recoverable=False；额度消息 body → PAYMENT_REQUIRED

## 验证

- `uv run pytest tests/runtime/test_turn_error_propagation.py tests/test_provider_resilience.py -q` → 92 passed（在 #529 之上）
- 合并栈上的全量 runtime 回归 → green

端到端已验证：在桌面端 app 用余额耗尽账号发消息，前端正确显示「模型服务账户余额不足或额度已用尽，请充值或检查账户额度后重试。」（见 issue 反馈）。

## 截图
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/dec8584a-7a3a-4d10-8235-4b546744b13a" />
