### PR TITLE
fix(provider): rotate bundled DeepSeek API key

### DIFF
--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -389,7 +389,7 @@ _BUILTIN_PROVIDERS = {"deepseek"}
 
 # Encrypted API key for DeepSeek internal testing.
 # Token generated via Fernet with activation-code-derived key.
-_BUILTIN_KEYS: dict[str, str] = {"deepseek": "gAAAAABqVvj-NrrD9IWE4hrbCvexuygd09CeYtOWuflv1ATJm-vaoBENzFakFX1tRQpX4jYshKb3pcc38wdO-faRSC4NSaZXm0C-Q4e8AdKO0u0oLyJhy0ppimff7Q7DHYRMseC31Gi0"}  # provider_name → encrypted_key
+_BUILTIN_KEYS: dict[str, str] = {"deepseek": "gAAAAABqcAKIbwGAo4su3S7LbqrXcazQI39QTE-Flr5B_NF8jo2feHUT4tMy7KK0C-Ieh7waUArthTYrBqcSvSNVsGZIPUFV9yFugT7_Lp_eHeTjL53VXi2drCLQ8_019316D__pjnMl"}  # provider_name → encrypted_key
 
 # Default activation code — the company name / internal code
 _DEFAULT_ACTIVATION_CODE = "weiguanjiyuan5g"


### PR DESCRIPTION
## Summary

- Replace the expired built-in DeepSeek API key with a new OPS-supplied key (`sk-eaa0bd...`)
- Only the Fernet-encrypted ciphertext is committed; the plaintext key is never stored in git
- Verified via decrypt round-trip and `_decrypt_builtin_key()` at runtime
- 65 provider tests pass cleanly

## Related Issue

Closes #556

## Test plan

- [x] Encrypt/decrypt round-trip verification
- [x] 65 provider tests pass
- [ ] Desktop build: clean install → activate DeepSeek built-in key → send message
- [ ] Verify old key is fully replaced in all release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)