### PR TITLE
fix(desktop): wrap long URLs in chat bubbles (#591)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2976,7 +2976,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto relative"
+            className="flex-1 overflow-y-auto overflow-x-hidden relative"
             style={{ background: 'var(--background)', paddingBottom: `calc(${composerHeight}px + ${ANSWER_GAP})` }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -3818,7 +3818,7 @@ function MessageBubble({
     return (
       <div
         className={cn(
-          'flex items-center gap-2 text-xs py-1 px-1',
+          'flex min-w-0 items-center gap-2 text-xs py-1 px-1',
           msg.collapsed && 'cursor-pointer select-none'
         )}
         style={{ color: msg.toolHint ? 'var(--info)' : 'var(--text-muted)' }}
@@ -3861,14 +3861,15 @@ function MessageBubble({
   }
   if (msg.role === 'error') {
     return (
-      <div className="flex items-start gap-3">
+      <div className="flex min-w-0 items-start gap-3">
         <AgentAvatar />
         <div
-          className="text-sm rounded-2xl px-4 py-3"
+          className="text-sm rounded-2xl px-4 py-3 min-w-0 max-w-[82%] break-words"
           style={{
             background: 'var(--danger-bg)',
             color: 'var(--danger)',
             border: '1px solid var(--danger)',
+            overflowWrap: 'anywhere',
           }}
         >
           <div className="whitespace-pre-wrap break-words">{msg.content}</div>
@@ -3893,7 +3894,7 @@ function MessageBubble({
 
   if (msg.role === 'subagent') {
     return (
-      <div className="flex items-start gap-3">
+      <div className="flex min-w-0 items-start gap-3">
         <GitMerge size={18} style={{ color: 'var(--accent)', marginTop: 6 }} />
         <div
           className="text-sm rounded-2xl px-4 py-3 prose prose-sm max-w-none break-words overflow-x-auto"
@@ -3973,7 +3974,7 @@ function MessageBubble({
       {({ onContextMenu }) => (
         <div
           ref={bubbleRef}
-          className={cn('flex items-start gap-3', isUser && 'justify-end')}
+          className={cn('flex min-w-0 items-start gap-3', isUser && 'justify-end')}
           onContextMenu={(e) => {
             // Capture any manual selection before hover-preview can replace it
             capturedSelectionRef.current = window.getSelection()?.toString().trim() ?? '';
@@ -3985,7 +3986,7 @@ function MessageBubble({
 
           <div
             className={cn(
-              'group flex flex-col gap-1.5',
+              'group flex min-w-0 flex-col gap-1.5',
               isUser ? 'items-end max-w-[70%]' : 'max-w-[82%]'
             )}
           >
@@ -4007,7 +4008,7 @@ function MessageBubble({
               .map((att, i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                  className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
                   style={{
                     background: 'var(--surface-muted)',
                     border: '1px solid var(--border-subtle)',
@@ -4015,7 +4016,7 @@ function MessageBubble({
                   }}
                 >
                   <FileText size={12} className="shrink-0 text-text-faint" />
-                  <span>{att.name}</span>
+                  <span className="truncate min-w-0" title={att.name}>{att.name}</span>
                 </div>
               ))}
             {/* document attachments */}
@@ -4028,7 +4029,7 @@ function MessageBubble({
                 return (
                   <div
                     key={i}
-                    className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-all duration-500"
+                    className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-all duration-500"
                     style={{
                       background: isDone && cat ? cat.bg : 'var(--surface-muted)',
                       border: `1px solid ${isDone && cat ? cat.color + '40' : 'var(--border-subtle)'}`,
@@ -4066,7 +4067,7 @@ function MessageBubble({
                 return chips.map((chip, i) => (
                   <div
                     key={`hist-${i}`}
-                    className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                    className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
                     style={{
                       background: chip.category.bg,
                       border: `1px solid ${chip.category.color}40`,
@@ -4079,7 +4080,7 @@ function MessageBubble({
                     >
                       {chip.category.label}
                     </span>
-                    <span>{chip.name}</span>
+                    <span className="truncate min-w-0" title={chip.name}>{chip.name}</span>
                     <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
                   </div>
                 ));
@@ -4088,7 +4089,7 @@ function MessageBubble({
             {/* Main bubble */}
             <div
               data-message-body
-              className="text-sm leading-relaxed rounded-2xl px-4 py-3"
+              className="text-sm leading-relaxed rounded-2xl px-4 py-3 min-w-0 break-words"
               style={
                 isUser
                   ? {
@@ -4096,12 +4097,14 @@ function MessageBubble({
                         'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
                       color: 'var(--bubble-user-text)',
                       borderBottomRightRadius: 6,
+                      overflowWrap: 'anywhere',
                     }
                   : {
                       background: 'var(--bubble-ai-bg)',
                       color: 'var(--bubble-ai-text)',
                       border: '1px solid var(--bubble-ai-border)',
                       borderBottomLeftRadius: 6,
+                      overflowWrap: 'anywhere',
                     }
               }
             >

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -100,7 +100,7 @@ function PaperCard({
 
   return (
     <div
-      className="my-2 rounded-xl border overflow-hidden"
+      className="my-2 min-w-0 max-w-full rounded-xl border overflow-hidden"
       style={{
         borderColor: 'var(--border)',
         background: 'var(--card-bg, var(--bg-secondary))',
@@ -110,7 +110,7 @@ function PaperCard({
       <div className="px-4 pt-3 pb-1">
         <div className="flex items-start justify-between gap-3">
           <h4
-            className="text-sm font-semibold leading-snug flex-1"
+            className="text-sm font-semibold leading-snug min-w-0 flex-1 break-words"
             style={{ color: 'var(--text-primary)' }}
           >
             <FileText
@@ -167,7 +167,7 @@ function PaperCard({
           </button>
           {showAbstract && (
             <p
-              className="text-xs mt-1 leading-relaxed whitespace-pre-wrap"
+              className="text-xs mt-1 leading-relaxed whitespace-pre-wrap break-words"
               style={{ color: 'var(--text-secondary)' }}
             >
               {paper.abstract}
@@ -178,7 +178,7 @@ function PaperCard({
 
       {/* ── Footer: actions ───────────────────────────────── */}
       <div
-        className="flex items-center gap-2 px-4 py-2"
+        className="flex min-w-0 flex-wrap items-center gap-2 px-4 py-2"
         style={{ borderTop: '1px solid var(--border)' }}
       >
         {/* Source badge */}
@@ -271,9 +271,9 @@ export default function PaperSearchResult({
     <div className="my-1">
       {/* Search meta */}
       <div
-        className="flex items-center gap-2 mb-2 text-[11px] text-text-muted"
+        className="flex min-w-0 flex-wrap items-center gap-2 mb-2 text-[11px] text-text-muted"
       >
-        <span>{data.query ? `"${data.query}"的搜索结果` : '搜索结果'}</span>
+        <span className="min-w-0 break-words">{data.query ? `"${data.query}"的搜索结果` : '搜索结果'}</span>
         {data.total != null && (
           <span style={{ color: 'var(--text-faint)' }}>
             · {data.total} found · showing {items.length}

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
@@ -34,14 +34,17 @@ export function MarkdownContent({ content }: { content: string }) {
       strong: ({ children }: any) => <strong className="font-semibold">{children}</strong>,
       em: ({ children }: any) => <em className="italic">{children}</em>,
       hr: () => <hr className="my-3" style={{ borderColor: 'var(--border-subtle)' }} />,
+      img: ({ src, alt }: any) => (
+        <img src={src} alt={alt ?? ''} className='max-w-full h-auto rounded-lg my-2' />
+      ),
       a: ({ href, children }: any) => (
-        <a href={href} className="underline cursor-pointer" style={{ color: 'var(--accent)' }}
+        <a href={href} className="underline cursor-pointer break-words" style={{ color: 'var(--accent)' }}
            onClick={(e) => { e.preventDefault(); if (href) window.open(href, '_blank'); }}>{children}</a>
       ),
       table: ({ children }: any) => <div className="overflow-x-auto my-2"><table className="text-xs w-full border-collapse">{children}</table></div>,
       th: ({ children }: any) => <th className="border px-2 py-1.5 text-left font-medium" style={{ borderColor: 'var(--border)', background: 'var(--surface-muted)' }}>{children}</th>,
       td: ({ children }: any) => <td className="border px-2 py-1.5" style={{ borderColor: 'var(--border-subtle)' }}>{children}</td>,
-      pre: ({ children }: any) => <pre className="relative group my-2 rounded-lg overflow-x-auto" style={{ background: 'rgba(0,0,0,0.06)' }}>{children}</pre>,
+      pre: ({ children }: any) => <pre className="relative group my-2 rounded-lg overflow-x-auto max-w-full" style={{ background: 'rgba(0,0,0,0.06)' }}>{children}</pre>,
       code: ({ className, children, ...props }: any) => {
         const codeStr = String(children);
         if (codeStr.endsWith('\n')) {
@@ -65,5 +68,11 @@ export function MarkdownContent({ content }: { content: string }) {
     [copiedCode]
   );
 
-  return <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{displayContent}</ReactMarkdown>;
+  return (
+    <div className="min-w-0 break-words" style={{ overflowWrap: 'anywhere' }}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {displayContent}
+      </ReactMarkdown>
+    </div>
+  );
 }

--- a/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
@@ -9,7 +9,7 @@ export function renderContent(text: string) {
       return (
         <pre
           key={i}
-          className="my-2 text-xs rounded-lg px-3 py-2 overflow-x-auto"
+          className="my-2 text-xs rounded-lg px-3 py-2 overflow-x-auto max-w-full"
           style={{ background: 'rgba(0,0,0,0.06)' }}
         >
           <code>{code}</code>


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复聊天消息气泡中长 URL 横向溢出会话列宽的问题。

## 背景/问题

#591：用户消息粘贴超长 URL 时，气泡被不可断行内容撑宽并横向溢出会话列。根因是消息气泡没有允许收缩，且正文未启用 overflow-wrap。

## 变更内容

- ChatConsole.tsx：消息行和气泡容器增加 min-w-0，气泡正文增加 break-words 与 overflow-wrap: anywhere。
- MarkdownContent.tsx：Markdown 外层增加相同换行约束，代码块限制 max-w-full。
- renderContent.tsx：用户消息代码块限制 max-w-full。

## 日志/验证证据

```text
npm run build 通过
chatConsoleMessages 单测 6/6 通过
```

## 测试情况

- npm run build：通过
- npm run test -- --run tests/chatConsoleMessages.test.ts：6/6 通过
- npm run typecheck:web：仍存在 4 个 HEAD 上已有的类型错误，与本次改动无关

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/c7747f0f-7bd4-4a00-bd4a-8403ff747909" />

Closes #591


___

### **PR Type**
Bug fix


___

### **Description**
- MessageBubble: add `min-w-0`, `break-words`, `overflow-wrap: anywhere`

- MarkdownContent, renderContent: `max-w-full` code blocks, wrap anchors

- PaperSearchResult: apply `min-w-0`, `max-w-full`, `break-words`


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["MessageBubble"] -- "min-w-0 + break-words + overflow-wrap:anywhere" --> B["Prevent horizontal overflow"]
    C["MarkdownContent"] -- "min-w-0 + break-words + overflow-wrap:anywhere" --> B
    D["PaperSearchResult"] -- "min-w-0 + max-w-full + break-words" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Prevent horizontal overflow in chat message components</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Add <code>min-w-0</code> to flex containers to allow shrinkage<br> <li> Apply <code>break-words</code> and <code>overflow-wrap: anywhere</code> to error, user, and <br>assistant bubbles<br> <li> Add <code>overflow-x-hidden</code> to message list container<br> <li> Introduce <code>min-w-0 max-w-full truncate</code> on attachment chips</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/593/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+16/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PaperSearchResult.tsx</strong><dd><code>Prevent text overflow in paper search result cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx

<ul><li>Add <code>min-w-0 max-w-full</code> to card container<br> <li> Set <code>min-w-0 flex-1 break-words</code> on paper title<br> <li> Apply <code>break-words</code> to abstract text and search query span<br> <li> Use <code>min-w-0 flex-wrap</code> on footer and meta bars</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/593/files#diff-52e59847eb62dd0bb9d1ee24db1fd1c43b6e0208ed08b4c942a5bb5d417afa9b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MarkdownContent.tsx</strong><dd><code>Apply overflow wrapping to MarkdownContent rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx

<ul><li>Wrap entire markdown output in <code>min-w-0 break-words</code> div with <br><code>overflow-wrap: anywhere</code><br> <li> Add <code>max-w-full</code> to <code><pre></code> code blocks and <code><img></code> tags<br> <li> Add <code>break-words</code> to anchor tags</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/593/files#diff-be640aa9bce4c389c56a914a09d02a04fe9521e0bead920cf2c2c2774e50da24">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>renderContent.tsx</strong><dd><code>Restrict code block width in simple content renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/components/renderContent.tsx

- Add `max-w-full` class to `<pre>` code block wrapper


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/593/files#diff-fd1f0d7963cefb7c0452257392d7ce8f244efe55a998aa21906896f35fc13326">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

