### PR TITLE
feat(desktop): 轮次刻度条导航——珠子 hover 预览 + 点击跳转（章节导航 #573）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { DiffView } from './components/DiffView';
@@ -2311,6 +2311,114 @@ export function ChatConsole({
     setTimeout(() => setCopiedIdx(null), 2000);
   };
 
+  // ── Turn gutter: one bead per user turn, hover shows the full Q+A ──
+  const turnsData = useMemo(() => {
+    const turns: { q: string; a: string }[] = [];
+    let cur: { q: string; a: string } | null = null;
+    for (const m of messages) {
+      if (m.role === 'user') {
+        cur = { q: m.content, a: '' };
+        turns.push(cur);
+      } else if (m.role === 'assistant' && cur) {
+        cur.a = m.content;
+      }
+    }
+    return turns;
+  }, [messages]);
+  const turnAnchors = useRef<(HTMLDivElement | null)[]>([]);
+  const [tickPercents, setTickPercents] = useState<number[]>([]);
+  const [showGutter, setShowGutter] = useState(false);
+  const [activeTurn, setActiveTurn] = useState(-1);
+  const [hoverTurn, setHoverTurn] = useState(-1);
+
+  const updateTurnUI = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || turnsData.length === 0) {
+      setShowGutter(false);
+      return;
+    }
+    const max = el.scrollHeight - el.clientHeight;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 4;
+    // Beads sit at each turn's real position, with a minimum gap — two turns
+    // whose messages are adjacent (short answer) would otherwise overlap.
+    const minGap = 0.035;
+    const percents: number[] = [];
+    turnAnchors.current.forEach((node, i) => {
+      if (!node) return;
+      const ratio = max > 0 ? node.offsetTop / max : (turnsData.length === 1 ? 0.5 : i / (turnsData.length - 1));
+      percents[i] = Math.min(1, Math.max(0, ratio));
+    });
+    for (let i = 0; i < turnsData.length; i++) {
+      if (percents[i] === undefined) {
+        percents[i] = turnsData.length === 1 ? 0.5 : i / (turnsData.length - 1);
+      }
+    }
+    // Push up from the bottom to enforce the minimum gap, then re-clamp.
+    for (let i = turnsData.length - 2; i >= 0; i--) {
+      if (percents[i + 1] - percents[i] < minGap) percents[i] = percents[i + 1] - minGap;
+    }
+    if (percents[0] < 0.02) {
+      const shift = 0.02 - percents[0];
+      for (let i = 0; i < turnsData.length; i++) percents[i] += shift;
+    }
+    if (percents[turnsData.length - 1] > 0.98) {
+      const k = (0.98 - 0.02) / (percents[turnsData.length - 1] - percents[0]);
+      for (let i = 0; i < turnsData.length; i++) percents[i] = 0.02 + (percents[i] - percents[0]) * k;
+    }
+    let cur = -1;
+    turnAnchors.current.forEach((node, i) => {
+      if (node && !atBottom && node.offsetTop - el.scrollTop <= 60) cur = i;
+    });
+    if (atBottom) cur = turnsData.length - 1; // scrolled to bottom → last bead lights up
+    // Keep the array identity when nothing changed — a fresh array on every
+    // scroll event would re-render every MessageBubble.
+    setTickPercents((prev) =>
+      prev.length === percents.length && prev.every((v, idx) => v === percents[idx]) ? prev : percents
+    );
+    setActiveTurn(cur);
+    // ≥2 turns → gutter always shows (beads spread evenly even when the
+    // content fits on one screen), matching the approved HTML demo v4.
+    setShowGutter(turnsData.length >= 2);
+  }, [turnsData.length]);
+
+  // Throttle scroll-driven updates to one per animation frame.
+  const scrollRafRef = useRef<number | null>(null);
+  const onScrollThrottled = useCallback(() => {
+    if (scrollRafRef.current != null) return;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      updateTurnUI();
+    });
+  }, [updateTurnUI]);
+
+  // Recompute on turn-count changes and when streaming stops (final layout) —
+  // NOT on every typewriter frame while streaming.
+  useLayoutEffect(() => {
+    updateTurnUI();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [turnsData.length, streaming, updateTurnUI]);
+
+  const jumpToTurn = (i: number) => {
+    const node = turnAnchors.current[i];
+    const el = scrollRef.current;
+    if (node && el) {
+      setActiveTurn(i); // light the clicked bead immediately
+      el.scrollTo({ top: Math.max(0, node.offsetTop - 12), behavior: 'smooth' });
+      setHoverTurn(-1);
+    }
+  };
+
+  // Closing the preview is delayed so the pointer can cross the gap from a
+  // bead to the preview card without it unmounting (mouseleave fires first).
+  const closePreviewTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleClosePreview = useCallback(() => {
+    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
+    closePreviewTimer.current = setTimeout(() => setHoverTurn(-1), 200);
+  }, []);
+  const cancelClosePreview = useCallback(() => {
+    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
+  }, []);
+
   const handleRetry = useCallback(
     async (msg: Message) => {
       if (streaming) return;
@@ -2614,7 +2722,7 @@ export function ChatConsole({
       {/* ── Main area: chat + right panel ── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Chat area */}
-        <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex flex-col flex-1 overflow-hidden relative">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
             className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
@@ -2695,7 +2803,8 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto relative"
+            onScroll={onScrollThrottled}
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -2719,21 +2828,41 @@ export function ChatConsole({
                   </div>
                 </div>
               ) : (
-                messages.map((msg, i) => (
-                  <MessageBubble
+                (() => {
+                  // Anchor each user message by TURN index, not message index —
+                  // tickPercents / activeTurn / jumpToTurn all index per turn.
+                  let turnIdx = -1;
+                  return messages.map((msg, i) => {
+                    if (msg.role === 'user') turnIdx += 1;
+                    const anchorTurn = msg.role === 'user' ? turnIdx : -1;
+                    return (
+                  <div
                     key={`${msg.timestamp}-${i}`}
-                    msg={msg}
-                    execOutputs={execOutputs}
-                    inlineExecOutput={inlineExecOutput}
-                    isLast={i === messages.length - 1}
-                    onCopy={(text) => handleCopy(text, i)}
-                    isCopied={copiedIdx === i}
-                    onRetry={() => handleRetry(msg)}
-                    onOpenProviderSettings={onOpenProviderSettings}
-                    onDownloadPaper={handleDownloadPaper}
-                    downloadingPaperId={downloadingPaperId}
-                  />
-                ))
+                    ref={
+                      msg.role === 'user'
+                        ? (el) => {
+                            turnAnchors.current[anchorTurn] = el;
+                          }
+                        : undefined
+                    }
+                    data-turn-role={msg.role}
+                  >
+                    <MessageBubble
+                      msg={msg}
+                      execOutputs={execOutputs}
+                      inlineExecOutput={inlineExecOutput}
+                      isLast={i === messages.length - 1}
+                      onCopy={(text) => handleCopy(text, i)}
+                      isCopied={copiedIdx === i}
+                      onRetry={() => handleRetry(msg)}
+                      onOpenProviderSettings={onOpenProviderSettings}
+                      onDownloadPaper={handleDownloadPaper}
+                      downloadingPaperId={downloadingPaperId}
+                    />
+                    </div>
+                    );
+                  });
+                })()
               )}
               {streaming && (
                 <div
@@ -2746,6 +2875,132 @@ export function ChatConsole({
               )}
             </div>
           </div>
+
+          {/* Turn gutter + preview — OUTSIDE the scroll container (siblings of
+              it), so they stay pinned to the visible chat area instead of
+              scrolling away with the messages. */}
+            {/* Turn gutter — one bead per user turn, hover previews the Q+A */}
+            {showGutter && turnsData.length > 0 && (
+              <div
+                className="absolute right-3 top-1/2 -translate-y-1/2 z-30 w-5"
+                style={{ height: 'min(400px, 62%)' }}
+                onMouseLeave={scheduleClosePreview}
+              >
+                <div
+                  className="absolute left-1/2 top-0 bottom-0 w-[3px] -translate-x-1/2 rounded-full"
+                  style={{ background: 'rgba(255,255,255,.07)' }}
+                />
+                {turnsData.map((_, i) => (
+                  <button
+                    key={i}
+                    className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-all duration-150 cursor-pointer"
+                    style={{
+                      top: `${((tickPercents[i] ?? 0) * 100).toFixed(2)}%`,
+                      width: activeTurn === i ? 11 : 8,
+                      height: activeTurn === i ? 11 : 8,
+                      background: activeTurn === i ? 'var(--accent)' : 'var(--text-faint)',
+                      boxShadow:
+                        activeTurn === i
+                          ? '0 0 10px color-mix(in srgb, var(--accent) 80%, transparent)'
+                          : 'none',
+                    }}
+                    onMouseEnter={() => {
+                    cancelClosePreview();
+                    setHoverTurn(i);
+                  }}
+                    onClick={() => jumpToTurn(i)}
+                    aria-label={`跳转到第 ${i + 1} 轮对话`}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Turn preview — hovered turn's full Q+A, height adapts to content */}
+            {hoverTurn >= 0 && turnsData[hoverTurn] && (
+              <div
+                className="absolute right-12 top-1/2 -translate-y-1/2 z-50 flex flex-col rounded-2xl overflow-hidden"
+                style={{
+                  width: 380,
+                  maxHeight: 'calc(100% - 28px)',
+                  background: 'var(--surface-elevated)',
+                  border: '1px solid var(--border)',
+                  boxShadow: '0 18px 60px rgba(0,0,0,.45)',
+                }}
+                onMouseEnter={cancelClosePreview}
+                onMouseLeave={scheduleClosePreview}
+              >
+                <div
+                  className="flex items-center gap-2 px-3.5 py-2.5 shrink-0"
+                  style={{
+                    borderBottom: '1px solid var(--border-subtle)',
+                    background: 'color-mix(in srgb, var(--accent) 8%, transparent)',
+                  }}
+                >
+                  <span
+                    className="text-[11px] font-bold px-2 py-0.5 rounded-md"
+                    style={{
+                      color: 'var(--accent)',
+                      background: 'color-mix(in srgb, var(--accent) 18%, transparent)',
+                    }}
+                  >
+                    Q{hoverTurn + 1}
+                  </span>
+                  <span className="text-[11px] flex-1" style={{ color: 'var(--text-muted)' }}>
+                    {turnsData[hoverTurn].q.slice(0, 24)}
+                    {turnsData[hoverTurn].q.length > 24 ? '…' : ''}
+                  </span>
+                </div>
+                <div className="px-3.5 py-3 overflow-y-auto flex flex-col gap-2.5">
+                  <div
+                    className="max-w-full px-3 py-2 rounded-xl text-[12.5px] leading-relaxed self-end"
+                    style={{
+                      background:
+                        'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
+                      color: 'var(--bubble-user-text)',
+                      borderBottomRightRadius: 4,
+                    }}
+                  >
+                    {turnsData[hoverTurn].q}
+                  </div>
+                  {turnsData[hoverTurn].a ? (
+                    <div
+                      className="max-w-full px-3 py-2 rounded-xl text-[12.5px] leading-relaxed self-start"
+                      style={{
+                        background: 'var(--surface-muted)',
+                        border: '1px solid var(--border-subtle)',
+                        color: 'var(--text)',
+                        borderBottomLeftRadius: 4,
+                      }}
+                    >
+                      {turnsData[hoverTurn].a}
+                    </div>
+                  ) : (
+                    <div className="text-[11.5px] px-3 py-2" style={{ color: 'var(--text-faint)' }}>
+                      回答生成中…
+                    </div>
+                  )}
+                </div>
+                <div
+                  className="px-3.5 py-2 shrink-0 text-right"
+                  style={{ borderTop: '1px solid var(--border-subtle)' }}
+                >
+                  <button
+                    onClick={() => jumpToTurn(hoverTurn)}
+                    className="text-[11px] rounded-full px-3 py-1 transition-colors"
+                    style={{
+                      color: 'var(--accent)',
+                      border: '1px solid color-mix(in srgb, var(--accent) 40%, transparent)',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'color-mix(in srgb, var(--accent) 18%, transparent)')
+                    }
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    📍 跳转到此轮查看完整内容
+                  </button>
+                </div>
+              </div>
+            )}
 
           {/* Composer */}
           <div


### PR DESCRIPTION
### **User description**
## 类型
- [x] ✨ 新功能

## 变更概述
右侧轮次刻度条（珠子）导航：每轮用户提问对应一颗珠子，hover 预览整轮问答，点击跳转并精确点亮。原为 #547 的一部分，按"一个 issue 一个 PR"原则拆出独立提交（章节导航 #573 的变体实现）。

## 背景/问题
长对话中定位某一轮问答需要反复滚动；ChatGPT/DeepSeek 均有类似导航。HTML demo（`chat-turn-preview-demo.html`）经用户逐项验收后按规格实现。

## 变更内容
- **珠子位置**：每轮一颗，位置 = 该轮消息在滚动区内的真实比例（长回答处间距大）；相邻最小间距 3.5%，短回答不再重叠；顶部/底部越界时平移/压缩
- **hover 预览**：整轮问答卡片（居中偏右，高度自适应内容，上限内滚动），关闭延迟 200ms，指针跨 gap 移动不消失
- **点击跳转**：点击珠子 → 平滑滚动到该轮并**立即点亮**对应珠子；滚到底部时点亮最后一颗
- **默认状态**：第一颗珠子亮；≥2 轮对话即显示刻度条（不满一屏时珠子均匀分布，不再整条隐藏）
- **索引对齐**：用户消息锚点按**轮次索引**存储（非消息索引），tickPercents / activeTurn / jumpToTurn 共用同一索引空间
- **不随滚动消失**：刻度条 + 预览卡片在滚动容器外（absolute 于 chat area wrapper），滚动消息时导航始终可见
- **性能**：scroll 更新 rAF 节流；tickPercents 内容不变保持数组 identity（不重渲染所有气泡）；useLayoutEffect 只在轮数变化/streaming 结束时重算

## 日志/验证证据
```
tsc --noEmit: 0 错误
Vitest: 128/128 passed (9 files)
```

## 测试情况
- Vitest 128/128（改动后全量跑）
- tsc web/node 0 新增错误
- 交互行为按 HTML demo v4 规格：点击精确点亮、滚底亮最后一颗、短对话显示、最小间距

关联 #573（章节导航栏，原 issue 已关闭，此为其实体实现）


___

### **PR Type**
Enhancement


___

### **Description**
- Add turn gutter navigation with beads for each user turn

- Hover bead shows a preview card with full Q&A pair

- Click bead jumps to the corresponding turn; active bead highlighted

- Gutter positioned outside scroll container, always visible when ≥2 turns

- Performance: rAF throttle, layout update only on turn count or streaming end


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Messages Stream"] --> B["turnsData (per turn)"] --> C["Turn Gutter (beads)"]
  C -- "hover" --> D["Preview Card (Q+A)"]
  C -- "click" --> E["Jump to Turn"]
  E --> F["Scroll container + active bead"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Add turn gutter navigation with hover preview and click jump</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Introduced <code>turnsData</code> memoizing per-turn Q&A pairs from messages<br> <li> Added <code>useRef</code>, <code>useState</code>, <code>useCallback</code>, <code>useLayoutEffect</code> for gutter state<br> <li> Implemented <code>updateTurnUI</code> to compute bead positions with min gap, <br>top/bottom clamping<br> <li> Added rAF‑throttled scroll handler to update active turn and percents<br> <li> Wrapped each user message in a <code>div</code> with a ref registered per turn <br>index<br> <li> Rendered a turn gutter container (position absolute relative to chat <br>area) with clickable beads<br> <li> Rendered a hover preview card showing the entire Q&A, with delayed <br>close on mouse leave<br> <li> Added button inside preview to jump to the hovered turn<br> <li> Styled beads with active state (size, color, glow) and gutter bar<br> <li> Applied <code>relative</code> to chat area wrapper and scroll container for <br>positioning context</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/580/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+272/-17</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

