### PR TITLE
fix(ci): 限制 PR Agent 输出长度——英文回复不再超长溢出 GitHub UI

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -31,6 +31,11 @@ jobs:
           config.model: "openai/deepseek-v4-pro"
           config.fallback_models: '["openai/deepseek-v4-pro"]'
           config.custom_model_max_tokens: "128000"
-          config.max_model_tokens: "128000"
+          # Cap output length — 128k output produced multi-thousand-line
+          # review comments that overflow the GitHub UI and get cut off.
+          # English replies hit the cap much sooner than Chinese (same info
+          # takes ~1.5-2x tokens), which is why English queries overflow.
+          config.max_model_tokens: "16000"
+          config.verbosity_level: "3"
           config.reasoning_effort: "xhigh"
           OPENAI.API_BASE: "https://new.sixiangjia.de/v1"


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 Bug 修复

## 变更概述
PR Agent（pr-agent.yml）生成的 review/describe/improve 评论在英文提问时超长，溢出 GitHub UI 边框导致内容不可见。限制输出 token 上限 + 降低详细度。

## 背景/问题
测试发现：给 PR Agent 发英文指令时回复超长（超出界面边框看不到），中文指令正常。原因：`config.max_model_tokens: 128000` 等于无输出上限，配合 `reasoning_effort: xhigh` 会生成数千行评论；英文回复同信息量 token 数约为中文 1.5-2 倍，所以英文更容易触发超长输出。

## 变更内容
- `.github/workflows/pr-agent.yml`：
  - `config.max_model_tokens` 128000 → 16000（评论输出上限，16k token 足够完整 review 且不会撑爆 UI）
  - 新增 `config.verbosity_level: "3"`（适中详细度，默认更高）
  - 保留其他配置（pr_actions / push 触发器 / reasoning_effort）

## 日志/验证证据
```
修复前：英文 /review 生成多千行评论，GitHub UI 溢出
修复后：输出上限 16k token + 详细度 3，评论长度可控
```

## 测试情况
- workflow 语法检查通过（YAML 结构有效）
- 实际效果待下个 PR 的 PR Agent 评论验证

## 截图
无需截图


___

### **PR Type**
Bug fix


___

### **Description**
- Cap PR Agent output tokens from 128k to 16k to prevent comment overflow in GitHub UI.

- Add `verbosity_level: 3` for moderate detail.

- Provide inline explanation linking the fix to token count differences between English and Chinese.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    Config["PR Agent Config"] --> Token["max_model_tokens: 128000 → 16000"]
    Config --> Verbose["verbosity_level: not set → 3"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Cap output tokens and reduce verbosity for PR Agent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Reduced <code>max_model_tokens</code> from 128000 to 16000 to limit output length.<br> <li> Added <code>verbosity_level: "3"</code> for moderate detail.<br> <li> Added comments explaining why English replies overflow while Chinese <br>does not (token count difference).</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/590/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

