### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1915,16 +1915,25 @@ for m in ("pydantic", "httpx", "loguru"):
 
   ipcMain.handle(IPC.AGENT_SPAWN, async (_event, payload: unknown) => {
     const input = AgentSpawnInput.parse(payload);
+    // Callers may pass an explicit session_key (the Python bridge rejects
+    // agent.spawn without a resolvable session — UNAUTHORIZED).
     return bridge.sendSafe('agent.spawn', {
       agent_type: input.agent_type,
       task: input.task,
       label: input.label,
+      session_key: input.session_key ?? 'desktop:default',
     });
   });
 
   ipcMain.handle(IPC.AGENT_KILL, async (_event, payload: unknown) => {
-    const { agent_id } = payload as { agent_id: string };
-    return bridge.sendSafe('agent.kill', { agent_id });
+    const { agent_id, session_key } = payload as {
+      agent_id: string;
+      session_key?: string;
+    };
+    return bridge.sendSafe('agent.kill', {
+      agent_id,
+      session_key: session_key ?? 'desktop:default',
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -109,8 +109,20 @@ const api = {
 
   // -- Chat -------------------------------------------------------------------
   chat: {
-    send: (content: string, sessionKey?: string, threadId?: string, mode?: string, attachments?: Array<{name: string, data_base64?: string, mime_type?: string}>): Promise<unknown> =>
-      ipcRenderer.invoke(IPC.CHAT_SEND, { content, session_key: sessionKey, thread_id: threadId, mode, attachments }),
+    send: (
+      content: string,
+      sessionKey?: string,
+      threadId?: string,
+      mode?: string,
+      attachments?: Array<{ name: string; data_base64?: string; mime_type?: string }>
+    ): Promise<unknown> =>
+      ipcRenderer.invoke(IPC.CHAT_SEND, {
+        content,
+        session_key: sessionKey,
+        thread_id: threadId,
+        mode,
+        attachments,
+      }),
     abort: (sessionKey?: string): Promise<unknown> =>
       ipcRenderer.invoke(IPC.CHAT_ABORT, { session_key: sessionKey }),
     onProgress: (callback: (data: ChatProgress) => void) => {
@@ -357,7 +369,11 @@ const api = {
 
   // -- Document parsing ----------------------------------------------------
   documents: {
-    parse: (path: string, sessionKey?: string, options?: { forceOcr?: boolean; preview?: boolean }): Promise<DocumentsParseResult> =>
+    parse: (
+      path: string,
+      sessionKey?: string,
+      options?: { forceOcr?: boolean; preview?: boolean }
+    ): Promise<DocumentsParseResult> =>
       ipcRenderer.invoke(IPC.DOCUMENTS_PARSE, {
         path,
         session_key: sessionKey,
@@ -378,9 +394,7 @@ const api = {
       ipcRenderer.invoke(IPC.WSL_INSTALL),
     installAndProvision: (): Promise<WslInstallAndProvisionResult> =>
       ipcRenderer.invoke(IPC.WSL_INSTALL_AND_PROVISION),
-    onInstallProgress: (
-      callback: (data: WslInstallProgress) => void
-    ): (() => void) => {
+    onInstallProgress: (callback: (data: WslInstallProgress) => void): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: WslInstallProgress) =>
         callback(data);
       ipcRenderer.on(IPC_EVENTS.WSL_INSTALL_PROGRESS, handler);
@@ -424,10 +438,20 @@ const api = {
   agents: {
     list: (sessionKey?: string): Promise<{ agents: LiveAgentInfo[] }> =>
       ipcRenderer.invoke(IPC.AGENT_LIST, { session_key: sessionKey }),
-    spawn: (agentType: string, task: string, label?: string): Promise<{ agent: LiveAgentInfo }> =>
-      ipcRenderer.invoke(IPC.AGENT_SPAWN, { agent_type: agentType, task, label }),
-    kill: (agentId: string): Promise<{ killed: boolean }> =>
-      ipcRenderer.invoke(IPC.AGENT_KILL, { agent_id: agentId }),
+    spawn: (
+      agentType: string,
+      task: string,
+      label?: string,
+      sessionKey?: string
+    ): Promise<{ agent: LiveAgentInfo }> =>
+      ipcRenderer.invoke(IPC.AGENT_SPAWN, {
+        agent_type: agentType,
+        task,
+        label,
+        session_key: sessionKey,
+      }),
+    kill: (agentId: string, sessionKey?: string): Promise<{ killed: boolean }> =>
+      ipcRenderer.invoke(IPC.AGENT_KILL, { agent_id: agentId, session_key: sessionKey }),
     onSpawned: (callback: (data: AgentSpawnedEvent) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: AgentSpawnedEvent) =>
         callback(data);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2976,7 +2976,7 @@ export function ChatConsole({
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="flex-1 overflow-y-auto relative"
+            className="flex-1 overflow-y-auto overflow-x-hidden relative"
             style={{ background: 'var(--background)', paddingBottom: `calc(${composerHeight}px + ${ANSWER_GAP})` }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-8">
@@ -3818,7 +3818,7 @@ function MessageBubble({
     return (
       <div
         className={cn(
-          'flex items-center gap-2 text-xs py-1 px-1',
+          'flex min-w-0 items-center gap-2 text-xs py-1 px-1',
           msg.collapsed && 'cursor-pointer select-none'
         )}
         style={{ color: msg.toolHint ? 'var(--info)' : 'var(--text-muted)' }}
@@ -3861,14 +3861,15 @@ function MessageBubble({
   }
   if (msg.role === 'error') {
     return (
-      <div className="flex items-start gap-3">
+      <div className="flex min-w-0 items-start gap-3">
         <AgentAvatar />
         <div
-          className="text-sm rounded-2xl px-4 py-3"
+          className="text-sm rounded-2xl px-4 py-3 min-w-0 max-w-[82%] break-words"
           style={{
             background: 'var(--danger-bg)',
             color: 'var(--danger)',
             border: '1px solid var(--danger)',
+            overflowWrap: 'anywhere',
           }}
         >
           <div className="whitespace-pre-wrap break-words">{msg.content}</div>
@@ -3893,7 +3894,7 @@ function MessageBubble({
 
   if (msg.role === 'subagent') {
     return (
-      <div className="flex items-start gap-3">
+      <div className="flex min-w-0 items-start gap-3">
         <GitMerge size={18} style={{ color: 'var(--accent)', marginTop: 6 }} />
         <div
           className="text-sm rounded-2xl px-4 py-3 prose prose-sm max-w-none break-words overflow-x-auto"
@@ -3973,7 +3974,7 @@ function MessageBubble({
       {({ onContextMenu }) => (
         <div
           ref={bubbleRef}
-          className={cn('flex items-start gap-3', isUser && 'justify-end')}
+          className={cn('flex min-w-0 items-start gap-3', isUser && 'justify-end')}
           onContextMenu={(e) => {
             // Capture any manual selection before hover-preview can replace it
             capturedSelectionRef.current = window.getSelection()?.toString().trim() ?? '';
@@ -3985,7 +3986,7 @@ function MessageBubble({
 
           <div
             className={cn(
-              'group flex flex-col gap-1.5',
+              'group flex min-w-0 flex-col gap-1.5',
               isUser ? 'items-end max-w-[70%]' : 'max-w-[82%]'
             )}
           >
@@ -4007,7 +4008,7 @@ function MessageBubble({
               .map((att, i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                  className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
                   style={{
                     background: 'var(--surface-muted)',
                     border: '1px solid var(--border-subtle)',
@@ -4015,7 +4016,7 @@ function MessageBubble({
                   }}
                 >
                   <FileText size={12} className="shrink-0 text-text-faint" />
-                  <span>{att.name}</span>
+                  <span className="truncate min-w-0" title={att.name}>{att.name}</span>
                 </div>
               ))}
             {/* document attachments */}
@@ -4028,7 +4029,7 @@ function MessageBubble({
                 return (
                   <div
                     key={i}
-                    className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-all duration-500"
+                    className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-all duration-500"
                     style={{
                       background: isDone && cat ? cat.bg : 'var(--surface-muted)',
                       border: `1px solid ${isDone && cat ? cat.color + '40' : 'var(--border-subtle)'}`,
@@ -4066,7 +4067,7 @@ function MessageBubble({
                 return chips.map((chip, i) => (
                   <div
                     key={`hist-${i}`}
-                    className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
+                    className="flex min-w-0 max-w-full items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs"
                     style={{
                       background: chip.category.bg,
                       border: `1px solid ${chip.category.color}40`,
@@ -4079,7 +4080,7 @@ function MessageBubble({
                     >
                       {chip.category.label}
                     </span>
-                    <span>{chip.name}</span>
+                    <span className="truncate min-w-0" title={chip.name}>{chip.name}</span>
                     <CheckCircle size={11} className="shrink-0" style={{ color: '#22c55e' }} />
                   </div>
                 ));
@@ -4088,7 +4089,7 @@ function MessageBubble({
             {/* Main bubble */}
             <div
               data-message-body
-              className="text-sm leading-relaxed rounded-2xl px-4 py-3"
+              className="text-sm leading-relaxed rounded-2xl px-4 py-3 min-w-0 break-words"
               style={
                 isUser
                   ? {
@@ -4096,12 +4097,14 @@ function MessageBubble({
                         'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
                       color: 'var(--bubble-user-text)',
                       borderBottomRightRadius: 6,
+                      overflowWrap: 'anywhere',
                     }
                   : {
                       background: 'var(--bubble-ai-bg)',
                       color: 'var(--bubble-ai-text)',
                       border: '1px solid var(--bubble-ai-border)',
                       borderBottomLeftRadius: 6,
+                      overflowWrap: 'anywhere',
                     }
               }
             >

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -100,7 +100,7 @@ function PaperCard({
 
   return (
     <div
-      className="my-2 rounded-xl border overflow-hidden"
+      className="my-2 min-w-0 max-w-full rounded-xl border overflow-hidden"
       style={{
         borderColor: 'var(--border)',
         background: 'var(--card-bg, var(--bg-secondary))',
@@ -110,7 +110,7 @@ function PaperCard({
       <div className="px-4 pt-3 pb-1">
         <div className="flex items-start justify-between gap-3">
           <h4
-            className="text-sm font-semibold leading-snug flex-1"
+            className="text-sm font-semibold leading-snug min-w-0 flex-1 break-words"
             style={{ color: 'var(--text-primary)' }}
           >
             <FileText
@@ -167,7 +167,7 @@ function PaperCard({
           </button>
           {showAbstract && (
             <p
-              className="text-xs mt-1 leading-relaxed whitespace-pre-wrap"
+              className="text-xs mt-1 leading-relaxed whitespace-pre-wrap break-words"
               style={{ color: 'var(--text-secondary)' }}
             >
               {paper.abstract}
@@ -178,7 +178,7 @@ function PaperCard({
 
       {/* ── Footer: actions ───────────────────────────────── */}
       <div
-        className="flex items-center gap-2 px-4 py-2"
+        className="flex min-w-0 flex-wrap items-center gap-2 px-4 py-2"
         style={{ borderTop: '1px solid var(--border)' }}
       >
         {/* Source badge */}
@@ -271,9 +271,9 @@ export default function PaperSearchResult({
     <div className="my-1">
       {/* Search meta */}
       <div
-        className="flex items-center gap-2 mb-2 text-[11px] text-text-muted"
+        className="flex min-w-0 flex-wrap items-center gap-2 mb-2 text-[11px] text-text-muted"
       >
-        <span>{data.query ? `"${data.query}"的搜索结果` : '搜索结果'}</span>
+        <span className="min-w-0 break-words">{data.query ? `"${data.query}"的搜索结果` : '搜索结果'}</span>
         {data.total != null && (
           <span style={{ color: 'var(--text-faint)' }}>
             · {data.total} found · showing {items.length}

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
@@ -34,14 +34,17 @@ export function MarkdownContent({ content }: { content: string }) {
       strong: ({ children }: any) => <strong className="font-semibold">{children}</strong>,
       em: ({ children }: any) => <em className="italic">{children}</em>,
       hr: () => <hr className="my-3" style={{ borderColor: 'var(--border-subtle)' }} />,
+      img: ({ src, alt }: any) => (
+        <img src={src} alt={alt ?? ''} className='max-w-full h-auto rounded-lg my-2' />
+      ),
       a: ({ href, children }: any) => (
-        <a href={href} className="underline cursor-pointer" style={{ color: 'var(--accent)' }}
+        <a href={href} className="underline cursor-pointer break-words" style={{ color: 'var(--accent)' }}
            onClick={(e) => { e.preventDefault(); if (href) window.open(href, '_blank'); }}>{children}</a>
       ),
       table: ({ children }: any) => <div className="overflow-x-auto my-2"><table className="text-xs w-full border-collapse">{children}</table></div>,
       th: ({ children }: any) => <th className="border px-2 py-1.5 text-left font-medium" style={{ borderColor: 'var(--border)', background: 'var(--surface-muted)' }}>{children}</th>,
       td: ({ children }: any) => <td className="border px-2 py-1.5" style={{ borderColor: 'var(--border-subtle)' }}>{children}</td>,
-      pre: ({ children }: any) => <pre className="relative group my-2 rounded-lg overflow-x-auto" style={{ background: 'rgba(0,0,0,0.06)' }}>{children}</pre>,
+      pre: ({ children }: any) => <pre className="relative group my-2 rounded-lg overflow-x-auto max-w-full" style={{ background: 'rgba(0,0,0,0.06)' }}>{children}</pre>,
       code: ({ className, children, ...props }: any) => {
         const codeStr = String(children);
         if (codeStr.endsWith('\n')) {
@@ -65,5 +68,11 @@ export function MarkdownContent({ content }: { content: string }) {
     [copiedCode]
   );
 
-  return <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{displayContent}</ReactMarkdown>;
+  return (
+    <div className="min-w-0 break-words" style={{ overflowWrap: 'anywhere' }}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {displayContent}
+      </ReactMarkdown>
+    </div>
+  );
 }

--- a/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
@@ -9,7 +9,7 @@ export function renderContent(text: string) {
       return (
         <pre
           key={i}
-          className="my-2 text-xs rounded-lg px-3 py-2 overflow-x-auto"
+          className="my-2 text-xs rounded-lg px-3 py-2 overflow-x-auto max-w-full"
           style={{ background: 'rgba(0,0,0,0.06)' }}
         >
           <code>{code}</code>

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -179,11 +179,15 @@ export const ChatSendInput = z.object({
   session_key: z.string().optional(),
   thread_id: z.string().optional(),
   mode: z.enum(['plan', 'manual', 'edit', 'auto']).optional(),
-  attachments: z.array(z.object({
-    name: z.string(),
-    data_base64: z.string().optional(),
-    mime_type: z.string().optional(),
-  })).optional(),
+  attachments: z
+    .array(
+      z.object({
+        name: z.string(),
+        data_base64: z.string().optional(),
+        mime_type: z.string().optional(),
+      })
+    )
+    .optional(),
 });
 
 export const SessionGetInput = z.object({
@@ -234,6 +238,7 @@ export const AgentSpawnInput = z.object({
   agent_type: z.string().min(1),
   task: z.string().min(1),
   label: z.string().optional(),
+  session_key: z.string().optional(),
 });
 
 export const PermissionsUpdateInput = z.object({
@@ -815,11 +820,11 @@ export interface PythonCheckResult {
 
 /** Granular WSL feature states detected during check */
 export type WslFeatureState =
-  | 'not-supported'           // Non-Windows or WSL not available
-  | 'not-enabled'             // Windows Optional Features not turned on
-  | 'not-installed'           // WSL kernel/package not installed
+  | 'not-supported' // Non-Windows or WSL not available
+  | 'not-enabled' // Windows Optional Features not turned on
+  | 'not-installed' // WSL kernel/package not installed
   | 'installed-but-not-initialized' // WSL installed but no distro launched
-  | 'ready';                  // Fully functional
+  | 'ready'; // Fully functional
 
 export interface WslCheckResult {
   isWindows: boolean;
@@ -1058,18 +1063,15 @@ const dataUrlScreenshot = z
   .string()
   .refine(
     (s) => s.startsWith('data:image/') && s.includes(';base64,'),
-    'Screenshot must be a base64-encoded data URL with image MIME type',
+    'Screenshot must be a base64-encoded data URL with image MIME type'
   )
-  .refine(
-    (s) => {
-      const comma = s.indexOf(',');
-      if (comma < 0) return false;
-      const b64 = s.slice(comma + 1);
-      // base64 inflates ~4/3, so 14 MB encoded → ~10.5 MB decoded
-      return b64.length * 3 <= MAX_DATA_URL_BYTES * 4 + 4;
-    },
-    'Screenshot exceeds 10 MB limit',
-  );
+  .refine((s) => {
+    const comma = s.indexOf(',');
+    if (comma < 0) return false;
+    const b64 = s.slice(comma + 1);
+    // base64 inflates ~4/3, so 14 MB encoded → ~10.5 MB decoded
+    return b64.length * 3 <= MAX_DATA_URL_BYTES * 4 + 4;
+  }, 'Screenshot exceeds 10 MB limit');
 
 export const FeedbackSubmitInput = z.object({
   category: z.enum(['bug', 'question', 'suggestion', 'other']),

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -573,7 +573,24 @@ export async function closeElectronApp(
   miqiHome?: string,
   keepHome = false,
 ) {
-  await app?.close().catch(() => {});
+  if (app) {
+    // Bound the close: some tests leave an in-flight LLM/bridge request
+    // behind, and Electron then waits on the bridge child process forever —
+    // a stuck `app.close()` would burn the whole CI afterAll timeout (600s)
+    // and then the worker force-kill (300s).  Race the close against a
+    // 15s deadline and force-kill the Electron process if it overruns.
+    await Promise.race([
+      app.close().catch(() => {}),
+      (async () => {
+        await new Promise((r) => setTimeout(r, 15_000));
+        try {
+          app.process().kill();
+        } catch {
+          /* already gone */
+        }
+      })(),
+    ]);
+  }
   if (miqiHome && !keepHome && existsSync(miqiHome)) {
     rmSync(miqiHome, { recursive: true, force: true });
     console.log(`[test] Cleaned up MIQI_HOME: ${miqiHome}`);

--- a/apps/desktop/tests/e2e/subagent-bridge-api.spec.ts
+++ b/apps/desktop/tests/e2e/subagent-bridge-api.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * Subagent bridge API integration tests
+ *
+ * Directly exercises window.miqi.agents.* bridge APIs (spawn / list / kill)
+ * and verifies the frontend renders subagent result cards correctly.
+ * These tests bypass the LLM tool-call path and call the bridge directly —
+ * they are integration tests, not true E2E (which would go through user input
+ * → LLM → tool call).  They still require a real Electron session because
+ * the bridge APIs are only available inside Electron.
+ *
+ * Issue #246 — Subagent subsystem needs end-to-end verification.
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts \
+ *      --project=electron subagent-bridge-api.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  launchElectronApp,
+  closeElectronApp,
+  waitForInputReady,
+  waitForBridgeInitialized,
+} from './helpers/electron-setup';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+interface LiveAgentInfo {
+  agent_id: string;
+  thread_id: string;
+  type: string;
+  status: string;
+  parent: string | null;
+  label: string;
+  result_preview?: string;
+  error?: string;
+}
+
+/** Read the renderer's active session key (persisted by App.tsx). */
+async function currentSessionKey(page: Page): Promise<string> {
+  const key = await page.evaluate(() => localStorage.getItem('miqi:lastSession'));
+  return key || 'desktop:default';
+}
+
+/** Raw bridge response — sendSafe returns the parsed JSON "result" envelope. */
+async function agentSpawn(
+  page: Page,
+  agentType: string,
+  task: string,
+  label?: string,
+  sessionKey?: string,
+): Promise<any> {
+  const raw: any = await page.evaluate(
+    ({ at, t, l, sk }: any) => (window as any).miqi.agents.spawn(at, t, l, sk),
+    { at: agentType, t: task, l: label ?? undefined, sk: sessionKey },
+  );
+  console.log('[test] agentSpawn raw result:', JSON.stringify(raw));
+  return raw;
+}
+
+async function agentList(page: Page, sessionKey?: string): Promise<any> {
+  const raw: any = await page.evaluate(
+    (sk?: string) => (window as any).miqi.agents.list(sk),
+    sessionKey,
+  );
+  console.log('[test] agentList raw result:', JSON.stringify(raw));
+  return raw;
+}
+
+/**
+ * Resolve the spawned-agent handle from the bridge spawn response.
+ *
+ * The real `agent.spawn` handler (miqi/bridge/loop.py:_agent_spawn_handler)
+ * returns `{"result": {"agent_id": ..., "thread_id": ...}}`; the desktop
+ * bridge resolves the response envelope with `resp.result`
+ * (apps/desktop/src/main/bridge.ts, `pending.resolve(resp.result)`), so
+ * `window.miqi.agents.spawn()` resolves to the FLAT `{ agent_id, thread_id }`
+ * object — there is no `agent` key and no nested `result.agent`.
+ *
+ * We still tolerate wrapped shapes (`{result: ...}`, `{agent: ...}`,
+ * `{result: {agent: ...}}`) defensively in case the handler shape changes,
+ * but the flat shape is the contract we assert on.
+ */
+function resolveSpawnedAgent(
+  spawnResult: any,
+): { agent_id: string; thread_id: string } | null {
+  const r = spawnResult ?? {};
+  for (const candidate of [r, r.result, r.agent, r.result?.agent]) {
+    if (candidate && typeof candidate.agent_id === 'string') {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the spawned-agent handle or fail the test loudly.  A failed/absent
+ * spawn must FAIL the test, not silently pass (the old `if (!agent) return;`
+ * made this suite green while verifying nothing).  Returns a non-null handle
+ * so callers avoid repeating `!` non-null assertions.
+ */
+function resolveSpawnedAgentOrThrow(
+  spawnResult: any,
+): { agent_id: string; thread_id: string } {
+  const agent = resolveSpawnedAgent(spawnResult);
+  if (agent === null) {
+    throw new Error(
+      'agent.spawn returned no agent handle: ' + JSON.stringify(spawnResult),
+    );
+  }
+  return agent;
+}
+
+/** Poll agent.list until an agent reaches a terminal status. */
+async function waitForAgentCompleted(
+  page: Page,
+  agentId: string,
+  sessionKey: string,
+  timeoutMs = 120_000,
+): Promise<LiveAgentInfo> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result: any = await agentList(page, sessionKey);
+    const agents: LiveAgentInfo[] = result?.agents ?? result?.result?.agents ?? [];
+    const found = agents.find((a) => a.agent_id === agentId);
+    if (found && ['completed', 'error', 'aborted'].includes(found.status)) {
+      return found;
+    }
+    await page.waitForTimeout(500);
+  }
+  throw new Error(`Agent ${agentId} did not reach terminal status within ${timeoutMs}ms`);
+}
+
+/**
+ * Poll the chat area until a subagent result card with the given label and
+ * status icon appears.  Subagent results arrive asynchronously via the
+ * `chat:subagent_result` IPC event (ChatConsole renders
+ * `✅ Subagent "label" completed` / `❌ Subagent "label" failed`), which can
+ * arrive long after the spawn call resolved — so we poll the rendered DOM
+ * rather than the bridge API.
+ */
+async function waitForSubagentRender(
+  page: Page,
+  label: string,
+  icon: string,
+  timeoutMs = 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const mainText = (await page.locator('main').textContent().catch(() => '')) || '';
+    if (mainText.includes(label) && mainText.includes(icon)) return;
+    await page.waitForTimeout(500);
+  }
+  throw new Error(
+    `Subagent result (${icon} "${label}") did not render within ${timeoutMs}ms`,
+  );
+}
+
+/** Ensure a session exists by sending a simple chat message and
+ *  waiting for the response.  Agents require an initialized runtime session. */
+async function ensureSession(page: Page): Promise<void> {
+  const textarea = await waitForInputReady(page);
+  await textarea.fill('回复 "ok"');
+  await textarea.press('Enter');
+  await expect(page.getByText('回复 "ok"').first()).toBeVisible({ timeout: 10_000 });
+
+  // Wait for the thinking indicator to appear and then disappear.
+  try {
+    await expect(page.locator('[data-testid="thinking-indicator"]')).toBeVisible({ timeout: 15_000 });
+  } catch { /* may appear faster than we can catch */ }
+  try {
+    await expect(page.locator('[data-testid="thinking-indicator"]')).toBeHidden({ timeout: 60_000 });
+  } catch { /* already hidden */ }
+
+  // Give the runtime a moment to fully settle after the turn completes.
+  await page.waitForTimeout(2000);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+test.describe('Subagent Bridge API', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    await waitForBridgeInitialized(page);
+
+    // Verify the agents bridge API is present.
+    const hasAgents = await page.evaluate(
+      () => typeof (window as any).miqi?.agents?.spawn === 'function',
+    );
+    if (!hasAgents) {
+      console.log('[test] agents API not available — skipping suite');
+      test.skip();
+    }
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp);
+  });
+
+  test.beforeEach(async () => {
+    // Fresh conversation so previous subagent results don't leak.
+    await page.keyboard.press('Control+N').catch(() => {});
+    await page.waitForTimeout(800);
+  });
+
+  // ── Test 1: spawn → execute → result callback ────────────────────
+
+  test('spawn subagent via bridge API and receive result', async () => {
+    // 1. Prime the session — agents require an active runtime.
+    await ensureSession(page);
+    const sessionKey = await currentSessionKey(page);
+
+    // 2. Spawn a code-agent with a simple task.
+    const spawnResult = await agentSpawn(
+      page,
+      'code-agent',
+      'Run the command "echo hello-from-subagent" and report the output. Keep it very short.',
+      'e2e-hello-test',
+      sessionKey,
+    );
+
+    // The bridge resolves agent.spawn to the flat { agent_id, thread_id }
+    // object — NOT { result: { agent: ... } } (see resolveSpawnedAgent).
+    const agent = resolveSpawnedAgentOrThrow(spawnResult);
+    console.log('[test] spawn-result: spawned agent', agent.agent_id);
+
+    // 3. Wait for the agent to reach a terminal status.
+    const completed = await waitForAgentCompleted(page, agent.agent_id, sessionKey, 120_000);
+    console.log('[test] spawn-result: final status =', completed.status);
+    expect(completed.status).toBe('completed');
+
+    // 4. The chat:subagent_result IPC event can arrive AFTER the agent reaches
+    //    a terminal status — wait for the card to render before reading the DOM.
+    await waitForSubagentRender(page, 'e2e-hello-test', '✅', 60_000);
+
+    // 5. Verify the subagent result was rendered in the chat UI.
+    const main = page.locator('main');
+    const mainText = (await main.textContent()) || '';
+    console.log('[test] spawn-result: main text length:', mainText.length);
+    console.log('[test] spawn-result: content (last 600 chars):', mainText.slice(-600));
+
+    // The rendered subagent result card should include the task label.
+    expect(mainText).toContain('e2e-hello-test');
+  });
+
+  // ── Test 2: ✅ / ❌ status icon rendering ────────────────────
+
+  test('subagent result renders with success status icon', async () => {
+    // 1. Prime the session.
+    await ensureSession(page);
+    const sessionKey = await currentSessionKey(page);
+
+    // 2. Spawn a simple subagent that will succeed.
+    const spawnResult = await agentSpawn(
+      page,
+      'code-agent',
+      'Run "echo ok" and report the result. One sentence only.',
+      'e2e-status-test',
+      sessionKey,
+    );
+
+    const agent = resolveSpawnedAgentOrThrow(spawnResult);
+
+    // 3. Wait for it to complete.
+    const completed = await waitForAgentCompleted(page, agent.agent_id, sessionKey, 120_000);
+    expect(completed.status).toBe('completed');
+
+    // 4. The chat:subagent_result event can arrive AFTER the agent reaches a
+    //    terminal status — wait for the card to render before reading the DOM.
+    await waitForSubagentRender(page, 'e2e-status-test', '✅', 60_000);
+
+    // 5. The ChatConsole renders subagent results with:
+    //      const statusIcon = data.status === 'ok' ? '✅' : '❌';
+    //      const content = `${statusIcon} Subagent "${label}" ${...}`;
+    const main = page.locator('main');
+    const mainText = (await main.textContent()) || '';
+    console.log('[test] status-icon: content (last 600 chars):', mainText.slice(-600));
+
+    const hasCheck = mainText.includes('✅');
+    const hasLabel = mainText.includes('e2e-status-test');
+    console.log('[test] status-icon: ✅ present:', hasCheck, 'label present:', hasLabel);
+
+    // The label must appear (the subagent result was rendered).
+    expect(hasLabel).toBe(true);
+    // The ✅ should appear on success.
+    expect(hasCheck).toBe(true);
+
+    // No error banner in the UI.
+    const errorBanner = page.getByTestId('chat-error-banner');
+    await expect(errorBanner).toHaveCount(0);
+  });
+
+  // ── Test 3: agent list tracks spawned agents ──────────────────
+
+  test('agent list API shows spawned agents', async () => {
+    // 1. Prime the session.
+    await ensureSession(page);
+    const sessionKey = await currentSessionKey(page);
+
+    // 2. Spawn an agent.
+    const spawnResult = await agentSpawn(
+      page,
+      'code-agent',
+      'Run "echo listed-agent" and output the result.',
+      'e2e-list-test',
+      sessionKey,
+    );
+
+    const agent = resolveSpawnedAgentOrThrow(spawnResult);
+
+    // 3. The spawned agent should appear in the list.
+    const listResult = await agentList(page, sessionKey);
+    const agents: LiveAgentInfo[] = listResult?.agents ?? listResult?.result?.agents ?? [];
+    const found = agents.find((a) => a.agent_id === agent.agent_id);
+    expect(found).toBeDefined();
+    expect(found!.type).toBe('Code Agent');
+    console.log('[test] agent-list: found agent in list, status =', found!.status);
+    console.log('[test] agent-list: total agents in list =', agents.length);
+
+    // 4. Wait for completion.
+    await waitForAgentCompleted(page, agent.agent_id, sessionKey, 120_000);
+
+    // 5. After completion, the list still contains the agent (now completed).
+    const finalListResult = await agentList(page, sessionKey);
+    const finalAgents: LiveAgentInfo[] = finalListResult?.agents ?? finalListResult?.result?.agents ?? [];
+    const finalAgent = finalAgents.find((a) => a.agent_id === agent.agent_id);
+    expect(finalAgent).toBeDefined();
+    expect(finalAgent!.status).toBe('completed');
+    console.log('[test] agent-list: final agent status =', finalAgent!.status);
+  });
+
+  // ── Test 4: ❌ failure status rendering (kill → aborted) ────────
+  //
+  // Issue #246 requires the frontend to render BOTH success (✅) and
+  // failure (❌) subagent statuses.  A deterministic failure is hard to
+  // produce through the LLM (tool errors are recoverable and usually end
+  // the agent in "completed"), so we force a terminal failure via
+  // agents.kill: AgentControl transitions the agent to ABORTED and the
+  // completion callback emits status="aborted", which ChatConsole renders
+  // as ❌.
+
+  test('killed subagent renders failure (❌) status icon', async () => {
+    // 1. Prime the session.
+    await ensureSession(page);
+    const sessionKey = await currentSessionKey(page);
+
+    // 2. Spawn a code-agent, then kill it immediately.
+    //    AgentControl.spawn synchronously transitions the agent to
+    //    THINKING and creates the background task before returning, so a
+    //    kill issued right after spawn reliably cancels the run (the LLM
+    //    cannot finish a turn within milliseconds).
+    const spawnResult = await agentSpawn(
+      page,
+      'code-agent',
+      'Run the command "ping -n 5 127.0.0.1" and report the output.',
+      'e2e-kill-test',
+      sessionKey,
+    );
+    const agent = resolveSpawnedAgentOrThrow(spawnResult);
+
+    const killResult: any = await page.evaluate(
+      ({ id, sk }: any) => (window as any).miqi.agents.kill(id, sk),
+      { id: agent.agent_id, sk: sessionKey },
+    );
+    console.log('[test] kill-result:', JSON.stringify(killResult));
+    expect(killResult?.killed ?? killResult?.result?.killed).toBe(true);
+
+    // 3. The aborted completion is pushed as chat:subagent_result with
+    //    status="aborted" → ChatConsole renders `❌ Subagent "label" failed:`.
+    await waitForSubagentRender(page, 'e2e-kill-test', '❌', 60_000);
+    console.log('[test] ❌ subagent failure rendered in chat');
+
+    // 4. No chat error banner — subagent failures render inline.
+    await expect(page.getByTestId('chat-error-banner')).toHaveCount(0);
+  });
+});

--- a/apps/desktop/tests/e2e/subagent-spawn.spec.ts
+++ b/apps/desktop/tests/e2e/subagent-spawn.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E: AI calls the spawn tool via chat (Issue #246 core)
+ *
+ * This is the ONLY true end-to-end test for subagent spawn —
+ * it drives the full user → LLM → tool-call → subagent → result render
+ * pipeline.  The user types a prompt, the LLM decides to invoke the spawn
+ * tool, the subagent runs, and the result card renders in chat.
+ *
+ * Bridge API integration tests (direct spawn/list/kill calls) live in
+ * subagent-bridge-api.spec.ts.
+ *
+ * Issue #246 — Subagent subsystem needs end-to-end verification.
+ * PR   #475 — This test.
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts \
+ *      --project=electron subagent-spawn.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  launchElectronApp,
+  closeElectronApp,
+  waitForInputReady,
+  waitForBridgeInitialized,
+} from './helpers/electron-setup';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Ensure a session exists by sending a simple chat message and
+ *  waiting for the response.  Agents require an initialized runtime session. */
+async function ensureSession(page: Page): Promise<void> {
+  const textarea = await waitForInputReady(page);
+  await textarea.fill('回复 "ok"');
+  await textarea.press('Enter');
+  await expect(page.getByText('回复 "ok"').first()).toBeVisible({ timeout: 10_000 });
+
+  // Wait for the thinking indicator to appear and then disappear.
+  try {
+    await expect(page.locator('[data-testid="thinking-indicator"]')).toBeVisible({ timeout: 15_000 });
+  } catch { /* may appear faster than we can catch */ }
+  try {
+    await expect(page.locator('[data-testid="thinking-indicator"]')).toBeHidden({ timeout: 60_000 });
+  } catch { /* already hidden */ }
+
+  // Give the runtime a moment to fully settle after the turn completes.
+  await page.waitForTimeout(2000);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+test.describe('Subagent Spawn E2E', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    await waitForBridgeInitialized(page);
+
+    // Verify the agents bridge API is present.
+    const hasAgents = await page.evaluate(
+      () => typeof (window as any).miqi?.agents?.spawn === 'function',
+    );
+    if (!hasAgents) {
+      console.log('[test] agents API not available — skipping suite');
+      test.skip();
+    }
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp);
+  });
+
+  test.beforeEach(async () => {
+    // Fresh conversation so previous subagent results don't leak.
+    await page.keyboard.press('Control+N').catch(() => {});
+    await page.waitForTimeout(800);
+  });
+
+  // ── Test: AI uses the spawn tool via chat (issue #246 core) ────
+  //
+  // Maintainer feedback on issue #246: "有这个工具，但是 ai 无法使用" —
+  // the spawn tool is registered but the AI cannot actually call it.  This
+  // test drives the REAL LLM tool-call path: the main agent must decide to
+  // invoke the spawn tool, and the subagent result must render in chat.
+  // If the tool-call path is broken, this test fails — which is exactly
+  // what the issue is asking to verify.
+
+  test('AI can call the spawn tool and the result renders', async () => {
+    // 1. Prime the session.
+    await ensureSession(page);
+
+    // 2. Ask the AI to use the spawn tool — explicitly, so a refusal or
+    //    silent fallback (running the command itself) is a real failure.
+    const textarea = await waitForInputReady(page);
+    const prompt =
+      '请使用 spawn 工具创建一个 subagent 来执行命令 "echo hello-ai-spawn" 并报告输出。' +
+      '这是对 spawn 工具的验证测试：你必须调用 spawn 工具，不要自己直接执行该命令。';
+    await textarea.fill(prompt);
+    await textarea.press('Enter');
+    await expect(page.getByText(/请使用 spawn 工具/).first()).toBeVisible({ timeout: 10_000 });
+
+    // 3. Wait for the subagent result card (rendered from chat:subagent_result).
+    //    NOTE: the chat area accumulates messages across tests (Control+N does
+    //    not clear it), so we cannot just check `includes('Subagent')` — the
+    //    old cards from tests 1-4 would match.  Instead: wait until a NEW
+    //    subagent card appears (card count increases) AND the newest ✅ card
+    //    actually contains the task text (proof the subagent ran it, not just
+    //    the main agent echoing the prompt).
+    const countCards = (t: string) => (t.match(/(?:✅|❌) Subagent/g) || []).length;
+    const initialCards = countCards(
+      (await page.locator('main').textContent().catch(() => '')) || '',
+    );
+    const deadline = Date.now() + 180_000;
+    let rendered = false;
+    let lastText = '';
+    while (Date.now() < deadline) {
+      const mainText = (await page.locator('main').textContent().catch(() => '')) || '';
+      lastText = mainText;
+      if (countCards(mainText) > initialCards) {
+        // New card appeared — extract the newest ✅ card and check its body.
+        const lastIdx = mainText.lastIndexOf('✅ Subagent');
+        const newestCard = lastIdx >= 0 ? mainText.slice(lastIdx) : '';
+        if (newestCard.includes('hello-ai-spawn')) {
+          rendered = true;
+          break;
+        }
+      }
+      await page.waitForTimeout(2000);
+    }
+    console.log('[test] ai-spawn: subagent result rendered:', rendered);
+    // Print the rendered chat area so we can verify WHO ran the command:
+    // the subagent card (role=subagent, from chat:subagent_result) vs any
+    // main-agent tool calls in the same conversation.
+    const mainTextFinal = (await page.locator('main').textContent().catch(() => '')) || '';
+    console.log('[test] ai-spawn: main text tail:', mainTextFinal.slice(-800));
+    expect(rendered).toBe(true);
+
+    // 4. Let the MAIN agent's own turn finish before the test ends.  The
+    //    subagent card renders while the main agent is still streaming its
+    //    reply; leaving that request in flight made afterAll's
+    //    closeElectronApp hang on the bridge child process (CI afterAll
+    //    600s timeout + 300s worker force-kill).  Wait for the thinking
+    //    indicator to disappear (tolerant — the UI may not show one).
+    await page
+      .getByText('Thinking…')
+      .first()
+      .waitFor({ state: 'hidden', timeout: 90_000 })
+      .catch(() => {});
+  });
+});

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from miqi.runtime.workspace_logging import append_workspace_log
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from loguru import logger
 
@@ -43,10 +43,17 @@ class LiveAgent:
     state: AgentStateMachine
     parent_agent_id: str | None = None
     spawned_at: float = field(default_factory=lambda: __import__("time").time())
+    # Spawn-time context (used for frontend subagent result rendering)
+    label: str | None = None
+    task: str | None = None
     result: str | None = None
     error: str | None = None
     messages: list[dict[str, Any]] = field(default_factory=list)
     completed_at: float | None = None
+    # Guard against duplicate frontend delivery: kill() emits aborted, then
+    # the cancelled _run_agent task's finally emits again — only the first
+    # terminal event should reach the renderer.
+    completion_emitted: bool = False
 
 
 class AgentControl:
@@ -70,6 +77,8 @@ class AgentControl:
         agent_jobs: Any = None,  # AgentJobRuntime — Phase 13
         hooks: HookRuntime | None = None,
         store: AgentGraphStore | None = None,
+        completion_callback: Callable[[dict], Awaitable[None]] | None = None,
+        max_concurrent: int = 3,
     ):
         self.session_id = session_id
         self.registry = registry
@@ -81,6 +90,11 @@ class AgentControl:
         self._agent_jobs = agent_jobs
         self._hooks = hooks
         self._store = store
+        self._completion_callback = completion_callback
+        # Issue #246: cap concurrently-running subagents (default 3, the
+        # legacy SubagentManager limit).  Terminal agents (completed/error/
+        # aborted) do not count; killed agents are removed from the registry.
+        self.max_concurrent = max_concurrent
         self._agents: dict[str, LiveAgent] = {}  # agent_id → LiveAgent
         self._thread_agents: dict[str, str] = {}  # thread_id → agent_id
         self._lock = asyncio.Lock()
@@ -111,6 +125,25 @@ class AgentControl:
         """
         metadata = self.registry.resolve(agent_type)
 
+        # Issue #246: enforce max_concurrent BEFORE starting the job — if the
+        # session already runs the limit of subagents, refuse to spawn so we
+        # don't leak a queued job.  Terminal agents (completed/error/aborted)
+        # do not count; a registered-but-not-yet-completed agent counts as
+        # running (its state is THINKING from the moment spawn() registers it).
+        async with self._lock:
+            running = sum(
+                1
+                for a in self._agents.values()
+                if a.state.current
+                not in (AgentStatus.COMPLETED, AgentStatus.ERROR, AgentStatus.ABORTED)
+            )
+            if running >= self.max_concurrent:
+                raise RuntimeError(
+                    f"Cannot spawn subagent: {self.max_concurrent} subagents "
+                    "already running. Wait for one to finish before spawning "
+                    "another."
+                )
+
         # Phase 13: when AgentJobRuntime is available, start the job FIRST
         # so the event carries the correct job-allocated IDs.
         if self._agent_jobs is not None:
@@ -131,6 +164,8 @@ class AgentControl:
             metadata=metadata,
             state=AgentStateMachine(),
             parent_agent_id=parent_agent_id,
+            label=label,
+            task=task,
         )
 
         async with self._lock:
@@ -300,6 +335,47 @@ class AgentControl:
             agent.state.transition(AgentStatus.ABORTED)
 
         logger.info("Killed agent {}", agent_id)
+
+        # The agent was removed from the registry, so the job/legacy run
+        # teardown can no longer reach it — emit the completion (aborted)
+        # here so the frontend still renders the ❌ status.
+        await self._emit_completed(agent, status="aborted")
+
+    async def notify_completed(self, agent_id: str, status: str) -> None:
+        """Notify the frontend of a subagent completion (AgentJobRuntime path).
+
+        Phase 13: when AgentJobRuntime owns the agent, the subagent runs in
+        ``AgentJobRuntime._run`` (via TurnRunner.run_agent_job) — NOT in
+        ``AgentControl._run_agent`` — so the ``finally`` completion hook there
+        never fires.  AgentJobRuntime calls this from its own ``_run`` finally.
+        """
+        agent = self._agents.get(agent_id)
+        if agent is None:
+            return
+        # Sync result/error from the job — the AgentJobRuntime path never
+        # sets LiveAgent.result/error (TurnRunner returns them to the job).
+        if self._agent_jobs is not None:
+            try:
+                job = self._agent_jobs.get(agent_id)
+                if job is not None:
+                    if job.result:
+                        agent.result = job.result
+                    if job.error:
+                        agent.error = job.error
+            except KeyError:
+                pass
+        # Keep the LiveAgent state machine in sync with the job status
+        # (the job path never transitions it).
+        terminal = (AgentStatus.COMPLETED, AgentStatus.ERROR, AgentStatus.ABORTED)
+        if agent.state.current not in terminal:
+            target = {
+                "completed": AgentStatus.COMPLETED,
+                "error": AgentStatus.ERROR,
+                "aborted": AgentStatus.ABORTED,
+            }.get(status)
+            if target is not None:
+                agent.state.transition(target)
+        await self._emit_completed(agent, status=status)
 
     async def get_status(self, agent_id: str) -> AgentStatus:
         """Get the current status of an agent."""
@@ -571,7 +647,7 @@ class AgentControl:
                     })
 
                     # Add tool results for each tool call
-                    for tc, result in zip(tool_calls, tool_results):
+                    for tc, result in zip(tool_call_dicts, tool_results):
                         messages.append({
                             "role": "tool",
                             "tool_call_id": tc.id,
@@ -683,6 +759,68 @@ class AgentControl:
                         "SUBAGENT_END hook failed for agent {}",
                         agent.agent_id,
                     )
+
+            # Push the subagent completion to the frontend callback (if any).
+            # This is what feeds the `chat:subagent_result` IPC event — the
+            # frontend's ChatConsole renders subagent results exclusively from
+            # that channel (Phase 13 removed the legacy SubagentManager
+            # result_callback, leaving no producer; the Desktop transport
+            # wires this callback to AppServer.emit_client_event).
+            await self._emit_completed(agent)
+
+    async def _emit_completed(
+        self, agent: LiveAgent, status: str | None = None,
+    ) -> None:
+        """Notify the frontend that a subagent reached a terminal state.
+
+        Payload matches the Desktop contract ``ChatSubagentResult``
+        (apps/desktop/src/shared/ipc.ts): task_id, label, task, result,
+        status ("ok" | "error" | "aborted"), session_key.
+        """
+        # Idempotent delivery: kill() emits aborted first; the cancelled
+        # _run_agent task's finally would then emit again.  Only the first
+        # terminal event reaches the frontend.
+        if agent.completion_emitted:
+            return
+        agent.completion_emitted = True
+        if self._completion_callback is None:
+            return
+        if status is None:
+            state = agent.state.current.value  # completed | error | aborted
+            status = "ok" if state == "completed" else state
+        elif status == "completed":
+            # ChatConsole keys on status === "ok" for the ✅ icon — normalize
+            # the job status ("completed") to the ChatSubagentResult contract.
+            status = "ok"
+        try:
+            await self._completion_callback({
+                "task_id": agent.agent_id,
+                "label": agent.label or agent.task or agent.agent_id,
+                "task": agent.task or "",
+                "result": agent.result or agent.error or "",
+                "status": status,
+                "session_key": self._renderer_session_key(),
+            })
+        except Exception:
+            logger.warning(
+                "Agent completion callback failed for {} ({})",
+                agent.agent_id, agent.metadata.name,
+            )
+
+    def _renderer_session_key(self) -> str:
+        """Strip the client_id prefix so the payload matches the renderer's
+        session key format.
+
+        ChatConsole's subagent handler compares ``data.session_key`` against
+        ``currentSessionRef`` (e.g. ``"desktop:<ts>"``), while
+        ``AgentControl.session_id`` is the namespaced
+        ``"miqi-desktop:desktop:<ts>"`` — a raw pass-through silently drops
+        every event.
+        """
+        sid = self.session_id
+        if ":" in sid:
+            return sid.split(":", 1)[1]
+        return sid
 
     @staticmethod
     def _format_tool_hint(name: str, args: dict) -> str:

--- a/miqi/runtime/agent_jobs.py
+++ b/miqi/runtime/agent_jobs.py
@@ -189,3 +189,15 @@ class AgentJobRuntime:
                     error=job.error,
                     completed_at=job.completed_at,
                 )
+            # Notify the frontend (AgentControl.completion_callback → Desktop
+            # `chat:subagent_result`).  The job path bypasses
+            # AgentControl._run_agent, so its completion hook never fires —
+            # this is the only notification point for AgentJobRuntime agents.
+            ac = getattr(self.services, "agent_control", None)
+            if ac is not None:
+                try:
+                    await ac.notify_completed(job.job_id, job.status)
+                except Exception:
+                    logger.warning(
+                        "notify_completed failed for job {}", job.job_id,
+                    )

--- a/miqi/runtime/app_server.py
+++ b/miqi/runtime/app_server.py
@@ -123,12 +123,32 @@ class ClientSessionRegistry:
                 self._last_activity[session_id] = time.time()
                 return existing
 
+            # Phase N: forward subagent completions to the creating client's
+            # event sink as `subagent_result`.  This is the only producer of
+            # the Desktop `chat:subagent_result` IPC event since Phase 13
+            # removed the legacy SubagentManager result_callback — without
+            # it the frontend never renders subagent results.
+            # NOTE: emit_client_event lives on AppServer, not on this
+            # registry — resolve it via bridge_context (populated by
+            # BridgeRuntimeLoop during init).
+            async def _on_agent_completed(data: dict) -> None:
+                try:
+                    app_server = self.bridge_context.get("app_server")
+                    if app_server is None:
+                        return
+                    await app_server.emit_client_event(
+                        client_id, "subagent_result", data,
+                    )
+                except Exception:
+                    pass  # sink missing/unavailable — never break agent teardown
+
             runtime = RuntimeSession.create(
                 config=config,
                 provider=provider,
                 session_id=session_id,
                 workspace=workspace,
                 sandbox_manager=sandbox_manager,
+                agent_completion_callback=_on_agent_completed,
             )
             await runtime.start()
 

--- a/miqi/runtime/feedback_handlers.py
+++ b/miqi/runtime/feedback_handlers.py
@@ -10,8 +10,9 @@ import json
 import platform
 import sys
 import os
+import re
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -52,72 +53,94 @@ def _collect_all_logs(log_dir: Path, max_age_days: int = 7) -> str:
     """Read files under workspace/logs/ recursively, limited to those
     modified within *max_age_days*, and return concatenated text.
 
-    Individual files are capped at 1 MB (tail end).  The combined payload
+    Individual files are capped at 50k chars (tail end).  The combined payload
     is capped at 196,608 UTF-8 bytes to fit within Feishu Bitable
-    text-field limits.
+    text-field limits.  Newest files are preserved first.
     """
     if not log_dir.exists():
         return "[日志目录不存在]"
 
-    cutoff = time.time() - max_age_days * 86400
+    MAX_LOG_BYTES = 196_608  # Feishu Bitable text-field limit
+    NOTICE_BUDGET = 300  # reserve bytes for skipped/unreadable notices and separators
+
+    _date_re = re.compile(r"(\d{4}-\d{2}-\d{2})")
     parts: list[str] = []
     recent_count = 0
     skipped_count = 0
     unreadable_count = 0
 
-    for f in sorted(log_dir.rglob("*"), key=lambda p: os.path.getmtime(str(p)), reverse=True):
+    def _file_sort_key(p: Path) -> float:
+        m = _date_re.search(p.name)
+        if m:
+            try:
+                return datetime.strptime(m.group(1), "%Y-%m-%d").timestamp()
+            except ValueError:
+                pass
+        try:
+            return os.path.getmtime(str(p))
+        except OSError:
+            return 0.0
+
+    def _file_age_days(p: Path) -> float | None:
+        m = _date_re.search(p.name)
+        if m:
+            try:
+                file_date = date.fromisoformat(m.group(1))
+                return (date.today() - file_date).days
+            except ValueError:
+                pass
+        try:
+            mtime = os.path.getmtime(str(p))
+            return (time.time() - mtime) / 86400
+        except OSError:
+            return None
+
+    for f in sorted(log_dir.rglob("*"), key=_file_sort_key, reverse=True):
         if not f.is_file():
             continue
-        try:
-            mtime = os.path.getmtime(str(f))
-        except OSError:
+        age = _file_age_days(f)
+        if age is None:
             unreadable_count += 1
             continue
-        if mtime < cutoff:
+        if age > max_age_days:
             skipped_count += 1
             continue
         recent_count += 1
         try:
             content = f.read_text(encoding="utf-8", errors="replace")
-            max_chars = 1_000_000
+            max_chars = 50_000
             if len(content) > max_chars:
-                content = f"...(截断 {len(content) - max_chars} 字符)\n{content[-max_chars:]}"
+                content = content[-max_chars:]
             rel = f.relative_to(log_dir)
             parts.append(f"=== {rel} ===\n{content}")
         except Exception as exc:
             parts.append(f"=== {f.name} === [读取失败: {exc}]")
 
-    if not parts:
+    final_parts: list[str] = []
+    total_bytes = NOTICE_BUDGET  # reserve for notices prepended later
+    for part in parts:
+        part_bytes = len(part.encode("utf-8"))
+        if total_bytes + part_bytes > MAX_LOG_BYTES:
+            remaining = MAX_LOG_BYTES - total_bytes
+            marker = "\n...(截断: 超出总大小限制)"
+            marker_bytes = len(marker.encode("utf-8"))
+            if remaining > marker_bytes:
+                tail = part.encode("utf-8")[:remaining - marker_bytes].decode("utf-8", errors="ignore")
+                final_parts.append(tail + marker)
+            break
+        final_parts.append(part)
+        total_bytes += part_bytes
+
+    if not final_parts:
         return f"[最近{max_age_days}天无日志文件（跳过{skipped_count}个旧文件）]"
 
-    marker = []
     if skipped_count:
-        marker.append(f"（跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件）")
+        final_parts.insert(0, f"（跳过了 {skipped_count} 个超过 {max_age_days} 天的旧日志文件）\n")
     if unreadable_count:
-        marker.append(f"（{unreadable_count} 个文件无法读取修改时间）")
-    if marker:
-        parts.insert(0, "\n".join(marker) + "\n")
+        final_parts.insert(1 if skipped_count else 0, f"（{unreadable_count} 个文件无法读取修改时间）\n")
 
-    combined = "\n\n".join(parts)
-    # Cap by UTF-8 byte size — Feishu Bitable text-field limit is 196,608 bytes.
-    # Not 100k chars (Chinese characters can be 3+ bytes each).  Encode once,
-    # then slice the tail bytes directly to avoid repeatedly re-encoding.
-    MAX_LOG_BYTES = 196_608
-    encoded = combined.encode("utf-8")
-    total_bytes = len(encoded)
-    if total_bytes > MAX_LOG_BYTES:
-        # Reserve 120 bytes for the marker text plus extra headroom
-        keep_bytes = MAX_LOG_BYTES - 120
-        retained = encoded[-keep_bytes:].decode("utf-8", errors="ignore")
-        retained_bytes = len(retained.encode("utf-8"))
-        dropped = total_bytes - retained_bytes
-        marker = f"...(总日志超出 {dropped} 字节，已截断)\n"
-        candidate = marker + retained
-        if len(candidate.encode("utf-8")) > MAX_LOG_BYTES:
-            excess = len(candidate.encode("utf-8")) - MAX_LOG_BYTES
-            retained = retained.encode("utf-8")[:-excess].decode("utf-8", errors="ignore")
-            return marker + retained
-        return candidate
+    combined = "\n\n".join(final_parts)
+
     return combined
 
 
@@ -417,9 +440,9 @@ async def feedback_submit_handler(
         encoded = value.encode("utf-8")
         if len(encoded) <= max_bytes:
             return value
-        tail = encoded[-max_bytes:].decode("utf-8", errors="ignore")
-        marker = f"...(截断 {len(encoded) - len(tail.encode('utf-8'))} 字节)\n"
-        return marker + tail
+        head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+        dropped = len(encoded) - len(head.encode("utf-8"))
+        return head + f"\n...(截断 {dropped} 字节)"
 
     fields: dict[str, Any] = {
         "类别": category,

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -95,6 +95,7 @@ class RuntimeServices:
         workspace: Path,
         event_sink: Any | None = None,
         sandbox_manager: Any = None,
+        agent_completion_callback: Any | None = None,
     ) -> "RuntimeServices":
         """Build the full service graph from a Config + provider.
 
@@ -199,6 +200,7 @@ class RuntimeServices:
             tool_registry=tool_registry,
             hooks=hook_runtime,
             store=agent_graph_store,
+            completion_callback=agent_completion_callback,
         )
 
         # Wire SpawnTool into AgentControl

--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -81,6 +81,7 @@ class RuntimeSession:
         session_id: str,
         workspace: Path,
         sandbox_manager: Any = None,
+        agent_completion_callback: Any | None = None,
     ) -> "RuntimeSession":
         """Create a RuntimeSession from config and provider.
 
@@ -102,6 +103,7 @@ class RuntimeSession:
             workspace=workspace,
             event_sink=events.put,  # asyncio.Queue.put is a coroutine sink
             sandbox_manager=sandbox_manager,
+            agent_completion_callback=agent_completion_callback,
         )
         runtime = cls(
             services=services,

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -291,17 +291,22 @@ def create_runtime_tool_registry(
 
         registry.register(MessageTool(send_callback=bus.publish_outbound))
 
-    # 11. Spawn tool (requires SubagentManager)
-    if subagent_manager is not None:
-        from miqi.agent.tools.spawn import SpawnTool
+    # 11. Spawn tool — always registered (Phase 13 removed the legacy
+    # SubagentManager fallback; the tool executes via AgentControl, which
+    # RuntimeServices wires in after the registry is built).  Gating it on
+    # subagent_manager silently dropped it from every runtime session —
+    # the main agent's available_tools advertised "spawn" but the registry
+    # had no implementation, so model calls failed with "Tool not found"
+    # (issue #246).
+    from miqi.agent.tools.spawn import SpawnTool
 
-        registry.register(
-            SpawnTool(
-                manager=subagent_manager,
-                agent_control=None,  # Wired later by RuntimeServices
-                event_emitter=None,
-            )
+    registry.register(
+        SpawnTool(
+            manager=subagent_manager,
+            agent_control=None,  # Wired later by RuntimeServices
+            event_emitter=None,
         )
+    )
 
     # 12. Cron tool (requires CronService)
     if cron_service is not None:

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -71,6 +71,7 @@ class TurnRunner:
         history: list[dict[str, Any]] | None = None,
         cancel_event: Any | None = None,
         steer_queue: Any | None = None,
+        max_iterations: int | None = None,
     ) -> TurnResult:
         """Execute a full turn: model calls until final response or max iters.
 
@@ -80,6 +81,9 @@ class TurnRunner:
         the same turn instead of completing immediately.
 
         Phase 51.3: fires PROMPT_SUBMIT, TURN_START, and TURN_END lifecycle hooks.
+
+        *max_iterations* overrides the session-wide iteration cap for this
+        call (e.g. sub-agents get a tighter 15-step limit — issue #246).
         """
         lifecycle_ctx = LifecycleHookContext(
             hook_point=HookPoint.PROMPT_SUBMIT,
@@ -103,6 +107,7 @@ class TurnRunner:
                 history=history,
                 cancel_event=cancel_event,
                 steer_queue=steer_queue,
+                max_iterations=max_iterations,
             )
         finally:
             if self._hooks is not None:
@@ -126,6 +131,7 @@ class TurnRunner:
         history: list[dict[str, Any]] | None = None,
         cancel_event: Any | None = None,
         steer_queue: Any | None = None,
+        max_iterations: int | None = None,
     ) -> TurnResult:
         """Core turn loop implementation."""
         messages = self._context.build_initial_messages(
@@ -150,7 +156,7 @@ class TurnRunner:
                     break
             return drained
 
-        for _iteration in range(self._max_iterations):
+        for _iteration in range(max_iterations or self._max_iterations):
             # Phase 14 follow-up: check cancellation before expensive work
             if cancel_event is not None and cancel_event.is_set():
                 raise asyncio.CancelledError("Turn cancelled via AbortTurn")
@@ -466,11 +472,15 @@ class TurnRunner:
         # edit: both flags False → normal approval flow
         # plan: bypass_approval already set above
 
+        # Issue #246: sub-agents get a tight 15-step iteration cap (the legacy
+        # SubagentManager limit), not the session-wide max_tool_iterations.
+        SUBAGENT_MAX_ITERATIONS = 15
         return await self.run(
             turn=turn,
             user_content=job.task,
             system_prompt=metadata.system_prompt,
             tools=tools,
+            max_iterations=SUBAGENT_MAX_ITERATIONS,
         )
 
     @staticmethod

--- a/tests/runtime/test_agent_control.py
+++ b/tests/runtime/test_agent_control.py
@@ -41,6 +41,46 @@ async def test_spawn_agent(agent_control, event_emitter):
 
 
 @pytest.mark.asyncio
+async def test_max_concurrent_blocks_4th_spawn(tmp_path, event_emitter):
+    """Issue #246: no more than max_concurrent (3) subagents at once."""
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=event_emitter,
+        workspace=tmp_path,
+        max_concurrent=3,
+    )
+    for i in range(3):
+        await control.spawn("code-agent", f"task {i}", label=f"a{i}")
+    with pytest.raises(RuntimeError, match="already running"):
+        await control.spawn("code-agent", "task 3", label="a3")
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_releases_terminal_agents(tmp_path, event_emitter):
+    """A completed subagent frees a slot for a new spawn."""
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=event_emitter,
+        workspace=tmp_path,
+        max_concurrent=3,
+    )
+    agents = [
+        await control.spawn("code-agent", f"task {i}", label=f"a{i}")
+        for i in range(3)
+    ]
+    # Two agents finish → only one slot is occupied → a new spawn fits.
+    for a in agents[:2]:
+        a.state.transition(AgentStatus.THINKING)
+        a.state.transition(AgentStatus.COMPLETED)
+    replacement = await control.spawn("code-agent", "task 3", label="a3")
+    assert replacement.agent_id
+    # Third still running + replacement = 2 < 3, so one more is allowed.
+    await control.spawn("code-agent", "task 4", label="a4")
+
+
+@pytest.mark.asyncio
 async def test_list_agents(agent_control):
     await agent_control.spawn("code-agent", "task 1", label="a")
     await agent_control.spawn("doc-agent", "task 2", label="b")
@@ -57,6 +97,81 @@ async def test_kill_agent(agent_control):
     await agent_control.kill(agent_id)
     with pytest.raises(KeyError):
         await agent_control.get_status(agent_id)
+
+
+@pytest.mark.asyncio
+async def test_completion_delivered_once(tmp_path):
+    """Issue #246 review: kill() emits aborted, and the cancelled _run_agent
+    task's finally would emit again — the completion must reach the frontend
+    exactly once (idempotent delivery)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    calls: list[dict] = []
+    async def on_complete(data: dict) -> None:
+        calls.append(data)
+
+    emitter = MagicMock()
+    emitter.emit = AsyncMock()
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=emitter,
+        workspace=tmp_path,
+        completion_callback=on_complete,
+    )
+    agent = await control.spawn("code-agent", "task", label="test")
+
+    # First emission (kill → aborted) is delivered…
+    await control._emit_completed(agent, status="aborted")
+    assert len(calls) == 1
+    assert calls[0]["status"] == "aborted"
+
+    # …the second (cancelled _run_agent finally) is suppressed.
+    await control._emit_completed(agent)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_notify_completed_advances_state_without_callback(tmp_path):
+    """Issue #246 review: notify_completed must sync the job result and
+    advance the state machine to terminal even when no completion callback is
+    wired — otherwise a finished agent stays THINKING and permanently occupies
+    a max_concurrent slot (CLI/TUI/gateway transports pass no callback)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    emitter = MagicMock()
+    emitter.emit = AsyncMock()
+    control = AgentControl(
+        session_id="test-session",
+        registry=AgentRegistry(),
+        event_emitter=emitter,
+        workspace=tmp_path,
+        completion_callback=None,  # no frontend transport
+    )
+    agent = await control.spawn("code-agent", "task", label="test")
+
+    # Simulate the AgentJobRuntime path: the agent is THINKING while the
+    # job runs (spawn with a job runtime transitions immediately).
+    agent.state.transition(AgentStatus.THINKING)
+
+    # Simulate AgentJobRuntime finishing the job.
+    fake_job = MagicMock()
+    fake_job.result = "done"
+    fake_job.error = None
+    fake_jobs = MagicMock()
+    fake_jobs.get = MagicMock(return_value=fake_job)
+    control._agent_jobs = fake_jobs
+
+    await control.notify_completed(agent.agent_id, "completed")
+
+    assert agent.state.current == AgentStatus.COMPLETED
+    assert agent.result == "done"
+
+    # The terminal state frees the concurrency slot for a new spawn.  Restore
+    # _agent_jobs so the replacement spawn takes the legacy path.
+    control._agent_jobs = None
+    replacement = await control.spawn("code-agent", "task 2", label="b")
+    assert replacement.agent_id
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -363,15 +363,16 @@ def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 400k ASCII chars -> ~400k bytes UTF-8
-    (log_dir / "big.log").write_text("a" * 400_000, encoding="utf-8")
+    # Create multiple large files so combined exceeds 196k byte cap
+    for i in range(10):
+        (log_dir / f"log-2026-08-{i:02d}.log").write_text("a" * 100_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     # Must be at most 196,608 bytes
     assert len(result.encode("utf-8")) <= 196_608, (
         f"Expected <= 196608 bytes, got {len(result.encode('utf-8'))}"
     )
     # And it must include the truncation marker
-    assert "已截断" in result
+    assert "截断" in result
 
 
 def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
@@ -379,8 +380,9 @@ def test_collect_all_logs_byte_cap_handles_multibyte_chars(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 80k CJK chars = ~240k bytes UTF-8, exceeds 196k byte cap
-    (log_dir / "cjk.log").write_text("中" * 80_000, encoding="utf-8")
+    # Create multiple CJK files so combined exceeds 196k byte cap
+    for i in range(10):
+        (log_dir / f"中-2026-08-{i:02d}.log").write_text("中" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     assert len(result.encode("utf-8")) <= 196_608
 
@@ -390,8 +392,9 @@ def test_collect_all_logs_byte_cap_exact_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # 210k ASCII chars = 210k bytes, just over the cap
-    (log_dir / "edge.log").write_text("x" * 210_000, encoding="utf-8")
+    # Create multiple files so combined exceeds the cap
+    for i in range(10):
+        (log_dir / f"edge-2026-08-{i:02d}.log").write_text("x" * 50_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     assert len(result.encode("utf-8")) <= 196_608
 

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -59,8 +59,12 @@ def test_runtime_tool_registry_factory_registers_core_tools(fake_config, tmp_pat
     assert "plan_update" in names
 
 
-def test_tool_registry_factory_spawn_requires_subagent_manager(fake_config, tmp_path):
-    """Spawn tool is only registered when subagent_manager is provided."""
+def test_tool_registry_factory_spawn_always_registered(fake_config, tmp_path):
+    """Spawn tool is always registered — Phase 13 removed the legacy
+    SubagentManager dependency; the tool executes via AgentControl, which
+    RuntimeServices wires in after the registry is built.  Gating it on
+    subagent_manager previously advertised "spawn" to the main agent while
+    leaving no implementation in the registry (issue #246)."""
     from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
 
     registry = create_runtime_tool_registry(
@@ -69,7 +73,7 @@ def test_tool_registry_factory_spawn_requires_subagent_manager(fake_config, tmp_
     )
 
     names = set(registry.tool_names)
-    assert "spawn" not in names
+    assert "spawn" in names
 
 
 def test_tool_registry_factory_optional_tools(fake_config, tmp_path):


### PR DESCRIPTION
### **User description**
## 类型

- [ ] 🔧 其他

## 变更概述

合并 develop 到 main，准备下一次发布。

## 背景/问题

develop 分支包含 3 个尚未合入 main 的提交，需要定期同步到 main 以发布新版本。

## 变更内容

本次 develop → main 合并包含以下提交：

- `f9f1b7ce` fix(feedback): use filename date for log sorting, head-preserving truncation (#592)
- `663468ad` fix(desktop): wrap long URLs in chat bubbles (#593)
- `34ae4d98` fix(#246): 修复 subagent 子系统端到端链路，AI 可真正使用 spawn 工具 (#562)

## 日志/验证证据

```
$ git log --oneline origin/main..origin/develop
f9f1b7ce fix(feedback): use filename date for log sorting, head-preserving truncation (#592)
663468ad fix(desktop): wrap long URLs in chat bubbles (#593)
34ae4d98 fix(#246): 修复 subagent 子系统端到端链路，AI 可真正使用 spawn 工具 (#562)
```

## 测试情况

- 所有 3 个提交已在 develop 通过各自 PR 评审并合并
- 自动化测试在各自原 PR 中已通过
- 本次为 release 合并，CI 将由 PR template check + title check 触发


___

### **PR Type**
Bug fix


___

### **Description**
- Wire subagent completion to frontend, enforce concurrency limits, always register spawn tool, cap sub-agent iterations at 15

- Improve log collection: sort by filename date, head‑preserving truncation, per‑file cap of 50k chars

- Prevent horizontal overflow in chat bubbles with `min-w-0`, `break-words`, `overflow-wrap: anywhere`

- Add E2E tests for subagent spawn, result rendering, and bridge API; improve app close robustness in tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SpawnTool always registered"] --> B["AgentControl with completion callback"]
  B --> C["Frontend renders subagent results"]
  D["Log sorting by filename date"] --> E["Head-preserving truncation & per-file cap"]
  F["Chat bubbles"] --> G["min-w-0, break-words, overflow-wrap:anywhere"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>agent_control.py</strong><dd><code>Wire subagent completion to frontend and add concurrency limits</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-865b6d18de4fe68ca3d7689effb0cdcfb6f504f8c47f3ff201ffde3e8de97c61">+140/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>agent_jobs.py</strong><dd><code>Notify AgentControl on job completion for frontend delivery</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-6da76feb74f9d0123b001225ff12cbb3b5b7295cd52f7b8805e5df8f785e132c">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_server.py</strong><dd><code>Forward subagent completions to client via event sink</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-babc1da0d9c056a4bf23a9db4a6f1e1240b3512ee5ccfc99253cfc85d28860b9">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>feedback_handlers.py</strong><dd><code>Use filename date for log sorting and head-preserving truncation</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-037c12a259e2c263bed9fd2785cf9659368af4f517300651d2005473b4a6cdd9">+64/-41</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong><dd><code>Pass agent_completion_callback to AgentControl</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-3f67e147cf7f5f862ddf78772f3a728ac8fbf3637b5950375ff997084db27dbc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>session.py</strong><dd><code>Propagate agent_completion_callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-3974e1eb72611b447053a6ce9895c3a4559de8bd134bfe658e5fe522fe3cf25b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_registry_factory.py</strong><dd><code>Always register SpawnTool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-bba7bdac87ba258004e88a6416dd357e77b6ab0c025e4c8134808fbcc37e2eac">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>turn_runner.py</strong><dd><code>Cap sub-agent iterations at 15</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-4627bd8e77d69d5a0d5be03c29bd0c3402cd0988e6d538cad1b99f4be0a60696">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Pass session_key for agent spawn/kill IPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Expose session_key in agent API methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+34/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx</strong><dd><code>Add min-w-0 and overflow-wrap to prevent horizontal overflow</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+16/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PaperSearchResult.tsx</strong><dd><code>Apply min-w-0 and break-words to search result cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-52e59847eb62dd0bb9d1ee24db1fd1c43b6e0208ed08b4c942a5bb5d417afa9b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MarkdownContent.tsx</strong><dd><code>Wrap markdown with overflow-wrap and max-w-full on code blocks</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-be640aa9bce4c389c56a914a09d02a04fe9521e0bead920cf2c2c2774e50da24">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderContent.tsx</strong><dd><code>Add max-w-full to user message code blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-fd1f0d7963cefb7c0452257392d7ce8f244efe55a998aa21906896f35fc13326">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>test_agent_control.py</strong><dd><code>Add tests for max_concurrent, completion idempotency, and state </code><br><code>advancement</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-ac960145241a240db29812c810e4339aeb2dc8f808e127d8dafbf71daafd2ba2">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_feedback_handlers.py</strong><dd><code>Update tests for filename-based sorting and byte cap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-ff26736b1a64aa7f36a3e8cbfac48f8952a6d2aeb6b1a9a45b5058e1e6b24de2">+10/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_registry_factory.py</strong><dd><code>Assert spawn tool is always registered</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-cff948657ad1cde008668a0a7eb25c696683f9617be95503514386c9f4a4937c">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>electron-setup.ts</strong><dd><code>Implement time-limited app close to avoid CI hang</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-58139259a2a9fb2e044aab7c7354e9c5a55ff21b376fcf99cfbb67b6be072845">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>subagent-bridge-api.spec.ts</strong><dd><code>E2E tests for subagent spawn, list, kill, and result rendering</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-62c3c8d2bb63e019a202a403d3313af9fb30a868a5948fbef0d38270412145d1">+381/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>subagent-spawn.spec.ts</strong><dd><code>E2E test for AI spawning subagent via chat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-4b96e040a0e5d60ad7e6a1afbffbc510302edc4aba7f04436b0485665d640693">+153/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ipc.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/594/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+22/-20</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

