### PR TITLE
feat(chat): think 推理内容渲染为可折叠「思考」区块

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3728,7 +3728,3 @@ function MessageBubble({
     </ContextMenu>
   );
 }
-
-/** Strip <think>...</think> reasoning blocks before rendering.
- *  Handles both complete blocks and cross-message orphans
- *  (tags split across streaming chunks). */

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
@@ -1,17 +1,111 @@
 import { useState, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { ChevronRight } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 
-/** Strip <think>...</think> reasoning blocks before rendering. */
-function stripThinkBlocks(text: string): string {
-  let result = text.replace(/<\/?think>/gi, '');
-  return result.trim();
+type Segment = { type: 'text'; value: string } | { type: 'think'; value: string };
+
+/** Split content into ordered text/think segments.
+ *  Handles complete `…` blocks (case-insensitive) and a trailing
+ *  unclosed `<think>` (orphan from streaming chunks) by treating the rest
+ *  as an in-progress reasoning block. */
+export function splitThink(content: string): Segment[] {
+  if (!content) return [];
+  const segments: Segment[] = [];
+  // Global, case-insensitive, match  opening tag and  closing tag.
+  const openRe = /<think(?:\s[^>]*)?>/gi;
+  const closeRe = /<\/think\s*>/gi;
+
+  let cursor = 0;
+  // We walk through opening tags; each opening tag starts a think span that
+  // ends at the next closing tag (or end-of-string if orphaned).
+  const opens: { idx: number; len: number }[] = [];
+  let m: RegExpExecArray | null;
+  openRe.lastIndex = 0;
+  while ((m = openRe.exec(content)) !== null) {
+    opens.push({ idx: m.index, len: m[0].length });
+  }
+
+  let thinkIdx = 0;
+  for (const open of opens) {
+    // text before this  tag
+    if (open.idx > cursor) {
+      segments.push({ type: 'text', value: content.slice(cursor, open.idx) });
+    }
+    const thinkStart = open.idx + open.len;
+    // find the next closing tag at or after thinkStart
+    closeRe.lastIndex = thinkStart;
+    const cm = closeRe.exec(content);
+    if (cm) {
+      segments.push({ type: 'think', value: content.slice(thinkStart, cm.index) });
+      cursor = cm.index + cm[0].length;
+    } else {
+      // orphaned opening tag (streaming, not yet closed): rest is in-progress think
+      segments.push({ type: 'think', value: content.slice(thinkStart) });
+      cursor = content.length;
+    }
+    thinkIdx++;
+  }
+  // trailing text after the last think block (or the whole string if no think tags)
+  if (cursor < content.length) {
+    segments.push({ type: 'text', value: content.slice(cursor) });
+  }
+  if (segments.length === 0 && content.length > 0) {
+    segments.push({ type: 'text', value: content });
+  }
+  return segments;
+}
+
+function ThinkBlock({ value }: { value: string }) {
+  const [open, setOpen] = useState(false);
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return (
+    <div
+      className="my-2 rounded-lg border text-xs"
+      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-muted)' }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-left"
+        style={{ color: 'var(--text-muted)' }}
+        aria-expanded={open}
+      >
+        <ChevronRight
+          size={12}
+          className={cn('shrink-0 transition-transform', open && 'rotate-90')}
+        />
+        <span className="font-medium">{open ? '思考（已展开）' : '思考'}</span>
+      </button>
+      {open && (
+        <div
+          className="px-3 pb-2.5 pt-0 leading-relaxed whitespace-pre-wrap"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          {trimmed}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function MarkdownContent({ content }: { content: string }) {
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
-  const displayContent = stripThinkBlocks(content);
+
+  const segments = useMemo(() => splitThink(content), [content]);
+  // Only the non-think text needs markdown; think blocks render as plain
+  // collapsible disclosure. Skip empty text segments so we don't emit empty
+  // markdown wrappers between consecutive think blocks.
+  const textSegments = useMemo(
+    () => segments.filter((s) => s.type === 'text' && s.value.length > 0),
+    [segments]
+  );
+  const hasThink = useMemo(
+    () => segments.some((s) => s.type === 'think' && s.value.trim().length > 0),
+    [segments]
+  );
 
   const handleCopyCode = (code: string) => {
     navigator.clipboard.writeText(code);
@@ -65,5 +159,21 @@ export function MarkdownContent({ content }: { content: string }) {
     [copiedCode]
   );
 
-  return <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{displayContent}</ReactMarkdown>;
+  return (
+    <div className="think-rendered">
+      {hasThink || textSegments.length > 0 ? (
+        segments.map((seg, i) =>
+          seg.type === 'think' ? (
+            <ThinkBlock key={`think-${i}`} value={seg.value} />
+          ) : seg.value.length > 0 ? (
+            <ReactMarkdown key={`text-${i}`} remarkPlugins={[remarkGfm]} components={components}>
+              {seg.value}
+            </ReactMarkdown>
+          ) : null
+        )
+      ) : (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{content}</ReactMarkdown>
+      )}
+    </div>
+  );
 }

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
@@ -3,59 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '../../../lib/utils';
-
-type Segment = { type: 'text'; value: string } | { type: 'think'; value: string };
-
-/** Split content into ordered text/think segments.
- *  Handles complete `…` blocks (case-insensitive) and a trailing
- *  unclosed `<think>` (orphan from streaming chunks) by treating the rest
- *  as an in-progress reasoning block. */
-export function splitThink(content: string): Segment[] {
-  if (!content) return [];
-  const segments: Segment[] = [];
-  // Global, case-insensitive, match  opening tag and  closing tag.
-  const openRe = /<think(?:\s[^>]*)?>/gi;
-  const closeRe = /<\/think\s*>/gi;
-
-  let cursor = 0;
-  // We walk through opening tags; each opening tag starts a think span that
-  // ends at the next closing tag (or end-of-string if orphaned).
-  const opens: { idx: number; len: number }[] = [];
-  let m: RegExpExecArray | null;
-  openRe.lastIndex = 0;
-  while ((m = openRe.exec(content)) !== null) {
-    opens.push({ idx: m.index, len: m[0].length });
-  }
-
-  let thinkIdx = 0;
-  for (const open of opens) {
-    // text before this  tag
-    if (open.idx > cursor) {
-      segments.push({ type: 'text', value: content.slice(cursor, open.idx) });
-    }
-    const thinkStart = open.idx + open.len;
-    // find the next closing tag at or after thinkStart
-    closeRe.lastIndex = thinkStart;
-    const cm = closeRe.exec(content);
-    if (cm) {
-      segments.push({ type: 'think', value: content.slice(thinkStart, cm.index) });
-      cursor = cm.index + cm[0].length;
-    } else {
-      // orphaned opening tag (streaming, not yet closed): rest is in-progress think
-      segments.push({ type: 'think', value: content.slice(thinkStart) });
-      cursor = content.length;
-    }
-    thinkIdx++;
-  }
-  // trailing text after the last think block (or the whole string if no think tags)
-  if (cursor < content.length) {
-    segments.push({ type: 'text', value: content.slice(cursor) });
-  }
-  if (segments.length === 0 && content.length > 0) {
-    segments.push({ type: 'text', value: content });
-  }
-  return segments;
-}
+import { splitThink } from './splitThink';
 
 function ThinkBlock({ value }: { value: string }) {
   const [open, setOpen] = useState(false);

--- a/apps/desktop/src/renderer/features/chat/components/splitThink.ts
+++ b/apps/desktop/src/renderer/features/chat/components/splitThink.ts
@@ -1,0 +1,60 @@
+// Pure parser that splits assistant content into ordered text/think segments.
+// Extracted from MarkdownContent.tsx so unit tests can exercise the string
+// parser without loading ReactMarkdown / remark-gfm / lucide-react.
+
+export type Segment = { type: 'text'; value: string } | { type: 'think'; value: string };
+
+const OPEN_RE = /<think(?:\s[^>]*)?>/gi;
+const CLOSE_RE = /<\/think\s*>/gi;
+
+/** Split content into ordered text/think segments.
+ *  Handles complete `…` blocks (case-insensitive) and a trailing
+ *  unclosed `` (orphan from streaming chunks) by treating the rest
+ *  as an in-progress reasoning block. Nested/overlapping opening tags
+ *  that fall inside an already-consumed think span are skipped so their
+ *  content is not duplicated. */
+export function splitThink(content: string): Segment[] {
+  if (!content) return [];
+  const segments: Segment[] = [];
+
+  // Collect every opening tag occurrence up-front, then walk them in order,
+  // pairing each with the next closing tag at/after it. Any opening tag whose
+  // index is behind the current cursor sits inside an already-consumed think
+  // span (nested/malformed input) and is skipped.
+  const opens: { idx: number; len: number }[] = [];
+  let m: RegExpExecArray | null;
+  OPEN_RE.lastIndex = 0;
+  while ((m = OPEN_RE.exec(content)) !== null) {
+    opens.push({ idx: m.index, len: m[0].length });
+  }
+
+  let cursor = 0;
+  for (const open of opens) {
+    // Skip opening tags inside an already-consumed think span (nested input).
+    if (open.idx < cursor) continue;
+    // text before this think tag
+    if (open.idx > cursor) {
+      segments.push({ type: 'text', value: content.slice(cursor, open.idx) });
+    }
+    const thinkStart = open.idx + open.len;
+    // find the next closing tag at or after thinkStart
+    CLOSE_RE.lastIndex = thinkStart;
+    const cm = CLOSE_RE.exec(content);
+    if (cm) {
+      segments.push({ type: 'think', value: content.slice(thinkStart, cm.index) });
+      cursor = cm.index + cm[0].length;
+    } else {
+      // orphaned opening tag (streaming, not yet closed): rest is in-progress think
+      segments.push({ type: 'think', value: content.slice(thinkStart) });
+      cursor = content.length;
+    }
+  }
+  // trailing text after the last think block (or the whole string if no think tags)
+  if (cursor < content.length) {
+    segments.push({ type: 'text', value: content.slice(cursor) });
+  }
+  if (segments.length === 0 && content.length > 0) {
+    segments.push({ type: 'text', value: content });
+  }
+  return segments;
+}

--- a/apps/desktop/tests/splitThink.test.ts
+++ b/apps/desktop/tests/splitThink.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { splitThink } from '../src/renderer/features/chat/components/MarkdownContent';
+import { splitThink } from '../src/renderer/features/chat/components/splitThink';
 
 // Construct think tags programmatically so the literal tags don't get
 // mangled by tooling / escaping when editing this file.
@@ -67,5 +67,26 @@ describe('splitThink', () => {
 
   it('preserves an empty think block as an empty think segment (no trailing text)', () => {
     expect(splitThink(tag(''))).toEqual([{ type: 'think', value: '' }]);
+  });
+
+  it('does not duplicate content for nested think tags', () => {
+    // Nested/overlapping opens: the inner  sits inside the outer span
+    // already consumed, so "inner" must NOT appear twice. The outer opening
+    // tag is paired with the FIRST closing tag (inner's), which leaves the
+    // outer's own closing tag unconsumed — it falls through into the trailing
+    // text segment. react-markdown drops raw HTML tags by default, so this
+    // residual is not user-visible; the regression we guard against here is
+    // the content-duplication ("inner" appearing twice) that the
+    // `open.idx < cursor` skip prevents.
+    const nested = `pre${OPEN}outer ${OPEN}inner${CLOSE}${CLOSE}post`;
+    const segs = splitThink(nested);
+    expect(segs.some((s) => s.type === 'think' && s.value.includes('inner'))).toBe(true);
+    // "inner" must appear in exactly ONE think segment (no duplication).
+    const thinkCount = segs.filter(
+      (s) => s.type === 'think' && s.value.includes('inner')
+    ).length;
+    expect(thinkCount).toBe(1);
+    // "post" survives in a trailing text segment.
+    expect(segs.some((s) => s.type === 'text' && s.value.includes('post'))).toBe(true);
   });
 });

--- a/apps/desktop/tests/splitThink.test.ts
+++ b/apps/desktop/tests/splitThink.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { splitThink } from '../src/renderer/features/chat/components/MarkdownContent';
+
+// Construct think tags programmatically so the literal tags don't get
+// mangled by tooling / escaping when editing this file.
+const OPEN = '<' + 'think>';
+const CLOSE = '<' + '/think>';
+const tag = (inner: string) => `${OPEN}${inner}${CLOSE}`;
+
+describe('splitThink', () => {
+  it('returns an empty array for empty input', () => {
+    expect(splitThink('')).toEqual([]);
+  });
+
+  it('returns plain text as a single text segment when no think tags present', () => {
+    expect(splitThink('hello world')).toEqual([{ type: 'text', value: 'hello world' }]);
+  });
+
+  it('extracts a complete think block into a think segment', () => {
+    expect(splitThink(`before${tag('inner')}after`)).toEqual([
+      { type: 'text', value: 'before' },
+      { type: 'think', value: 'inner' },
+      { type: 'text', value: 'after' },
+    ]);
+  });
+
+  it('handles multiple consecutive think blocks', () => {
+    expect(splitThink(`one${tag('1')}two${tag('2')}three`)).toEqual([
+      { type: 'text', value: 'one' },
+      { type: 'think', value: '1' },
+      { type: 'text', value: 'two' },
+      { type: 'think', value: '2' },
+      { type: 'text', value: 'three' },
+    ]);
+  });
+
+  it('treats an unclosed think tag as an in-progress think segment to end of string', () => {
+    expect(splitThink(`pre${OPEN}still thinking`)).toEqual([
+      { type: 'text', value: 'pre' },
+      { type: 'think', value: 'still thinking' },
+    ]);
+  });
+
+  it('is case-insensitive on tag names', () => {
+    const upperOpen = '<' + 'THINK>';
+    const upperClose = '<' + '/THINK>';
+    expect(splitThink(`a${upperOpen}INNER${upperClose}b`)).toEqual([
+      { type: 'text', value: 'a' },
+      { type: 'think', value: 'INNER' },
+      { type: 'text', value: 'b' },
+    ]);
+  });
+
+  it('handles a think block at the very start (no leading text)', () => {
+    expect(splitThink(`${tag('only thinking')}then text`)).toEqual([
+      { type: 'think', value: 'only thinking' },
+      { type: 'text', value: 'then text' },
+    ]);
+  });
+
+  it('handles a think block at the very end (no trailing text)', () => {
+    expect(splitThink(`text${tag('then')}`)).toEqual([
+      { type: 'text', value: 'text' },
+      { type: 'think', value: 'then' },
+    ]);
+  });
+
+  it('preserves an empty think block as an empty think segment (no trailing text)', () => {
+    expect(splitThink(tag(''))).toEqual([{ type: 'think', value: '' }]);
+  });
+});


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

把 Agent 回复里内联的 `…` 推理内容渲染为**默认折叠的「思考」区块**，取代原先"删标签、把思考正文当普通文字混排"的处理。

## 背景/问题

- **现象**：模型的思考内容混在正文里没视觉区分，配上一串 tool use 行显得杂乱；用户反馈"think 没真正实现，只是行行罗列 tool use，UI 美感差"。
- **根因**：`MarkdownContent`（`apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx:7-9`）的 `stripThinkBlocks` 只做 `text.replace(/<\/?think>/gi, '')`——**只删开/闭标签，留下推理正文当普通 markdown 渲染**。代码层面就没做结构化。
- 后端 `miqi/runtime/turn_runner.py` 会把原始 `response.content`（含内联 `…`）原样存进 session JSONL 并经 `chat:final` 送前端，所以**内容是有的，只是渲染没做**。

详见 #535。

## 变更内容

- `apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx`
  - 删除 `stripThinkBlocks`（tag-only strip），新增 `splitThink(content)`：把内容拆成有序的 `text` / `think` 段。处理：成对块、多个连续块、不闭合孤儿开标签（流式残缺，把后续当 in-progress think）、大小写不敏感。`splitThink` 已 export 供测试。
  - 新增 `ThinkBlock` 组件：默认折叠，chevron 图标（展开时旋转 90°）+「思考」/「思考（已展开）」标签，灰字 `var(--text-muted)` + 浅底 `var(--surface-muted)`，点击展开/收起，`aria-expanded` 可访问。
  - 渲染：按段渲染，`think` 段走 `ThinkBlock`，`text` 段走原有 `ReactMarkdown`；空 text 段跳过避免空 wrapper。
  - 解析结果 `useMemo` 缓存（依赖 `content`），避免打字机动画每帧 `setMessages` 重渲染时重复分割（explore 已确认打字机每帧触发全量重渲染 + markdown 重解析，此处必须轻量）。
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：移除文件末尾遗留的 `stripThinkBlocks` 孤儿注释（函数早已不存在）。
- `apps/desktop/tests/splitThink.test.ts`（新增）：9 个用例锁住 `splitThink` 行为（空输入、纯文本、单块、多块、孤儿标签、大小写、首尾边界、空块）。

## 日志/验证证据

```
$ npx vitest run tests/splitThink.test.ts tests/chatConsoleMessages.test.ts tests/chatConsoleThreadResume.test.ts
 Test Files  3 passed (3)
      Tests  32 passed (32)
```

类型检查（`tsc --noEmit -p tsconfig.web.json`）：本次改动文件零新增错误。仓库基线有 4 个预先存在的错误（`Sidebar.tsx:231` onContextMenu、`ChatConsole.tsx:1509-1514` reader），均为 develop 上既有，与本 PR 无关——已通过 `git stash` 对比干净 develop 确认同样 4 个。

## 测试情况

- 新增 `tests/splitThink.test.ts` 9 用例全过。
- 现有 `chatConsoleMessages.test.ts`（6）、`chatConsoleThreadResume.test.ts`（17）全过，未破坏消息转换/thread 恢复逻辑。
- 待补充：桌面端打开一个会触发 `…` 的回复，确认思考块默认折叠、点击展开/收起正常、正文 markdown 渲染不受影响（浅色/深色主题各看一次）。

## 截图

待补充运行时截图。

## 补充

- 本 PR 只做**渲染层**（内联 `…` → 折叠块）。以下相关但独立的事项不在本 PR 范围：
  - **流式 `reasoning_content`（DeepSeek-R1/Kimi）**：当前被 `miqi/bridge/loop.py:989-997` 丢弃且不进 session 存储，接通需后端改造，另开 issue。
  - **切 session 丢回复**：是通用 partial-message 持久化 bug（`App.tsx:270` key 卸载 + `ChatConsole.tsx:1214-1222` 不 abort 不保存），与本 issue 独立，另案处理。
  - **agent 假死**：性能嫌疑点（无虚拟化、打字机 O(n×token) 重渲染）需复现路径，另开 issue。

Closes #535
