### PR TITLE
feat(desktop): 轮次刻度条 + hover 整轮对话预览

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ComponentProps } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect, type ComponentProps } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { ThinkBlock } from './components/ThinkBlock';
@@ -4089,6 +4089,140 @@ export function ChatConsole({
 
   /** Retry a user message: rewind to it, resend automatically with a
    *  "answer differently" hint so the model doesn't repeat itself. */
+  // ── Turn gutter: one bead per user turn, hover shows the full Q+A ──
+  const turnsData = useMemo(() => {
+    const turns: { q: string; a: string; t: string }[] = [];
+    let cur: { q: string; a: string; t: string } | null = null;
+    for (const m of messages) {
+      if (m.role === 'user') {
+        const d = new Date(m.timestamp);
+        const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+        cur = { q: m.content, a: '', t };
+        turns.push(cur);
+      } else if (m.role === 'assistant' && cur) {
+        cur.a = m.content;
+      }
+    }
+    return turns;
+  }, [messages]);
+  const turnAnchors = useRef<(HTMLDivElement | null)[]>([]);
+  const gutterRef = useRef<HTMLDivElement>(null);
+  const [tickPercents, setTickPercents] = useState<number[]>([]);
+  const [showGutter, setShowGutter] = useState(false);
+  const [activeTurn, setActiveTurn] = useState(-1);
+  const [hoverTurn, setHoverTurn] = useState(-1);
+
+  const updateTurnUI = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || turnsData.length === 0) {
+      setShowGutter(false);
+      return;
+    }
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 4;
+    // 珠子固定间距（36px）从中间开始向上/下等距排列、整体居中——
+    // 轮次多时内容高度自动增长，刻度条内滚动承载（无滚动条）。
+    // tickPercents 存 px 位置（相对刻度条内容顶部）。
+    const SPACING = 36;
+    const positions: number[] = [];
+    for (let i = 0; i < turnsData.length; i++) {
+      positions[i] = 20 + i * SPACING;
+    }
+    setTickPercents((prev) =>
+      prev.length === positions.length && prev.every((v, idx) => v === positions[idx]) ? prev : positions
+    );
+    let cur = -1;
+    turnAnchors.current.forEach((node, i) => {
+      if (node && !atBottom && node.offsetTop - el.scrollTop <= 60) cur = i;
+    });
+    if (atBottom) cur = turnsData.length - 1; // scrolled to bottom → last bead lights up
+    setActiveTurn(cur);
+    // ≥2 turns → gutter always shows, matching the approved HTML demo v4.
+    setShowGutter(turnsData.length >= 2);
+  }, [turnsData.length]);
+
+  // Throttle scroll-driven updates to one per animation frame.
+  const scrollRafRef = useRef<number | null>(null);
+  const onScrollThrottled = useCallback(() => {
+    if (scrollRafRef.current != null) return;
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
+      updateTurnUI();
+    });
+  }, [updateTurnUI]);
+
+  // Recompute on turn-count changes, streaming end, and composer height changes
+  // (scrollHeight shifts with the composer paddingBottom) — NOT on every
+  // typewriter frame while streaming.
+  useLayoutEffect(() => {
+    updateTurnUI();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [turnsData.length, streaming, updateTurnUI]);
+
+  // Window resize changes the scroll container geometry — refresh bead positions.
+  useEffect(() => {
+    window.addEventListener('resize', onScrollThrottled);
+    return () => window.removeEventListener('resize', onScrollThrottled);
+  }, [onScrollThrottled]);
+
+  const jumpToTurn = (i: number) => {
+    const node = turnAnchors.current[i];
+    const el = scrollRef.current;
+    if (node && el) {
+      setActiveTurn(i); // light the clicked bead immediately
+      el.scrollTo({ top: Math.max(0, node.offsetTop - 12), behavior: 'smooth' });
+      setHoverTurn(-1);
+      // Flash the turn's user-message bubble (aligned to HTML demo: one bubble,
+      // ring follows the bubble's rounded shape — not a full-row square box).
+      const bubble = el.querySelector(`[data-turn-idx="${i}"] [data-message-body]`);
+      if (bubble) {
+        bubble.classList.remove('turn-flash');
+        void (bubble as HTMLElement).offsetWidth;
+        bubble.classList.add('turn-flash');
+      }
+    }
+  };
+
+  // Closing the preview is delayed so the pointer can cross the gap from a
+  // bead to the preview card without it unmounting (mouseleave fires first).
+  const closePreviewTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleClosePreview = useCallback(() => {
+    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
+    closePreviewTimer.current = setTimeout(() => setHoverTurn(-1), 200);
+  }, []);
+  const cancelClosePreview = useCallback(() => {
+    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
+  }, []);
+
+
+  // 刻度条垂直居中于消息区（scroll 容器）中心，而不是 chat area 中心——
+  // chat area 顶部有 header，top-1/2 会整体偏上。
+  const [gutterTop, setGutterTop] = useState(0);
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    const wrap = el?.parentElement;
+    if (!el || !wrap) return;
+    const update = () => setGutterTop(el.offsetTop + el.clientHeight / 2);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // 预览弹窗顶部位置：跟随 hover 珠子的可视位置（相对 chat area），
+  // 而不是固定居中——hover 哪颗珠子弹窗就出现在哪颗的高度，不遮挡内容。
+  const previewTop = useMemo(() => {
+    if (hoverTurn < 0 || !gutterRef.current) return undefined;
+    const g = gutterRef.current;
+    const beadY = (tickPercents[hoverTurn] ?? 20) - g.scrollTop; // px，相对容器可视区顶部
+    const gRect = g.getBoundingClientRect();
+    const aRect = g.parentElement?.getBoundingClientRect();
+    if (!aRect) return undefined;
+    const top = gRect.top - aRect.top + beadY;
+    return Math.min(Math.max(top, 80), aRect.height - 80);
+  }, [hoverTurn, tickPercents]);
+
+
+
   const handleRetry = useCallback(
     async (msg: Message) => {
       if (streaming) return;
@@ -4468,7 +4602,7 @@ export function ChatConsole({
       {/* ── Main area: chat + right panel ── */}
       <div className="flex flex-1 overflow-hidden">
         {/* Chat area */}
-        <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="flex flex-col flex-1 overflow-hidden relative">
           {/* ── Sub header: task title + status (inside chat area) ── */}
           <div
             className="flex items-center gap-3 px-5 min-h-12 border-b shrink-0"
@@ -4582,7 +4716,8 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto"
+            className="flex-1 overflow-y-auto relative"
+            onScroll={onScrollThrottled}
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-2">
@@ -4606,8 +4741,14 @@ export function ChatConsole({
                   </div>
                 </div>
               ) : (
-                chatGroups.map((group, i) =>
-                  group.kind === 'chain' ? (
+                (() => {
+                  // Anchor each message by TURN index — tickPercents / activeTurn /
+                  // jumpToTurn all index per user turn (bead positions).
+                  let turnIdx = -1;
+                  return chatGroups.map((group, i) => {
+                    if (group.kind !== 'chain' && group.msg.role === 'user') turnIdx += 1;
+                    const anchorTurn = group.kind !== 'chain' && group.msg.role === 'user' ? turnIdx : -1;
+                    return group.kind === 'chain' ? (
                     <ToolChainGroup
                       key={`chain-${group.rows[0]?.timestamp ?? i}-${i}`}
                       rows={group.rows}
@@ -4625,8 +4766,19 @@ export function ChatConsole({
                       onDownloadPaper={handleDownloadPaper}
                       downloadingPaperId={downloadingPaperId}
                     />
-                  ) : (
-                    <div key={`${group.msg.timestamp}-${i}`}>
+                    ) : (
+                    <div
+                      key={`${group.msg.timestamp}-${i}`}
+                      ref={
+                        group.kind !== 'chain' && group.msg.role === 'user'
+                          ? (el) => {
+                              turnAnchors.current[anchorTurn] = el;
+                            }
+                          : undefined
+                      }
+                      data-turn-role={group.msg.role}
+                      data-turn-idx={turnIdx}
+                    >
                       <MessageBubble
                         msg={group.msg}
                         sessionKey={sessionKey}
@@ -4650,11 +4802,198 @@ export function ChatConsole({
                         downloadingPaperId={downloadingPaperId}
                       />
                     </div>
-                  )
-                )
+                    );
+                  });
+                })()
               )}
             </div>
           </div>
+
+          {/* Turn gutter + preview — OUTSIDE the scroll container (siblings of
+              it), so they stay pinned to the visible chat area instead of
+              scrolling away with the messages. */}
+            {/* Turn gutter — one bead per user turn, hover previews the Q+A */}
+            {showGutter && turnsData.length > 0 && (
+              <div
+                ref={gutterRef}
+                className="turn-gutter absolute right-3 z-30 w-5"
+                style={{
+                  top: gutterTop,
+                  height: 'min(400px, 62%)',
+                  overflowY: 'auto',
+                  scrollbarWidth: 'none',
+                  msOverflowStyle: 'none',
+                }}
+                onMouseLeave={scheduleClosePreview}
+              >
+                {/* track 线（对齐 demo）：内容区中轴淡线 */}
+                <div className="relative" style={{ height: Math.max(400, (turnsData.length - 1) * 36 + 40) }}>
+                  <div
+                    className="absolute left-1/2 top-0 bottom-0 w-[3px] -translate-x-1/2 rounded-full"
+                    style={{ background: 'rgba(255,255,255,.07)' }}
+                  />
+                  {turnsData.map((_, i) => (
+                    <button
+                      key={i}
+                      className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-all duration-150 cursor-pointer before:absolute before:left-1/2 before:top-1/2 before:h-[22px] before:w-[22px] before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:content-[''] hover:!bg-[var(--accent)] hover:scale-[1.7]"
+                      style={{
+                        top: `${tickPercents[i] ?? 20}px`,
+                        width: activeTurn === i ? 11 : 8,
+                        height: activeTurn === i ? 11 : 8,
+                        background: activeTurn === i ? 'var(--accent)' : 'var(--text-faint)',
+                        boxShadow:
+                          activeTurn === i
+                            ? '0 0 10px color-mix(in srgb, var(--accent) 80%, transparent)'
+                            : 'none',
+                      }}
+                      onMouseEnter={() => {
+                        cancelClosePreview();
+                        setHoverTurn(i);
+                      }}
+                      onClick={() => jumpToTurn(i)}
+                      aria-label={`跳转到第 ${i + 1} 轮对话`}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 连接线：珠子列 → 预览弹窗（跟随珠子高度，宽度自适应弹窗位置） */}
+            {previewTop !== undefined && (
+              <div
+                className="pointer-events-none absolute z-40"
+                style={{
+                  left: 'calc(100% - 48px - 470px)',
+                  right: 14,
+                  top: previewTop,
+                  height: 2,
+                  background:
+                    'color-mix(in srgb, var(--accent) 35%, transparent)',
+                  transform: 'translateY(-50%)',
+                  borderRadius: 1,
+                }}
+              />
+            )}
+
+            {/* Turn preview — hovered turn's full Q+A, follows the bead's height */}
+            {hoverTurn >= 0 && turnsData[hoverTurn] && (
+              <div
+                className="turn-preview-enter absolute right-12 z-50 flex flex-col rounded-2xl overflow-hidden"
+                style={{
+                  width: 470,
+                  maxWidth: 'calc(100% - 60px)',
+                  top: previewTop,
+                  transform: 'translateY(-50%)',
+                  maxHeight: 'calc(100% - 28px)',
+                  background: 'var(--surface-elevated)',
+                  border: '1px solid var(--border)',
+                  boxShadow: '0 18px 60px rgba(0,0,0,.45)',
+                }}
+                onMouseEnter={cancelClosePreview}
+                onMouseLeave={scheduleClosePreview}
+              >
+                <div
+                  className="flex items-center gap-2 px-3.5 py-2.5 shrink-0"
+                  style={{
+                    borderBottom: '1px solid var(--border-subtle)',
+                    background: 'color-mix(in srgb, var(--accent) 8%, transparent)',
+                  }}
+                >
+                  <span
+                    className="text-[11px] font-bold px-2 py-0.5 rounded-md"
+                    style={{
+                      color: 'var(--accent)',
+                      background: 'color-mix(in srgb, var(--accent) 18%, transparent)',
+                    }}
+                  >
+                    Q{hoverTurn + 1}
+                  </span>
+                  <span className="text-[11px] flex-1" style={{ color: 'var(--text-muted)' }}>
+                    {turnsData[hoverTurn].t}
+                  </span>
+                </div>
+                <div className="px-3.5 py-3 overflow-y-auto flex flex-col gap-4">
+                  <div
+                    className="max-w-full self-end rounded-xl px-3 py-2"
+                    style={{
+                      background:
+                        'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
+                      color: 'var(--bubble-user-text)',
+                      borderBottomRightRadius: 4,
+                    }}
+                  >
+                    <div className="mb-1 text-[10px]" style={{ color: 'rgba(255,255,255,.55)' }}>
+                      你 · {turnsData[hoverTurn].t}
+                    </div>
+                    {/* 预览：正文最多 3 行，多了省略（meta 不占行数）；长 URL/代码换行不溢出 */}
+                    <div
+                      className="text-[12.5px] leading-relaxed"
+                      style={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 3,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                        // -webkit-box 布局下 overflow-wrap 无效，长 URL 必须 break-all
+                        wordBreak: 'break-all',
+                      }}
+                    >
+                      {turnsData[hoverTurn].q}
+                    </div>
+                  </div>
+                  {turnsData[hoverTurn].a ? (
+                    <div
+                      className="max-w-full self-start rounded-xl px-3 py-2"
+                      style={{
+                        background: 'var(--surface-muted)',
+                        border: '1px solid var(--border-subtle)',
+                        color: 'var(--text)',
+                        borderBottomLeftRadius: 4,
+                      }}
+                    >
+                      <div className="mb-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                        MiQi
+                      </div>
+                      <div
+                        className="text-[12.5px] leading-relaxed"
+                        style={{
+                          display: '-webkit-box',
+                          WebkitLineClamp: 3,
+                          WebkitBoxOrient: 'vertical',
+                          overflow: 'hidden',
+                          // -webkit-box 布局下 overflow-wrap 无效，长 URL 必须 break-all
+                          wordBreak: 'break-all',
+                        }}
+                      >
+                        {turnsData[hoverTurn].a}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="text-[11.5px] px-3 py-2" style={{ color: 'var(--text-faint)' }}>
+                      回答生成中…
+                    </div>
+                  )}
+                </div>
+                <div
+                  className="px-3.5 py-2 shrink-0 text-right"
+                  style={{ borderTop: '1px solid var(--border-subtle)' }}
+                >
+                  <button
+                    onClick={() => jumpToTurn(hoverTurn)}
+                    className="text-[11px] rounded-full px-3 py-1 transition-colors"
+                    style={{
+                      color: 'var(--accent)',
+                      border: '1px solid color-mix(in srgb, var(--accent) 40%, transparent)',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.background = 'color-mix(in srgb, var(--accent) 18%, transparent)')
+                    }
+                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+                  >
+                    📍 跳转到此轮查看完整内容
+                  </button>
+                </div>
+              </div>
+            )}
 
           {/* Composer */}
           <div
@@ -6074,7 +6413,8 @@ function MessageBubble({
 
             {/* Main bubble */}
             <div
-              className="text-sm leading-relaxed rounded-2xl px-4 py-3"
+              data-message-body
+              className="text-sm leading-relaxed rounded-2xl px-4 py-3 break-words"
               style={
                 isUser
                   ? { background: 'var(--bubble-user-bg)', color: 'var(--bubble-user-text)' }


### PR DESCRIPTION
### **User description**
## 类型
- [x] ✨ 新功能

## 变更概述
聊天区右侧中部新增轮次刻度条：每轮用户提问对应一颗珠子（按消息真实位置分布），悬停珠子弹出整轮问答预览卡片，点击跳转定位。

## 背景/问题
长对话难以定位关键轮次（来自 #549 讨论演进）：手动滚动查找效率低；独立游标/书签方案操作成本高。参考 ChatGPT/DeepSeek 的定位刻度设计，采用"每轮一颗珠子 + hover 预览"方案——零操作、上下文感知。

## 变更内容
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：
  - 每轮用户提问一颗珠子，位置 = 该轮消息真实 offsetTop 比例（最小间距 3.5%，短回答不重叠）
  - 当前阅读轮次珠子高亮发光（珠子即游标，无独立游标）
  - hover 珠子（扩大触发区）→ 居中偏右弹出整轮 Q+A 预览卡片，高度自适应内容（上限内滚动，不截断）
  - 点击珠子/预览底部按钮 → 平滑跳转并立即点亮；滚到底部点亮最后一颗
  - 刻度条在滚动容器外（absolute 于 chat area），滚动消息时不消失
  - 预览关闭 200ms 延迟，指针跨 gap 不消失；scroll 更新 rAF 节流
  - useLayoutEffect 只在轮数变化/streaming 结束时重算，不逐打字帧触发
  - ≥2 轮对话显示（不满一屏时珠子均匀分布）
  - 全部使用主题变量（浅/深色主题自适应）

## 日志/验证证据
```
esbuild: Done
Vitest: 128 passed (9 files)
tsc: 0 新增错误
```

## 测试情况
- Vitest 128/128 通过
- TypeScript 0 新增错误
- UI 实机验证中

## 截图
无（UI 功能，实机验证）

## 后续计划
- 长对话可叠加搜索框（后续 issue）


___

### **PR Type**
Enhancement


___

### **Description**
- Add turn gutter with bead navigation for quick turn location

- Implement hover preview showing full Q&A with delayed close

- Auto-track active turn based on scroll position and highlight bead

- Jump-to-turn with smooth scroll and flash animation on target bubble


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scroll event (throttled)"] --> B["updateTurnUI()"]
  B --> C["Compute bead positions (fixed 36 px spacing)"]
  B --> D["Determine active turn from scroll position"]
  B --> E["Show/hide gutter (≥2 turns)"]
  D --> F["Highlight active bead"]
  G["Hover bead"] --> H["Show preview card at bead height"]
  H --> I["Delayed close (200 ms) to allow crossing gap"]
  H --> J["Click "跳转到此轮查看完整内容""]
  J --> K["jumpToTurn()"]
  K --> L["ScrollTo + flash animation on user bubble"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Implement turn gutter navigation and hover preview in chat</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Import useLayoutEffect for layout-bound updates<br> <li> Build turnsData from messages to extract each user turn with Q&A and <br>time<br> <li> Compute bead positions with fixed 36 px spacing, show gutter only when <br>≥2 turns<br> <li> Track active turn based on scroll proximity and bottom-of-chat <br>detection<br> <li> Throttle scroll updates with requestAnimationFrame to avoid <br>over‑rendering<br> <li> Center gutter vertically within scroll container using ResizeObserver<br> <li> Implement jumpToTurn that smooth‑scrolls and adds flash animation via <br>CSS class toggle<br> <li> Add hover preview card that appears at bead‑relative height, with 200 <br>ms close delay to allow cursor transition<br> <li> Pre‑compute previewTop to align the preview card vertically with the <br>hovered bead<br> <li> Render connection line between bead column and preview card when <br>visible<br> <li> Adjust message rendering loop to assign DOM refs to user messages and <br>set data‑attributes (data-turn-idx, data‑turn-role)<br> <li> Add data-message-body attribute and break-words class to message <br>bubbles for styling and overflow handling<br> <li> Wrap gutter and preview elements outside the scroll container to keep <br>them pinned during scrolling</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/586/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+350/-10</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

