### PR TITLE
fix(feedback): prevent TooLargeCell error and suppress cmd popup on WSL check

### DIFF
--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -110,9 +110,11 @@ def _collect_system_info() -> dict[str, str]:
     # Try WSL check
     try:
         import subprocess
+        import os as _os
         r = subprocess.run(
             ["wsl", "--list", "--verbose"],
-            capture_output=True, text=True, timeout=5,  # noqa: S603
+            capture_output=True, text=True, timeout=5,
+            creationflags=subprocess.CREATE_NO_WINDOW if _os.name == "nt" else 0,  # noqa: S603
         )
         info["wsl_status"] = r.stdout.strip() or "[未安装或无权限]"
     except Exception:
@@ -384,7 +386,9 @@ async def feedback_submit_handler(
 
     # 4. Build Bitable fields — cap per-field text sizes to stay within
     #    Feishu per-cell limits (multiline text ≈ 196,608 bytes per cell).
-    MAX_CELL_BYTES = 196_000  # 196 KiB with headroom for JSON escaping overhead
+    MAX_CELL_BYTES = 98_000  # ~half of Feishu 196,608 limit — JSON escaping of
+    # backslashes (Windows paths) and other special chars can inflate the
+    # payload by up to 2×, so a 50% safety margin avoids TooLargeCell.
 
     def _cap_text(value: str, max_bytes: int = MAX_CELL_BYTES) -> str:
         """Truncate *value* so its UTF-8 encoding fits within *max_bytes*."""


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复反馈提交 TooLargeCell 错误和 WSL 检测弹出命令行黑框

## 背景/问题

1. **TooLargeCell**：用户提交反馈时，飞书多维表格返回 `TooLargeCell (code=1254130)` 错误。`MAX_CELL_BYTES` 设为 196k，但日志内容中 Windows 路径的 `\` 经 JSON 编码后翻倍（`\`），超过飞书 196,608 字节的单格限制。
2. **命令行黑框**：`_collect_system_info()` 中 `subprocess.run(["wsl", ...])` 未设置 `CREATE_NO_WINDOW`，每次提交反馈都会在 Windows 上弹出 cmd 黑框。

## 变更内容

- `miqi/runtime/feedback_handlers.py`：`MAX_CELL_BYTES` 从 196k 降到 98k，为 JSON 转义预留 50% 安全余量
- `miqi/runtime/feedback_handlers.py`：WSL 检测的 `subprocess.run` 加上 `CREATE_NO_WINDOW` 标志

## 日志/验证证据

```
# 修复前：飞书返回
Error invoking remote method 'feedback:submit': Error:写入飞书多维表格失败: TooLargeCell (code=1254130) (FEISHU_BITABLE_ERROR)

# 修复后：98k 字节上限 + JSON 编码后仍不超过 196k 限制
```

## 测试情况

- [x] 单元测试通过：`tests/runtime/test_feedback_handlers.py`
- [ ] 手动提交反馈（含日志）确认不再报 TooLargeCell
- [ ] 手动提交反馈确认无 cmd 黑框弹出

## 截图

无需截图