### PR TITLE
feat(desktop): 增强右键上下文菜单，消息/输入框分区域差异化

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -49,6 +49,13 @@ import {
   AlertCircle,
   FileType,
   Loader,
+  Scissors,
+  ClipboardPaste,
+  Pin,
+  Flag,
+  Clock,
+  Code2,
+  Braces,
 } from 'lucide-react';
 import type {
   ChatProgress,
@@ -937,6 +944,8 @@ export function ChatConsole({
   const [executionPolicy, setExecutionPolicy] = useState<ExecutionPolicy>('edit');
   const [streaming, setStreaming] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  /** Pinned chapter message indices (visual markers in conversation) */
+  const [pinnedChapters, setPinnedChapters] = useState<Set<number>>(new Set());
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [downloadingPaperId, setDownloadingPaperId] = useState<string | null>(null);
@@ -2311,6 +2320,18 @@ export function ChatConsole({
     setTimeout(() => setCopiedIdx(null), 2000);
   };
 
+  const handleTogglePin = useCallback((idx: number) => {
+    setPinnedChapters((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  }, []);
+
   const handleRetry = useCallback(
     async (msg: Message) => {
       if (streaming) return;
@@ -2418,6 +2439,45 @@ export function ChatConsole({
       },
     ],
     [handleCopyReproContext, handleCopyTaskSummary, handleExportTaskMarkdown, messages]
+  );
+
+  const inputContextItems = useMemo<ContextMenuAction[]>(
+    () => [
+      {
+        label: '剪切',
+        icon: <Scissors size={14} />,
+        shortcut: 'Ctrl+X',
+        onSelect: () => {
+          document.execCommand('cut');
+        },
+      },
+      {
+        label: '复制',
+        icon: <Copy size={14} />,
+        shortcut: 'Ctrl+C',
+        onSelect: () => {
+          document.execCommand('copy');
+        },
+      },
+      {
+        label: '粘贴',
+        icon: <ClipboardPaste size={14} />,
+        shortcut: 'Ctrl+V',
+        onSelect: () => {
+          document.execCommand('paste');
+        },
+      },
+      {
+        label: '全选',
+        icon: <CheckCircle size={14} />,
+        shortcut: 'Ctrl+A',
+        divider: true,
+        onSelect: () => {
+          document.execCommand('selectAll');
+        },
+      },
+    ],
+    []
   );
 
   const shareButtonLabel =
@@ -2723,6 +2783,7 @@ export function ChatConsole({
                   <MessageBubble
                     key={`${msg.timestamp}-${i}`}
                     msg={msg}
+                    msgIndex={i}
                     execOutputs={execOutputs}
                     inlineExecOutput={inlineExecOutput}
                     isLast={i === messages.length - 1}
@@ -2732,6 +2793,8 @@ export function ChatConsole({
                     onOpenProviderSettings={onOpenProviderSettings}
                     onDownloadPaper={handleDownloadPaper}
                     downloadingPaperId={downloadingPaperId}
+                    pinnedChapters={pinnedChapters}
+                    onTogglePin={handleTogglePin}
                   />
                 ))
               )}
@@ -2875,9 +2938,12 @@ export function ChatConsole({
                 </div>
               )}
 
+              <ContextMenu items={inputContextItems} minWidth={160}>
+                {({ onContextMenu }) => (
               <div
                 className="flex items-end gap-2 rounded-xl px-4 py-3.5 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
+                onContextMenu={onContextMenu}
                 style={{
                   background: 'var(--surface)',
                   border: '1px solid var(--border)',
@@ -2932,6 +2998,8 @@ export function ChatConsole({
                   </button>
                 )}
               </div>
+                )}
+              </ContextMenu>
             </div>
           </div>
         </div>
@@ -3399,6 +3467,7 @@ function SectionLabel({ label, sectionKey }: { label: string; sectionKey: string
 
 function MessageBubble({
   msg,
+  msgIndex,
   execOutputs,
   inlineExecOutput,
   isLast,
@@ -3408,8 +3477,11 @@ function MessageBubble({
   onOpenProviderSettings,
   onDownloadPaper,
   downloadingPaperId,
+  pinnedChapters,
+  onTogglePin,
 }: {
   msg: Message;
+  msgIndex: number;
   execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
   inlineExecOutput: boolean;
   isLast: boolean;
@@ -3419,6 +3491,8 @@ function MessageBubble({
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
   downloadingPaperId?: string | null;
+  pinnedChapters: Set<number>;
+  onTogglePin: (idx: number) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -3533,31 +3607,101 @@ function MessageBubble({
 
   const isUser = msg.role === 'user';
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
+  const isPinned = pinnedChapters.has(msgIndex);
 
-  const contextItems: ContextMenuAction[] = isUser
-    ? [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
-        { label: '重试', onSelect: () => onRetry?.() },
-      ]
-    : [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
-        ...(hasCodeBlock
-          ? [
-              {
-                label: '复制代码',
-                onSelect: () => {
-                  const codeMatch = msg.content.match(/```[\s\S]*?```/g);
-                  if (codeMatch) {
-                    const code = codeMatch
-                      .map((b) => b.replace(/```\w*\n?/g, '').replace(/```$/g, ''))
-                      .join('\n\n');
-                    navigator.clipboard.writeText(code).catch(() => {});
-                  }
-                },
-              },
-            ]
-          : []),
-      ];
+  const buildAttachContext = () => {
+    const role = isUser ? '用户' : 'MiQi';
+    const ts = new Date(msg.timestamp).toLocaleString('zh-CN');
+    return `--- ${role} 消息上下文 (${ts}) ---
+${msg.content.trim()}
+--- 结束 ---`;
+  };
+
+  const baseContextItems: ContextMenuAction[] = [
+    {
+      label: '复制文本',
+      icon: <Copy size={14} />,
+      onSelect: () => onCopy(msg.content),
+    },
+    {
+      label: '复制为 Markdown',
+      icon: <Braces size={14} />,
+      onSelect: () => {
+        navigator.clipboard.writeText(msg.content).catch(() => {});
+      },
+    },
+    ...(hasCodeBlock && !isUser
+      ? [
+          {
+            label: '复制代码',
+            icon: <Code2 size={14} />,
+            onSelect: () => {
+              const codeMatch = msg.content.match(/```[\s\S]*?```/g);
+              if (codeMatch) {
+                const code = codeMatch
+                  .map((b) => b.replace(/```\w*\n?/g, '').replace(/```$/g, ''))
+                  .join('\n\n');
+                navigator.clipboard.writeText(code).catch(() => {});
+              }
+            },
+          },
+        ]
+      : []),
+    {
+      label: '附加为上下文',
+      icon: <ClipboardPaste size={14} />,
+      divider: true,
+      onSelect: () => {
+        const ctx = buildAttachContext();
+        navigator.clipboard.writeText(ctx).catch(() => {});
+      },
+    },
+    {
+      label: isPinned ? '取消固定章节' : '固定为章节 🚩',
+      icon: <Pin size={14} />,
+      onSelect: () => onTogglePin(msgIndex),
+    },
+    ...(isUser
+      ? [
+          {
+            label: '重试',
+            icon: <Undo2 size={14} />,
+            divider: true,
+            onSelect: () => onRetry?.(),
+          },
+        ]
+      : []),
+    {
+      label: '查看原始消息',
+      icon: <Braces size={14} />,
+      divider: true,
+      danger: false,
+      onSelect: () => {
+        const raw = JSON.stringify(
+          {
+            role: msg.role,
+            content: msg.content.slice(0, 500),
+            ...(msg.toolCallId && { toolCallId: msg.toolCallId }),
+            ...(msg.toolName && { toolName: msg.toolName }),
+            timestamp: new Date(msg.timestamp).toISOString(),
+          },
+          null,
+          2
+        );
+        navigator.clipboard.writeText(raw).catch(() => {});
+      },
+    },
+    {
+      label: '复制时间戳',
+      icon: <Clock size={14} />,
+      onSelect: () => {
+        const ts = new Date(msg.timestamp).toLocaleString('zh-CN');
+        navigator.clipboard.writeText(ts).catch(() => {});
+      },
+    },
+  ];
+
+  const contextItems: ContextMenuAction[] = baseContextItems;
 
   return (
     <ContextMenu items={contextItems}>
@@ -3568,6 +3712,20 @@ function MessageBubble({
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
           {!isUser && <AgentAvatar />}
+
+          {/* Pinned chapter indicator */}
+          {isPinned && (
+            <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium"
+              style={{
+                background: 'var(--accent-bg)',
+                color: 'var(--accent)',
+                border: '1px solid var(--accent-border)',
+              }}
+            >
+              <Pin size={10} />
+              <span>章节</span>
+            </div>
+          )}
 
           <div
             className={cn(

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type MutableRefObject } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { DiffView } from './components/DiffView';
@@ -52,7 +52,6 @@ import {
   Scissors,
   ClipboardPaste,
   Pin,
-  Flag,
   Clock,
   Code2,
   Braces,
@@ -3563,7 +3562,7 @@ function MessageBubble({
   onTogglePin: (idx: number) => void;
   onSaveToMemory?: (idx: number, content: string) => void;
   onQuoteReply?: (content: string) => void;
-  messageRefs?: React.MutableRefObject<Map<number, HTMLDivElement>>;
+  messageRefs?: MutableRefObject<Map<number, HTMLDivElement>>;
 }) {
   const [expanded, setExpanded] = useState(false);
 

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { DiffView } from './components/DiffView';
@@ -944,8 +944,10 @@ export function ChatConsole({
   const [executionPolicy, setExecutionPolicy] = useState<ExecutionPolicy>('edit');
   const [streaming, setStreaming] = useState(false);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
-  /** Pinned chapter message indices (visual markers in conversation) */
-  const [pinnedChapters, setPinnedChapters] = useState<Set<number>>(new Set());
+  /** Pinned chapter message indices (ordered, for navigation bar) */
+  const [pinnedChapters, setPinnedChapters] = useState<number[]>([]);
+  /** Refs for scrolling to messages */
+  const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [downloadingPaperId, setDownloadingPaperId] = useState<string | null>(null);
@@ -2322,14 +2324,41 @@ export function ChatConsole({
 
   const handleTogglePin = useCallback((idx: number) => {
     setPinnedChapters((prev) => {
-      const next = new Set(prev);
-      if (next.has(idx)) {
-        next.delete(idx);
-      } else {
-        next.add(idx);
+      const existing = prev.indexOf(idx);
+      if (existing >= 0) {
+        return prev.filter((i) => i !== idx);
       }
-      return next;
+      return [...prev, idx];
     });
+  }, []);
+
+  const scrollToMessage = useCallback((idx: number) => {
+    const el = messageRefs.current.get(idx);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
+  const handleSaveToMemory = useCallback(async (idx: number, content: string) => {
+    try {
+      const ts = new Date().toISOString().slice(0, 10);
+      await window.miqi.memory.update(
+        `chat-chapter-${ts}-${idx}`,
+        `# 来自对话的记忆\n\n> ${content.slice(0, 500)}\n\n保存时间：${new Date().toLocaleString('zh-CN')}\n\n会话：${sessionKey}`
+      );
+      // Show brief feedback via the existing copiedIdx mechanism
+      setCopiedIdx(-1); // use -1 as "saved to memory" signal
+      setTimeout(() => setCopiedIdx(null), 2000);
+    } catch {
+      // Silently fail — memory API may not be available
+    }
+  }, [sessionKey]);
+
+  const handleQuoteReply = useCallback((content: string) => {
+    const quote = content
+      .split('\n')
+      .map((line) => `> ${line}`)
+      .join('\n');
+    setInput((prev) => (prev ? `${prev}\n\n${quote}\n\n` : `${quote}\n\n`));
+    textareaRef.current?.focus();
   }, []);
 
   const handleRetry = useCallback(
@@ -2752,6 +2781,39 @@ export function ChatConsole({
               </button>
             </Tooltip>
           </div>
+          {/* Chapter navigation bar */}
+          {pinnedChapters.length > 0 && (
+            <div className="shrink-0 border-b border-[var(--border-subtle)] bg-[var(--surface-elevated)]">
+              <div className="max-w-[760px] mx-auto px-4 py-1.5 flex items-center gap-1.5 overflow-x-auto">
+                <span className="text-[10px] font-semibold text-[var(--text-faint)] shrink-0 mr-1">
+                  章节
+                </span>
+                {pinnedChapters.map((chapterIdx, i) => {
+                  const chapterMsg = messages[chapterIdx];
+                  if (!chapterMsg) return null;
+                  const preview = chapterMsg.content.replace(/\n/g, ' ').slice(0, 30);
+                  return (
+                    <button
+                      key={chapterIdx}
+                      onClick={() => scrollToMessage(chapterIdx)}
+                      className="flex items-center gap-1 shrink-0 rounded-full px-2.5 py-0.5 text-[10px] transition-colors hover:brightness-95"
+                      style={{
+                        background: 'var(--accent-bg)',
+                        color: 'var(--accent)',
+                        border: '1px solid var(--accent-border)',
+                      }}
+                    >
+                      <Pin size={9} />
+                      <span className="max-w-[120px] truncate">
+                        {i + 1}. {preview || '(空消息)'}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
           {/* Messages */}
           <div
             ref={scrollRef}
@@ -2795,6 +2857,9 @@ export function ChatConsole({
                     downloadingPaperId={downloadingPaperId}
                     pinnedChapters={pinnedChapters}
                     onTogglePin={handleTogglePin}
+                    onSaveToMemory={handleSaveToMemory}
+                    onQuoteReply={handleQuoteReply}
+                    messageRefs={messageRefs}
                   />
                 ))
               )}
@@ -3479,6 +3544,9 @@ function MessageBubble({
   downloadingPaperId,
   pinnedChapters,
   onTogglePin,
+  onSaveToMemory,
+  onQuoteReply,
+  messageRefs,
 }: {
   msg: Message;
   msgIndex: number;
@@ -3491,8 +3559,11 @@ function MessageBubble({
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
   downloadingPaperId?: string | null;
-  pinnedChapters: Set<number>;
+  pinnedChapters: number[];
   onTogglePin: (idx: number) => void;
+  onSaveToMemory?: (idx: number, content: string) => void;
+  onQuoteReply?: (content: string) => void;
+  messageRefs?: React.MutableRefObject<Map<number, HTMLDivElement>>;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -3607,7 +3678,7 @@ function MessageBubble({
 
   const isUser = msg.role === 'user';
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
-  const isPinned = pinnedChapters.has(msgIndex);
+  const isPinned = pinnedChapters.includes(msgIndex);
 
   const buildAttachContext = () => {
     const role = isUser ? '用户' : 'MiQi';
@@ -3621,6 +3692,7 @@ ${msg.content.trim()}
     {
       label: '复制文本',
       icon: <Copy size={14} />,
+      shortcut: 'Ctrl+C',
       onSelect: () => onCopy(msg.content),
     },
     {
@@ -3648,18 +3720,32 @@ ${msg.content.trim()}
         ]
       : []),
     {
+      label: '引用回复',
+      icon: <Undo2 size={14} />,
+      divider: true,
+      onSelect: () => onQuoteReply?.(msg.content),
+    },
+    {
       label: '附加为上下文',
       icon: <ClipboardPaste size={14} />,
-      divider: true,
       onSelect: () => {
         const ctx = buildAttachContext();
         navigator.clipboard.writeText(ctx).catch(() => {});
       },
     },
     {
-      label: isPinned ? '取消固定章节' : '固定为章节 🚩',
+      label: isPinned ? '取消固定章节' : '固定为章节 📌',
       icon: <Pin size={14} />,
       onSelect: () => onTogglePin(msgIndex),
+    },
+    {
+      label: '保存到记忆',
+      icon: <BookOpen size={14} />,
+      divider: true,
+      onSelect: () => {
+        const summary = msg.content.slice(0, 200).replace(/\n/g, ' ');
+        onSaveToMemory?.(msgIndex, summary);
+      },
     },
     ...(isUser
       ? [
@@ -3675,7 +3761,6 @@ ${msg.content.trim()}
       label: '查看原始消息',
       icon: <Braces size={14} />,
       divider: true,
-      danger: false,
       onSelect: () => {
         const raw = JSON.stringify(
           {
@@ -3707,25 +3792,16 @@ ${msg.content.trim()}
     <ContextMenu items={contextItems}>
       {({ onContextMenu }) => (
         <div
+          ref={(el) => {
+            if (el && messageRefs) {
+              messageRefs.current.set(msgIndex, el);
+            }
+          }}
           className={cn('flex items-start gap-3', isUser && 'justify-end')}
           onContextMenu={onContextMenu}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
           {!isUser && <AgentAvatar />}
-
-          {/* Pinned chapter indicator */}
-          {isPinned && (
-            <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium"
-              style={{
-                background: 'var(--accent-bg)',
-                color: 'var(--accent)',
-                border: '1px solid var(--accent-border)',
-              }}
-            >
-              <Pin size={10} />
-              <span>章节</span>
-            </div>
-          )}
 
           <div
             className={cn(


### PR DESCRIPTION
## 类型
- [x] ✨ 新功能

## 变更概述
增强桌面端右键上下文菜单，针对消息气泡和输入框提供差异化右键操作。新增章节导航栏、引用回复、保存到记忆等功能。

## 背景/问题
当前右键菜单仅有「复制文本」和「重试」两个选项，功能过于单薄（#543）。

## 变更内容

### 📌 章节导航栏（**核心新功能**）
- 右键消息 →「固定为章节」→ 顶部出现横向滚动导航栏
- 每个章节显示：序号 + 消息前 30 字预览 + 📌 图标
- 点击章节 → `scrollIntoView` 平滑滚动到对应消息
- 再次右键 →「取消固定章节」移除
- 纯客户端状态 (`number[]`)，无需后端

### 消息右键菜单（用户 + 助手统一）
| 操作 | 图标 | 说明 |
|------|------|------|
| 复制文本 | 📋 | 保留 |
| 复制为 Markdown | { } | **新增** |
| 复制代码 | 💻 | 保留（有代码块时） |
| 引用回复 | ↩️ | **新增** — 以 `> quote` 格式插入输入框 |
| 附加为上下文 | 📎 | **新增** — 格式化上下文块复制到剪贴板 |
| 固定/取消章节 | 📌 | **新增** — 加入/移出章节导航栏 |
| 保存到记忆 | 📖 | **新增** — 通过 `window.miqi.memory.update()` 持久化 |
| 重试 | 🔄 | 保留（仅用户消息） |
| 查看原始消息 | 🔧 | **新增** — JSON 格式消息元数据 |
| 复制时间戳 | 🕐 | **新增** |

### 输入框右键
| 操作 | 快捷键 |
|------|--------|
| 剪切 | Ctrl+X |
| 复制 | Ctrl+C |
| 粘贴 | Ctrl+V |
| 全选 | Ctrl+A |

## 实现细节
- 使用 `messageRefs` (useRef<Map>) 实现章节跳转
- 引用回复自动 focus 输入框
- 保存到记忆通过 `window.miqi.memory.update()` API
- 所有菜单项带 Lucide 图标 + `divider` 分区

## 测试情况
- TypeScript 编译通过（0 新增错误，4 个预存在）
- `electron-vite dev` 热更新正常

Closes #543