### PR TITLE
fix(feedback): only collect recent 7-day logs, add Triage Needed to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug 报告
 description: 报告 Bug，必须附带日志和复现步骤
 title: "[BUG] "
-labels: [bug]
+labels: [bug, "Triage Needed"]
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨ Feature 请求
 description: 提出新功能或改进建议
 title: "[FEATURE] "
-labels: [enhancement]
+labels: [enhancement, "Triage Needed"]
 assignees: []
 body:
   - type: textarea

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -63,6 +63,7 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
     parts: list[str] = []
     recent_count = 0
     skipped_count = 0
+    unreadable_count = 0
 
     for f in sorted(log_dir.rglob("*"), key=lambda p: os.path.getmtime(str(p)), reverse=True):
         if not f.is_file():
@@ -70,7 +71,8 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
         try:
             mtime = os.path.getmtime(str(f))
         except OSError:
-            mtime = 0
+            unreadable_count += 1
+            continue
         if mtime < cutoff:
             skipped_count += 1
             continue
@@ -88,8 +90,13 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
     if not parts:
         return f"[最近{max_age_days}天无日志文件（跳过{skipped_count}个旧文件）]"
 
+    marker = []
     if skipped_count:
-        parts.insert(0, f"(跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件)\n")
+        marker.append(f"（跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件）")
+    if unreadable_count:
+        marker.append(f"（{unreadable_count} 个文件无法读取修改时间）")
+    if marker:
+        parts.insert(0, "\n".join(marker) + "\n")
 
     combined = "\n\n".join(parts)
     # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 196,608 bytes.
@@ -403,7 +410,7 @@ async def feedback_submit_handler(
     #    Feishu per-cell limits (multiline text ≈ 196,608 bytes per cell).
     MAX_CELL_BYTES = 88_000  # ~45% of Feishu 196,608 limit — JSON escaping of
     # backslashes (Windows paths) and other special chars can inflate the
-    # payload by up to 2×, so a 50% safety margin avoids TooLargeCell.
+    # payload by up to 2x, so a 50% safety margin avoids TooLargeCell.
 
     def _cap_text(value: str, max_bytes: int = MAX_CELL_BYTES) -> str:
         """Truncate *value* so its UTF-8 encoding fits within *max_bytes*."""

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -64,7 +64,7 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
     recent_count = 0
     skipped_count = 0
 
-    for f in sorted(log_dir.rglob("*")):
+    for f in sorted(log_dir.rglob("*"), key=lambda p: os.path.getmtime(str(p)), reverse=True):
         if not f.is_file():
             continue
         try:

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import platform
 import sys
+import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -46,23 +48,33 @@ def _ensure_memory_dir() -> None:
     memory_dir.mkdir(parents=True, exist_ok=True)
 
 
-def _collect_all_logs(log_dir: Path) -> str:
-    """Read every file under workspace/logs/ recursively (relative path
-    shown for nested files) and return concatenated text.
+def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
+    """Read files under workspace/logs/ recursively, limited to those
+    modified within *max_age_days*, and return concatenated text.
 
     Individual files are capped at 1 MB (tail end).  The combined payload
-    is capped at 100,000 UTF-8 bytes to fit within Feishu Bitable
-    text-field limits (per official docs).
+    is capped at 196,608 UTF-8 bytes to fit within Feishu Bitable
+    text-field limits.
     """
     if not log_dir.exists():
         return "[日志目录不存在]"
 
+    cutoff = time.time() - max_age_days * 86400
     parts: list[str] = []
-    # Recursive walk: catches nested logs and any extension (binary-safe
-    # via errors='replace' below).
+    recent_count = 0
+    skipped_count = 0
+
     for f in sorted(log_dir.rglob("*")):
         if not f.is_file():
             continue
+        try:
+            mtime = os.path.getmtime(str(f))
+        except OSError:
+            mtime = 0
+        if mtime < cutoff:
+            skipped_count += 1
+            continue
+        recent_count += 1
         try:
             content = f.read_text(encoding="utf-8", errors="replace")
             max_chars = 1_000_000
@@ -74,7 +86,10 @@ def _collect_all_logs(log_dir: Path) -> str:
             parts.append(f"=== {f.name} === [读取失败: {exc}]")
 
     if not parts:
-        return "[无日志文件]"
+        return f"[最近{max_age_days}天无日志文件（跳过{skipped_count}个旧文件）]"
+
+    if skipped_count:
+        parts.insert(0, f"(跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件)\n")
 
     combined = "\n\n".join(parts)
     # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 196,608 bytes.

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -401,7 +401,7 @@ async def feedback_submit_handler(
 
     # 4. Build Bitable fields — cap per-field text sizes to stay within
     #    Feishu per-cell limits (multiline text ≈ 196,608 bytes per cell).
-    MAX_CELL_BYTES = 98_000  # ~half of Feishu 196,608 limit — JSON escaping of
+    MAX_CELL_BYTES = 88_000  # ~45% of Feishu 196,608 limit — JSON escaping of
     # backslashes (Windows paths) and other special chars can inflate the
     # payload by up to 2×, so a 50% safety margin avoids TooLargeCell.
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [x] ✨ 新功能

## 变更概述

反馈日志只收集最近 7 天 + Issue 模板自动打 Triage Needed 标签

## 背景/问题

1. `_collect_all_logs` 读取 workspace/logs/ 下所有文件，几个月前的旧日志对排错无帮助，浪费飞书单元格空间
2. 团队需要所有新 Issue 自动标记为 Triage Needed

## 变更内容

- `miqi/runtime/feedback_handlers.py`：`_collect_all_logs` 按 `mtime` 过滤（默认 7 天），旧文件跳过并在日志头标注
- `.github/ISSUE_TEMPLATE/bug_report.yml`：labels 加 `Triage Needed`
- `.github/ISSUE_TEMPLATE/feature_request.yml`：labels 加 `Triage Needed`

## 日志/验证证据

```
# 当有旧文件被跳过时，日志头会显示
(跳过了 12 个超过 7 天的旧日志文件)
=== recent.log ===
...
```

## 测试情况

- [x] 现有测试通过
- [ ] 确认反馈提交只附加最近 7 天日志
- [ ] 确认新 Issue 自动打 Triage Needed 标签

## 截图

无需截图