### PR TITLE
fix(feedback): use filename date for log sorting, head-preserving truncation

### DIFF
--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -10,6 +10,7 @@ import json
 import platform
 import sys
 import os
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -52,72 +53,88 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
     """Read files under workspace/logs/ recursively, limited to those
     modified within *max_age_days*, and return concatenated text.
 
-    Individual files are capped at 1 MB (tail end).  The combined payload
+    Individual files are capped at 50k chars (tail end).  The combined payload
     is capped at 196,608 UTF-8 bytes to fit within Feishu Bitable
-    text-field limits.
+    text-field limits.  Newest files are preserved first.
     """
     if not log_dir.exists():
         return "[日志目录不存在]"
 
+    MAX_LOG_BYTES = 196_608  # Feishu Bitable text-field limit
+
     cutoff = time.time() - max_age_days * 86400
+    _date_re = re.compile(r"(\d{4}-\d{2}-\d{2})")
     parts: list[str] = []
     recent_count = 0
     skipped_count = 0
     unreadable_count = 0
 
-    for f in sorted(log_dir.rglob("*"), key=lambda p: os.path.getmtime(str(p)), reverse=True):
+    def _file_sort_key(p: Path) -> float:
+        m = _date_re.search(p.name)
+        if m:
+            try:
+                t = time.mktime(time.strptime(m.group(1), "%Y-%m-%d"))
+                return t
+            except ValueError:
+                pass
+        try:
+            return os.path.getmtime(str(p))
+        except OSError:
+            return 0.0
+
+    def _file_age_days(p: Path) -> float:
+        m = _date_re.search(p.name)
+        if m:
+            try:
+                t = time.mktime(time.strptime(m.group(1), "%Y-%m-%d"))
+                return (time.time() - t) / 86400
+            except ValueError:
+                pass
+        try:
+            return (time.time() - os.path.getmtime(str(p))) / 86400
+        except OSError:
+            return 999
+
+    for f in sorted(log_dir.rglob("*"), key=_file_sort_key, reverse=True):
         if not f.is_file():
             continue
-        try:
-            mtime = os.path.getmtime(str(f))
-        except OSError:
-            unreadable_count += 1
-            continue
-        if mtime < cutoff:
+        if _file_age_days(f) > max_age_days:
             skipped_count += 1
             continue
         recent_count += 1
         try:
             content = f.read_text(encoding="utf-8", errors="replace")
-            max_chars = 1_000_000
+            max_chars = 50_000
             if len(content) > max_chars:
-                content = f"...(截断 {len(content) - max_chars} 字符)\n{content[-max_chars:]}"
+                content = content[-max_chars:]
             rel = f.relative_to(log_dir)
             parts.append(f"=== {rel} ===\n{content}")
         except Exception as exc:
             parts.append(f"=== {f.name} === [读取失败: {exc}]")
 
-    if not parts:
+    final_parts: list[str] = []
+    total_bytes = 0
+    for part in parts:
+        part_bytes = len(part.encode("utf-8"))
+        if total_bytes + part_bytes > MAX_LOG_BYTES:
+            remaining = MAX_LOG_BYTES - total_bytes
+            if remaining > 200:
+                tail = part.encode("utf-8")[:remaining].decode("utf-8", errors="ignore")
+                final_parts.append(tail + "\n...(截断: 超出总大小限制)")
+            break
+        final_parts.append(part)
+        total_bytes += part_bytes
+
+    if not final_parts:
         return f"[最近{max_age_days}天无日志文件（跳过{skipped_count}个旧文件）]"
 
-    marker = []
     if skipped_count:
-        marker.append(f"（跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件）")
+        final_parts.insert(0, f"（跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件）\n")
     if unreadable_count:
-        marker.append(f"（{unreadable_count} 个文件无法读取修改时间）")
-    if marker:
-        parts.insert(0, "\n".join(marker) + "\n")
+        final_parts.insert(1 if skipped_count else 0, f"（{unreadable_count} 个文件无法读取修改时间）\n")
 
-    combined = "\n\n".join(parts)
-    # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 196,608 bytes.
-    # Not 100k chars (Chinese characters can be 3+ bytes each).  Encode once,
-    # then slice the tail bytes directly to avoid repeatedly re-encoding.
-    MAX_LOG_BYTES = 196_608
-    encoded = combined.encode("utf-8")
-    total_bytes = len(encoded)
-    if total_bytes > MAX_LOG_BYTES:
-        # Reserve 120 bytes for the marker text plus extra headroom
-        keep_bytes = MAX_LOG_BYTES - 120
-        retained = encoded[-keep_bytes:].decode("utf-8", errors="ignore")
-        retained_bytes = len(retained.encode("utf-8"))
-        dropped = total_bytes - retained_bytes
-        marker = f"...(总日志超出 {dropped} 字节，已截断)\n"
-        candidate = marker + retained
-        if len(candidate.encode("utf-8")) > MAX_LOG_BYTES:
-            excess = len(candidate.encode("utf-8")) - MAX_LOG_BYTES
-            retained = retained.encode("utf-8")[:-excess].decode("utf-8", errors="ignore")
-            return marker + retained
-        return candidate
+    combined = "\n\n".join(final_parts)
+
     return combined
 
 

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -12,7 +12,7 @@ import sys
 import os
 import re
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -61,8 +61,8 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
         return "[日志目录不存在]"
 
     MAX_LOG_BYTES = 196_608  # Feishu Bitable text-field limit
+    NOTICE_BUDGET = 300  # reserve bytes for skipped/unreadable notices and separators
 
-    cutoff = time.time() - max_age_days * 86400
     _date_re = re.compile(r"(\d{4}-\d{2}-\d{2})")
     parts: list[str] = []
     recent_count = 0
@@ -73,8 +73,7 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
         m = _date_re.search(p.name)
         if m:
             try:
-                t = time.mktime(time.strptime(m.group(1), "%Y-%m-%d"))
-                return t
+                return datetime.strptime(m.group(1), "%Y-%m-%d").timestamp()
             except ValueError:
                 pass
         try:
@@ -82,23 +81,28 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
         except OSError:
             return 0.0
 
-    def _file_age_days(p: Path) -> float:
+    def _file_age_days(p: Path) -> float | None:
         m = _date_re.search(p.name)
         if m:
             try:
-                t = time.mktime(time.strptime(m.group(1), "%Y-%m-%d"))
-                return (time.time() - t) / 86400
+                file_date = date.fromisoformat(m.group(1))
+                return (date.today() - file_date).days
             except ValueError:
                 pass
         try:
-            return (time.time() - os.path.getmtime(str(p))) / 86400
+            mtime = os.path.getmtime(str(p))
+            return (time.time() - mtime) / 86400
         except OSError:
-            return 999
+            return None
 
     for f in sorted(log_dir.rglob("*"), key=_file_sort_key, reverse=True):
         if not f.is_file():
             continue
-        if _file_age_days(f) > max_age_days:
+        age = _file_age_days(f)
+        if age is None:
+            unreadable_count += 1
+            continue
+        if age > max_age_days:
             skipped_count += 1
             continue
         recent_count += 1
@@ -113,7 +117,7 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
             parts.append(f"=== {f.name} === [读取失败: {exc}]")
 
     final_parts: list[str] = []
-    total_bytes = 0
+    total_bytes = NOTICE_BUDGET  # reserve for notices prepended later
     for part in parts:
         part_bytes = len(part.encode("utf-8"))
         if total_bytes + part_bytes > MAX_LOG_BYTES:
@@ -434,9 +438,9 @@ async def feedback_submit_handler(
         encoded = value.encode("utf-8")
         if len(encoded) <= max_bytes:
             return value
-        tail = encoded[-max_bytes:].decode("utf-8", errors="ignore")
-        marker = f"...(截断 {len(encoded) - len(tail.encode('utf-8'))} 字节)\n"
-        return marker + tail
+        head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+        dropped = len(encoded) - len(head.encode("utf-8"))
+        return head + f"\n...(截断 {dropped} 字节)"
 
     fields: dict[str, Any] = {
         "类别": category,

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -122,9 +122,11 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
         part_bytes = len(part.encode("utf-8"))
         if total_bytes + part_bytes > MAX_LOG_BYTES:
             remaining = MAX_LOG_BYTES - total_bytes
-            if remaining > 200:
-                tail = part.encode("utf-8")[:remaining].decode("utf-8", errors="ignore")
-                final_parts.append(tail + "\n...(截断: 超出总大小限制)")
+            marker = "\n...(截断: 超出总大小限制)"
+            marker_bytes = len(marker.encode("utf-8"))
+            if remaining > marker_bytes:
+                tail = part.encode("utf-8")[:remaining - marker_bytes].decode("utf-8", errors="ignore")
+                final_parts.append(tail + marker)
             break
         final_parts.append(part)
         total_bytes += part_bytes

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -363,15 +363,16 @@ def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 400k ASCII chars -> ~400k bytes UTF-8
-    (log_dir / "big.log").write_text("a" * 400_000, encoding="utf-8")
+    # Create multiple large files so combined exceeds 196k byte cap
+    for i in range(10):
+        (log_dir / f"log-2026-08-{i:02d}.log").write_text("a" * 100_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     # Must be at most 196,608 bytes
     assert len(result.encode("utf-8")) <= 196_608, (
         f"Expected <= 196608 bytes, got {len(result.encode('utf-8'))}"
     )
     # And it must include the truncation marker
-    assert "已截断" in result
+    assert "截断" in result
 
 
 def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
@@ -379,8 +380,9 @@ def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 80k CJK chars = ~240k bytes UTF-8, exceeds 196k byte cap
-    (log_dir / "cjk.log").write_text("中" * 80_000, encoding="utf-8")
+    # Create multiple CJK files so combined exceeds 196k byte cap
+    for i in range(10):
+        (log_dir / f"中-2026-08-{i:02d}.log").write_text("中" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     assert len(result.encode("utf-8")) <= 196_608
 
@@ -390,8 +392,9 @@ def test_collect_all_logs_byte_cap_exact_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 210k ASCII chars = 210k bytes, just over the cap
-    (log_dir / "edge.log").write_text("x" * 210_000, encoding="utf-8")
+    # Create multiple files so combined exceeds the cap
+    for i in range(10):
+        (log_dir / f"edge-2026-08-{i:02d}.log").write_text("x" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     assert len(result.encode("utf-8")) <= 196_608
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

使用文件名中的日期进行日志排序和年龄过滤，替代不可靠的 mtime；改为头部保留截断策略，确保最新日志优先保留。

## 背景/问题

PR #569 squash merge 后，后续优化 commit 未包含进来：
1. `os.path.getmtime()` 不可靠（在某些文件系统上返回不准确的修改时间），且 WSL 环境下 mtime 可能与实际日志日期不一致
2. 日志文件名本身就包含日期（`bridge-2026-08-04.log`），应直接从中提取
3. 旧的字节截断逻辑对整体已拼好的内容做 `encoded[-keep_bytes:]`，会截掉开头的最新文件，导致用户看到的是旧日志
4. 每个文件 1MB 上限太宽松，50k chars 足够覆盖关键信息

## 变更内容

- **`miqi/runtime/feedback_handlers.py`** — `_collect_all_logs()`:
  - 新增 `_file_sort_key()` 和 `_file_age_days()`：优先从文件名正则提取日期，fallback 到 mtime
  - `_file_age_days()` 对不可读 mtime 返回 None，由外层 `unreadable_count` 统计并跳过
  - 日期比较改用 `date.fromisoformat()`，避免 `time.mktime()` 午夜边界问题
  - 每文件上限从 1MB 降至 50k chars
  - 头部保留截断：文件按最新优先排序，按顺序累加直到超出 196KB 限制
  - `NOTICE_BUDGET` 预留 300 字节给跳过/不可读提示
- **`_cap_text()`**: 从尾部保留改为头部保留，与日志排序方向一致

## 日志/验证证据

```
测试环境：本地 ~/.miqi/workspace/logs/

develop (当前): sandbox-2026-07-30.log ONLY — 最新日志全丢失
PR #592: 6 files (196,125 chars, 196,353 bytes)
  bridge-2026-08-04.log  IN
  sandbox-2026-08-04.log IN
  bridge-2026-08-03.log  IN
  bridge-2026-07-31.log  IN
  sandbox-2026-07-31.log IN
  bridge-2026-07-30.log  IN
  sandbox-2026-07-30.log OUT (超出限制被截断)
```

## 截图

N/A（纯后端日志收集逻辑，无 UI 变更）

## 测试情况

- 本地运行 `_collect_all_logs()` 验证文件顺序和截断行为正确
- 确认最新 8.4 日志排在开头且被保留
- `_cap_text()` 头部保留逻辑单独验证通过


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use filename date for log sorting and age filtering instead of mtime.

- Reduce per-file log cap from 1 MB to 50k chars.

- Apply head‑preserving truncation to keep newest logs within Feishu byte limit.

- Handle unreadable file metadata gracefully and switch `_cap_text` to head‑preserving.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scan log_dir"] --> B["sort by filename date"]
  B --> C["filter by age (≤7 days)"]
  C --> D["per‑file cap tail 50k chars"]
  D --> E["accumulate head‑first with byte budget"]
  E --> F["truncate oldest files that exceed limit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feedback_handlers.py</strong><dd><code>Sort logs by filename date, head‑preserving truncation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/feedback_handlers.py

<ul><li>Implement <code>_file_sort_key</code> to extract date from filename using regex, <br>fallback to mtime.<br> <li> Implement <code>_file_age_days</code>; return <code>None</code> on unreadable mtime, count as <br>unreadable.<br> <li> Reduce per-file cap from 1 MB to 50k chars (tail truncation).<br> <li> Use head‑preserving truncation: accumulate newest files first, reserve <br><code>NOTICE_BUDGET</code> for notices.<br> <li> Insert skipped/unreadable count notices at the head of <code>final_parts</code>.<br> <li> Switch <code>_cap_text</code> from tail‑preserving to head‑preserving truncation.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/592/files#diff-037c12a259e2c263bed9fd2785cf9659368af4f517300651d2005473b4a6cdd9">+64/-41</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_feedback_handlers.py</strong><dd><code>Update log collection tests for filename‑based sorting and byte cap</code></dd></summary>
<hr>

tests/runtime/test_feedback_handlers.py

<ul><li>Update byte‑cap tests to use multiple files (50k chars each) to <br>exercise new per‑file limit.<br> <li> Adjust truncation marker assertions to match head‑preserving output.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/592/files#diff-ff26736b1a64aa7f36a3e8cbfac48f8952a6d2aeb6b1a9a45b5058e1e6b24de2">+10/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

