### PR TITLE
fix(provider): 消除编辑弹窗的双重白色面板

### DIFF
--- a/apps/desktop/src/renderer/features/providers/components/EditProviderSheet.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/EditProviderSheet.tsx
@@ -200,8 +200,8 @@ export function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
   };
 
   return (
-    <Modal open onOpenChange={onClose} hideClose>
-      <div className="bg-[var(--surface-elevated)] border border-[var(--border)] rounded-xl shadow-xl w-[480px] max-h-[80vh] overflow-y-auto">
+    <Modal open onOpenChange={onClose} hideClose className="max-w-[480px] w-[480px] p-0">
+      <div className="w-full max-h-[80vh] overflow-y-auto">
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border-subtle)]">
           <div>
             <h2 className="text-sm font-semibold text-[var(--text)]">


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

消除「模型提供商」编辑弹窗的双重白色面板——去掉内层重复绘制的背景框，使弹窗只剩一层白色面板。

## 背景/问题

打开 Provider 编辑弹窗时，弹窗后面会出现一圈多余的白色框（浅色主题 `--surface-elevated: #FFFFFF` 下尤其明显），看起来像“画了两个框”。

- **现象**：编辑弹窗主面板之外叠加了第二层白底面板。
- **根因**：`EditSheet` 经由 `<Modal>`（Radix `DialogContent`）渲染。`DialogContent` 本身已是完整面板（`bg-[var(--surface-elevated)]` + `border` + `rounded-xl` + `shadow-lg` + `p-6` + `max-w-md`=448px）；而 `EditSheet` 的内层 `div` 又自行绘制了一个 `bg-[var(--surface-elevated)] border rounded-xl shadow-xl w-[480px]` 的面板。
- **影响**：两层白底面板嵌套，且内层 `w-[480px]` 比外层 `max-w-md`(448px) 宽、再叠加外层 `p-6`(24px) 内边距，内层面板从外层溢出，外层那圈白框露在后面 → “后面还有一个白色框”。

详见 #533。

## 变更内容

- `apps/desktop/src/renderer/features/providers/components/EditProviderSheet.tsx`
  - 内层 `div` 去掉重复的 `bg-[var(--surface-elevated)]` / `border` / `rounded-xl` / `shadow-xl`，仅保留布局类 `w-full max-h-[80vh] overflow-y-auto`。
  - 通过 `Modal` 的 `className="max-w-[480px] w-[480px] p-0"` 把宽度和内边距交给 `DialogContent`（`cn`/twMerge 会用 `max-w-[480px]` / `p-0` 覆盖默认的 `max-w-md` / `p-6`），使 `DialogContent` 成为唯一面板。
  - 弹窗内 header（`px-5 py-4`）、body（`px-5 py-4`）、footer（`px-5 py-3`）自带内边距，去掉外层 `p-6` 后内容不会贴边。

## 日志/验证证据


纯 CSS/样式 bug，无运行时报错。修复前后对比（代码层）：

```
// 修复前：两层白底面板嵌套
<Modal open onOpenChange={onClose} hideClose>
  <div className="bg-[var(--surface-elevated)] border border-[var(--border)] rounded-xl shadow-xl w-[480px] max-h-[80vh] overflow-y-auto">
    ...
  </div>
</Modal>

// 修复后：DialogContent 成为唯一面板
<Modal open onOpenChange={onClose} hideClose className="max-w-[480px] w-[480px] p-0">
  <div className="w-full max-h-[80vh] overflow-y-auto">
    ...
  </div>
</Modal>
```

```
$ git diff --stat
 .../src/renderer/features/providers/components/EditProviderSheet.tsx | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## 测试情况

- 改动仅 2 行，手写时遵循该文件已有的 prettier 风格（单引号 / 2 空格 / 行宽 ≤100，新增最长行 89 字符）。
- 本机 prettier/lint-staged 因 npm 代理（127.0.0.1:7899）不可用无法本地运行，依赖 CI 校验。
- 待补充：请在桌面端打开「模型提供商」→ 任一 Provider「编辑」，确认弹窗只剩一层白色面板、不再有后方白框（浅色/深色主题各看一次）。

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/73880700-bd37-4c17-ba18-b10344f6a347" />

## 补充

- 同目录多个页面（SkillsPage、CronPage、MemoryPage、ChatConsole、WorkspacePage、ApprovalsPage、MCPsPage、FeedbackPage、ExperiencePage）存在相同的 `<Modal><div class="bg/border/rounded/shadow">` 双层模式，属同类潜在隐患。本 PR 仅修复已确认可见症状的 Provider 编辑弹窗（#533），其余作为后续 follow-up。

Closes #533
