### PR TITLE
fix(desktop): add cross-session inFlightCache to recover streaming reply (#378)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1206,6 +1206,24 @@ export function ChatConsole({
   // Track the active thread ID for new-protocol thread-aware conversations
   const currentThreadIdRef = useRef<string | null>(null);
 
+  // ── Cross-session in-flight event cache (#378) ──────────────────
+  // When the user switches sessions mid-stream, the per-send listeners
+  // silently bail (data.session_key !== currentSessionRef.current).
+  // This cache captures those events so the session-load effect can
+  // replay them when the user switches back, avoiding the permanent
+  // loss of the assistant reply.
+  interface InFlightEvent {
+    type: 'progress' | 'final' | 'error' | 'aborted';
+    data: unknown;
+    timestamp: number;
+  }
+  interface InFlightSnapshot {
+    events: InFlightEvent[];
+    userMsgTimestamp: number;
+  }
+  const inFlightCacheRef = useRef<Map<string, InFlightSnapshot>>(new Map());
+  const fullContentRef = useRef('');
+
   // ── Thread tabs for multi-agent support ──
   interface ThreadTab {
     threadId: string;
@@ -1386,6 +1404,44 @@ export function ChatConsole({
         const rawMsgs: any[] = (detail as any)?.messages ?? [];
         const uiMsgs = sessionMsgsToUi(rawMsgs);
         setMessages(uiMsgs);
+
+        // ── Replay cached cross-session in-flight events (#378) ─────
+        // If events arrived while the user was on another session, the
+        // per-send listeners stored them in inFlightCacheRef.  Replay
+        // them now so the assistant reply and progress messages appear
+        // immediately without requiring a manual refresh.
+        var cached = inFlightCacheRef.current.get(sessionKey);
+        if (cached && cached.events.length > 0) {
+          setStreaming(true);
+          for (var _j = 0; _j < cached.events.length; _j++) {
+            var _ev = cached.events[_j];
+            if (_ev.type === 'progress') {
+              var _pd = _ev.data as any;
+              if (_pd?.text && !_pd?.stream) {
+                setMessages(function (_prev) { return _prev.concat([{ role: 'progress', content: _pd.text, timestamp: Date.now() }]); });
+              }
+            } else if (_ev.type === 'final') {
+              var _fd = _ev.data as any;
+              setMessages(function (_prev) {
+                var _cl = _prev.filter(function (_m) { return _m.role !== 'progress' || _m.toolHint; });
+                var _lu = _cl[_cl.length - 1];
+                if (_lu?.role === 'user' && _fd?.content) {
+                  return _cl.concat([{ role: 'assistant', content: _fd.content, timestamp: _lu.timestamp + 1 }]);
+                }
+                return _cl;
+              });
+              setStreaming(false);
+            } else if (_ev.type === 'error') {
+              var _ed = _ev.data as any;
+              setMessages(function (_prev) { return _prev.concat([{ role: 'error', content: _ed?.message || 'Unknown error', timestamp: Date.now() }]); });
+              setStreaming(false);
+            } else if (_ev.type === 'aborted') {
+              setMessages(function (_prev) { return _prev.concat([{ role: 'progress', content: '已停止。', timestamp: Date.now() }]); });
+              setStreaming(false);
+            }
+          }
+          inFlightCacheRef.current.delete(sessionKey);
+        }
         setSessionUpdatedAt((detail as any)?.updated_at ?? null);
         // Restore tracked files from dedicated tracked_files.json
         let tfList: any[] = [];
@@ -1785,6 +1841,7 @@ export function ChatConsole({
     cleanupListeners();
 
     let fullContent = '';
+    fullContentRef.current = '';
     let displayed = '';
     let animId: number | null = null;
     let finalDone = false;
@@ -1869,7 +1926,12 @@ export function ChatConsole({
     };
 
     const unsubProgress = window.miqi.chat.onProgress((data: ChatProgress) => {
-      if (data.session_key && data.session_key !== currentSessionRef.current) return;
+      if (data.session_key && data.session_key !== currentSessionRef.current) {
+        var buf = inFlightCacheRef.current.get(data.session_key);
+        if (!buf) { buf = { events: [], userMsgTimestamp: 0 }; inFlightCacheRef.current.set(data.session_key, buf); }
+        buf.events.push({ type: 'progress', data, timestamp: Date.now() });
+        return;
+      }
       lastEventAt = Date.now();
 
       // ── Document progress events ───────────────────────────────
@@ -1977,7 +2039,12 @@ export function ChatConsole({
     });
 
     const unsubFinal = window.miqi.chat.onFinal((data: ChatFinal) => {
-      if (data.session_key && data.session_key !== currentSessionRef.current) return;
+      if (data.session_key && data.session_key !== currentSessionRef.current) {
+        var buf = inFlightCacheRef.current.get(data.session_key);
+        if (!buf) { buf = { events: [], userMsgTimestamp: 0 }; inFlightCacheRef.current.set(data.session_key, buf); }
+        buf.events.push({ type: 'final', data, timestamp: Date.now() });
+        return;
+      }
       clearFinalCleanupTimer();
       if (animId !== null) {
         cancelAnimationFrame(animId);
@@ -2080,7 +2147,12 @@ export function ChatConsole({
     });
 
     const unsubError = window.miqi.chat.onError((data: ChatError) => {
-      if (data.session_key && data.session_key !== currentSessionRef.current) return;
+      if (data.session_key && data.session_key !== currentSessionRef.current) {
+        var buf = inFlightCacheRef.current.get(data.session_key);
+        if (!buf) { buf = { events: [], userMsgTimestamp: 0 }; inFlightCacheRef.current.set(data.session_key, buf); }
+        buf.events.push({ type: 'error', data, timestamp: Date.now() });
+        return;
+      }
       streamErrorHandled = true;
       if (animId !== null) cancelAnimationFrame(animId);
       const message = sanitizeUiMessage(data.message);
@@ -2096,7 +2168,12 @@ export function ChatConsole({
     });
 
     const unsubAborted = window.miqi.chat.onAborted((_data: ChatAborted) => {
-      if (_data.session_key && _data.session_key !== currentSessionRef.current) return;
+      if (_data.session_key && _data.session_key !== currentSessionRef.current) {
+        var buf = inFlightCacheRef.current.get(_data.session_key);
+        if (!buf) { buf = { events: [], userMsgTimestamp: 0 }; inFlightCacheRef.current.set(_data.session_key, buf); }
+        buf.events.push({ type: 'aborted', data: _data, timestamp: Date.now() });
+        return;
+      }
       if (animId !== null) cancelAnimationFrame(animId);
       setStreaming(false);
       setCurrentReqId(null);


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复跨会话切换时流式回复丢失的问题：切回原会话后，助手气泡会持续显示而无需手动刷新。

## 背景/问题

Issue #378：用户在会话 A 中发送消息，在流式回复生成过程中切换到会话 B，再切回 A 时只能看到已发送的问题，必须按 F5 刷新才能看到回复。

根本原因：ChatConsole 的 per-send 监听器在切换到其他会话后，对携带其他 session_key 的事件直接 return 丢弃了。

## 变更内容

只改一个文件 ChatConsole.tsx（+81 行）：

1. 添加 InFlightEvent/InFlightSnapshot 类型和 inFlightCacheRef 缓存 Map
2. 在 onProgress/onFinal/onError/onAborted 中，当事件 session_key 与当前会话不匹配时，存入缓存而非直接丢弃
3. 在 session-load effect 中，切换回会话时重放缓存的事件，恢复 assistant bubble

## 日志/验证证据

```
# 修复前：切回 A 只有 heading，无 assistant bubble
heading "QUESTION_A" [level=2]
text: QUESTION_A U

# 修复后：切回 A 可见 assistant 内容
heading "QUESTION_A" [level=2]
Cats are curious creatures who often nap in sunbeams
QUESTION_A U
```

## 测试情况

- vitest: 128 passed
- TypeScript: 0 errors
- Playwright smoke: 待跑

## 截图

无需截图（纯逻辑修复，无 UI 变更）。


___

### **PR Type**
Bug fix


___

### **Description**
- Add InFlightEvent/InFlightSnapshot types and in‑flight event cache Map

- Cache progress/final/error/aborted events when session_key does not match current session

- Replay cached events on session‑load to display assistant reply after switching back

- Prevent permanent loss of streaming assistant content on session switch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User sends message"] --> B["Backend streams events"]
  B --> C{"Session matches?"}
  C -- "No" --> D["Store in inFlightCacheRef"]
  C -- "Yes" --> E["Update UI"]
  D --> F["User switches back"]
  F --> G["Session‑load replays cache"]
  G --> H["Assistant reply visible"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Cache off‑screen session chat events and replay on session return</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Added InFlightEvent, InFlightSnapshot types and inFlightCacheRef Map <br>for cross‑session event caching.<br> <li> Modified onProgress, onFinal, onError, onAborted listeners to push <br>events into the cache when the session_key does not match the current <br>session.<br> <li> In the session‑load effect, cached events are replayed to reconstruct <br>assistant messages and progress notes, then the cache is cleared.<br> <li> Introduced fullContentRef (set during send, minor addition).</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/588/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+81/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

