### PR TITLE
fix(desktop): add unsaved-content guard and hints to feedback modal (#595)

### DIFF
--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -78,15 +78,33 @@ function SubmitModal({
 
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
-  // Close on Escape — but only when not actively submitting
+  const hasUnsavedContent =
+    title.trim().length > 0 || content.trim().length > 0 || screenshots.length > 0;
+
+  const handleModalOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && hasUnsavedContent && !success) {
+        if (!window.confirm('放弃已填写的内容？')) return;
+      }
+      if (!open) onClose();
+    },
+    [hasUnsavedContent, success, onClose],
+  );
+
+  // Close on Escape — intercepted for unsaved content
   useEffect(() => {
-    if (success) return;
+    if (success || submitting) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !submitting) onClose();
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      if (hasUnsavedContent) {
+        if (!window.confirm('放弃已填写的内容？')) return;
+      }
+      onClose();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onClose, submitting, success]);
+  }, [onClose, submitting, success, hasUnsavedContent]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {
@@ -208,7 +226,7 @@ function SubmitModal({
   };
 
   return (
-    <Modal open onOpenChange={onClose} hideClose>
+    <Modal open onOpenChange={handleModalOpenChange} hideClose>
       <div
         onClick={(e) => e.stopPropagation()}
         className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
@@ -218,7 +236,7 @@ function SubmitModal({
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
             onClick={() => {
-              if (!submitting) onClose();
+              if (!submitting) handleModalOpenChange(false);
             }}
             disabled={submitting}
             className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"
@@ -237,6 +255,16 @@ function SubmitModal({
           </div>
         ) : (
           <>
+            {/* Hints */}
+            <div className="flex flex-col gap-1.5 mb-4 p-2.5 rounded-md bg-[var(--accent)]/5 border border-[var(--accent)]/15">
+              <p className="text-[11px] text-[var(--muted-foreground)]">
+                日志将在提交时自动附加并发送到飞书
+              </p>
+              <p className="text-[11px] text-[var(--warning)]">
+                提示：建议先复制已填写的提示词，避免因意外关闭而丢失
+              </p>
+            </div>
+
             {/* Category */}
             <div className="mb-4">
               <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

反馈弹窗点击空白区域直接关闭导致内容丢失，增加关闭确认 + 日志提示 + 备份提醒。

## 背景/问题

用户填写反馈时点到弹窗外空白区域（或按 Esc），弹窗直接关闭，已填写的标题、描述、截图全部丢失。

另外，提交前用户不知道日志会被自动附加——目前仅提交成功后才显示"日志已自动附加"。

Closes #595

## 变更内容

改动文件：`apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx`

1. **关闭确认** — `handleModalOpenChange` 在弹窗有未保存内容时弹出 `window.confirm('放弃已填写的内容？')`，用户取消则不关闭。同时覆盖 Overlay 点击（Radix Dialog `onOpenChange`）和 Esc 键两个关闭路径。
2. **日志提示** — 表单顶部新增提示栏："日志将在提交时自动附加并发送到飞书"。
3. **备份提醒** — 同一提示栏第二行用 `--warning` 色显示："提示：建议先复制已填写的提示词，避免因意外关闭而丢失"。

## 日志/验证证据

```
$ npx tsc --noEmit --project apps/desktop/tsconfig.json
(clean exit 0)
```

## 测试情况

- TypeScript 编译通过
- 改动仅涉及受控的 UI 行为（confirm 弹窗 + 提示文本），不涉及数据流或 IPC 变更


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added confirmation dialog before closing modal with unsaved content

- Added hint about automatic log attachment before submission

- Added suggestion to copy prompt to avoid accidental data loss


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Close Attempted"] --> B{"Unsaved Content?"}
  B -- "Yes" --> C["Show Confirm Dialog"]
  C -- "Cancel" --> D["Stay Open"]
  C -- "OK" --> E["Close Modal"]
  B -- "No" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FeedbackPage.tsx</strong><dd><code>Add unsaved-content guard and hints to feedback modal</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx

<ul><li>Introduced <code>hasUnsavedContent</code> check and <code>handleModalOpenChange</code> to show <br>confirmation before closing<br> <li> Intercepted Escape key to trigger confirmation when unsaved content <br>exists<br> <li> Added hints bar notifying that logs will be automatically attached and <br>advising to copy the prompt</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/596/files#diff-fede6e3b7129e73dbfdf22f1a44058e02ebcbd90f27476bd17a96ddb154a0dfa">+34/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

