### PR TITLE
feat(desktop): 右键菜单图标化 + 输入框编辑菜单 + composer 打磨 + 消息操作栏 + 查看来源

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -11,3 +11,4 @@ test-results/
 # Ad-hoc scripts
 ocr.js
 ocr2.js
+dev/

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miqi-desktop",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miqi-desktop",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.5",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -371,7 +371,13 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
           method,
           redirect: 'follow',
           signal: controller.signal,
-          ...(method === 'GET' ? { headers: { Range: 'bytes=0-2047' } } : {}),
+          headers: {
+            // Real browser UA — many sites reject bare HEAD/bot requests,
+            // which used to misclassify valid links as dead.
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+            ...(method === 'GET' ? { Range: 'bytes=0-2047' } : {}),
+          },
         });
         return res;
       } finally {
@@ -385,10 +391,17 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
       if ([403, 405, 429, 500, 501, 502, 503].includes(res.status)) {
         res = await check('GET');
       }
-      // 404/410 or network failure = dead; anything else keeps the link.
+      // Only explicit 404/410 = dead; anything else keeps the link.
       return { ok: ![404, 410].includes(res.status), status: res.status };
     } catch {
-      return { ok: false, status: 0 };
+      // Network error / timeout — retry once via GET (transient failures
+      // are common), then conservatively keep the link if still unverifiable.
+      try {
+        const res2 = await check('GET');
+        return { ok: ![404, 410].includes(res2.status), status: res2.status };
+      } catch {
+        return { ok: true, status: 0 };
+      }
     }
   });
 

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -342,6 +342,27 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
   ipcMain.handle(IPC.WEB_CHECK_URL, async (_event, payload: { url?: unknown }) => {
     const url = typeof payload?.url === 'string' ? payload.url : '';
     if (!/^https?:\/\//i.test(url)) return { ok: false, status: 0 };
+    // SSRF guard: never reach loopback / link-local / private ranges from the
+    // privileged main process (mirrors _validate_url on the Python side).
+    let host = '';
+    try {
+      host = new URL(url).hostname.toLowerCase();
+    } catch {
+      return { ok: false, status: 0 };
+    }
+    if (
+      host === 'localhost' ||
+      host.endsWith('.localhost') ||
+      /^(127\.|10\.|192\.168\.|169\.254\.|0\.)/.test(host) ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+      host === '::1' ||
+      host === '::' ||
+      host.startsWith('fe80:') ||
+      host.startsWith('fc') ||
+      host.startsWith('fd')
+    ) {
+      return { ok: false, status: 0 };
+    }
     const check = async (method: 'HEAD' | 'GET'): Promise<Response> => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 8000);

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -337,6 +337,26 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
     return bridge.send('chat.abort', { session_key: input.session_key });
   });
 
+  // HEAD-check a URL in the main process (no CORS) — used by "查看来源"
+  // to drop dead links before the user clicks them.
+  ipcMain.handle(IPC.WEB_CHECK_URL, async (_event, payload: { url?: unknown }) => {
+    const url = typeof payload?.url === 'string' ? payload.url : '';
+    if (!/^https?:\/\//i.test(url)) return { ok: false, status: 0 };
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 6000);
+      const res = await electron.net.fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      return { ok: res.ok, status: res.status };
+    } catch {
+      return { ok: false, status: 0 };
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Sessions
   // -----------------------------------------------------------------------

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -342,16 +342,30 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
   ipcMain.handle(IPC.WEB_CHECK_URL, async (_event, payload: { url?: unknown }) => {
     const url = typeof payload?.url === 'string' ? payload.url : '';
     if (!/^https?:\/\//i.test(url)) return { ok: false, status: 0 };
-    try {
+    const check = async (method: 'HEAD' | 'GET'): Promise<Response> => {
       const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 6000);
-      const res = await electron.net.fetch(url, {
-        method: 'HEAD',
-        redirect: 'follow',
-        signal: controller.signal,
-      });
-      clearTimeout(timer);
-      return { ok: res.ok, status: res.status };
+      const timer = setTimeout(() => controller.abort(), 8000);
+      try {
+        const res = await electron.net.fetch(url, {
+          method,
+          redirect: 'follow',
+          signal: controller.signal,
+          ...(method === 'GET' ? { headers: { Range: 'bytes=0-2047' } } : {}),
+        });
+        return res;
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+    try {
+      let res = await check('HEAD');
+      // Many sites reject HEAD (405) or block bots (403/429) but serve GET
+      // fine — retry with GET before declaring the link dead.
+      if ([403, 405, 429, 500, 501, 502, 503].includes(res.status)) {
+        res = await check('GET');
+      }
+      // 404/410 or network failure = dead; anything else keeps the link.
+      return { ok: ![404, 410].includes(res.status), status: res.status };
     } catch {
       return { ok: false, status: 0 };
     }

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -344,32 +344,67 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
     if (!/^https?:\/\//i.test(url)) return { ok: false, status: 0 };
     // SSRF guard: never reach loopback / link-local / private ranges from the
     // privileged main process (mirrors _validate_url on the Python side).
-    let host = '';
-    try {
-      host = new URL(url).hostname.toLowerCase();
-    } catch {
-      return { ok: false, status: 0 };
-    }
-    if (
-      host === 'localhost' ||
-      host.endsWith('.localhost') ||
-      /^(127\.|10\.|192\.168\.|169\.254\.|0\.)/.test(host) ||
-      /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-      host === '::1' ||
-      host === '::' ||
-      host.startsWith('fe80:') ||
-      host.startsWith('fc') ||
-      host.startsWith('fd')
-    ) {
-      return { ok: false, status: 0 };
-    }
-    const check = async (method: 'HEAD' | 'GET'): Promise<Response> => {
+    // URL.hostname keeps brackets for IPv6 literals ("[::1]") — strip them so
+    // the IPv6 comparisons actually match; IPv6 checks apply only to literals,
+    // so ordinary DNS names like fcc.gov / fda.gov are never rejected.
+    const isSafeHost = (u: string): boolean => {
+      let host = '';
+      try {
+        host = new URL(u).hostname.toLowerCase();
+      } catch {
+        return false;
+      }
+      const isIpv6Literal = host.startsWith('[') && host.endsWith(']');
+      const bare = isIpv6Literal ? host.slice(1, -1) : host;
+      if (
+        host === 'localhost' ||
+        host.endsWith('.localhost') ||
+        /^(127\.|10\.|192\.168\.|169\.254\.|0\.)/.test(host) ||
+        /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+        /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(host) ||
+        (isIpv6Literal &&
+          (bare === '::1' ||
+            bare === '::' ||
+            bare.startsWith('fe80:') ||
+            /^f[cd][0-9a-f]{0,2}:/.test(bare)))
+      ) {
+        return false;
+      }
+      return true;
+    };
+    if (!isSafeHost(url)) return { ok: false, status: 0 };
+    // Redirects are followed manually — every hop re-runs the host validation,
+    // so a public URL can never bounce the privileged main process to a
+    // loopback/private address (e.g. 302 Location: http://127.0.0.1:9200/).
+    const MAX_REDIRECTS = 5;
+    const fetchWithSafeRedirects = async (
+      method: 'HEAD' | 'GET',
+      startUrl: string
+    ): Promise<Response | null> => {
+      let current = startUrl;
+      for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+        const res = await check(method, current);
+        if (res.status >= 300 && res.status < 400) {
+          const loc = res.headers.get('location');
+          if (!loc) return res; // no Location header — treat as final response
+          const next = new URL(loc, current).toString();
+          if (!/^https?:\/\//i.test(next) || !isSafeHost(next)) {
+            return null; // unsafe redirect target — refuse to follow
+          }
+          current = next;
+          continue;
+        }
+        return res;
+      }
+      return null; // too many hops — unverifiable
+    };
+    const check = async (method: 'HEAD' | 'GET', target: string): Promise<Response> => {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 8000);
       try {
-        const res = await electron.net.fetch(url, {
+        const res = await electron.net.fetch(target, {
           method,
-          redirect: 'follow',
+          redirect: 'manual',
           signal: controller.signal,
           headers: {
             // Real browser UA — many sites reject bare HEAD/bot requests,
@@ -385,19 +420,22 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
       }
     };
     try {
-      let res = await check('HEAD');
+      let res = await fetchWithSafeRedirects('HEAD', url);
       // Many sites reject HEAD (405) or block bots (403/429) but serve GET
       // fine — retry with GET before declaring the link dead.
-      if ([403, 405, 429, 500, 501, 502, 503].includes(res.status)) {
-        res = await check('GET');
+      if (res && [403, 405, 429, 500, 501, 502, 503].includes(res.status)) {
+        res = await fetchWithSafeRedirects('GET', url);
       }
+      // null = unsafe redirect / too many hops — conservatively keep the link.
+      if (!res) return { ok: true, status: 0 };
       // Only explicit 404/410 = dead; anything else keeps the link.
       return { ok: ![404, 410].includes(res.status), status: res.status };
     } catch {
       // Network error / timeout — retry once via GET (transient failures
       // are common), then conservatively keep the link if still unverifiable.
       try {
-        const res2 = await check('GET');
+        const res2 = await fetchWithSafeRedirects('GET', url);
+        if (!res2) return { ok: true, status: 0 };
         return { ok: ![404, 410].includes(res2.status), status: res2.status };
       } catch {
         return { ok: true, status: 0 };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -141,6 +141,12 @@ const api = {
     },
   },
 
+  // -- Web helpers -------------------------------------------------------------
+  web: {
+    checkUrl: (url: string): Promise<{ ok: boolean; status: number }> =>
+      ipcRenderer.invoke(IPC.WEB_CHECK_URL, { url }),
+  },
+
   // -- Sessions ---------------------------------------------------------------
   sessions: {
     list: (): Promise<{ sessions: SessionInfo[] }> => ipcRenderer.invoke(IPC.SESSIONS_LIST),

--- a/apps/desktop/src/renderer/components/ContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/ContextMenu.tsx
@@ -2,17 +2,16 @@ import { useState, useEffect, useCallback, useRef, type MouseEvent, type ReactNo
 
 export interface ContextMenuAction {
   label: string;
-  /** Optional keyboard shortcut hint */
   shortcut?: string;
-  /** Optional disabled state */
   disabled?: boolean;
-  /** Danger action (renders in red) */
   danger?: boolean;
-  /** Divider before this item */
   divider?: boolean;
-  /** Optional icon to show before label */
   icon?: ReactNode;
   onSelect: () => void;
+  /** Called when mouse enters this item (for preview/highlight) */
+  onEnter?: () => void;
+  /** Called when mouse leaves this item */
+  onLeave?: () => void;
 }
 
 interface Position {
@@ -120,9 +119,12 @@ export function ContextMenu({ children, items, minWidth = 180 }: Props) {
                   onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
+                    item.onLeave?.(); // clear preview before action
                     item.onSelect();
                     close();
                   }}
+                  onMouseEnter={() => item.onEnter?.()}
+                  onMouseLeave={() => item.onLeave?.()}
                   disabled={item.disabled}
                   className={`w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center justify-between gap-4 ${
                     item.disabled

--- a/apps/desktop/src/renderer/components/ContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/ContextMenu.tsx
@@ -33,6 +33,7 @@ export function ContextMenu({ children, items, minWidth = 180 }: Props) {
   const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
   const [adjustedPos, setAdjustedPos] = useState<Position>({ x: 0, y: 0 });
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   const onContextMenu = useCallback((e: MouseEvent) => {
     e.preventDefault();
@@ -42,8 +43,12 @@ export function ContextMenu({ children, items, minWidth = 180 }: Props) {
   }, []);
 
   const close = useCallback(() => {
+    // Every dismissal path (Escape, outside click, item select) must clear
+    // any pending hover preview, not just onMouseDown.
+    if (hoveredIndex !== null) items[hoveredIndex]?.onLeave?.();
+    setHoveredIndex(null);
     setOpen(false);
-  }, []);
+  }, [hoveredIndex, items]);
 
   // Adjust position after render to avoid screen edges
   useEffect(() => {
@@ -119,12 +124,17 @@ export function ContextMenu({ children, items, minWidth = 180 }: Props) {
                   onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    item.onLeave?.(); // clear preview before action
                     item.onSelect();
-                    close();
+                    close(); // close() invokes onLeave for the hovered item
                   }}
-                  onMouseEnter={() => item.onEnter?.()}
-                  onMouseLeave={() => item.onLeave?.()}
+                  onMouseEnter={() => {
+                    setHoveredIndex(i);
+                    item.onEnter?.();
+                  }}
+                  onMouseLeave={() => {
+                    setHoveredIndex(null);
+                    item.onLeave?.();
+                  }}
                   disabled={item.disabled}
                   className={`w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center justify-between gap-4 ${
                     item.disabled

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -12,9 +12,9 @@ const ITEMS: P[] = [
 ];
 const LABELS: Record<string, string> = Object.fromEntries(ITEMS.map(p => [p.key, p.label]));
 
-interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void; iconOnly?: boolean }
+interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void }
 
-export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals, iconOnly }: Props) {
+export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals }: Props) {
   const [open, setOpen] = useState(false);
   const [confirmAuto, setConfirmAuto] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -72,27 +72,26 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
       <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
         <button
           type="button" onClick={() => setOpen(!open)} disabled={disabled}
-          title={iconOnly ? `${cur.label} — ${cur.desc}` : undefined}
           style={{
-            display: 'flex', alignItems: 'center', gap: iconOnly ? 0 : 6,
-            padding: iconOnly ? '5px 6px' : '4px 10px', borderRadius: 7,
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '4px 10px', borderRadius: 7,
             fontSize: 11, fontWeight: 600, cursor: 'pointer',
-            border: iconOnly ? 'none' : `1px solid ${policy === 'auto' ? cur.color : 'var(--border)'}`,
-            background: iconOnly ? 'transparent' : policy === 'auto' ? `${cur.color}14` : 'var(--surface)',
+            border: `1px solid ${policy === 'auto' ? cur.color : 'var(--border)'}`,
+            background: policy === 'auto' ? `${cur.color}14` : 'var(--surface)',
             color: policy === 'auto' ? cur.color : 'var(--text)',
             transition: 'all .15s',
           }}
           onMouseEnter={e => {
-            e.currentTarget.style.background = iconOnly ? 'var(--surface-muted)' : policy === 'auto' ? `${cur.color}22` : 'var(--surface-muted)';
+            e.currentTarget.style.background = policy === 'auto' ? `${cur.color}22` : 'var(--surface-muted)';
           }}
           onMouseLeave={e => {
-            e.currentTarget.style.background = iconOnly ? 'transparent' : policy === 'auto' ? `${cur.color}14` : 'var(--surface)';
+            e.currentTarget.style.background = policy === 'auto' ? `${cur.color}14` : 'var(--surface)';
           }}
         >
           <span style={{ width: 6, height: 6, borderRadius: '50%', background: cur.color }} />
-          {!iconOnly && <span>{cur.label}</span>}
-          {!iconOnly && <span style={{ fontSize: 8, opacity: .3 }}>▾</span>}
-          {!iconOnly && cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
+          <span>{cur.label}</span>
+          <span style={{ fontSize: 8, opacity: .3 }}>▾</span>
+          {cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
         </button>
 
         <div

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -12,9 +12,9 @@ const ITEMS: P[] = [
 ];
 const LABELS: Record<string, string> = Object.fromEntries(ITEMS.map(p => [p.key, p.label]));
 
-interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void }
+interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void; compact?: boolean }
 
-export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals }: Props) {
+export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals, compact }: Props) {
   const [open, setOpen] = useState(false);
   const [confirmAuto, setConfirmAuto] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -72,9 +72,10 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
       <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
         <button
           type="button" onClick={() => setOpen(!open)} disabled={disabled}
+          title={compact ? cur.label : undefined}
           style={{
-            display: 'flex', alignItems: 'center', gap: 6,
-            padding: '4px 10px', borderRadius: 7,
+            display: 'flex', alignItems: 'center', gap: compact ? 0 : 6,
+            padding: compact ? '5px 6px' : '4px 10px', borderRadius: 7,
             fontSize: 11, fontWeight: 600, cursor: 'pointer',
             border: `1px solid ${policy === 'auto' ? cur.color : 'var(--border)'}`,
             background: policy === 'auto' ? `${cur.color}14` : 'var(--surface)',
@@ -89,9 +90,9 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
           }}
         >
           <span style={{ width: 6, height: 6, borderRadius: '50%', background: cur.color }} />
-          <span>{cur.label}</span>
-          <span style={{ fontSize: 8, opacity: .3 }}>▾</span>
-          {cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
+          {!compact && <span>{cur.label}</span>}
+          {!compact && <span style={{ fontSize: 8, opacity: .3 }}>▾</span>}
+          {!compact && cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
         </button>
 
         <div

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -96,16 +96,25 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
 
         <div
           className={cn(
-            'absolute left-0 bottom-full mb-1 z-50 overflow-hidden',
-            'transition-all duration-150',
-            open ? 'opacity-100 scale-100 translate-y-0' : 'opacity-0 scale-95 translate-y-1 pointer-events-none',
+            'fixed inset-0 z-[150] flex items-center justify-center transition-opacity duration-150',
+            open ? 'opacity-100' : 'opacity-0 pointer-events-none',
           )}
-          style={{
-            minWidth: 240, background: 'var(--surface)',
-            border: '1px solid var(--border)', borderRadius: 12,
-            boxShadow: '0 8px 30px rgba(0,0,0,0.12)',
-          }}
+          style={{ background: 'rgba(0,0,0,0.25)' }}
+          onClick={() => setOpen(false)}
         >
+          <div
+            className={cn(
+              'transition-all duration-150',
+              open ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
+            )}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              minWidth: 280, maxWidth: '90vw', background: 'var(--surface)',
+              border: '1px solid var(--border)', borderRadius: 16,
+              boxShadow: '0 16px 48px rgba(0,0,0,0.16)',
+              overflow: 'hidden',
+            }}
+          >
           <div style={{ padding: '5px 14px 2px', fontSize: 10, color: 'var(--text-faint)', letterSpacing: .5, textTransform: 'uppercase' }}>
             Agent 模式
           </div>
@@ -160,6 +169,7 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
               </button>
             )}
           </div>
+        </div>
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -96,25 +96,16 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
 
         <div
           className={cn(
-            'fixed inset-0 z-[150] flex items-center justify-center transition-opacity duration-150',
-            open ? 'opacity-100' : 'opacity-0 pointer-events-none',
+            'absolute left-0 bottom-full mb-1 z-50 overflow-hidden',
+            'transition-all duration-150',
+            open ? 'opacity-100 scale-100 translate-y-0' : 'opacity-0 scale-95 translate-y-1 pointer-events-none',
           )}
-          style={{ background: 'rgba(0,0,0,0.25)' }}
-          onClick={() => setOpen(false)}
+          style={{
+            minWidth: 240, background: 'var(--surface)',
+            border: '1px solid var(--border)', borderRadius: 12,
+            boxShadow: '0 8px 30px rgba(0,0,0,0.12)',
+          }}
         >
-          <div
-            className={cn(
-              'transition-all duration-150',
-              open ? 'opacity-100 scale-100' : 'opacity-0 scale-95',
-            )}
-            onClick={(e) => e.stopPropagation()}
-            style={{
-              minWidth: 280, maxWidth: '90vw', background: 'var(--surface)',
-              border: '1px solid var(--border)', borderRadius: 16,
-              boxShadow: '0 16px 48px rgba(0,0,0,0.16)',
-              overflow: 'hidden',
-            }}
-          >
           <div style={{ padding: '5px 14px 2px', fontSize: 10, color: 'var(--text-faint)', letterSpacing: .5, textTransform: 'uppercase' }}>
             Agent 模式
           </div>
@@ -169,7 +160,6 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
               </button>
             )}
           </div>
-        </div>
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '../lib/utils';
 
 export type ExecutionPolicy = 'plan' | 'manual' | 'edit' | 'auto';
@@ -163,20 +164,25 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
         </div>
       </div>
 
-      {confirmAuto && (
-        <div onClick={() => setConfirmAuto(false)} style={{ position: 'fixed', inset: 0, zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.35)' }}>
-          <div onClick={e => e.stopPropagation()} style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 18, padding: '12px 18px', maxWidth: 300, width: '90%', boxShadow: '0 16px 48px rgba(0,0,0,0.16)' }}>
-            <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)' }}>开启自动模式</div>
-            <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '3px 0 0' }}>Agent 将完全自主执行，不再弹窗确认</p>
-            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 10 }}>
-              <button onClick={() => setConfirmAuto(false)} style={{ padding: '5px 14px', borderRadius: 8, fontSize: 11, fontWeight: 500, cursor: 'pointer', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-muted)' }}>取消</button>
-              <button onClick={() => { onChange('auto'); setConfirmAuto(false); toastFn('✓ 自主 已启用'); }} style={{ padding: '5px 14px', borderRadius: 8, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: 'none', background: '#f59e0b', color: '#fff' }}>确认</button>
+      {confirmAuto &&
+        createPortal(
+          <div onClick={() => setConfirmAuto(false)} style={{ position: 'fixed', inset: 0, zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(0,0,0,0.35)' }}>
+            <div onClick={e => e.stopPropagation()} style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 18, padding: '12px 18px', maxWidth: 300, width: '90%', boxShadow: '0 16px 48px rgba(0,0,0,0.16)' }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)' }}>开启自动模式</div>
+              <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '3px 0 0' }}>Agent 将完全自主执行，不再弹窗确认</p>
+              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 10 }}>
+                <button onClick={() => setConfirmAuto(false)} style={{ padding: '5px 14px', borderRadius: 8, fontSize: 11, fontWeight: 500, cursor: 'pointer', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-muted)' }}>取消</button>
+                <button onClick={() => { onChange('auto'); setConfirmAuto(false); toastFn('✓ 自主 已启用'); }} style={{ padding: '5px 14px', borderRadius: 8, fontSize: 11, fontWeight: 600, cursor: 'pointer', border: 'none', background: '#f59e0b', color: '#fff' }}>确认</button>
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
 
-      <div className={cn('fixed bottom-24 left-1/2 -translate-x-1/2 z-[150] px-4 py-2 rounded-full text-[11px] font-medium whitespace-nowrap transition-all duration-200', toast ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 pointer-events-none')} style={{ background: 'var(--surface)', border: '1px solid var(--border)', boxShadow: '0 4px 20px rgba(0,0,0,0.12)', color: 'var(--text)' }}>{toast}</div>
+      {createPortal(
+        <div className={cn('fixed bottom-24 left-1/2 -translate-x-1/2 z-[150] px-4 py-2 rounded-full text-[11px] font-medium whitespace-nowrap transition-all duration-200', toast ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2 pointer-events-none')} style={{ background: 'var(--surface)', border: '1px solid var(--border)', boxShadow: '0 4px 20px rgba(0,0,0,0.12)', color: 'var(--text)' }}>{toast}</div>,
+        document.body
+      )}
     </>
   );
 }

--- a/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
+++ b/apps/desktop/src/renderer/components/ExecutionPolicySelector.tsx
@@ -12,9 +12,9 @@ const ITEMS: P[] = [
 ];
 const LABELS: Record<string, string> = Object.fromEntries(ITEMS.map(p => [p.key, p.label]));
 
-interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void; compact?: boolean }
+interface Props { policy: ExecutionPolicy; onChange: (p: ExecutionPolicy) => void; disabled?: boolean; onOpenApprovals?: () => void; iconOnly?: boolean }
 
-export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals, compact }: Props) {
+export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenApprovals, iconOnly }: Props) {
   const [open, setOpen] = useState(false);
   const [confirmAuto, setConfirmAuto] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -72,27 +72,27 @@ export function ExecutionPolicySelector({ policy, onChange, disabled, onOpenAppr
       <div ref={ref} style={{ position: 'relative', flexShrink: 0 }}>
         <button
           type="button" onClick={() => setOpen(!open)} disabled={disabled}
-          title={compact ? cur.label : undefined}
+          title={iconOnly ? `${cur.label} — ${cur.desc}` : undefined}
           style={{
-            display: 'flex', alignItems: 'center', gap: compact ? 0 : 6,
-            padding: compact ? '5px 6px' : '4px 10px', borderRadius: 7,
+            display: 'flex', alignItems: 'center', gap: iconOnly ? 0 : 6,
+            padding: iconOnly ? '5px 6px' : '4px 10px', borderRadius: 7,
             fontSize: 11, fontWeight: 600, cursor: 'pointer',
-            border: `1px solid ${policy === 'auto' ? cur.color : 'var(--border)'}`,
-            background: policy === 'auto' ? `${cur.color}14` : 'var(--surface)',
+            border: iconOnly ? 'none' : `1px solid ${policy === 'auto' ? cur.color : 'var(--border)'}`,
+            background: iconOnly ? 'transparent' : policy === 'auto' ? `${cur.color}14` : 'var(--surface)',
             color: policy === 'auto' ? cur.color : 'var(--text)',
             transition: 'all .15s',
           }}
           onMouseEnter={e => {
-            e.currentTarget.style.background = policy === 'auto' ? `${cur.color}22` : 'var(--surface-muted)';
+            e.currentTarget.style.background = iconOnly ? 'var(--surface-muted)' : policy === 'auto' ? `${cur.color}22` : 'var(--surface-muted)';
           }}
           onMouseLeave={e => {
-            e.currentTarget.style.background = policy === 'auto' ? `${cur.color}14` : 'var(--surface)';
+            e.currentTarget.style.background = iconOnly ? 'transparent' : policy === 'auto' ? `${cur.color}14` : 'var(--surface)';
           }}
         >
           <span style={{ width: 6, height: 6, borderRadius: '50%', background: cur.color }} />
-          {!compact && <span>{cur.label}</span>}
-          {!compact && <span style={{ fontSize: 8, opacity: .3 }}>▾</span>}
-          {!compact && cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
+          {!iconOnly && <span>{cur.label}</span>}
+          {!iconOnly && <span style={{ fontSize: 8, opacity: .3 }}>▾</span>}
+          {!iconOnly && cur.key === 'auto' && <span style={{ fontSize: 13 }}>⚠</span>}
         </button>
 
         <div

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2924,6 +2924,13 @@ export function ChatConsole({
                 </div>
               )}
 
+              {/* AI disclaimer — above the input box, centered (ChatGPT style) */}
+              {!input.trim() && attachments.length === 0 && (
+                <div className="text-center pb-2.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
+                  AI 也会犯错误，对于重要答案请谨慎验证
+                </div>
+              )}
+
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
@@ -2937,12 +2944,6 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                {/* Disclaimer hint — fades away once user types or attaches */}
-                {!input.trim() && attachments.length === 0 && (
-                  <div className="pb-1.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
-                    AI 也会犯错误，对于重要答案请谨慎验证
-                  </div>
-                )}
                 {/* Textarea on top — grows up to 1/3 of viewport (DeepSeek style) */}
                 <Textarea
                   ref={textareaRef}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3676,8 +3676,12 @@ function MessageBubble({
     window.getSelection()?.removeAllRanges();
   };
 
+  // Selection captured when the menu opens — hover/leave must not clobber it,
+  // otherwise copyWithSelection always falls back to the full message.
+  const capturedSelectionRef = useRef('');
+
   const copyWithSelection = () => {
-    const selText = window.getSelection()?.toString().trim();
+    const selText = capturedSelectionRef.current;
     if (selText) { navigator.clipboard.writeText(selText); deselectMessageText(); return; }
     // No manual selection — copy full message
     onCopy(msg.content);
@@ -3716,7 +3720,11 @@ function MessageBubble({
         <div
           ref={bubbleRef}
           className={cn('flex items-start gap-3', isUser && 'justify-end')}
-          onContextMenu={onContextMenu}
+          onContextMenu={(e) => {
+            // Capture any manual selection before hover-preview can replace it
+            capturedSelectionRef.current = window.getSelection()?.toString().trim() ?? '';
+            onContextMenu(e);
+          }}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
           {!isUser && <AgentAvatar />}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2716,7 +2716,7 @@ export function ChatConsole({
       {/* ── Main area: chat + right panel ── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Chat area */}
-        <div className="flex flex-col flex-1 overflow-hidden relative">
+        <div className="flex flex-col flex-1 overflow-hidden">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
             className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
@@ -2797,7 +2797,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto pb-[210px]"
+            className="flex-1 overflow-y-auto"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2850,9 +2850,9 @@ export function ChatConsole({
             </div>
           </div>
 
-          {/* Composer — floats over the bottom, fully transparent so answers show through */}
+          {/* Composer — in normal flow, never covers the answer stream */}
           <div
-            className="absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
+            className="shrink-0 px-5 pb-10 pt-3"
             style={{
               background: 'transparent',
             }}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2458,6 +2458,11 @@ export function ChatConsole({
             setInput(el.value);
             adjustTextareaHeight();
             el.focus();
+            // Jump message area to the latest (bottom) so newest answer stays visible
+            requestAnimationFrame(() => {
+              const sc = scrollRef.current;
+              if (sc) sc.scrollTop = sc.scrollHeight;
+            });
           }).catch(() => {});
         },
       },

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -203,7 +203,10 @@ interface MessageSource {
 /** Extract reference URLs from a tool/progress message (paper_search cards, web fetches, …). */
 function extractMessageSources(msg: Message): MessageSource[] {
   const sources: MessageSource[] = [];
-  if (msg.toolName === 'paper_search' && msg.toolData) {
+  if (msg.toolName === 'paper_search') {
+    // Structured card data is the source of truth; empty/failed searches
+    // carry only internal API URLs — never surface those as references.
+    if (!msg.toolData) return sources;
     const items = (msg.toolData as { items?: { url?: string; arxiv_id?: string }[] }).items ?? [];
     for (const it of items) {
       const url = it.url || (it.arxiv_id ? `https://arxiv.org/abs/${it.arxiv_id}` : '');
@@ -211,13 +214,15 @@ function extractMessageSources(msg: Message): MessageSource[] {
     }
     return sources;
   }
+  // Skip internal/API machinery URLs — not user-facing references.
+  const skip = ['api.semanticscholar.org', '/graph/v1/', 'developer.mozilla.org/en-US/docs/Web/HTTP'];
   // Generic: pull http(s) links from the tool output text, then strip
   // trailing punctuation / markdown noise (e.g. `}{GitHub}.`).
   const seen = new Set<string>();
   const content = String(msg.content ?? '');
   for (const m of content.matchAll(/https?:\/\/[^\s"'<>)\]]+/g)) {
     let url = m[0].split('{')[0].replace(/[.,;:!?。，；：、）\]]+$/, '');
-    if (!url || seen.has(url)) continue;
+    if (!url || seen.has(url) || skip.some((s) => url.includes(s))) continue;
     seen.add(url);
     sources.push({ tool: msg.toolName || 'tool', url });
   }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -49,6 +49,10 @@ import {
   AlertCircle,
   FileType,
   Loader,
+  Scissors,
+  ClipboardPaste,
+  Code2,
+  Braces,
 } from 'lucide-react';
 import type {
   ChatProgress,
@@ -2420,6 +2424,16 @@ export function ChatConsole({
     [handleCopyReproContext, handleCopyTaskSummary, handleExportTaskMarkdown, messages]
   );
 
+  const inputContextItems = useMemo<ContextMenuAction[]>(
+    () => [
+      { label: '剪切', icon: <Scissors size={14} />, shortcut: 'Ctrl+X', onSelect: () => document.execCommand('cut') },
+      { label: '复制', icon: <Copy size={14} />, shortcut: 'Ctrl+C', onSelect: () => document.execCommand('copy') },
+      { label: '粘贴', icon: <ClipboardPaste size={14} />, shortcut: 'Ctrl+V', onSelect: () => document.execCommand('paste') },
+      { label: '全选', icon: <CheckCircle size={14} />, shortcut: 'Ctrl+A', divider: true, onSelect: () => document.execCommand('selectAll') },
+    ],
+    []
+  );
+
   const shareButtonLabel =
     shareStatus === 'copied'
       ? '已复制摘要'
@@ -2875,9 +2889,12 @@ export function ChatConsole({
                 </div>
               )}
 
+              <ContextMenu items={inputContextItems} minWidth={160}>
+                {({ onContextMenu }) => (
               <div
                 className="flex items-end gap-2 rounded-xl px-4 py-3.5 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
+                onContextMenu={onContextMenu}
                 style={{
                   background: 'var(--surface)',
                   border: '1px solid var(--border)',
@@ -2932,6 +2949,8 @@ export function ChatConsole({
                   </button>
                 )}
               </div>
+                )}
+              </ContextMenu>
             </div>
           </div>
         </div>
@@ -3536,15 +3555,18 @@ function MessageBubble({
 
   const contextItems: ContextMenuAction[] = isUser
     ? [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
-        { label: '重试', onSelect: () => onRetry?.() },
+        { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
+        { label: '复制为 Markdown', icon: <Braces size={14} />, onSelect: () => { navigator.clipboard.writeText(msg.content).catch(() => {}); } },
+        { label: '重试', icon: <Undo2 size={14} />, divider: true, onSelect: () => onRetry?.() },
       ]
     : [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
+        { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
+        { label: '复制为 Markdown', icon: <Braces size={14} />, onSelect: () => { navigator.clipboard.writeText(msg.content).catch(() => {}); } },
         ...(hasCodeBlock
           ? [
               {
                 label: '复制代码',
+                icon: <Code2 size={14} />,
                 onSelect: () => {
                   const codeMatch = msg.content.match(/```[\s\S]*?```/g);
                   if (codeMatch) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2663,7 +2663,7 @@ export function ChatConsole({
       {/* ── Main area: chat + right panel ── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Chat area */}
-        <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex flex-col flex-1 overflow-hidden relative">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
             className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
@@ -2744,7 +2744,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto pb-[170px]"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2796,9 +2796,9 @@ export function ChatConsole({
             </div>
           </div>
 
-          {/* Composer */}
+          {/* Composer — floats over the bottom, messages never get squeezed */}
           <div
-            className="shrink-0 px-5 pb-4 pt-3"
+            className="absolute bottom-0 left-0 right-0 px-5 pb-4 pt-3"
             style={{
               background: 'var(--background)',
             }}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -202,6 +202,22 @@ interface MessageSource {
   url: string;
 }
 
+const TOOL_LABELS: Record<string, string> = {
+  web_fetch: '网页抓取',
+  web_search: '网页搜索',
+  paper_search: '论文搜索',
+  paper_get: '论文详情',
+};
+
+/** Hostname (no www.) for a URL — used for the favicon + primary label. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
 /** Extract reference URLs from a tool/progress message.
  *  Priority: the URL the tool actually touched (toolArgs) > structured
  *  paper_search cards > links found in result text (fallback). */
@@ -4081,43 +4097,74 @@ function MessageBubble({
     <Modal
       open={showSources}
       onOpenChange={setShowSources}
-      title="查看来源"
+      title={`查看来源${(sources ?? []).filter((s) => !deadUrls.has(s.url)).length > 0 ? `（${(sources ?? []).filter((s) => !deadUrls.has(s.url)).length}）` : ''}`}
     >
       <div className="flex flex-col gap-3">
         {(sources ?? []).length === 0 ? (
           <p className="text-xs text-text-faint py-2">该回答未使用网络工具，没有参考资料。</p>
         ) : (
-          <div className="flex flex-col gap-1.5 max-h-[50vh] overflow-y-auto pr-1 -mr-1">
-            {(sources ?? [])
-              .filter((s) => !deadUrls.has(s.url))
-              .map((s, i) => (
-                <a
-                  key={i}
-                  href={s.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
-                >
-                  <span
-                    className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
-                    style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
-                  >
-                    {s.tool}
-                  </span>
-                  <span
-                    className="text-[11px] truncate flex-1"
-                    style={{ color: 'var(--accent)' }}
-                    title={s.url}
-                  >
-                    {s.url}
-                  </span>
-                </a>
-              ))}
+          <div className="flex flex-col gap-3 max-h-[55vh] overflow-y-auto pr-1 -mr-1">
+            {(() => {
+              // Group valid sources by tool, keep a global running number.
+              const groups = new Map<string, MessageSource[]>();
+              for (const s of sources ?? []) {
+                if (deadUrls.has(s.url)) continue;
+                const arr = groups.get(s.tool) ?? [];
+                arr.push(s);
+                groups.set(s.tool, arr);
+              }
+              if (groups.size === 0) {
+                return (
+                  <p className="text-xs text-text-faint py-2">所有来源链接均已失效（404），没有可访问的参考资料。</p>
+                );
+              }
+              let num = 0;
+              return Array.from(groups.entries()).map(([tool, items]) => (
+                <div key={tool} className="flex flex-col gap-1.5">
+                  <div className="text-[10px] font-semibold tracking-wider uppercase px-0.5" style={{ color: 'var(--text-faint)' }}>
+                    {TOOL_LABELS[tool] ?? tool}
+                  </div>
+                  {items.map((s) => {
+                    num += 1;
+                    const n = num;
+                    const host = hostOf(s.url);
+                    return (
+                      <a
+                        key={s.url}
+                        href={s.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={s.url}
+                        className="flex items-center gap-2.5 px-2.5 py-2 rounded-xl border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
+                      >
+                        <span
+                          className="shrink-0 w-5 h-5 rounded-md flex items-center justify-center text-[10px] font-semibold"
+                          style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+                        >
+                          {n}
+                        </span>
+                        <img
+                          src={`https://www.google.com/s2/favicons?domain=${host}&sz=32`}
+                          alt=""
+                          className="w-4 h-4 shrink-0 rounded-sm"
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).style.visibility = 'hidden';
+                          }}
+                        />
+                        <span className="flex-1 min-w-0">
+                          <span className="block text-xs font-medium truncate" style={{ color: 'var(--text)' }}>
+                            {host}
+                          </span>
+                          <span className="block text-[10px] truncate text-text-faint">{s.url}</span>
+                        </span>
+                      </a>
+                    );
+                  })}
+                </div>
+              ));
+            })()}
             {deadUrls.size === 0 && (sources ?? []).length > 0 && (
               <p className="text-[11px] text-text-faint py-0.5">正在验证链接可用性…</p>
-            )}
-            {(sources ?? []).every((s) => deadUrls.has(s.url)) && (
-              <p className="text-xs text-text-faint py-2">所有来源链接均已失效（404），没有可访问的参考资料。</p>
             )}
           </div>
         )}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2927,11 +2927,11 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex flex-col rounded-3xl px-5 py-3.5 focus-within:ring-2 transition-all"
+                className="flex flex-col rounded-3xl px-7 py-3.5 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
-                  background: 'color-mix(in srgb, var(--surface) 72%, transparent)',
+                  background: 'color-mix(in srgb, var(--surface) 85%, transparent)',
                   backdropFilter: 'blur(16px)',
                   WebkitBackdropFilter: 'blur(16px)',
                   border: '1px solid color-mix(in srgb, var(--border) 60%, transparent)',
@@ -2956,7 +2956,7 @@ export function ChatConsole({
                   style={{ color: 'var(--text)' }}
                 />
                 {/* Icon row at the bottom — no text, like DeepSeek */}
-                <div className="flex items-center gap-2 pt-2 mt-1 border-t border-[var(--border-subtle)]">
+                <div className="flex items-center gap-3 pt-1.5 mt-0.5 border-t border-[var(--border-subtle)]">
                   <ExecutionPolicySelector
                     policy={executionPolicy}
                     onChange={setExecutionPolicy}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2744,7 +2744,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto pb-[170px]"
+            className="flex-1 overflow-y-auto pb-[260px]"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2807,7 +2807,7 @@ export function ChatConsole({
             className="absolute bottom-0 left-0 right-0 px-5 pb-4 pt-3"
             style={{
               background:
-                'linear-gradient(to top, var(--background) 55%, rgba(0,0,0,0) 100%)',
+                'linear-gradient(to top, var(--background) 45%, rgba(0,0,0,0) 100%)',
             }}
           >
             <div className="max-w-[760px] mx-auto">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2573,13 +2573,6 @@ export function ChatConsole({
 
         {/* Right: Badges + user + actions */}
         <div className="flex items-center gap-2 shrink-0">
-          {/* Execution mode selector — top bar, keeps input pure */}
-          <ExecutionPolicySelector
-            policy={executionPolicy}
-            onChange={setExecutionPolicy}
-            disabled={streaming}
-            onOpenApprovals={onOpenApprovals}
-          />
           {/* User avatar + name */}
           <div className="flex items-center gap-1.5 pl-2 ml-1 border-l border-border-subtle">
             <div
@@ -2934,7 +2927,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex items-end gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
+                className="flex flex-col rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2944,14 +2937,6 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                <button
-                  onClick={handleAttachClick}
-                  className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
-                  title="Attach file or image"
-                  aria-label="Attach file or image"
-                >
-                  <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
-                </button>
                 <Textarea
                   ref={textareaRef}
                   value={input}
@@ -2963,27 +2948,45 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
+                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />
-                {streaming ? (
+                {/* Bottom toolbar (Claude Desktop style): mode left, attach+send right */}
+                <div className="flex items-center gap-2 pt-2">
+                  <ExecutionPolicySelector
+                    policy={executionPolicy}
+                    onChange={setExecutionPolicy}
+                    disabled={streaming}
+                    onOpenApprovals={onOpenApprovals}
+                  />
+                  <div className="flex-1" />
                   <button
-                    onClick={handleAbort}
-                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
+                    onClick={handleAttachClick}
+                    className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
+                    title="Attach file or image"
+                    aria-label="Attach file or image"
                   >
-                    <Square size={14} style={{ color: 'var(--text-muted)' }} />
+                    <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
                   </button>
-                ) : (
-                  <button
-                    onClick={handleSend}
-                    disabled={!input.trim() && attachments.length === 0}
-                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
-                    style={{ background: 'var(--accent)' }}
-                  >
-                    <Send size={13} style={{ color: '#fff' }} />
-                  </button>
-                )}
+                  {streaming ? (
+                    <button
+                      onClick={handleAbort}
+                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
+                    >
+                      <Square size={14} style={{ color: 'var(--text-muted)' }} />
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleSend}
+                      disabled={!input.trim() && attachments.length === 0}
+                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
+                      style={{ background: 'var(--accent)' }}
+                    >
+                      <Send size={13} style={{ color: '#fff' }} />
+                    </button>
+                  )}
+                </div>
               </div>
                 )}
               </ContextMenu>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2434,6 +2434,7 @@ export function ChatConsole({
           navigator.clipboard.writeText(el.value.slice(s, e));
           el.setRangeText('', s, e, 'end');
           setInput(el.value);
+          adjustTextareaHeight();
           el.focus();
         },
       },
@@ -2454,6 +2455,7 @@ export function ChatConsole({
             const s = el.selectionStart, e = el.selectionEnd;
             el.setRangeText(text, s, e, 'end');
             setInput(el.value);
+            adjustTextareaHeight();
             el.focus();
           }).catch(() => {});
         },

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1095,6 +1095,7 @@ export function ChatConsole({
   const justOpened = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
   const previewJustClosed = useRef(false);
   const unsubsRef = useRef<Array<() => void>>([]);
   const finalCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2123,6 +2124,21 @@ export function ChatConsole({
    * always shrinks back when emptied. min/max-height still clamp it.
    */
 
+  /** Fixed gap between the last answer and the composer (px) */
+  const ANSWER_GAP = 10;
+  const [composerHeight, setComposerHeight] = useState(0);
+  useEffect(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    // Keep the message area's bottom padding in sync with the composer's real
+    // height, so scrolling to the bottom always leaves ANSWER_GAP between the
+    // last answer and the input box — regardless of pasted content size.
+    const ro = new ResizeObserver(() => setComposerHeight(el.offsetHeight));
+    ro.observe(el);
+    setComposerHeight(el.offsetHeight);
+    return () => ro.disconnect();
+  }, []);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -2703,7 +2719,7 @@ export function ChatConsole({
       {/* ── Main area: chat + right panel ── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Chat area */}
-        <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex flex-col flex-1 overflow-hidden relative">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
             className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
@@ -2784,8 +2800,8 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto pb-[20vh]"
-            style={{ background: 'var(--background)' }}
+            className="flex-1 overflow-y-auto"
+            style={{ background: 'var(--background)', paddingBottom: composerHeight + ANSWER_GAP }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
               {!historyLoaded ? (
@@ -2837,9 +2853,13 @@ export function ChatConsole({
             </div>
           </div>
 
-          {/* Composer — in normal flow, never covers the answer stream */}
+          {/* Composer — floats over the bottom; the answer stream never moves.
+              Messages reserve composerHeight + ANSWER_GAP via paddingBottom, so
+              the gap between the last answer and the box stays constant no
+              matter how tall the textarea grows. */}
           <div
-            className="shrink-0 px-5 pb-10 pt-3"
+            ref={composerRef}
+            className="absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
             style={{
               background: 'transparent',
             }}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2802,16 +2802,8 @@ export function ChatConsole({
             }}
           >
             <div className="max-w-[760px] mx-auto">
-              {/* Top row: mode selector + attachment chips (never blocks input) */}
-              <div className="flex flex-wrap items-center gap-2 mb-2">
-                <ExecutionPolicySelector
-                  policy={executionPolicy}
-                  onChange={setExecutionPolicy}
-                  disabled={streaming}
-                  onOpenApprovals={onOpenApprovals}
-                />
               {attachments.length > 0 && (
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2 mb-2">
                   {attachments.map((att, i) => {
                     const isDoc = att.type === 'document';
                     const cat = isDoc ? getDocCategory(att.name) : null;
@@ -2929,7 +2921,6 @@ export function ChatConsole({
                   })}
                 </div>
               )}
-              </div>
 
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
@@ -2944,6 +2935,12 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
+                <ExecutionPolicySelector
+                  policy={executionPolicy}
+                  onChange={setExecutionPolicy}
+                  disabled={streaming}
+                  onOpenApprovals={onOpenApprovals}
+                />
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2744,7 +2744,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto pb-[150px]"
+            className="flex-1 overflow-y-auto pb-[210px]"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2937,15 +2937,7 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                <div className="flex items-end gap-2">
-                <button
-                  onClick={handleAttachClick}
-                  className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
-                  title="Attach file or image"
-                  aria-label="Attach file or image"
-                >
-                  <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
-                </button>
+                {/* Textarea on top — grows up to 1/3 of viewport (DeepSeek style) */}
                 <Textarea
                   ref={textareaRef}
                   value={input}
@@ -2957,40 +2949,49 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
+                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[33vh] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />
-                {streaming ? (
+                {/* Icon row at the bottom — no text, like DeepSeek */}
+                <div className="flex items-center gap-1 pt-2 mt-1 border-t border-[var(--border-subtle)]">
+                  <ExecutionPolicySelector
+                    policy={executionPolicy}
+                    onChange={setExecutionPolicy}
+                    disabled={streaming}
+                    onOpenApprovals={onOpenApprovals}
+                    iconOnly
+                  />
+                  <div className="flex-1" />
                   <button
-                    onClick={handleAbort}
-                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
+                    onClick={handleAttachClick}
+                    className="shrink-0 p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
+                    title="Attach file or image"
+                    aria-label="Attach file or image"
                   >
-                    <Square size={14} style={{ color: 'var(--text-muted)' }} />
+                    <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
                   </button>
-                ) : (
-                  <button
-                    onClick={handleSend}
-                    disabled={!input.trim() && attachments.length === 0}
-                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
-                    style={{ background: 'var(--accent)' }}
-                  >
-                    <Send size={13} style={{ color: '#fff' }} />
-                  </button>
-                )}
+                  {streaming ? (
+                    <button
+                      onClick={handleAbort}
+                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
+                    >
+                      <Square size={14} style={{ color: 'var(--text-muted)' }} />
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleSend}
+                      disabled={!input.trim() && attachments.length === 0}
+                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
+                      style={{ background: 'var(--accent)' }}
+                    >
+                      <Send size={13} style={{ color: '#fff' }} />
+                    </button>
+                  )}
                 </div>
               </div>
                 )}
               </ContextMenu>
-              {/* Mode selector — BELOW the input box, bottom-left corner */}
-              <div className="flex items-center justify-start mt-2">
-                <ExecutionPolicySelector
-                  policy={executionPolicy}
-                  onChange={setExecutionPolicy}
-                  disabled={streaming}
-                  onOpenApprovals={onOpenApprovals}
-                />
-              </div>
             </div>
           </div>
         </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -219,12 +219,17 @@ function extractMessageSources(msg: Message): MessageSource[] {
     'api.semanticscholar.org',
     '/graph/v1/',
     'developer.mozilla.org/en-US/docs/Web/HTTP',
-    // Search-engine invocation URLs (the tool's own query, not a result page)
+    // Search-engine invocation / redirect URLs (the tool's own query, not a result page)
     'bing.com/search',
     'duckduckgo.com/?q=',
     'duckduckgo.com/html',
     'search.brave.com',
     'google.com/search',
+    'so.com/s?q=',      // 360 搜索调用
+    'so.com/link?',     // 360 搜索结果跳转链接
+    'sogou.com/web?query=',
+    'user.guancha.cn/main/search',
+    'beian.miit.gov.cn',
   ];
   // Generic: pull http(s) links from the tool output text, then strip
   // trailing punctuation / markdown noise (e.g. `}{GitHub}.`).

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3693,6 +3693,7 @@ function MessageBubble({
   const [feedback, setFeedback] = useState<'up' | 'down' | null>(null);
   const [showSources, setShowSources] = useState(false);
   const [deadUrls, setDeadUrls] = useState<Set<string>>(new Set());
+  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   // Verify source links when the modal opens — drop 404s so users never
@@ -4135,6 +4136,12 @@ function MessageBubble({
                         target="_blank"
                         rel="noreferrer"
                         title={s.url}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          navigator.clipboard.writeText(s.url).catch(() => {});
+                          setCopiedUrl(s.url);
+                          setTimeout(() => setCopiedUrl(null), 1500);
+                        }}
                         className="flex items-center gap-2.5 px-2.5 py-2 rounded-xl border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
                       >
                         <span
@@ -4157,6 +4164,9 @@ function MessageBubble({
                           </span>
                           <span className="block text-[10px] truncate text-text-faint">{s.url}</span>
                         </span>
+                        {copiedUrl === s.url && (
+                          <Check size={13} className="shrink-0" style={{ color: 'var(--success)' }} />
+                        )}
                       </a>
                     );
                   })}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3642,7 +3642,29 @@ function MessageBubble({
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState<'up' | 'down' | null>(null);
   const [showSources, setShowSources] = useState(false);
+  const [deadUrls, setDeadUrls] = useState<Set<string>>(new Set());
   const bubbleRef = useRef<HTMLDivElement>(null);
+
+  // Verify source links when the modal opens — drop 404s so users never
+  // click a dead reference.
+  useEffect(() => {
+    if (!showSources) return;
+    let cancelled = false;
+    setDeadUrls(new Set());
+    (sources ?? []).forEach((s) => {
+      window.miqi.web
+        .checkUrl(s.url)
+        .then((r) => {
+          if (!cancelled && !r.ok) setDeadUrls((prev) => new Set(prev).add(s.url));
+        })
+        .catch(() => {
+          if (!cancelled) setDeadUrls((prev) => new Set(prev).add(s.url));
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [showSources, sources]);
 
   if (msg.role === 'progress') {
     // ── Paper search result: render formatted cards ──────────────
@@ -4032,29 +4054,37 @@ function MessageBubble({
           <p className="text-xs text-text-faint py-2">该回答未使用网络工具，没有参考资料。</p>
         ) : (
           <div className="flex flex-col gap-1.5 max-h-[50vh] overflow-y-auto pr-1 -mr-1">
-            {(sources ?? []).map((s, i) => (
-              <a
-                key={i}
-                href={s.url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
-              >
-                <span
-                  className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
-                  style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+            {(sources ?? [])
+              .filter((s) => !deadUrls.has(s.url))
+              .map((s, i) => (
+                <a
+                  key={i}
+                  href={s.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
                 >
-                  {s.tool}
-                </span>
-                <span
-                  className="text-[11px] truncate flex-1"
-                  style={{ color: 'var(--accent)' }}
-                  title={s.url}
-                >
-                  {s.url}
-                </span>
-              </a>
-            ))}
+                  <span
+                    className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
+                    style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+                  >
+                    {s.tool}
+                  </span>
+                  <span
+                    className="text-[11px] truncate flex-1"
+                    style={{ color: 'var(--accent)' }}
+                    title={s.url}
+                  >
+                    {s.url}
+                  </span>
+                </a>
+              ))}
+            {deadUrls.size === 0 && (sources ?? []).length > 0 && (
+              <p className="text-[11px] text-text-faint py-0.5">正在验证链接可用性…</p>
+            )}
+            {(sources ?? []).every((s) => deadUrls.has(s.url)) && (
+              <p className="text-xs text-text-faint py-2">所有来源链接均已失效（404），没有可访问的参考资料。</p>
+            )}
           </div>
         )}
         <div className="flex gap-2 pt-2 border-t border-[var(--border-subtle)]">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2573,6 +2573,13 @@ export function ChatConsole({
 
         {/* Right: Badges + user + actions */}
         <div className="flex items-center gap-2 shrink-0">
+          {/* Execution mode selector — top bar, keeps input pure */}
+          <ExecutionPolicySelector
+            policy={executionPolicy}
+            onChange={setExecutionPolicy}
+            disabled={streaming}
+            onOpenApprovals={onOpenApprovals}
+          />
           {/* User avatar + name */}
           <div className="flex items-center gap-1.5 pl-2 ml-1 border-l border-border-subtle">
             <div
@@ -2927,7 +2934,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex flex-col rounded-xl px-4 py-2.5 focus-within:ring-2 transition-all"
+                className="flex items-end gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2937,17 +2944,6 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                {/* Mode selector — inside input, doesn't eat textarea width */}
-                <div className="flex items-center pb-1.5">
-                  <ExecutionPolicySelector
-                    policy={executionPolicy}
-                    onChange={setExecutionPolicy}
-                    disabled={streaming}
-                    onOpenApprovals={onOpenApprovals}
-                  />
-                </div>
-                {/* Input row — textarea gets full width like ChatGPT/DeepSeek */}
-                <div className="flex items-end gap-2">
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
@@ -2988,7 +2984,6 @@ export function ChatConsole({
                     <Send size={13} style={{ color: '#fff' }} />
                   </button>
                 )}
-                </div>
               </div>
                 )}
               </ContextMenu>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2960,7 +2960,7 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[33vh] text-sm"
+                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2748,12 +2748,6 @@ export function ChatConsole({
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
-              {/* AI disclaimer — part of the answer stream, hides once user types */}
-              {!input.trim() && attachments.length === 0 && (
-                <div className="text-center text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
-                  AI 也会犯错误，对于重要答案请谨慎验证
-                </div>
-              )}
               {!historyLoaded ? (
                 <div className="flex items-center justify-center min-h-[300px]">
                   <Loader2 size={16} className="animate-spin text-text-faint" />
@@ -2969,7 +2963,15 @@ export function ChatConsole({
                     disabled={streaming}
                     onOpenApprovals={onOpenApprovals}
                   />
-                  <div className="flex-1" />
+                  {/* AI disclaimer — centered in the mode row, fades when typing */}
+                  <div className="flex-1 flex items-center justify-center">
+                    <span
+                      className="text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none transition-opacity duration-300"
+                      style={{ opacity: !input.trim() && attachments.length === 0 ? 1 : 0 }}
+                    >
+                      AI 也会犯错误，对于重要答案请谨慎验证
+                    </span>
+                  </div>
                   <button
                     onClick={handleAttachClick}
                     className="shrink-0 p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -717,10 +717,9 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
           });
         } else {
           // Search returned empty or errored — still show normally
-          const preview = content.length > 120 ? content.slice(0, 120) + '…' : content;
           result.push({
             role: 'progress',
-            content: `paper_search: ${preview}`,
+            content: content, // full output — sources extraction needs all URLs
             summary: 'paper_search',
             toolHint: true,
             collapsed: true,
@@ -728,10 +727,11 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
           });
         }
       } else {
-        const preview = content.length > 120 ? content.slice(0, 120) + '…' : content;
+        // Full output kept (collapsed by default; expanded view scrolls) so
+        // "查看来源" can extract every reference URL the tool touched.
         result.push({
           role: 'progress',
-          content: `${toolName}: ${preview}`,
+          content: content,
           summary: toolName,
           toolHint: true,
           collapsed: true,
@@ -3643,7 +3643,7 @@ function MessageBubble({
         {isCollapsed ? (
           <span>{msg.summary || msg.content}</span>
         ) : (
-          <span className="whitespace-pre-wrap break-all">{msg.content}</span>
+          <span className="whitespace-pre-wrap break-all max-h-64 overflow-y-auto block">{msg.content}</span>
         )}
         {/* Inline exec output (Phase 7.4) — gated by ui.inlineExecOutput setting */}
         {inlineExecOutput && msg.toolCallId && execOutputs[msg.toolCallId] && (

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -52,7 +52,6 @@ import {
   Scissors,
   ClipboardPaste,
   Code2,
-  Braces,
 } from 'lucide-react';
 import type {
   ChatProgress,
@@ -3556,12 +3555,10 @@ function MessageBubble({
   const contextItems: ContextMenuAction[] = isUser
     ? [
         { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
-        { label: '复制为 Markdown', icon: <Braces size={14} />, onSelect: () => { navigator.clipboard.writeText(msg.content).catch(() => {}); } },
         { label: '重试', icon: <Undo2 size={14} />, divider: true, onSelect: () => onRetry?.() },
       ]
     : [
         { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
-        { label: '复制为 Markdown', icon: <Braces size={14} />, onSelect: () => { navigator.clipboard.writeText(msg.content).catch(() => {}); } },
         ...(hasCodeBlock
           ? [
               {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3592,15 +3592,18 @@ function MessageBubble({
     const sel = window.getSelection();
     const selText = sel?.toString().trim();
     if (selText) { navigator.clipboard.writeText(selText); return; }
-    // Flash-select the message text so user sees what's being copied
-    if (bubbleRef.current) {
-      const range = document.createRange();
-      range.selectNodeContents(bubbleRef.current);
-      sel?.removeAllRanges();
-      sel?.addRange(range);
-    }
     onCopy(msg.content);
-    setTimeout(() => window.getSelection()?.removeAllRanges(), 1200);
+    // Flash-select after context menu overlay is dismissed
+    requestAnimationFrame(() => {
+      const textEl = bubbleRef.current?.querySelector('[class*="leading-relaxed"]') as HTMLElement | null;
+      if (textEl) {
+        const range = document.createRange();
+        range.selectNodeContents(textEl);
+        window.getSelection()?.removeAllRanges();
+        window.getSelection()?.addRange(range);
+        setTimeout(() => window.getSelection()?.removeAllRanges(), 1200);
+      }
+    });
   };
 
   const contextItems: ContextMenuAction[] = isUser

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -211,10 +211,15 @@ function extractMessageSources(msg: Message): MessageSource[] {
     }
     return sources;
   }
-  // Generic: pull http(s) links from the tool output text
+  // Generic: pull http(s) links from the tool output text, then strip
+  // trailing punctuation / markdown noise (e.g. `}{GitHub}.`).
+  const seen = new Set<string>();
   const content = String(msg.content ?? '');
   for (const m of content.matchAll(/https?:\/\/[^\s"'<>)\]]+/g)) {
-    sources.push({ tool: msg.toolName || 'tool', url: m[0] });
+    let url = m[0].split('{')[0].replace(/[.,;:!?。，；：、）\]]+$/, '');
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    sources.push({ tool: msg.toolName || 'tool', url });
   }
   return sources;
 }
@@ -4002,31 +4007,41 @@ function MessageBubble({
       onOpenChange={setShowSources}
       title="查看来源"
     >
-      <div className="text-xs space-y-2">
+      <div className="flex flex-col gap-3">
         {(sources ?? []).length === 0 ? (
-          <p className="text-text-faint py-2">该回答未使用网络工具，没有参考资料。</p>
+          <p className="text-xs text-text-faint py-2">该回答未使用网络工具，没有参考资料。</p>
         ) : (
-          (sources ?? []).map((s, i) => (
-            <a
-              key={i}
-              href={s.url}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-start gap-2 p-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] transition-colors break-all"
-            >
-              <span
-                className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded mt-0.5"
-                style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+          <div className="flex flex-col gap-1.5 max-h-[50vh] overflow-y-auto pr-1 -mr-1">
+            {(sources ?? []).map((s, i) => (
+              <a
+                key={i}
+                href={s.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2 px-2.5 py-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] hover:border-[var(--border)] transition-colors"
               >
-                {s.tool}
-              </span>
-              <span style={{ color: 'var(--accent)' }}>{s.url}</span>
-            </a>
-          ))
+                <span
+                  className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
+                  style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+                >
+                  {s.tool}
+                </span>
+                <span
+                  className="text-[11px] truncate flex-1"
+                  style={{ color: 'var(--accent)' }}
+                  title={s.url}
+                >
+                  {s.url}
+                </span>
+              </a>
+            ))}
+          </div>
         )}
-        <div className="pt-1 border-t border-[var(--border-subtle)] flex gap-2">
-          <span className="text-text-faint w-16 shrink-0">时间</span>
-          <span>{new Date(msg.timestamp).toLocaleString('zh-CN')}</span>
+        <div className="flex gap-2 pt-2 border-t border-[var(--border-subtle)]">
+          <span className="text-[11px] text-text-faint shrink-0">回答时间</span>
+          <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            {new Date(msg.timestamp).toLocaleString('zh-CN')}
+          </span>
         </div>
       </div>
     </Modal>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2925,7 +2925,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex items-end gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
+                className="flex flex-col rounded-xl px-4 py-2.5 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2935,12 +2935,17 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                <ExecutionPolicySelector
-                  policy={executionPolicy}
-                  onChange={setExecutionPolicy}
-                  disabled={streaming}
-                  onOpenApprovals={onOpenApprovals}
-                />
+                {/* Mode selector — inside input, doesn't eat textarea width */}
+                <div className="flex items-center pb-1.5">
+                  <ExecutionPolicySelector
+                    policy={executionPolicy}
+                    onChange={setExecutionPolicy}
+                    disabled={streaming}
+                    onOpenApprovals={onOpenApprovals}
+                  />
+                </div>
+                {/* Input row — textarea gets full width like ChatGPT/DeepSeek */}
+                <div className="flex items-end gap-2">
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
@@ -2981,6 +2986,7 @@ export function ChatConsole({
                     <Send size={13} style={{ color: '#fff' }} />
                   </button>
                 )}
+                </div>
               </div>
                 )}
               </ContextMenu>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -241,6 +241,14 @@ function extractMessageSources(msg: Message): MessageSource[] {
   ];
   const clean = (raw: string): string =>
     raw.split('{')[0].replace(/[.,;:!?。，；：、）\]]+$/, '');
+  // Deduplicate across all branches + cap: duplicate URLs produce duplicate
+  // React keys and one checkUrl request each (CodeRabbit #564 review).
+  const seen = new Set<string>();
+  const push = (tool: string, url: string) => {
+    if (!url || seen.has(url) || sources.length >= 20) return;
+    seen.add(url);
+    sources.push({ tool, url });
+  };
 
   // 1. The exact URL the tool fetched/searched — most trustworthy.
   if (msg.toolArgs && typeof msg.toolArgs === 'object') {
@@ -248,7 +256,7 @@ function extractMessageSources(msg: Message): MessageSource[] {
     for (const key of ['url', 'link', 'href', 'query']) {
       const v = args[key];
       if (typeof v === 'string' && /^https?:\/\//i.test(v) && !skip.some((s) => v.includes(s))) {
-        sources.push({ tool: msg.toolName || 'tool', url: clean(v) });
+        push(msg.toolName || 'tool', clean(v));
       }
     }
   }
@@ -258,20 +266,16 @@ function extractMessageSources(msg: Message): MessageSource[] {
     const items = (msg.toolData as { items?: { url?: string; arxiv_id?: string }[] }).items ?? [];
     for (const it of items) {
       const url = it.url || (it.arxiv_id ? `https://arxiv.org/abs/${it.arxiv_id}` : '');
-      if (url) sources.push({ tool: 'paper_search', url: clean(url) });
+      if (url) push('paper_search', clean(url));
     }
     return sources;
   }
   if (msg.toolName === 'paper_search') return sources; // failed search: no refs
 
   // 3. Fallback: links inside the result text (deduped, noise filtered).
-  const seen = new Set<string>();
   const content = String(msg.content ?? '');
   for (const m of content.matchAll(/https?:\/\/[^\s"'<>)\]]+/g)) {
-    const url = clean(m[0]);
-    if (!url || seen.has(url) || skip.some((s) => url.includes(s))) continue;
-    seen.add(url);
-    sources.push({ tool: msg.toolName || 'tool', url });
+    push(msg.toolName || 'tool', clean(m[0]));
   }
   return sources;
 }
@@ -2444,6 +2448,25 @@ export function ChatConsole({
     setTimeout(() => setCopiedIdx(null), 2000);
   };
 
+  // Associate each assistant answer with the tool URLs that preceded it in
+  // the same turn. Memoized — extractMessageSources scans full tool outputs,
+  // which would otherwise re-run on every animation frame while streaming.
+  const sourcesByMsg = useMemo(() => {
+    const map = new Map<Message, MessageSource[]>();
+    let pending: MessageSource[] = [];
+    for (const m of messages) {
+      if (m.role === 'progress') {
+        pending = [...pending, ...extractMessageSources(m)];
+      } else if (m.role === 'user') {
+        pending = [];
+      } else if (m.role === 'assistant') {
+        map.set(m, pending);
+        pending = [];
+      }
+    }
+    return map;
+  }, [messages]);
+
   /** Retry a user message: rewind to it, resend automatically with a
    *  "answer differently" hint so the model doesn't repeat itself. */
   const handleRetry = useCallback(
@@ -2456,7 +2479,7 @@ export function ChatConsole({
         attachments: msg.attachments ?? [],
         retry: true,
       };
-      setMessages((prev) => prev.slice(0, idx + 1)); // keep the retried message
+      setMessages((prev) => prev.slice(0, idx)); // handleSend re-appends the user message
       setInput(msg.content);
       setAttachments(msg.attachments ?? []);
       requestAnimationFrame(() => handleSendRef.current());
@@ -2484,7 +2507,7 @@ export function ChatConsole({
         attachments: userMsg.attachments ?? [],
         retry: true,
       };
-      setMessages((prev) => prev.slice(0, userIdx + 1)); // drop answer + everything after
+      setMessages((prev) => prev.slice(0, userIdx)); // handleSend re-appends the user message
       setInput(userMsg.content);
       setAttachments(userMsg.attachments ?? []);
       requestAnimationFrame(() => handleSendRef.current());
@@ -2942,22 +2965,7 @@ export function ChatConsole({
                   </div>
                 </div>
               ) : (
-                (() => {
-                  // Associate each assistant answer with the tool URLs that
-                  // preceded it in the same turn (webfetch/search/paper_search).
-                  const sourcesByMsg = new Map<Message, MessageSource[]>();
-                  let pending: MessageSource[] = [];
-                  for (const m of messages) {
-                    if (m.role === 'progress') {
-                      pending = [...pending, ...extractMessageSources(m)];
-                    } else if (m.role === 'user') {
-                      pending = [];
-                    } else if (m.role === 'assistant') {
-                      sourcesByMsg.set(m, pending);
-                      pending = [];
-                    }
-                  }
-                  return messages.map((msg, i) => (
+                messages.map((msg, i) => (
                   <MessageBubble
                     key={`${msg.timestamp}-${i}`}
                     msg={msg}
@@ -2973,8 +2981,7 @@ export function ChatConsole({
                     onDownloadPaper={handleDownloadPaper}
                     downloadingPaperId={downloadingPaperId}
                   />
-                  ))
-                })()
+                ))
               )}
               {streaming && (
                 <div
@@ -3707,11 +3714,19 @@ function MessageBubble({
 
   // Verify source links when the modal opens — drop 404s so users never
   // click a dead reference.
+  const [validating, setValidating] = useState(false);
   useEffect(() => {
     if (!showSources) return;
     let cancelled = false;
     setDeadUrls(new Set());
-    (sources ?? []).forEach((s) => {
+    const list = sources ?? [];
+    if (list.length === 0) {
+      setValidating(false);
+      return;
+    }
+    setValidating(true);
+    let done = 0;
+    list.forEach((s) => {
       window.miqi.web
         .checkUrl(s.url)
         .then((r) => {
@@ -3719,6 +3734,12 @@ function MessageBubble({
         })
         .catch(() => {
           if (!cancelled) setDeadUrls((prev) => new Set(prev).add(s.url));
+        })
+        .finally(() => {
+          if (!cancelled) {
+            done += 1;
+            if (done === list.length) setValidating(false);
+          }
         });
     });
     return () => {
@@ -4182,7 +4203,7 @@ function MessageBubble({
                 </div>
               ));
             })()}
-            {deadUrls.size === 0 && (sources ?? []).length > 0 && (
+            {validating && (
               <p className="text-[11px] text-text-faint py-0.5">正在验证链接可用性…</p>
             )}
             {deadUrls.size > 0 && (

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2744,7 +2744,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto pb-[260px]"
+            className="flex-1 overflow-y-auto pb-[150px]"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2804,10 +2804,10 @@ export function ChatConsole({
 
           {/* Composer — floats over the bottom, messages never get squeezed */}
           <div
-            className="absolute bottom-0 left-0 right-0 px-5 pb-4 pt-3"
+            className="absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
             style={{
               background:
-                'linear-gradient(to top, var(--background) 45%, rgba(0,0,0,0) 100%)',
+                'linear-gradient(to top, var(--background) 15%, rgba(0,0,0,0) 100%)',
             }}
           >
             <div className="max-w-[760px] mx-auto">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2925,7 +2925,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex items-end gap-2 rounded-xl px-4 py-3.5 focus-within:ring-2 transition-all"
+                className="flex flex-col gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2935,12 +2935,18 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                <ExecutionPolicySelector
-                  policy={executionPolicy}
-                  onChange={setExecutionPolicy}
-                  disabled={streaming}
-                  onOpenApprovals={onOpenApprovals}
-                />
+                {/* Toolbar row: mode selector + spacer */}
+                <div className="flex items-center gap-2">
+                  <ExecutionPolicySelector
+                    policy={executionPolicy}
+                    onChange={setExecutionPolicy}
+                    disabled={streaming}
+                    onOpenApprovals={onOpenApprovals}
+                  />
+                  <div className="flex-1" />
+                </div>
+                {/* Input row: attach + textarea + send */}
+                <div className="flex items-end gap-2">
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
@@ -2981,6 +2987,7 @@ export function ChatConsole({
                     <Send size={13} style={{ color: '#fff' }} />
                   </button>
                 )}
+                </div>
               </div>
                 )}
               </ContextMenu>
@@ -3604,10 +3611,8 @@ function MessageBubble({
   const copyWithSelection = () => {
     const selText = window.getSelection()?.toString().trim();
     if (selText) { navigator.clipboard.writeText(selText); deselectMessageText(); return; }
-    // No selection — copy full message with flash
-    selectMessageText();
+    // No manual selection — copy full message
     onCopy(msg.content);
-    setTimeout(deselectMessageText, 1000);
   };
 
   const contextItems: ContextMenuAction[] = isUser

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3178,18 +3178,27 @@ export function ChatConsole({
                   {streaming ? (
                     <button
                       onClick={handleAbort}
-                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
+                      title="停止生成"
+                      aria-label="停止生成"
+                      className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:bg-[var(--surface-muted)] active:scale-95"
                     >
-                      <Square size={14} style={{ color: 'var(--text-muted)' }} />
+                      <Square size={12} style={{ color: 'var(--text-muted)' }} fill="currentColor" />
                     </button>
                   ) : (
                     <button
                       onClick={handleSend}
                       disabled={!input.trim() && attachments.length === 0}
-                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
-                      style={{ background: 'var(--accent)' }}
+                      title="发送"
+                      aria-label="发送"
+                      className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:brightness-110 hover:-translate-y-px active:scale-95 disabled:opacity-30 disabled:hover:brightness-100 disabled:hover:translate-y-0 disabled:shadow-none"
+                      style={{
+                        background:
+                          'linear-gradient(135deg, var(--accent), color-mix(in srgb, var(--accent) 65%, #000))',
+                        boxShadow:
+                          '0 2px 10px color-mix(in srgb, var(--accent) 35%, transparent)',
+                      }}
                     >
-                      <Send size={13} style={{ color: '#fff' }} />
+                      <Send size={14} style={{ color: '#fff' }} />
                     </button>
                   )}
                 </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2802,8 +2802,16 @@ export function ChatConsole({
             }}
           >
             <div className="max-w-[760px] mx-auto">
+              {/* Top row: mode selector + attachment chips (never blocks input) */}
+              <div className="flex flex-wrap items-center gap-2 mb-2">
+                <ExecutionPolicySelector
+                  policy={executionPolicy}
+                  onChange={setExecutionPolicy}
+                  disabled={streaming}
+                  onOpenApprovals={onOpenApprovals}
+                />
               {attachments.length > 0 && (
-                <div className="flex flex-wrap gap-2 mb-2">
+                <div className="flex flex-wrap gap-2">
                   {attachments.map((att, i) => {
                     const isDoc = att.type === 'document';
                     const cat = isDoc ? getDocCategory(att.name) : null;
@@ -2921,6 +2929,7 @@ export function ChatConsole({
                   })}
                 </div>
               )}
+              </div>
 
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
@@ -2935,13 +2944,6 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                <ExecutionPolicySelector
-                  policy={executionPolicy}
-                  onChange={setExecutionPolicy}
-                  disabled={streaming}
-                  onOpenApprovals={onOpenApprovals}
-                  compact
-                />
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -195,6 +195,30 @@ interface Message {
   timestamp: number;
 }
 
+interface MessageSource {
+  tool: string;
+  url: string;
+}
+
+/** Extract reference URLs from a tool/progress message (paper_search cards, web fetches, …). */
+function extractMessageSources(msg: Message): MessageSource[] {
+  const sources: MessageSource[] = [];
+  if (msg.toolName === 'paper_search' && msg.toolData) {
+    const items = (msg.toolData as { items?: { url?: string; arxiv_id?: string }[] }).items ?? [];
+    for (const it of items) {
+      const url = it.url || (it.arxiv_id ? `https://arxiv.org/abs/${it.arxiv_id}` : '');
+      if (url) sources.push({ tool: 'paper_search', url });
+    }
+    return sources;
+  }
+  // Generic: pull http(s) links from the tool output text
+  const content = String(msg.content ?? '');
+  for (const m of content.matchAll(/https?:\/\/[^\s"'<>)\]]+/g)) {
+    sources.push({ tool: msg.toolName || 'tool', url: m[0] });
+  }
+  return sources;
+}
+
 function isMissingProviderConfigMessage(message: string) {
   const normalized = message.toLowerCase();
   return normalized.includes('no api key configured');
@@ -2486,7 +2510,9 @@ export function ChatConsole({
           if (s === e) return;
           navigator.clipboard.writeText(el.value.slice(s, e));
           el.setRangeText('', s, e, 'end');
-          setInput(el.value);
+          // Let React's onChange pick up the new value — manual setInput can
+          // drift from the DOM (deleting then requires two passes).
+          el.dispatchEvent(new Event('input', { bubbles: true }));
           el.focus();
         },
       },
@@ -2507,7 +2533,9 @@ export function ChatConsole({
             // Always append to the end, cursor lands after pasted content
             const end = el.value.length;
             el.setRangeText(text, end, end, 'end');
-            setInput(el.value);
+            // Let React's onChange pick up the new value (single source of
+            // truth for state vs DOM — avoids double-delete drift).
+            el.dispatchEvent(new Event('input', { bubbles: true }));
             el.focus();
             // Jump message area to the latest (bottom) so newest answer stays visible
             requestAnimationFrame(() => {
@@ -2825,12 +2853,28 @@ export function ChatConsole({
                   </div>
                 </div>
               ) : (
-                messages.map((msg, i) => (
+                (() => {
+                  // Associate each assistant answer with the tool URLs that
+                  // preceded it in the same turn (webfetch/search/paper_search).
+                  const sourcesByMsg = new Map<Message, MessageSource[]>();
+                  let pending: MessageSource[] = [];
+                  for (const m of messages) {
+                    if (m.role === 'progress') {
+                      pending = [...pending, ...extractMessageSources(m)];
+                    } else if (m.role === 'user') {
+                      pending = [];
+                    } else if (m.role === 'assistant') {
+                      sourcesByMsg.set(m, pending);
+                      pending = [];
+                    }
+                  }
+                  return messages.map((msg, i) => (
                   <MessageBubble
                     key={`${msg.timestamp}-${i}`}
                     msg={msg}
                     execOutputs={execOutputs}
                     inlineExecOutput={inlineExecOutput}
+                    sources={sourcesByMsg.get(msg) ?? []}
                     isLast={i === messages.length - 1}
                     onCopy={(text) => handleCopy(text, i)}
                     isCopied={copiedIdx === i}
@@ -2840,7 +2884,8 @@ export function ChatConsole({
                     onDownloadPaper={handleDownloadPaper}
                     downloadingPaperId={downloadingPaperId}
                   />
-                ))
+                  ))
+                })()
               )}
               {streaming && (
                 <div
@@ -3539,6 +3584,7 @@ function MessageBubble({
   onOpenProviderSettings,
   onDownloadPaper,
   downloadingPaperId,
+  sources,
 }: {
   msg: Message;
   execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
@@ -3551,6 +3597,8 @@ function MessageBubble({
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
   downloadingPaperId?: string | null;
+  /** Reference URLs collected from the tool calls preceding this answer */
+  sources?: MessageSource[];
 }) {
   const [expanded, setExpanded] = useState(false);
   const [feedback, setFeedback] = useState<'up' | 'down' | null>(null);
@@ -3934,41 +3982,38 @@ function MessageBubble({
       )}
     </ContextMenu>
 
-    {/* Sources modal */}
+    {/* Sources modal — tools used for this answer + reference URLs */}
     <Modal
       open={showSources}
       onOpenChange={setShowSources}
-      title="消息来源"
+      title="查看来源"
     >
       <div className="text-xs space-y-2">
-        <div className="flex gap-2">
-          <span className="text-text-faint w-16 shrink-0">角色</span>
-          <span>{isUser ? '用户' : msg.role === 'assistant' ? 'MiQi' : msg.role}</span>
-        </div>
-        {msg.toolName && (
-          <div className="flex gap-2">
-            <span className="text-text-faint w-16 shrink-0">工具</span>
-            <span className="font-mono">{msg.toolName}</span>
-          </div>
+        {(sources ?? []).length === 0 ? (
+          <p className="text-text-faint py-2">该回答未使用网络工具，没有参考资料。</p>
+        ) : (
+          (sources ?? []).map((s, i) => (
+            <a
+              key={i}
+              href={s.url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-start gap-2 p-2 rounded-lg border border-[var(--border-subtle)] hover:bg-[var(--surface-muted)] transition-colors break-all"
+            >
+              <span
+                className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded mt-0.5"
+                style={{ background: 'var(--surface-muted)', color: 'var(--text-muted)' }}
+              >
+                {s.tool}
+              </span>
+              <span style={{ color: 'var(--accent)' }}>{s.url}</span>
+            </a>
+          ))
         )}
-        {msg.toolCallId && (
-          <div className="flex gap-2">
-            <span className="text-text-faint w-16 shrink-0">调用 ID</span>
-            <span className="font-mono break-all">{msg.toolCallId}</span>
-          </div>
-        )}
-        <div className="flex gap-2">
+        <div className="pt-1 border-t border-[var(--border-subtle)] flex gap-2">
           <span className="text-text-faint w-16 shrink-0">时间</span>
           <span>{new Date(msg.timestamp).toLocaleString('zh-CN')}</span>
         </div>
-        {msg.toolData ? (
-          <div className="pt-1 border-t border-[var(--border-subtle)]">
-            <div className="text-text-faint mb-1">工具数据</div>
-            <pre className="bg-[var(--surface-muted)] rounded-lg p-2 overflow-x-auto text-[10px] leading-relaxed max-h-48 overflow-y-auto">
-              {JSON.stringify(msg.toolData, null, 2).slice(0, 2000)}
-            </pre>
-          </div>
-        ) : null}
       </div>
     </Modal>
     </>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2452,8 +2452,9 @@ export function ChatConsole({
           const el = textareaRef.current; if (!el) return;
           navigator.clipboard.readText().then((text) => {
             if (!text) return;
-            const s = el.selectionStart, e = el.selectionEnd;
-            el.setRangeText(text, s, e, 'end');
+            // Always append to the end, cursor lands after pasted content
+            const end = el.value.length;
+            el.setRangeText(text, end, end, 'end');
             setInput(el.value);
             adjustTextareaHeight();
             el.focus();

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2937,6 +2937,15 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
+                <div className="flex items-end gap-2">
+                <button
+                  onClick={handleAttachClick}
+                  className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
+                  title="Attach file or image"
+                  aria-label="Attach file or image"
+                >
+                  <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
+                </button>
                 <Textarea
                   ref={textareaRef}
                   value={input}
@@ -2948,48 +2957,40 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
+                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[200px] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />
-                {/* Bottom toolbar (Claude Desktop style): mode left, attach+send right */}
-                <div className="flex items-center gap-2 pt-2">
-                  <ExecutionPolicySelector
-                    policy={executionPolicy}
-                    onChange={setExecutionPolicy}
-                    disabled={streaming}
-                    onOpenApprovals={onOpenApprovals}
-                  />
-                  <div className="flex-1" />
+                {streaming ? (
                   <button
-                    onClick={handleAttachClick}
-                    className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
-                    title="Attach file or image"
-                    aria-label="Attach file or image"
+                    onClick={handleAbort}
+                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
                   >
-                    <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
+                    <Square size={14} style={{ color: 'var(--text-muted)' }} />
                   </button>
-                  {streaming ? (
-                    <button
-                      onClick={handleAbort}
-                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors hover:bg-[var(--surface-muted)]"
-                    >
-                      <Square size={14} style={{ color: 'var(--text-muted)' }} />
-                    </button>
-                  ) : (
-                    <button
-                      onClick={handleSend}
-                      disabled={!input.trim() && attachments.length === 0}
-                      className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
-                      style={{ background: 'var(--accent)' }}
-                    >
-                      <Send size={13} style={{ color: '#fff' }} />
-                    </button>
-                  )}
+                ) : (
+                  <button
+                    onClick={handleSend}
+                    disabled={!input.trim() && attachments.length === 0}
+                    className="shrink-0 w-7 h-7 rounded-lg flex items-center justify-center transition-colors disabled:opacity-30"
+                    style={{ background: 'var(--accent)' }}
+                  >
+                    <Send size={13} style={{ color: '#fff' }} />
+                  </button>
+                )}
                 </div>
               </div>
                 )}
               </ContextMenu>
+              {/* Mode selector — BELOW the input box, outside its container */}
+              <div className="flex items-center justify-center mt-2">
+                <ExecutionPolicySelector
+                  policy={executionPolicy}
+                  onChange={setExecutionPolicy}
+                  disabled={streaming}
+                  onOpenApprovals={onOpenApprovals}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2482,6 +2482,8 @@ export function ChatConsole({
           navigator.clipboard.writeText(el.value.slice(s, e));
           el.setRangeText('', s, e, 'end');
           setInput(el.value);
+          el.style.height = 'auto';
+          el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
           el.focus();
         },
       },
@@ -2503,6 +2505,8 @@ export function ChatConsole({
             const end = el.value.length;
             el.setRangeText(text, end, end, 'end');
             setInput(el.value);
+            el.style.height = 'auto';
+            el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
             el.focus();
             // Jump message area to the latest (bottom) so newest answer stays visible
             requestAnimationFrame(() => {
@@ -2998,6 +3002,14 @@ export function ChatConsole({
                   value={input}
                   onChange={(e) => {
                     setInput(e.target.value);
+                    // Synchronous resize: at onChange time the DOM value is
+                    // already the new one, so scrollHeight is exact. Belt-and-
+                    // braces with the useLayoutEffect below.
+                    const el = textareaRef.current;
+                    if (el) {
+                      el.style.height = 'auto';
+                      el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
+                    }
                   }}
                   onKeyDown={handleKeyDown}
                   placeholder="请输入消息或拖入文件..."

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2952,7 +2952,7 @@ export function ChatConsole({
                   placeholder="请输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[35vh] text-[15px]"
+                  className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { DiffView } from './components/DiffView';
@@ -2124,16 +2124,16 @@ export function ChatConsole({
 
   /**
    * Auto-resize textarea to fit content.
-   * Runs as an effect after React commits, so the controlled value is always
-   * synced to the DOM — rAF could race React's render and read a stale
-   * scrollHeight (input box stays tall after deleting everything).
+   * Runs synchronously after EVERY render (no dep array) — any path that
+   * changes the value (typing, paste, cut, delete, undo, send) gets its
+   * height recomputed, so a tall box always shrinks back once emptied.
    */
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
     el.style.height = `${Math.max(el.scrollHeight, 52)}px`; // floor = min-h-[52px]
-  }, [input]);
+  });
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2927,7 +2927,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex flex-col rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
+                className="flex flex-col rounded-3xl px-5 py-3.5 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2937,6 +2937,12 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
+                {/* Disclaimer hint — fades away once user types or attaches */}
+                {!input.trim() && attachments.length === 0 && (
+                  <div className="pb-1.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
+                    AI 也会犯错误，对于重要答案请谨慎验证
+                  </div>
+                )}
                 {/* Textarea on top — grows up to 1/3 of viewport (DeepSeek style) */}
                 <Textarea
                   ref={textareaRef}
@@ -2954,13 +2960,12 @@ export function ChatConsole({
                   style={{ color: 'var(--text)' }}
                 />
                 {/* Icon row at the bottom — no text, like DeepSeek */}
-                <div className="flex items-center gap-1 pt-2 mt-1 border-t border-[var(--border-subtle)]">
+                <div className="flex items-center gap-2 pt-2 mt-1 border-t border-[var(--border-subtle)]">
                   <ExecutionPolicySelector
                     policy={executionPolicy}
                     onChange={setExecutionPolicy}
                     disabled={streaming}
                     onOpenApprovals={onOpenApprovals}
-                    iconOnly
                   />
                   <div className="flex-1" />
                   <button

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -215,7 +215,17 @@ function extractMessageSources(msg: Message): MessageSource[] {
     return sources;
   }
   // Skip internal/API machinery URLs — not user-facing references.
-  const skip = ['api.semanticscholar.org', '/graph/v1/', 'developer.mozilla.org/en-US/docs/Web/HTTP'];
+  const skip = [
+    'api.semanticscholar.org',
+    '/graph/v1/',
+    'developer.mozilla.org/en-US/docs/Web/HTTP',
+    // Search-engine invocation URLs (the tool's own query, not a result page)
+    'bing.com/search',
+    'duckduckgo.com/?q=',
+    'duckduckgo.com/html',
+    'search.brave.com',
+    'google.com/search',
+  ];
   // Generic: pull http(s) links from the tool output text, then strip
   // trailing punctuation / markdown noise (e.g. `}{GitHub}.`).
   const seen = new Set<string>();

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2957,7 +2957,7 @@ export function ChatConsole({
                   placeholder="请输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-[70px] max-h-[45vh] text-sm"
+                  className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[35vh] text-[15px]"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3587,32 +3587,36 @@ function MessageBubble({
   const isUser = msg.role === 'user';
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
 
-  const copyWithSelection = () => {
-    // If user has manually selected text, copy that
+  const selectMessageText = () => {
+    const textEl = bubbleRef.current?.querySelector('[class*="leading-relaxed"]') as HTMLElement | null;
+    if (!textEl) return;
+    const range = document.createRange();
+    range.selectNodeContents(textEl);
     const sel = window.getSelection();
-    const selText = sel?.toString().trim();
-    if (selText) { navigator.clipboard.writeText(selText); return; }
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  };
+
+  const deselectMessageText = () => {
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const copyWithSelection = () => {
+    const selText = window.getSelection()?.toString().trim();
+    if (selText) { navigator.clipboard.writeText(selText); deselectMessageText(); return; }
+    // No selection — copy full message with flash
+    selectMessageText();
     onCopy(msg.content);
-    // Flash-select after context menu overlay is dismissed
-    requestAnimationFrame(() => {
-      const textEl = bubbleRef.current?.querySelector('[class*="leading-relaxed"]') as HTMLElement | null;
-      if (textEl) {
-        const range = document.createRange();
-        range.selectNodeContents(textEl);
-        window.getSelection()?.removeAllRanges();
-        window.getSelection()?.addRange(range);
-        setTimeout(() => window.getSelection()?.removeAllRanges(), 1200);
-      }
-    });
+    setTimeout(deselectMessageText, 1000);
   };
 
   const contextItems: ContextMenuAction[] = isUser
     ? [
-        { label: '复制文本', icon: <Copy size={14} />, onSelect: copyWithSelection },
+        { label: '复制文本', icon: <Copy size={14} />, onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
         { label: '重试', icon: <Undo2 size={14} />, divider: true, onSelect: () => onRetry?.() },
       ]
     : [
-        { label: '复制文本', icon: <Copy size={14} />, onSelect: copyWithSelection },
+        { label: '复制文本', icon: <Copy size={14} />, onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
         ...(hasCodeBlock
           ? [
               {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2126,8 +2126,12 @@ export function ChatConsole({
   const adjustTextareaHeight = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+    // Defer to next frame so React's controlled value has synced to the DOM —
+    // otherwise fast deletes read a stale scrollHeight and the box stays big.
+    requestAnimationFrame(() => {
+      el.style.height = 'auto';
+      el.style.height = `${Math.max(el.scrollHeight, 52)}px`; // floor = min-h-[52px]
+    });
   }, []);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2122,17 +2122,18 @@ export function ChatConsole({
     [sessionKey]
   );
 
-  /** Auto-resize textarea to fit content */
-  const adjustTextareaHeight = useCallback(() => {
+  /**
+   * Auto-resize textarea to fit content.
+   * Runs as an effect after React commits, so the controlled value is always
+   * synced to the DOM — rAF could race React's render and read a stale
+   * scrollHeight (input box stays tall after deleting everything).
+   */
+  useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
-    // Defer to next frame so React's controlled value has synced to the DOM —
-    // otherwise fast deletes read a stale scrollHeight and the box stays big.
-    requestAnimationFrame(() => {
-      el.style.height = 'auto';
-      el.style.height = `${Math.max(el.scrollHeight, 52)}px`; // floor = min-h-[52px]
-    });
-  }, []);
+    el.style.height = 'auto';
+    el.style.height = `${Math.max(el.scrollHeight, 52)}px`; // floor = min-h-[52px]
+  }, [input]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -2481,7 +2482,6 @@ export function ChatConsole({
           navigator.clipboard.writeText(el.value.slice(s, e));
           el.setRangeText('', s, e, 'end');
           setInput(el.value);
-          adjustTextareaHeight();
           el.focus();
         },
       },
@@ -2503,7 +2503,6 @@ export function ChatConsole({
             const end = el.value.length;
             el.setRangeText(text, end, end, 'end');
             setInput(el.value);
-            adjustTextareaHeight();
             el.focus();
             // Jump message area to the latest (bottom) so newest answer stays visible
             requestAnimationFrame(() => {
@@ -2999,7 +2998,6 @@ export function ChatConsole({
                   value={input}
                   onChange={(e) => {
                     setInput(e.target.value);
-                    adjustTextareaHeight();
                   }}
                   onKeyDown={handleKeyDown}
                   placeholder="请输入消息或拖入文件..."

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -52,6 +52,9 @@ import {
   Scissors,
   ClipboardPaste,
   Code2,
+  RefreshCw,
+  ThumbsUp,
+  ThumbsDown,
 } from 'lucide-react';
 import type {
   ChatProgress,
@@ -1558,9 +1561,16 @@ export function ChatConsole({
     handleNewSession();
   }, [handleNewSession]);
 
+  /** Payload for programmatic sends (e.g. regenerate) — bypasses input state */
+  const retryPayloadRef = useRef<{ text: string; attachments: Attachment[] } | null>(null);
+  const handleSendRef = useRef<() => void>(() => {});
+
   const handleSend = useCallback(async () => {
-    const text = input.trim();
-    if (!text && attachments.length === 0) return;
+    const payload = retryPayloadRef.current;
+    retryPayloadRef.current = null;
+    const text = (payload?.text ?? input).trim();
+    const atts = payload?.attachments ?? attachments;
+    if (!text && atts.length === 0) return;
 
     try {
       const result = await window.miqi.providers.list();
@@ -1593,7 +1603,7 @@ export function ChatConsole({
     let content = text;
 
     // Build message content with embedded document text
-    for (const att of attachments) {
+    for (const att of atts) {
       if (att.type === 'text' && att.content) {
         content += `\n\n[File: ${att.name}]\n\`\`\`\n${att.content}\n\`\`\``;
       } else if (att.type === 'image' && att.dataUrl) {
@@ -1648,7 +1658,7 @@ export function ChatConsole({
     const userMsg: Message = {
       role: 'user',
       content: text || '(attachment)',
-      attachments: [...attachments],
+      attachments: [...atts],
       timestamp: Date.now(),
     };
     setMessages((prev) => [...prev, userMsg]);
@@ -1662,7 +1672,7 @@ export function ChatConsole({
     }, 0);
     setAttachments([]);
     // Save a snapshot before clearing — chat.send needs it later
-    const sentAttachments = [...attachments];
+    const sentAttachments = [...atts];
     setStreaming(true);
     cleanupListeners();
 
@@ -2079,6 +2089,12 @@ export function ChatConsole({
     }
   }, [input, attachments, streaming, cleanupListeners, onChatFinished, executionPolicy]);
 
+  // Keep handleSendRef fresh for programmatic sends (regenerate)
+  useEffect(() => {
+    handleSendRef.current = () => handleSend();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleSend]);
+
   // ── Download paper via chat ─────────────────────────────────────
   const handleDownloadPaper = useCallback(
     (paper: PaperItem) => {
@@ -2324,6 +2340,33 @@ export function ChatConsole({
       setAttachments(msg.attachments ?? []);
     },
     [streaming, cleanupListeners, messages]
+  );
+
+  /** Regenerate an assistant answer: rewind to its user message, resend automatically */
+  const handleRegenerate = useCallback(
+    async (assistantMsg: Message) => {
+      if (streaming) return;
+      const idx = messages.indexOf(assistantMsg);
+      if (idx < 0) return;
+      let userIdx = -1;
+      for (let i = idx - 1; i >= 0; i--) {
+        if (messages[i].role === 'user') {
+          userIdx = i;
+          break;
+        }
+      }
+      if (userIdx < 0) return;
+      const userMsg = messages[userIdx];
+      retryPayloadRef.current = {
+        text: userMsg.content,
+        attachments: userMsg.attachments ?? [],
+      };
+      setMessages((prev) => prev.slice(0, userIdx + 1)); // drop answer + everything after
+      setInput(userMsg.content);
+      setAttachments(userMsg.attachments ?? []);
+      requestAnimationFrame(() => handleSendRef.current());
+    },
+    [streaming, messages]
   );
 
   /* session display name — use the first user message as title */
@@ -2784,6 +2827,7 @@ export function ChatConsole({
                     onCopy={(text) => handleCopy(text, i)}
                     isCopied={copiedIdx === i}
                     onRetry={() => handleRetry(msg)}
+                    onRegenerate={() => handleRegenerate(msg)}
                     onOpenProviderSettings={onOpenProviderSettings}
                     onDownloadPaper={handleDownloadPaper}
                     downloadingPaperId={downloadingPaperId}
@@ -3480,6 +3524,7 @@ function MessageBubble({
   onCopy,
   isCopied,
   onRetry,
+  onRegenerate,
   onOpenProviderSettings,
   onDownloadPaper,
   downloadingPaperId,
@@ -3491,11 +3536,14 @@ function MessageBubble({
   onCopy: (text: string) => void;
   isCopied: boolean;
   onRetry?: () => void;
+  onRegenerate?: () => void;
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
   downloadingPaperId?: string | null;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [feedback, setFeedback] = useState<'up' | 'down' | null>(null);
+  const [showSources, setShowSources] = useState(false);
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   if (msg.role === 'progress') {
@@ -3658,6 +3706,7 @@ function MessageBubble({
       ];
 
   return (
+    <>
     <ContextMenu items={contextItems}>
       {({ onContextMenu }) => (
         <div
@@ -3819,12 +3868,85 @@ function MessageBubble({
                 {isCopied ? <Check size={12} /> : <Copy size={12} />}
               </button>
             )}
+
+            {/* action bar — regenerate / like / dislike / sources */}
+            {!isUser && msg.content !== '' && (
+              <div className="flex items-center gap-0.5 self-start pt-0.5 text-text-faint">
+                <button
+                  onClick={() => onRegenerate?.()}
+                  title="重新生成"
+                  className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
+                >
+                  <RefreshCw size={13} />
+                </button>
+                <button
+                  onClick={() => setFeedback((f) => (f === 'up' ? null : 'up'))}
+                  title="喜欢"
+                  className={`p-1 rounded hover:bg-[var(--surface-muted)] transition-colors ${feedback === 'up' ? 'text-[var(--accent)]' : ''}`}
+                >
+                  <ThumbsUp size={13} />
+                </button>
+                <button
+                  onClick={() => setFeedback((f) => (f === 'down' ? null : 'down'))}
+                  title="不喜欢"
+                  className={`p-1 rounded hover:bg-[var(--surface-muted)] transition-colors ${feedback === 'down' ? 'text-[var(--danger)]' : ''}`}
+                >
+                  <ThumbsDown size={13} />
+                </button>
+                <button
+                  onClick={() => setShowSources(true)}
+                  title="查看来源"
+                  className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
+                >
+                  <ExternalLink size={13} />
+                </button>
+              </div>
+            )}
           </div>
 
           {isUser && <UserAvatar />}
         </div>
       )}
     </ContextMenu>
+
+    {/* Sources modal */}
+    <Modal
+      open={showSources}
+      onOpenChange={setShowSources}
+      title="消息来源"
+    >
+      <div className="text-xs space-y-2">
+        <div className="flex gap-2">
+          <span className="text-text-faint w-16 shrink-0">角色</span>
+          <span>{isUser ? '用户' : msg.role === 'assistant' ? 'MiQi' : msg.role}</span>
+        </div>
+        {msg.toolName && (
+          <div className="flex gap-2">
+            <span className="text-text-faint w-16 shrink-0">工具</span>
+            <span className="font-mono">{msg.toolName}</span>
+          </div>
+        )}
+        {msg.toolCallId && (
+          <div className="flex gap-2">
+            <span className="text-text-faint w-16 shrink-0">调用 ID</span>
+            <span className="font-mono break-all">{msg.toolCallId}</span>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <span className="text-text-faint w-16 shrink-0">时间</span>
+          <span>{new Date(msg.timestamp).toLocaleString('zh-CN')}</span>
+        </div>
+        {msg.toolData ? (
+          <div className="pt-1 border-t border-[var(--border-subtle)]">
+            <div className="text-text-faint mb-1">工具数据</div>
+            <pre className="bg-[var(--surface-muted)] rounded-lg p-2 overflow-x-auto text-[10px] leading-relaxed max-h-48 overflow-y-auto">
+              {JSON.stringify(msg.toolData, null, 2).slice(0, 2000)}
+            </pre>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2924,12 +2924,16 @@ export function ChatConsole({
                 </div>
               )}
 
-              {/* AI disclaimer — above the input box, centered (ChatGPT style) */}
-              {!input.trim() && attachments.length === 0 && (
-                <div className="text-center pb-2.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
-                  AI 也会犯错误，对于重要答案请谨慎验证
-                </div>
-              )}
+              {/* AI disclaimer — keeps its space, only fades (no layout jump) */}
+              <div
+                className="text-center pb-2.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none transition-opacity duration-300"
+                style={{
+                  opacity: !input.trim() && attachments.length === 0 ? 1 : 0,
+                  pointerEvents: !input.trim() && attachments.length === 0 ? 'auto' : 'none',
+                }}
+              >
+                AI 也会犯错误，对于重要答案请谨慎验证
+              </div>
 
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2802,12 +2802,11 @@ export function ChatConsole({
             </div>
           </div>
 
-          {/* Composer — floats over the bottom, messages never get squeezed */}
+          {/* Composer — floats over the bottom, fully transparent so answers show through */}
           <div
             className="absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
             style={{
-              background:
-                'linear-gradient(to top, var(--background) 15%, rgba(0,0,0,0) 100%)',
+              background: 'transparent',
             }}
           >
             <div className="max-w-[760px] mx-auto">
@@ -2955,10 +2954,10 @@ export function ChatConsole({
                     adjustTextareaHeight();
                   }}
                   onKeyDown={handleKeyDown}
-                  placeholder="输入消息或拖入文件..."
+                  placeholder="请输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[33vh] text-sm"
+                  className="w-full border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-[70px] max-h-[45vh] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -186,6 +186,8 @@ interface Message {
   toolName?: string;
   /** Parsed tool data for card rendering */
   toolData?: unknown;
+  /** Original tool-call arguments (e.g. web_fetch's url) — real references */
+  toolArgs?: unknown;
   action?: 'open-provider-settings';
   actionLabel?: string;
   /** When true the message is collapsed by default (user can click to expand) */
@@ -200,21 +202,11 @@ interface MessageSource {
   url: string;
 }
 
-/** Extract reference URLs from a tool/progress message (paper_search cards, web fetches, …). */
+/** Extract reference URLs from a tool/progress message.
+ *  Priority: the URL the tool actually touched (toolArgs) > structured
+ *  paper_search cards > links found in result text (fallback). */
 function extractMessageSources(msg: Message): MessageSource[] {
   const sources: MessageSource[] = [];
-  if (msg.toolName === 'paper_search') {
-    // Structured card data is the source of truth; empty/failed searches
-    // carry only internal API URLs — never surface those as references.
-    if (!msg.toolData) return sources;
-    const items = (msg.toolData as { items?: { url?: string; arxiv_id?: string }[] }).items ?? [];
-    for (const it of items) {
-      const url = it.url || (it.arxiv_id ? `https://arxiv.org/abs/${it.arxiv_id}` : '');
-      if (url) sources.push({ tool: 'paper_search', url });
-    }
-    return sources;
-  }
-  // Skip internal/API machinery URLs — not user-facing references.
   const skip = [
     'api.semanticscholar.org',
     '/graph/v1/',
@@ -231,12 +223,36 @@ function extractMessageSources(msg: Message): MessageSource[] {
     'user.guancha.cn/main/search',
     'beian.miit.gov.cn',
   ];
-  // Generic: pull http(s) links from the tool output text, then strip
-  // trailing punctuation / markdown noise (e.g. `}{GitHub}.`).
+  const clean = (raw: string): string =>
+    raw.split('{')[0].replace(/[.,;:!?。，；：、）\]]+$/, '');
+
+  // 1. The exact URL the tool fetched/searched — most trustworthy.
+  if (msg.toolArgs && typeof msg.toolArgs === 'object') {
+    const args = msg.toolArgs as Record<string, unknown>;
+    for (const key of ['url', 'link', 'href', 'query']) {
+      const v = args[key];
+      if (typeof v === 'string' && /^https?:\/\//i.test(v) && !skip.some((s) => v.includes(s))) {
+        sources.push({ tool: msg.toolName || 'tool', url: clean(v) });
+      }
+    }
+  }
+
+  // 2. paper_search card data.
+  if (msg.toolName === 'paper_search' && msg.toolData) {
+    const items = (msg.toolData as { items?: { url?: string; arxiv_id?: string }[] }).items ?? [];
+    for (const it of items) {
+      const url = it.url || (it.arxiv_id ? `https://arxiv.org/abs/${it.arxiv_id}` : '');
+      if (url) sources.push({ tool: 'paper_search', url: clean(url) });
+    }
+    return sources;
+  }
+  if (msg.toolName === 'paper_search') return sources; // failed search: no refs
+
+  // 3. Fallback: links inside the result text (deduped, noise filtered).
   const seen = new Set<string>();
   const content = String(msg.content ?? '');
   for (const m of content.matchAll(/https?:\/\/[^\s"'<>)\]]+/g)) {
-    let url = m[0].split('{')[0].replace(/[.,;:!?。，；：、）\]]+$/, '');
+    const url = clean(m[0]);
     if (!url || seen.has(url) || skip.some((s) => url.includes(s))) continue;
     seen.add(url);
     sources.push({ tool: msg.toolName || 'tool', url });
@@ -725,6 +741,7 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
       // Tool result messages → show as collapsed progress with toolHint
       const toolName = m.name || 'tool';
       const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+      const toolArgs = (m as { arguments?: unknown }).arguments;
 
       // Detect paper_search results → render as cards (not collapsed)
       if (toolName === 'paper_search') {
@@ -737,6 +754,7 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
             toolHint: true,
             toolName: 'paper_search',
             toolData: paperData,
+            toolArgs,
             collapsed: false,
             timestamp: ts,
           });
@@ -747,6 +765,7 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
             content: content, // full output — sources extraction needs all URLs
             summary: 'paper_search',
             toolHint: true,
+            toolArgs,
             collapsed: true,
             timestamp: ts,
           });
@@ -759,6 +778,7 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
           content: content,
           summary: toolName,
           toolHint: true,
+          toolArgs,
           collapsed: true,
           timestamp: ts,
         });
@@ -1145,6 +1165,7 @@ export function ChatConsole({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composerRef = useRef<HTMLDivElement>(null);
+  const toolArgsByCallId = useRef<Map<string, unknown>>(new Map());
   const previewJustClosed = useRef(false);
   const unsubsRef = useRef<Array<() => void>>([]);
   const finalCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1897,6 +1918,9 @@ export function ChatConsole({
             toolCallId: data.tool_call_id,
             toolName,
             toolData,
+            toolArgs: data.tool_call_id
+              ? toolArgsByCallId.current.get(data.tool_call_id)
+              : undefined,
             timestamp: Date.now(),
           },
         ]);
@@ -1934,6 +1958,16 @@ export function ChatConsole({
           const fn = tc?.function || tc?.tool?.function || {};
           const toolName: string = fn?.name || '';
           if (!toolName) continue;
+          // Remember call args so the matching tool result can show the exact
+          // URL the tool touched (web_fetch etc.) in "查看来源".
+          const callId: string = tc?.id || '';
+          if (callId && fn?.arguments) {
+            try {
+              toolArgsByCallId.current.set(callId, JSON.parse(fn.arguments));
+            } catch {
+              toolArgsByCallId.current.set(callId, fn.arguments);
+            }
+          }
           const filePath: string = _extractPathFromArgs(fn?.arguments || '{}') || '';
           if (!filePath) continue;
           if (_FILE_WRITE_TOOLS.includes(toolName)) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2425,11 +2425,45 @@ export function ChatConsole({
 
   const inputContextItems = useMemo<ContextMenuAction[]>(
     () => [
-      { label: '剪切', icon: <Scissors size={14} />, shortcut: 'Ctrl+X', onSelect: () => document.execCommand('cut') },
-      { label: '复制', icon: <Copy size={14} />, shortcut: 'Ctrl+C', onSelect: () => document.execCommand('copy') },
-      { label: '粘贴', icon: <ClipboardPaste size={14} />, shortcut: 'Ctrl+V', onSelect: () => document.execCommand('paste') },
-      { label: '全选', icon: <CheckCircle size={14} />, shortcut: 'Ctrl+A', divider: true, onSelect: () => document.execCommand('selectAll') },
+      {
+        label: '剪切', icon: <Scissors size={14} />, shortcut: 'Ctrl+X',
+        onSelect: () => {
+          const el = textareaRef.current; if (!el) return;
+          const s = el.selectionStart, e = el.selectionEnd;
+          if (s === e) return;
+          navigator.clipboard.writeText(el.value.slice(s, e));
+          el.setRangeText('', s, e, 'end');
+          setInput(el.value);
+          el.focus();
+        },
+      },
+      {
+        label: '复制', icon: <Copy size={14} />, shortcut: 'Ctrl+C',
+        onSelect: () => {
+          const el = textareaRef.current; if (!el) return;
+          const txt = el.value.slice(el.selectionStart, el.selectionEnd);
+          if (txt) navigator.clipboard.writeText(txt);
+        },
+      },
+      {
+        label: '粘贴', icon: <ClipboardPaste size={14} />, shortcut: 'Ctrl+V',
+        onSelect: () => {
+          const el = textareaRef.current; if (!el) return;
+          navigator.clipboard.readText().then((text) => {
+            if (!text) return;
+            const s = el.selectionStart, e = el.selectionEnd;
+            el.setRangeText(text, s, e, 'end');
+            setInput(el.value);
+            el.focus();
+          }).catch(() => {});
+        },
+      },
+      {
+        label: '全选', icon: <CheckCircle size={14} />, shortcut: 'Ctrl+A', divider: true,
+        onSelect: () => textareaRef.current?.select(),
+      },
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 
@@ -3552,13 +3586,19 @@ function MessageBubble({
   const isUser = msg.role === 'user';
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
 
+  const copyWithSelection = () => {
+    const sel = window.getSelection()?.toString().trim();
+    if (sel) { navigator.clipboard.writeText(sel); return; }
+    onCopy(msg.content);
+  };
+
   const contextItems: ContextMenuAction[] = isUser
     ? [
-        { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
+        { label: '复制文本', icon: <Copy size={14} />, onSelect: copyWithSelection },
         { label: '重试', icon: <Undo2 size={14} />, divider: true, onSelect: () => onRetry?.() },
       ]
     : [
-        { label: '复制文本', icon: <Copy size={14} />, onSelect: () => onCopy(msg.content) },
+        { label: '复制文本', icon: <Copy size={14} />, onSelect: copyWithSelection },
         ...(hasCodeBlock
           ? [
               {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2319,7 +2319,7 @@ export function ChatConsole({
       if (streaming) return;
       cleanupListeners();
       const idx = messages.indexOf(msg);
-      if (idx >= 0) setMessages((prev) => prev.slice(0, idx));
+      if (idx >= 0) setMessages((prev) => prev.slice(0, idx + 1)); // keep the retried message
       setInput(msg.content);
       setAttachments(msg.attachments ?? []);
     },
@@ -2960,7 +2960,7 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 text-sm"
+                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-32 text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />
@@ -3473,6 +3473,7 @@ function MessageBubble({
   downloadingPaperId?: string | null;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const bubbleRef = useRef<HTMLDivElement>(null);
 
   if (msg.role === 'progress') {
     // ── Paper search result: render formatted cards ──────────────
@@ -3587,9 +3588,19 @@ function MessageBubble({
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
 
   const copyWithSelection = () => {
-    const sel = window.getSelection()?.toString().trim();
-    if (sel) { navigator.clipboard.writeText(sel); return; }
+    // If user has manually selected text, copy that
+    const sel = window.getSelection();
+    const selText = sel?.toString().trim();
+    if (selText) { navigator.clipboard.writeText(selText); return; }
+    // Flash-select the message text so user sees what's being copied
+    if (bubbleRef.current) {
+      const range = document.createRange();
+      range.selectNodeContents(bubbleRef.current);
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+    }
     onCopy(msg.content);
+    setTimeout(() => window.getSelection()?.removeAllRanges(), 1200);
   };
 
   const contextItems: ContextMenuAction[] = isUser
@@ -3622,6 +3633,7 @@ function MessageBubble({
     <ContextMenu items={contextItems}>
       {({ onContextMenu }) => (
         <div
+          ref={bubbleRef}
           className={cn('flex items-start gap-3', isUser && 'justify-end')}
           onContextMenu={onContextMenu}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2982,8 +2982,8 @@ export function ChatConsole({
               </div>
                 )}
               </ContextMenu>
-              {/* Mode selector — BELOW the input box, outside its container */}
-              <div className="flex items-center justify-center mt-2">
+              {/* Mode selector — BELOW the input box, bottom-left corner */}
+              <div className="flex items-center justify-start mt-2">
                 <ExecutionPolicySelector
                   policy={executionPolicy}
                   onChange={setExecutionPolicy}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -251,8 +251,11 @@ function extractMessageSources(msg: Message): MessageSource[] {
   };
 
   // 1. The exact URL the tool fetched/searched — most trustworthy.
-  if (msg.toolArgs && typeof msg.toolArgs === 'object') {
-    const args = msg.toolArgs as Record<string, unknown>;
+  //    toolArgs may be a single object or an array (merged tool-result group).
+  const argsList = Array.isArray(msg.toolArgs) ? msg.toolArgs : [msg.toolArgs];
+  for (const argsRaw of argsList) {
+    if (!argsRaw || typeof argsRaw !== 'object') continue;
+    const args = argsRaw as Record<string, unknown>;
     for (const key of ['url', 'link', 'href', 'query']) {
       const v = args[key];
       if (typeof v === 'string' && /^https?:\/\//i.test(v) && !skip.some((s) => v.includes(s))) {
@@ -819,6 +822,15 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
         : `${prev.summary}, ${msg.summary}`; // merge two single items
       // Use the later timestamp
       prev.timestamp = msg.timestamp;
+      // Keep every tool call's arguments in the group — "查看来源" needs the
+      // exact URL each web_fetch/web_search actually touched, not just the first.
+      const prevArgs = Array.isArray(prev.toolArgs)
+        ? prev.toolArgs
+        : prev.toolArgs !== undefined
+          ? [prev.toolArgs]
+          : [];
+      if (msg.toolArgs !== undefined) prevArgs.push(msg.toolArgs);
+      if (prevArgs.length > 0) prev.toolArgs = prevArgs;
     } else {
       merged.push({ ...msg });
     }
@@ -1315,6 +1327,7 @@ export function ChatConsole({
     cleanupListeners();
     currentSessionRef.current = sessionKey;
     currentThreadIdRef.current = null; // Reset on session change
+    toolArgsByCallId.current.clear(); // drop tool-call args from the previous session
     setHistoryLoaded(false);
     setMessages([]);
     setSessionUpdatedAt(null);
@@ -1658,10 +1671,12 @@ export function ChatConsole({
 
   const handleSend = useCallback(async () => {
     const payload = retryPayloadRef.current;
-    retryPayloadRef.current = null;
     const text = (payload?.text ?? input).trim();
     const atts = payload?.attachments ?? attachments;
-    if (!text && atts.length === 0) return;
+    if (!text && atts.length === 0) {
+      retryPayloadRef.current = null;
+      return;
+    }
     // Retry/regenerate: nudge the model to answer differently — the stored
     // user message stays clean, only the outbound content gets the hint.
     const retryHint = payload?.retry
@@ -1672,6 +1687,7 @@ export function ChatConsole({
       const result = await window.miqi.providers.list();
       const hasConfiguredProvider = result.providers.some((provider) => provider.configured);
       if (!hasConfiguredProvider) {
+        retryPayloadRef.current = null;
         setMessages((prev) => [...prev, createProviderConfigMessage()]);
         return;
       }
@@ -1679,6 +1695,8 @@ export function ChatConsole({
       // If provider status cannot be read, keep the original send path so the
       // bridge can surface the underlying runtime error.
     }
+    // All early-return guards passed — the retry payload is now consumed.
+    retryPayloadRef.current = null;
 
     // If a reveal animation is still running from the previous response,
     // cancel it and abort the in-flight request so we can start fresh.
@@ -2022,10 +2040,19 @@ export function ChatConsole({
 
         setMessages((prev) => {
           const cleaned = removeTransientTurnMessagesSinceLastUser(prev);
+          // Backfill toolArgs on streamed progress messages — call arguments
+          // only arrive in chat:final, after the progress events rendered.
+          const backfilled = cleaned.map((m) => {
+            if (m.role === 'progress' && m.toolCallId && m.toolArgs === undefined) {
+              const args = toolArgsByCallId.current.get(m.toolCallId);
+              if (args !== undefined) return { ...m, toolArgs: args };
+            }
+            return m;
+          });
           // Only append collapsed tool-call group if streaming didn't
           // already render toolHint progress for this turn (avoids dupes).
-          const hasToolHints = cleaned.some((m) => m.role === 'progress' && m.toolHint);
-          if (hasToolHints) return cleaned;
+          const hasToolHints = backfilled.some((m) => m.role === 'progress' && m.toolHint);
+          if (hasToolHints) return backfilled;
           const toolMessages = sessionMsgsToUi([
             {
               role: 'assistant',
@@ -2034,7 +2061,7 @@ export function ChatConsole({
               timestamp: new Date().toISOString(),
             },
           ]);
-          return [...cleaned, ...toolMessages];
+          return [...backfilled, ...toolMessages];
         });
       } else {
         setMessages((prev) => removeTransientTurnMessagesSinceLastUser(prev));
@@ -2454,14 +2481,25 @@ export function ChatConsole({
   const sourcesByMsg = useMemo(() => {
     const map = new Map<Message, MessageSource[]>();
     let pending: MessageSource[] = [];
+    let seen = new Set<string>();
+    const MAX_SOURCES = 20;
+    const merge = (next: MessageSource[]) => {
+      for (const s of next) {
+        if (seen.has(s.url) || pending.length >= MAX_SOURCES) continue;
+        seen.add(s.url);
+        pending.push(s);
+      }
+    };
     for (const m of messages) {
       if (m.role === 'progress') {
-        pending = [...pending, ...extractMessageSources(m)];
+        merge(extractMessageSources(m));
       } else if (m.role === 'user') {
         pending = [];
+        seen = new Set();
       } else if (m.role === 'assistant') {
         map.set(m, pending);
         pending = [];
+        seen = new Set();
       }
     }
     return map;
@@ -2620,7 +2658,7 @@ export function ChatConsole({
           const el = textareaRef.current; if (!el) return;
           const s = el.selectionStart, e = el.selectionEnd;
           if (s === e) return;
-          navigator.clipboard.writeText(el.value.slice(s, e));
+          navigator.clipboard.writeText(el.value.slice(s, e)).catch(() => {});
           el.setRangeText('', s, e, 'end');
           // Let React's onChange pick up the new value — manual setInput can
           // drift from the DOM (deleting then requires two passes).
@@ -2633,7 +2671,7 @@ export function ChatConsole({
         onSelect: () => {
           const el = textareaRef.current; if (!el) return;
           const txt = el.value.slice(el.selectionStart, el.selectionEnd);
-          if (txt) navigator.clipboard.writeText(txt);
+          if (txt) navigator.clipboard.writeText(txt).catch(() => {});
         },
       },
       {
@@ -2642,18 +2680,15 @@ export function ChatConsole({
           const el = textareaRef.current; if (!el) return;
           navigator.clipboard.readText().then((text) => {
             if (!text) return;
-            // Always append to the end, cursor lands after pasted content
-            const end = el.value.length;
-            el.setRangeText(text, end, end, 'end');
+            // Insert at the caret like native Ctrl+V — replace the current
+            // selection range instead of always appending at the end.
+            const s = el.selectionStart ?? el.value.length;
+            const e = el.selectionEnd ?? s;
+            el.setRangeText(text, s, e, 'end');
             // Let React's onChange pick up the new value (single source of
             // truth for state vs DOM — avoids double-delete drift).
             el.dispatchEvent(new Event('input', { bubbles: true }));
             el.focus();
-            // Jump message area to the latest (bottom) so newest answer stays visible
-            requestAnimationFrame(() => {
-              const sc = scrollRef.current;
-              if (sc) sc.scrollTop = sc.scrollHeight;
-            });
           }).catch(() => {});
         },
       },
@@ -2941,7 +2976,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto relative"
             style={{ background: 'var(--background)', paddingBottom: `calc(${composerHeight}px + ${ANSWER_GAP})` }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2966,21 +3001,24 @@ export function ChatConsole({
                 </div>
               ) : (
                 messages.map((msg, i) => (
-                  <MessageBubble
+                  <div
                     key={`${msg.timestamp}-${i}`}
-                    msg={msg}
-                    execOutputs={execOutputs}
-                    inlineExecOutput={inlineExecOutput}
-                    sources={sourcesByMsg.get(msg) ?? []}
-                    isLast={i === messages.length - 1}
-                    onCopy={(text) => handleCopy(text, i)}
-                    isCopied={copiedIdx === i}
-                    onRetry={() => handleRetry(msg)}
-                    onRegenerate={() => handleRegenerate(msg)}
-                    onOpenProviderSettings={onOpenProviderSettings}
-                    onDownloadPaper={handleDownloadPaper}
-                    downloadingPaperId={downloadingPaperId}
-                  />
+                  >
+                    <MessageBubble
+                      msg={msg}
+                      execOutputs={execOutputs}
+                      inlineExecOutput={inlineExecOutput}
+                      sources={sourcesByMsg.get(msg) ?? []}
+                      isLast={i === messages.length - 1}
+                      onCopy={(text) => handleCopy(text, i)}
+                      isCopied={copiedIdx === i}
+                      onRetry={() => handleRetry(msg)}
+                      onRegenerate={() => handleRegenerate(msg)}
+                      onOpenProviderSettings={onOpenProviderSettings}
+                      onDownloadPaper={handleDownloadPaper}
+                      downloadingPaperId={downloadingPaperId}
+                    />
+                  </div>
                 ))
               )}
               {streaming && (
@@ -2993,7 +3031,10 @@ export function ChatConsole({
                 </div>
               )}
             </div>
+
           </div>
+
+
 
           {/* Composer — floats over the bottom; the answer stream never moves.
               Messages reserve composerHeight + ANSWER_GAP via paddingBottom, so
@@ -3001,12 +3042,12 @@ export function ChatConsole({
               matter how tall the textarea grows. */}
           <div
             ref={composerRef}
-            className="absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
+            className="pointer-events-none absolute bottom-0 left-0 right-0 px-5 pb-10 pt-3"
             style={{
               background: 'transparent',
             }}
           >
-            <div className="max-w-[760px] mx-auto">
+            <div className="pointer-events-auto max-w-[760px] mx-auto">
               {attachments.length > 0 && (
                 <div className="flex flex-wrap gap-2 mb-2">
                   {attachments.map((att, i) => {
@@ -3715,6 +3756,9 @@ function MessageBubble({
   // Verify source links when the modal opens — drop 404s so users never
   // click a dead reference.
   const [validating, setValidating] = useState(false);
+  // Stable key from the URL list — the sources array identity changes on every
+  // streaming re-render; depending on it would restart validation each frame.
+  const sourceKey = useMemo(() => (sources ?? []).map((s) => s.url).join('|'), [sources]);
   useEffect(() => {
     if (!showSources) return;
     let cancelled = false;
@@ -3726,7 +3770,15 @@ function MessageBubble({
     }
     setValidating(true);
     let done = 0;
-    list.forEach((s) => {
+    // Bounded worker pool — 4 concurrent checks max (each can take up to 16s
+    // in the main process: 8s HEAD + 8s GET retry).
+    const MAX_CONCURRENT = 4;
+    let idx = 0;
+    const runNext = () => {
+      if (cancelled) return;
+      const s = list[idx];
+      if (!s) return;
+      idx += 1;
       window.miqi.web
         .checkUrl(s.url)
         .then((r) => {
@@ -3739,13 +3791,16 @@ function MessageBubble({
           if (!cancelled) {
             done += 1;
             if (done === list.length) setValidating(false);
+            else runNext();
           }
         });
-    });
+    };
+    for (let i = 0; i < Math.min(MAX_CONCURRENT, list.length); i++) runNext();
     return () => {
       cancelled = true;
     };
-  }, [showSources, sources]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSources, sourceKey]);
 
   if (msg.role === 'progress') {
     // ── Paper search result: render formatted cards ──────────────
@@ -3860,7 +3915,9 @@ function MessageBubble({
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
 
   const selectMessageText = () => {
-    const textEl = bubbleRef.current?.querySelector('[class*="leading-relaxed"]') as HTMLElement | null;
+    // Stable hook attribute — a Tailwind class substring would silently break
+    // if the bubble's styling classes ever change.
+    const textEl = bubbleRef.current?.querySelector('[data-message-body]') as HTMLElement | null;
     if (!textEl) return;
     const range = document.createRange();
     range.selectNodeContents(textEl);
@@ -4030,14 +4087,21 @@ function MessageBubble({
 
             {/* Main bubble */}
             <div
+              data-message-body
               className="text-sm leading-relaxed rounded-2xl px-4 py-3"
               style={
                 isUser
-                  ? { background: 'var(--bubble-user-bg)', color: 'var(--bubble-user-text)' }
+                  ? {
+                      background:
+                        'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
+                      color: 'var(--bubble-user-text)',
+                      borderBottomRightRadius: 6,
+                    }
                   : {
                       background: 'var(--bubble-ai-bg)',
                       color: 'var(--bubble-ai-text)',
                       border: '1px solid var(--bubble-ai-border)',
+                      borderBottomLeftRadius: 6,
                     }
               }
             >
@@ -4181,7 +4245,7 @@ function MessageBubble({
                           {n}
                         </span>
                         <img
-                          src={`https://www.google.com/s2/favicons?domain=${host}&sz=32`}
+                          src={`${new URL(s.url).origin}/favicon.ico`}
                           alt=""
                           className="w-4 h-4 shrink-0 rounded-sm"
                           onError={(e) => {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2797,7 +2797,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto pb-[20vh]"
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1587,7 +1587,7 @@ export function ChatConsole({
   }, [handleNewSession]);
 
   /** Payload for programmatic sends (e.g. regenerate) — bypasses input state */
-  const retryPayloadRef = useRef<{ text: string; attachments: Attachment[] } | null>(null);
+  const retryPayloadRef = useRef<{ text: string; attachments: Attachment[]; retry?: boolean } | null>(null);
   const handleSendRef = useRef<() => void>(() => {});
 
   const handleSend = useCallback(async () => {
@@ -1596,6 +1596,11 @@ export function ChatConsole({
     const text = (payload?.text ?? input).trim();
     const atts = payload?.attachments ?? attachments;
     if (!text && atts.length === 0) return;
+    // Retry/regenerate: nudge the model to answer differently — the stored
+    // user message stays clean, only the outbound content gets the hint.
+    const retryHint = payload?.retry
+      ? '\n\n[系统提示：这是重试请求。请换一个角度重新回答，不要复述之前的答案。]'
+      : '';
 
     try {
       const result = await window.miqi.providers.list();
@@ -1625,7 +1630,7 @@ export function ChatConsole({
     const reqId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     setCurrentReqId(reqId);
 
-    let content = text;
+    let content = text + retryHint;
 
     // Build message content with embedded document text
     for (const att of atts) {
@@ -2364,16 +2369,24 @@ export function ChatConsole({
     setTimeout(() => setCopiedIdx(null), 2000);
   };
 
+  /** Retry a user message: rewind to it, resend automatically with a
+   *  "answer differently" hint so the model doesn't repeat itself. */
   const handleRetry = useCallback(
     async (msg: Message) => {
       if (streaming) return;
-      cleanupListeners();
       const idx = messages.indexOf(msg);
-      if (idx >= 0) setMessages((prev) => prev.slice(0, idx + 1)); // keep the retried message
+      if (idx < 0) return;
+      retryPayloadRef.current = {
+        text: msg.content,
+        attachments: msg.attachments ?? [],
+        retry: true,
+      };
+      setMessages((prev) => prev.slice(0, idx + 1)); // keep the retried message
       setInput(msg.content);
       setAttachments(msg.attachments ?? []);
+      requestAnimationFrame(() => handleSendRef.current());
     },
-    [streaming, cleanupListeners, messages]
+    [streaming, messages]
   );
 
   /** Regenerate an assistant answer: rewind to its user message, resend automatically */
@@ -2394,6 +2407,7 @@ export function ChatConsole({
       retryPayloadRef.current = {
         text: userMsg.content,
         attachments: userMsg.attachments ?? [],
+        retry: true,
       };
       setMessages((prev) => prev.slice(0, userIdx + 1)); // drop answer + everything after
       setInput(userMsg.content);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2124,8 +2124,9 @@ export function ChatConsole({
    * always shrinks back when emptied. min/max-height still clamp it.
    */
 
-  /** Fixed gap between the last answer and the composer (px) */
-  const ANSWER_GAP = 10;
+  /** Fixed gap between the last answer and the composer — 1/5 of the viewport,
+   *  the distance the user confirmed earlier. */
+  const ANSWER_GAP = '20vh';
   const [composerHeight, setComposerHeight] = useState(0);
   useEffect(() => {
     const el = composerRef.current;
@@ -2801,7 +2802,7 @@ export function ChatConsole({
           <div
             ref={scrollRef}
             className="flex-1 overflow-y-auto"
-            style={{ background: 'var(--background)', paddingBottom: composerHeight + ANSWER_GAP }}
+            style={{ background: 'var(--background)', paddingBottom: `calc(${composerHeight}px + ${ANSWER_GAP})` }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
               {!historyLoaded ? (

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { DiffView } from './components/DiffView';
@@ -1663,13 +1663,7 @@ export function ChatConsole({
     };
     setMessages((prev) => [...prev, userMsg]);
     userScrolledUp.current = false; // user sent a message — resume auto-scroll
-    setInput('');
-    // Reset textarea height after sending
-    setTimeout(() => {
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto';
-      }
-    }, 0);
+    setInput(''); // field-sizing: content shrinks the textarea automatically
     setAttachments([]);
     // Save a snapshot before clearing — chat.send needs it later
     const sentAttachments = [...atts];
@@ -2123,17 +2117,11 @@ export function ChatConsole({
   );
 
   /**
-   * Auto-resize textarea to fit content.
-   * Runs synchronously after EVERY render (no dep array) — any path that
-   * changes the value (typing, paste, cut, delete, undo, send) gets its
-   * height recomputed, so a tall box always shrinks back once emptied.
+   * Textarea auto-height is handled natively via `field-sizing: content`
+   * (Chromium 123+; Electron 39 = Chromium 142). No JS resize logic —
+   * the browser recomputes height on every value change, so a tall box
+   * always shrinks back when emptied. min/max-height still clamp it.
    */
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${Math.max(el.scrollHeight, 52)}px`; // floor = min-h-[52px]
-  });
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -2482,8 +2470,6 @@ export function ChatConsole({
           navigator.clipboard.writeText(el.value.slice(s, e));
           el.setRangeText('', s, e, 'end');
           setInput(el.value);
-          el.style.height = 'auto';
-          el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
           el.focus();
         },
       },
@@ -2505,8 +2491,6 @@ export function ChatConsole({
             const end = el.value.length;
             el.setRangeText(text, end, end, 'end');
             setInput(el.value);
-            el.style.height = 'auto';
-            el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
             el.focus();
             // Jump message area to the latest (bottom) so newest answer stays visible
             requestAnimationFrame(() => {
@@ -3002,14 +2986,6 @@ export function ChatConsole({
                   value={input}
                   onChange={(e) => {
                     setInput(e.target.value);
-                    // Synchronous resize: at onChange time the DOM value is
-                    // already the new one, so scrollHeight is exact. Belt-and-
-                    // braces with the useLayoutEffect below.
-                    const el = textareaRef.current;
-                    if (el) {
-                      el.style.height = 'auto';
-                      el.style.height = `${Math.max(el.scrollHeight, 52)}px`;
-                    }
                   }}
                   onKeyDown={handleKeyDown}
                   placeholder="请输入消息或拖入文件..."
@@ -3017,7 +2993,7 @@ export function ChatConsole({
                   allowResize={true}
                   className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
                   disabled={streaming}
-                  style={{ color: 'var(--text)' }}
+                  style={{ color: 'var(--text)', fieldSizing: 'content' }}
                 />
                 {/* Icon row at the bottom — no text, like DeepSeek */}
                 <div className="flex items-center gap-3 pt-1.5 mt-0.5 border-t border-[var(--border-subtle)]">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2960,7 +2960,7 @@ export function ChatConsole({
                   placeholder="输入消息或拖入文件..."
                   rows={1}
                   allowResize={true}
-                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-32 text-sm"
+                  className="flex-1 border-0 bg-transparent p-0! leading-6! focus:ring-0 focus:border-0 min-h-0 max-h-[33vh] text-sm"
                   disabled={streaming}
                   style={{ color: 'var(--text)' }}
                 />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4185,6 +4185,9 @@ function MessageBubble({
             {deadUrls.size === 0 && (sources ?? []).length > 0 && (
               <p className="text-[11px] text-text-faint py-0.5">正在验证链接可用性…</p>
             )}
+            {deadUrls.size > 0 && (
+              <p className="text-[11px] text-text-faint py-0.5">已过滤 {deadUrls.size} 个失效链接</p>
+            )}
           </div>
         )}
         <div className="flex gap-2 pt-2 border-t border-[var(--border-subtle)]">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2925,7 +2925,7 @@ export function ChatConsole({
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
-                className="flex flex-col gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
+                className="flex items-end gap-2 rounded-xl px-4 py-3 focus-within:ring-2 transition-all"
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
@@ -2935,18 +2935,13 @@ export function ChatConsole({
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}
               >
-                {/* Toolbar row: mode selector + spacer */}
-                <div className="flex items-center gap-2">
-                  <ExecutionPolicySelector
-                    policy={executionPolicy}
-                    onChange={setExecutionPolicy}
-                    disabled={streaming}
-                    onOpenApprovals={onOpenApprovals}
-                  />
-                  <div className="flex-1" />
-                </div>
-                {/* Input row: attach + textarea + send */}
-                <div className="flex items-end gap-2">
+                <ExecutionPolicySelector
+                  policy={executionPolicy}
+                  onChange={setExecutionPolicy}
+                  disabled={streaming}
+                  onOpenApprovals={onOpenApprovals}
+                  compact
+                />
                 <button
                   onClick={handleAttachClick}
                   className="shrink-0 p-1 rounded hover:bg-[var(--surface-muted)] transition-colors"
@@ -2987,7 +2982,6 @@ export function ChatConsole({
                     <Send size={13} style={{ color: '#fff' }} />
                   </button>
                 )}
-                </div>
               </div>
                 )}
               </ContextMenu>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4206,9 +4206,6 @@ function MessageBubble({
             {validating && (
               <p className="text-[11px] text-text-faint py-0.5">正在验证链接可用性…</p>
             )}
-            {deadUrls.size > 0 && (
-              <p className="text-[11px] text-text-faint py-0.5">已过滤 {deadUrls.size} 个失效链接</p>
-            )}
           </div>
         )}
         <div className="flex gap-2 pt-2 border-t border-[var(--border-subtle)]">

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2748,6 +2748,12 @@ export function ChatConsole({
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
+              {/* AI disclaimer — part of the answer stream, hides once user types */}
+              {!input.trim() && attachments.length === 0 && (
+                <div className="text-center text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none">
+                  AI 也会犯错误，对于重要答案请谨慎验证
+                </div>
+              )}
               {!historyLoaded ? (
                 <div className="flex items-center justify-center min-h-[300px]">
                   <Loader2 size={16} className="animate-spin text-text-faint" />
@@ -2800,7 +2806,8 @@ export function ChatConsole({
           <div
             className="absolute bottom-0 left-0 right-0 px-5 pb-4 pt-3"
             style={{
-              background: 'var(--background)',
+              background:
+                'linear-gradient(to top, var(--background) 55%, rgba(0,0,0,0) 100%)',
             }}
           >
             <div className="max-w-[760px] mx-auto">
@@ -2924,17 +2931,6 @@ export function ChatConsole({
                 </div>
               )}
 
-              {/* AI disclaimer — keeps its space, only fades (no layout jump) */}
-              <div
-                className="text-center pb-2.5 text-[11px] leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none transition-opacity duration-300"
-                style={{
-                  opacity: !input.trim() && attachments.length === 0 ? 1 : 0,
-                  pointerEvents: !input.trim() && attachments.length === 0 ? 'auto' : 'none',
-                }}
-              >
-                AI 也会犯错误，对于重要答案请谨慎验证
-              </div>
-
               <ContextMenu items={inputContextItems} minWidth={160}>
                 {({ onContextMenu }) => (
               <div
@@ -2942,8 +2938,10 @@ export function ChatConsole({
                 data-testid="chat-input-container"
                 onContextMenu={onContextMenu}
                 style={{
-                  background: 'var(--surface)',
-                  border: '1px solid var(--border)',
+                  background: 'color-mix(in srgb, var(--surface) 72%, transparent)',
+                  backdropFilter: 'blur(16px)',
+                  WebkitBackdropFilter: 'blur(16px)',
+                  border: '1px solid color-mix(in srgb, var(--border) 60%, transparent)',
                   outline: 'none',
                   boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
                 }}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3859,19 +3859,25 @@ function MessageBubble({
               </ErrorBoundary>
             </div>
 
-            {/* copy button */}
-            {!isUser && msg.content !== '' && (
-              <button
-                onClick={() => onCopy(msg.content)}
-                className="self-start opacity-0 group-hover:opacity-100 transition-opacity p-0.5 text-text-faint"
-              >
-                {isCopied ? <Check size={12} /> : <Copy size={12} />}
-              </button>
-            )}
-
-            {/* action bar — regenerate / like / dislike / sources */}
+            {/* action bar — copy / regenerate / like / dislike / sources */}
             {!isUser && msg.content !== '' && (
               <div className="flex items-center gap-0.5 self-start pt-0.5 text-text-faint">
+                <button
+                  onClick={() => onCopy(msg.content)}
+                  title="复制"
+                  className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
+                >
+                  <span
+                    className="block transition-transform duration-200"
+                    style={{ transform: isCopied ? 'scale(1.15)' : 'scale(1)' }}
+                  >
+                    {isCopied ? (
+                      <Check size={13} style={{ color: 'var(--success)' }} />
+                    ) : (
+                      <Copy size={13} />
+                    )}
+                  </span>
+                </button>
                 <button
                   onClick={() => onRegenerate?.()}
                   title="重新生成"

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -17,6 +17,9 @@ export const IPC = {
   CHAT_SEND: 'chat:send',
   CHAT_ABORT: 'chat:abort',
 
+  // Web helpers
+  WEB_CHECK_URL: 'web:checkUrl',
+
   // Threads (Codex-style, Phase 36+)
   THREAD_START: 'thread:start',
   THREAD_LIST: 'thread:list',

--- a/miqi/agent/context.py
+++ b/miqi/agent/context.py
@@ -455,7 +455,12 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
         return images + [{"type": "text", "text": text}]
 
     def add_tool_result(
-        self, messages: list[dict[str, Any]], tool_call_id: str, tool_name: str, result: str
+        self,
+        messages: list[dict[str, Any]],
+        tool_call_id: str,
+        tool_name: str,
+        result: str,
+        arguments: Any = None,
     ) -> list[dict[str, Any]]:
         """
         Add a tool result to the message list.
@@ -465,13 +470,22 @@ Reply directly with text for conversations. Only use the 'message' tool to send 
             tool_call_id: ID of the tool call.
             tool_name: Name of the tool.
             result: Tool execution result.
+            arguments: Tool call arguments (recorded so the frontend can show
+                the exact URL a web_fetch/web_search actually touched, instead
+                of guessing from result text).
 
         Returns:
             Updated message list.
         """
-        messages.append(
-            {"role": "tool", "tool_call_id": tool_call_id, "name": tool_name, "content": result}
-        )
+        msg: dict[str, Any] = {
+            "role": "tool",
+            "tool_call_id": tool_call_id,
+            "name": tool_name,
+            "content": result,
+        }
+        if arguments is not None:
+            msg["arguments"] = arguments
+        messages.append(msg)
         return messages
 
     def add_assistant_message(

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -128,9 +128,13 @@ def _validate_url(url: str) -> tuple[bool, str]:
                 f"Requests to private/reserved addresses are not allowed (host: {host})"
             )
         host_l = host.lower()
-        if any(host_l == h or host_l.endswith("." + h) for h in _SEARCH_PAGE_HOSTS) and (
-            p.path in ("", "/", "/search", "/web", "/s") or "/search" in p.path or p.path == "/s"
-        ):
+        # Block only search-query pages, never bare roots — docs.google.com/ or
+        # pan.baidu.com/ are legitimate pages, not search result pages.
+        is_search_host = any(
+            host_l == h or host_l.endswith("." + h) for h in _SEARCH_PAGE_HOSTS
+        )
+        is_query_path = "/search" in p.path or p.path == "/s" or p.path == "/web"
+        if is_search_host and is_query_path:
             return False, (
                 "Search-engine result pages are blocked — use web_search instead "
                 f"of fetching '{host}' query pages"
@@ -205,7 +209,11 @@ class WebSearchTool(Tool):
                     lines.append(f"   {body}")
             return "\n".join(lines)
         except Exception as e:
-            return f"Error: {e}"
+            return (
+                f"Error: web search failed: {e}. 搜索服务暂不可用——请勿尝试用 "
+                "web_fetch 抓取搜索引擎页面（会被拒绝且结果不可用）。"
+                "直接告知用户搜索暂不可用，或建议稍后重试。"
+            )
 
     async def _brave_search(self, query: str, n: int) -> str:
         if not self.api_key:

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -94,11 +94,27 @@ def _is_private_host(host: str) -> bool:
     return False
 
 
+# Search-engine result/query pages that must never be fetched directly —
+# scraping them yields redirect junk, and searching belongs in web_search.
+_SEARCH_PAGE_HOSTS = (
+    "so.com",
+    "sogou.com",
+    "bing.com",
+    "google.com",
+    "google.com.hk",
+    "duckduckgo.com",
+    "search.brave.com",
+    "baidu.com",
+)
+
+
 def _validate_url(url: str) -> tuple[bool, str]:
     """Validate URL: must be http(s) with a publicly routable destination.
 
     Rejects requests targeting private, loopback, or link-local addresses to
-    prevent Server-Side Request Forgery (SSRF) attacks.
+    prevent Server-Side Request Forgery (SSRF) attacks, and rejects search-
+    engine query pages (the model should use web_search instead of scraping
+    search result HTML).
     """
     try:
         p = urlparse(url)
@@ -110,6 +126,14 @@ def _validate_url(url: str) -> tuple[bool, str]:
         if _is_private_host(host):
             return False, (
                 f"Requests to private/reserved addresses are not allowed (host: {host})"
+            )
+        host_l = host.lower()
+        if any(host_l == h or host_l.endswith("." + h) for h in _SEARCH_PAGE_HOSTS) and (
+            p.path in ("", "/", "/search", "/web", "/s") or "/search" in p.path or p.path == "/s"
+        ):
+            return False, (
+                "Search-engine result pages are blocked — use web_search instead "
+                f"of fetching '{host}' query pages"
             )
         return True, ""
     except Exception as e:

--- a/miqi/runtime/context_runtime.py
+++ b/miqi/runtime/context_runtime.py
@@ -116,14 +116,18 @@ class ContextRuntime:
         tool_call_id: str,
         name: str,
         content: str,
+        arguments: Any = None,
     ) -> list[dict[str, Any]]:
         """Append a tool result message."""
-        return [*messages, {
+        msg: dict[str, Any] = {
             "role": "tool",
             "tool_call_id": tool_call_id,
             "name": name,
             "content": content,
-        }]
+        }
+        if arguments is not None:
+            msg["arguments"] = arguments
+        return [*messages, msg]
 
     # ── Phase 19: context compaction ────────────────────────────────────
 

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -383,6 +383,7 @@ class TurnRunner:
                     tool_call_id=tool_call.id,
                     name=tool_call.name,
                     content=ctx.result or "",
+                    arguments=tool_call.arguments,
                 )
                 # Persist tool result in messages_delta
                 messages_delta.append({

--- a/uv.lock
+++ b/uv.lock
@@ -1305,7 +1305,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.9.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -1305,7 +1305,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
### **User description**
## 类型
- [x] ✨ 新功能
- [x] 🐛 Bug 修复

## 变更概述
右键菜单增强 + 输入框（composer）全面打磨 + 消息操作栏 + 查看来源系统：覆盖右键菜单、输入框布局/质感、重试语义、来源提取与验证、发送按钮等。

## 背景/问题
#543 右键菜单仅有纯文本项；输入框无编辑菜单；composer 布局经多轮用户反馈（模式选择器、AI 免责提示、输入框高度收缩、回答不跳变）；回答来源无法查看且混入大量无效链接。

## 变更内容
### 右键菜单
- 消息右键：图标化菜单（复制/复制 Markdown/复制代码/重试/保存等）
- 输入框右键：剪切/复制/粘贴/全选（粘贴追加到末尾，dispatchEvent 统一 state，修复"删除两遍"）

### 输入框（composer）
- DeepSeek 风格布局：textarea 全宽 + 底部工具栏（模式选择器带文字 + AI 免责提示居中淡出 + 附件/发送）
- 高度收缩：原生 field-sizing（删除全部 JS 重算）
- 浮动定位 + ResizeObserver 动态间距：回答永不跳变，滚动到底间距恒为 20vh
- 发送按钮：圆形渐变 + 彩色阴影 + 微动效

### 消息操作栏
- 复制（并入操作栏，Check 反馈）/ 重新生成 / 喜欢 / 不喜欢 / 查看来源
- 重试/重新生成真正生效：自动重发 + 注入"换角度回答"提示，用户消息不再重复显示

### 查看来源（新）
- 真实 URL 提取：后端 tool 消息记录 arguments（web_fetch 实际抓取 URL），来源只显示工具真实访问的链接
- 404 验证：主进程 HEAD→GET 回退 + 浏览器 UA + 保守判定，仅确凿 404/410 过滤
- Perplexity 风格 UI：按工具分组 + 编号 + favicon + 域名，右键复制链接
- 去重 + 上限 20

### 搜索修复（配合来源）
- web_fetch 禁止抓取搜索引擎搜索页（360/搜狗/Bing/Google 等）
- web_search 失败时明确引导模型：不绕道抓搜索页，直接告知用户

## 日志/验证证据
```
前端：Vitest 128/128 passed (9 files)；tsc 0 新增错误（4 个预存在）
后端：pytest web/search 59 passed；loop/drain 相关 291 passed
来源验证：HEAD→GET 回退 + UA，仅 404/410 判失效
```

## 测试情况
- Vitest 128/128（每次改动后跑）
- tsc web/node 0 新增错误
- 后端定向 pytest 通过（web/filesystem/turn_runner/context）
- UI 实机验证进行中（用户逐项反馈迭代）

## 截图
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/cdc752b4-5179-406c-997a-b9fe5b432931" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/d1b46a05-4f45-4a61-bd7a-a87721ff650f" />

## 后续计划（已拆分独立 issue）
- #548 附加为上下文
- #572 引用回复
- #549 固定为章节
- #573 章节导航栏
- #550 保存到记忆
- #574 开发者工具

Closes #543


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 右键菜单图标化与悬浮预览：为复制、重试等菜单项添加图标；鼠标悬停可高亮消息文本，点击复制优先使用手动选区

- 输入框全面重塑：DeepSeek 风格全宽布局、底部工具栏（模式选择器 + AI 免责提示 + 附件/发送）；原生 field-sizing 替代 JS 自缩；浮动定位保证回答间隙恒为 20vh；新增输入框右键菜单（剪切/复制/粘贴/全选，基于 Clipboard API 且避免状态漂移）

- 消息操作栏与重试增强：助手消息下方添加复制、重新生成、喜欢/不喜欢、查看来源按钮；重试/重新生成自动发送并注入“换角度回答”提示，保留原用户消息

- 查看来源系统：后端记录工具调用的真实 URL（web_fetch 等），前端提取并关联到回答；主进程 HEAD→GET 验证链接可达性（含 SSRF 防护与重定向安全检测），过滤 404 链接；按工具分组、编号展示，每个链接显示 favicon 与域名

- 安全加固：web_fetch 工具拒绝直接抓取搜索引擎结果页（bing/google 等），避免模型误用；URL 验证层增加对搜索页面的识别与拦截


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RightClick["右键菜单增强"]
  RightClick --> Icons["菜单项图标化"]
  RightClick --> HoverPreview["悬浮预览高亮"]
  Icons --> CopySelect["复制优先选区"]
  HoverPreview --> CopySelect
  InputContext["输入框右键菜单"] --> ClipboardAPI["剪切/复制/粘贴/全选"]
  Composer["输入框重新设计"] --> Layout["DeepSeek 布局"]
  Composer --> FieldSizing["field-sizing 自伸缩"]
  Composer --> Gap["浮动间隙恒定 20vh"]
  Tools["后端工具记录"] --> ToolArgs["记录实际 URL"]
  ToolArgs --> SourcesExt["前端提取来源"]
  SourcesExt --> CheckURL["主进程 URL 可达性校验"]
  CheckURL --> Modal["查看来源模态框"]
  CheckURL --> SSRF["SSRF 安全重定向"]
  Modal --> Grouped["按工具分组+编号+favicon"]
  WebFetch["web_fetch 安全"] --> SearchBlock["拦截搜索引擎结果页"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>context.py</strong><dd><code>工具结果记录原始调用参数 arguments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-f1d07b4d7af64e9f9b53a0e023f7fc49b25abca7f94fff874f8ac36e7e943d6f">+18/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context_runtime.py</strong><dd><code>传递工具调用参数至消息记录</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-2daeb5b70e6c19ae178307c867cf4036f297c6cc32975b79382c79a231dc8840">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>turn_runner.py</strong><dd><code>将 tool_call.arguments 传入 add_tool_result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-4627bd8e77d69d5a0d5be03c29bd0c3402cd0988e6d538cad1b99f4be0a60696">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>主进程 URL 可达性校验（HEAD/GET 回退、SSRF 安全重定向）</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+106/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>暴露 web.checkUrl 方法供渲染进程调用</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContextMenu.tsx</strong><dd><code>添加 onEnter/onLeave 回调，支持悬浮预览与自动清理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-1e650451e54b35618fca97e922f8160c76077f076007bbd59dee8e64d0508aa4">+19/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx</strong><dd><code>全面升级：右键图标化、输入框重设计、消息操作栏、查看来源、重试重构</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+650/-95</a></td>

</tr>

<tr>
  <td><strong>ipc.ts</strong><dd><code>新增 IPC 通道 WEB_CHECK_URL 常量</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>web.py</strong><dd><code>拦截搜索引擎结果页；完善 URL 验证与错误提示</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-e9ac9012d9f53f0d1e4bd1cdd0faa9d5cbc50a6101ab752bfd45ce3d8855341a">+34/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ExecutionPolicySelector.tsx</strong><dd><code>弹窗与 Toast 改用 createPortal 挂载至 body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/547/files#diff-8bb5ac2fa8ad3cc94b28b32f9000075ac27a0702d8b4a738ed5451058a3a7756">+18/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

