### PR TITLE
fix(ci): increase max_model_tokens to 128000, remove custom_reasoning_model

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -28,5 +28,6 @@ jobs:
           config.model: "openai/deepseek-v4-pro"
           config.fallback_models: '["openai/deepseek-v4-pro"]'
           config.custom_model_max_tokens: "128000"
+          config.max_model_tokens: "128000"
           config.reasoning_effort: "xhigh"
           OPENAI.API_BASE: "https://new.sixiangjia.de/v1"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -25,8 +25,8 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"
-          config.model: "openai/deepseek-v4-pro"
-          config.fallback_models: '["openai/deepseek-v4-pro"]'
+          config.model: "openai/deepseek-ai/DeepSeek-V3.2"
+          config.fallback_models: '["openai/deepseek-ai/DeepSeek-V3.2"]'
           config.custom_model_max_tokens: "128000"
           config.max_model_tokens: "128000"
           config.reasoning_effort: "xhigh"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -25,8 +25,8 @@ jobs:
           github_action_config.auto_review: "true"
           github_action_config.auto_describe: "true"
           github_action_config.auto_improve: "true"
-          config.model: "openai/deepseek-ai/DeepSeek-V3.2"
-          config.fallback_models: '["openai/deepseek-ai/DeepSeek-V3.2"]'
+          config.model: "openai/deepseek-v4-pro"
+          config.fallback_models: '["openai/deepseek-v4-pro"]'
           config.custom_model_max_tokens: "128000"
           config.max_model_tokens: "128000"
           config.reasoning_effort: "xhigh"


### PR DESCRIPTION
### **User description**
Adds config.max_model_tokens: 128000 to remove the 32000 token ceiling. This ensures the model has full output budget for code suggestions even with xhigh reasoning effort.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove 32000 token ceiling by setting max_model_tokens to 128000


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Add max_model_tokens config to PR-Agent workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Added <code>config.max_model_tokens: "128000"</code> to override the default limit</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/582/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

