### PR TITLE
fix(feedback): lower MAX_CELL_BYTES from 98k to 88k

### DIFF
--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -386,7 +386,7 @@ async def feedback_submit_handler(
 
     # 4. Build Bitable fields — cap per-field text sizes to stay within
     #    Feishu per-cell limits (multiline text ≈ 196,608 bytes per cell).
-    MAX_CELL_BYTES = 98_000  # ~half of Feishu 196,608 limit — JSON escaping of
+    MAX_CELL_BYTES = 88_000  # ~45% of Feishu 196,608 limit — JSON escaping of
     # backslashes (Windows paths) and other special chars can inflate the
     # payload by up to 2×, so a 50% safety margin avoids TooLargeCell.
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

将 MAX_CELL_BYTES 从 98,000 降到 88,000，为 JSON 转义留更多安全余量

## 背景/问题

98k 在 JSON 编码后仍可能超出飞书 Bitable 196,608 字节限制。再降 10k 确保不会触发 TooLargeCell。

## 变更内容

- `miqi/runtime/feedback_handlers.py`：`MAX_CELL_BYTES` 98,000 → 88,000

## 日志/验证证据

无需日志

## 测试情况

- [x] 单元测试通过

## 截图

无需截图