### PR TITLE
fix(sandbox): 允许 Agent 只读访问 config.json（issue #553）

### DIFF
--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -317,8 +317,14 @@ def _canonicalize_wsl_mnt_path(
 
     for root in roots:
         try:
-            resolved.relative_to(root)
-            break  # contained in this root — accept
+            if root.is_file():
+                # File roots (e.g. config.json) gate the exact file only —
+                # never sibling/descendant paths like config.json.bak.
+                if resolved == root.resolve():
+                    break
+            else:
+                resolved.relative_to(root)
+                break  # contained in this root — accept
         except ValueError:
             continue
     else:

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from miqi.agent.tools.registry import ToolRegistry
+from miqi.paths import get_config_path
 
 
 def create_runtime_tool_registry(
@@ -96,6 +97,11 @@ def create_runtime_tool_registry(
         _shared_dir.mkdir(parents=True, exist_ok=True)
         _shared_roots.append(_shared_dir)
 
+    # Read-only whitelist for the host config file (issue #553): agents may
+    # inspect settings, but write/edit/patch tools keep rejecting it so the
+    # config (API keys, model setup) can never be tampered with.
+    _read_shared_roots = [*_shared_roots, get_config_path()]
+
     # Resolve config sections
     tools_cfg = getattr(config, "tools", None)
     restrict_to_workspace = getattr(tools_cfg, "restrict_to_workspace", False) if tools_cfg is not None else False
@@ -122,7 +128,7 @@ def create_runtime_tool_registry(
 
     # 1. Filesystem tools
     for cls in (ReadFileTool, ListDirTool):
-        registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm, shared_roots=_shared_roots))
+        registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm, shared_roots=_read_shared_roots))
     registry.register(
         WriteFileTool(
             workspace=_write_workspace,


### PR DESCRIPTION
## 类型
- [x] Bug 修复

## 变更概述
Agent 的文件工具读取宿主配置文件 ~/.miqi/config.json 时被沙箱路径白名单拒绝（PermissionError），本 PR 允许**只读**访问，写入类工具保持拒绝。

## 背景/问题
对话中让 Agent 检查自身配置（模型、路径、工具设置）时，read_file 访问 config.json 报错：

```
PermissionError: Path 'C:\Users\admin\.miqi\config.json' ... which is outside all legal roots
```

沙箱白名单（tool_registry_factory.py）只含会话工作区 + memory/ + skills/，config.json 不在其中。

## 变更内容
- miqi/runtime/tool_registry_factory.py：
  - 新增 _read_shared_roots = [*_shared_roots, get_config_path()]（仅读工具使用）
  - ReadFileTool/ListDirTool 改用 _read_shared_roots
  - WriteFileTool/EditFileTool/ApplyPatchTool 保持 _shared_roots（config.json 仍不可写，防止篡改 API key/模型配置）
- 白名单为精确匹配：config.json.bak 等相邻路径依然拒绝

## 日志/验证证据
手动验证 _canonicalize_wsl_mnt_path（win32 环境）：
```
- config.json（白名单内）-> 通过
- config.json.bak -> 拒绝
- C:\Windows\...\hosts -> 拒绝
- 无白名单（写工具场景）-> config.json 拒绝
```

## 测试情况
- 后端全量：2643 passed, 19 skipped（tests/ 目录，.venv pytest）
- 定向：filesystem/tool_registry 51 passed

## 截图
无（后端逻辑改动）

Closes #553