### PR TITLE
fix(desktop): KWP group path filter + slash command LLM-independent E2E

### DIFF
--- a/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
+++ b/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
@@ -195,14 +195,17 @@ export function SkillsPage() {
     return s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q);
   });
 
-  const builtin = filtered.filter((s) => s.source === 'builtin');
+  // Match either forward or backslash separators so KWP skills are
+  // recognized on Windows where the path arrives with backslashes.
+  // (The server normalizes to forward slashes in skills.list, but we
+  // still tolerate either for safety.)
+  const KWP_PATH_RE = /[/\\]kwp[/\\]/;
+  const builtin = filtered.filter(
+    (s) => s.source === 'builtin' && !KWP_PATH_RE.test(s.path),
+  );
   const workspace = filtered.filter((s) => s.source === 'workspace');
   const kwp = filtered.filter(
-    // Match either forward or backslashes between path segments so
-    // KWP skills are recognized on Windows where the path arrives
-    // with backslashes. (The server normalizes to forward slashes
-    // in skills.list, but we still tolerate either for safety.)
-    (s) => s.source === 'builtin' && /[/\\]kwp[/\\]/.test(s.path)
+    (s) => s.source === 'builtin' && KWP_PATH_RE.test(s.path),
   );
 
   const handleCopyContent = () => {

--- a/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
+++ b/apps/desktop/src/renderer/features/skills/SkillsPage.tsx
@@ -198,7 +198,11 @@ export function SkillsPage() {
   const builtin = filtered.filter((s) => s.source === 'builtin');
   const workspace = filtered.filter((s) => s.source === 'workspace');
   const kwp = filtered.filter(
-    (s) => s.source === 'builtin' && s.path.includes('/kwp/')
+    // Match either forward or backslashes between path segments so
+    // KWP skills are recognized on Windows where the path arrives
+    // with backslashes. (The server normalizes to forward slashes
+    // in skills.list, but we still tolerate either for safety.)
+    (s) => s.source === 'builtin' && /[/\\]kwp[/\\]/.test(s.path)
   );
 
   const handleCopyContent = () => {

--- a/apps/desktop/tests/e2e/kwp-commands.spec.ts
+++ b/apps/desktop/tests/e2e/kwp-commands.spec.ts
@@ -190,16 +190,20 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
     await textarea.fill(`/brainstorm ${marker}`);
     await textarea.press('Enter');
 
-    // User message bubble must contain the args…
-    await expect(page.getByText(marker, { exact: false }).first()).toBeVisible({
-      timeout: 10_000,
-    });
+    // Scope both assertions to the just-submitted user-message bubble
+    // (data-testid="chat-message-user").  Searching page-wide or
+    // main-wide could match stale DOM (older turn, in-flight text,
+    // placeholders) and silently break the test.
+    const userBubble = page
+      .getByTestId('chat-message-user')
+      .filter({ hasText: marker })
+      .first();
+
+    // The user message bubble must contain the args…
+    await expect(userBubble).toBeVisible({ timeout: 10_000 });
     // …and must NOT contain the bare `/brainstorm` token (which would
     // mean the slash detector never ran and the raw text was sent
     // through to the LLM as the user message).
-    const userBubble = page
-      .locator('main')
-      .getByText('/brainstorm', { exact: false });
-    await expect(userBubble).toHaveCount(0);
+    await expect(userBubble).not.toContainText('/brainstorm');
   });
 });

--- a/apps/desktop/tests/e2e/kwp-commands.spec.ts
+++ b/apps/desktop/tests/e2e/kwp-commands.spec.ts
@@ -59,7 +59,9 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
       const s = await (window as any).miqi.runtime.status();
       return { state: s?.state, initialized: s?.initialized };
     });
+    console.log(`[test] beforeAll bridge state: ${JSON.stringify(skillsCheck)}`);
     if (skillsCheck.initialized !== true) {
+      console.log('[test] Bridge not initialized — skipping KWP E2E');
       test.skip(true, 'Bridge not initialized — skipping KWP E2E');
     }
   }, 60_000);
@@ -167,5 +169,37 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
     // Account-research should be visible among the converted skills.
     await expect(page.getByText('account-research', { exact: false }).first())
       .toBeVisible({ timeout: 5_000 });
+  });
+
+  // ──────── Test 5: slash command is detected without LLM round-trip ───
+
+  // Verifies that `/brainstorm <args>` reaches the slash-command
+  // detector in the bridge — observed via the user-message bubble in
+  // <main>:
+  //   • On detection, TaskRunner strips the `/brainstorm` prefix and
+  //     sends only the args to the LLM (slash_content is prepended
+  //     to the system prompt instead).
+  //   • Without detection, the bubble shows the full `/brainstorm foo`.
+  // We assert the bubble contains the args but NOT the literal
+  // `/brainstorm` token — that confirms the bridge handled the slash
+  // command.  Crucially, we do NOT wait for the LLM response, so
+  // the test runs in < 5s and doesn't depend on provider availability.
+  test('/brainstorm <args> strips the slash prefix before the LLM', async () => {
+    const marker = `STRIP_PROBE_${Date.now()}`;
+    const textarea = await waitForInputReady(page);
+    await textarea.fill(`/brainstorm ${marker}`);
+    await textarea.press('Enter');
+
+    // User message bubble must contain the args…
+    await expect(page.getByText(marker, { exact: false }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    // …and must NOT contain the bare `/brainstorm` token (which would
+    // mean the slash detector never ran and the raw text was sent
+    // through to the LLM as the user message).
+    const userBubble = page
+      .locator('main')
+      .getByText('/brainstorm', { exact: false });
+    await expect(userBubble).toHaveCount(0);
   });
 });

--- a/apps/desktop/tests/e2e/kwp-commands.spec.ts
+++ b/apps/desktop/tests/e2e/kwp-commands.spec.ts
@@ -184,6 +184,13 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
   // `/brainstorm` token — that confirms the bridge handled the slash
   // command.  Crucially, we do NOT wait for the LLM response, so
   // the test runs in < 5s and doesn't depend on provider availability.
+
+  // Counter-verification: also send a NON-registered slash command
+  // and confirm that its prefix is NOT stripped — proving the
+  // detector only strips registered commands, not all /-prefixed
+  // text.  Without this counter-check, a naive "strip everything
+  // starting with /" regex would pass test 5 but not test 6.
+
   test('/brainstorm <args> strips the slash prefix before the LLM', async () => {
     const marker = `STRIP_PROBE_${Date.now()}`;
     const textarea = await waitForInputReady(page);
@@ -205,5 +212,20 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
     // mean the slash detector never ran and the raw text was sent
     // through to the LLM as the user message).
     await expect(userBubble).not.toContainText('/brainstorm');
+  });
+
+  test('/<unknown-cmd> does NOT strip (slash detector only acts on registered cmds)', async () => {
+    const textarea = await waitForInputReady(page);
+    await textarea.fill('/no-such-slash-command-x');
+    await textarea.press('Enter');
+
+    // For an unknown command the bubble must contain the full text
+    // because the detector doesn't know about it.
+    await expect(
+      page
+        .getByTestId('chat-message-user')
+        .filter({ hasText: '/no-such-slash-command-x' })
+        .first(),
+    ).toBeVisible({ timeout: 10_000 });
   });
 });


### PR DESCRIPTION
## 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [x] 🧪 测试
- [x] 🔧 其他

## 变更概述

KWP 集成（PR #504）的两个 follow-up 修复：Windows 路径分隔符修复 + slash command E2E 探针。

## 背景/问题

PR #504 review 期间发现两个问题：Windows 路径分隔符导致 KWP 分组不可见；slash command E2E 依赖 LLM 无法快速验证。

## 变更内容

- `SkillsPage.tsx` 过滤器从 `s.path.includes('/kwp/')` 改为 `/[/\\]kwp[/\\]/`
- 新增 `/brainstorm <args> strips the slash prefix before the LLM` E2E 测试
- CodeRabbit 反馈修复：KWP 与 builtin 分组互斥、E2E 断言限定到消息气泡

## 日志/验证证据

```
uv run pytest tests/skills/ tests/runtime/test_agent_registry.py tests/runtime/test_skills_app_handlers.py
→ 100 passed

cd apps/desktop && npx tsc --noEmit -p tsconfig.json
→ Exit: 0
```

## 测试情况

- tests/skills/ 72 passed
- test_agent_registry.py 15 passed
- TypeScript 类型检查通过

## 截图

无截图，本 PR 仅涉及代码逻辑修复和 E2E 测试，不涉及 UI 视觉变更。