### PR TITLE
fix(desktop): use onBeforeClose to reliably intercept feedback modal dismiss (#595)

### DIFF
--- a/apps/desktop/src/renderer/components/shared/Modal.tsx
+++ b/apps/desktop/src/renderer/components/shared/Modal.tsx
@@ -16,16 +16,9 @@ interface ModalProps {
 
 /** General-purpose modal powered by Radix Dialog — use for custom-body modals. */
 export function Modal({ open, onOpenChange, title, children, className, hideClose, onBeforeClose }: ModalProps) {
-  const handleOpenChange = (next: boolean) => {
-    if (!next && onBeforeClose) {
-      if (onBeforeClose()) return;
-    }
-    onOpenChange(next);
-  };
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className={cn('max-w-md', className)} hideClose={hideClose}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={cn('max-w-md', className)} hideClose={hideClose} onBeforeClose={onBeforeClose}>
         {title && (
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>

--- a/apps/desktop/src/renderer/components/shared/Modal.tsx
+++ b/apps/desktop/src/renderer/components/shared/Modal.tsx
@@ -9,12 +9,22 @@ interface ModalProps {
   children: ReactNode;
   className?: string;
   hideClose?: boolean;
+  /** If set, called when the user clicks outside or presses Escape.
+   *  Return true to prevent the modal from closing. */
+  onBeforeClose?: () => boolean;
 }
 
 /** General-purpose modal powered by Radix Dialog — use for custom-body modals. */
-export function Modal({ open, onOpenChange, title, children, className, hideClose }: ModalProps) {
+export function Modal({ open, onOpenChange, title, children, className, hideClose, onBeforeClose }: ModalProps) {
+  const handleOpenChange = (next: boolean) => {
+    if (!next && onBeforeClose) {
+      if (onBeforeClose()) return;
+    }
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className={cn('max-w-md', className)} hideClose={hideClose}>
         {title && (
           <DialogHeader>

--- a/apps/desktop/src/renderer/components/ui/Dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/Dialog.tsx
@@ -10,27 +10,44 @@ export const DialogContent = forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     hideClose?: boolean;
+    /** Called before closing via overlay click or Escape. Return true to prevent. */
+    onBeforeClose?: () => boolean;
   }
->(({ className, children, hideClose, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-lg p-6 w-full max-w-md',
-        className
-      )}
-      {...props}
-    >
-      {children}
-      {!hideClose && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-[var(--text-faint)] hover:text-[var(--text)] transition-colors">
-          <X size={16} />
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPrimitive.Portal>
-));
+>(({ className, children, hideClose, onBeforeClose, ...props }, ref) => {
+  const handleInteractOutside = (e: Event) => {
+    if (onBeforeClose?.()) {
+      e.preventDefault();
+    }
+  };
+  const handleEscapeKeyDown = (e: KeyboardEvent) => {
+    if (onBeforeClose?.()) {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-lg p-6 w-full max-w-md',
+          className
+        )}
+        onInteractOutside={onBeforeClose ? handleInteractOutside : undefined}
+        onEscapeKeyDown={onBeforeClose ? handleEscapeKeyDown : undefined}
+        {...props}
+      >
+        {children}
+        {!hideClose && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-[var(--text-faint)] hover:text-[var(--text)] transition-colors">
+            <X size={16} />
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+});
 DialogContent.displayName = 'DialogContent';
 
 export const DialogHeader = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -82,9 +82,10 @@ function SubmitModal({
     title.trim().length > 0 || content.trim().length > 0 || contact.trim().length > 0 || screenshots.length > 0;
 
   const onBeforeClose = useCallback(() => {
+    if (submitting) return true;
     if (!hasUnsavedContent || success) return false;
     return !window.confirm('放弃已填写的内容？');
-  }, [hasUnsavedContent, success]);
+  }, [hasUnsavedContent, submitting, success]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -81,30 +81,10 @@ function SubmitModal({
   const hasUnsavedContent =
     title.trim().length > 0 || content.trim().length > 0 || screenshots.length > 0;
 
-  const handleModalOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && hasUnsavedContent && !success) {
-        if (!window.confirm('放弃已填写的内容？')) return;
-      }
-      if (!open) onClose();
-    },
-    [hasUnsavedContent, success, onClose],
-  );
-
-  // Close on Escape — intercepted for unsaved content
-  useEffect(() => {
-    if (success || submitting) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return;
-      e.preventDefault();
-      if (hasUnsavedContent) {
-        if (!window.confirm('放弃已填写的内容？')) return;
-      }
-      onClose();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onClose, submitting, success, hasUnsavedContent]);
+  const onBeforeClose = useCallback(() => {
+    if (!hasUnsavedContent || success) return false;
+    return !window.confirm('放弃已填写的内容？');
+  }, [hasUnsavedContent, success]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {
@@ -226,7 +206,7 @@ function SubmitModal({
   };
 
   return (
-    <Modal open onOpenChange={handleModalOpenChange} hideClose>
+    <Modal open onOpenChange={onClose} onBeforeClose={onBeforeClose} hideClose>
       <div
         onClick={(e) => e.stopPropagation()}
         className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
@@ -236,7 +216,7 @@ function SubmitModal({
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
             onClick={() => {
-              if (!submitting) handleModalOpenChange(false);
+              if (!submitting) onClose();
             }}
             disabled={submitting}
             className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -79,7 +79,7 @@ function SubmitModal({
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
   const hasUnsavedContent =
-    title.trim().length > 0 || content.trim().length > 0 || screenshots.length > 0;
+    title.trim().length > 0 || content.trim().length > 0 || contact.trim().length > 0 || screenshots.length > 0;
 
   const onBeforeClose = useCallback(() => {
     if (!hasUnsavedContent || success) return false;

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -216,7 +216,7 @@ function SubmitModal({
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
             onClick={() => {
-              if (!submitting) onClose();
+              if (!submitting && !onBeforeClose()) onClose();
             }}
             disabled={submitting}
             className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -61,6 +61,8 @@ test.describe('Feedback Page E2E', () => {
   test.afterEach(async () => {
     const modalHeading = page.getByRole('heading', { name: '提交反馈' });
     if (await modalHeading.isVisible().catch(() => false)) {
+      // Accept any confirm dialog that fires (e.g. unsaved-content guard)
+      page.once('dialog', async (dialog) => { await dialog.accept(); });
       await page.keyboard.press('Escape');
       await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
     }
@@ -124,6 +126,94 @@ test.describe('Feedback Page E2E', () => {
     await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
       timeout: 2_000,
     });
+  });
+
+  test('unsaved content shows confirm dialog on Escape — dismiss keeps modal open', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    // Fill title → hasUnsavedContent becomes true
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('测试未保存拦截');
+
+    // Intercept the confirm dialog — dismiss it (return false)
+    let dialogMessage = '';
+    page.once('dialog', async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss();
+    });
+    await page.keyboard.press('Escape');
+
+    expect(dialogMessage).toBe('放弃已填写的内容？');
+    // Modal should still be visible
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test('unsaved content shows confirm dialog on Escape — accept closes modal', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('测试接受');
+
+    // Accept the confirm dialog
+    page.once('dialog', async (dialog) => {
+      await dialog.accept();
+    });
+    await page.keyboard.press('Escape');
+
+    // Modal should close
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test('empty form closes normally on Escape without confirm', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    // Leave form completely empty — no unsaved content
+    // Should close without firing a dialog
+    let dialogFired = false;
+    page.on('dialog', () => { dialogFired = true; });
+    await page.keyboard.press('Escape');
+
+    expect(dialogFired).toBe(false);
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
+      timeout: 2_000,
+    });
+  });
+
+  test('hints are visible in the submit modal', async () => {
+    await openFeedbackTab(page);
+
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
+      name: '提交反馈',
+      exact: true,
+    });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+
+    await expect(page.getByText('日志将在提交时自动附加并发送到飞书')).toBeVisible();
+    await expect(page.getByText('提示：建议先复制已填写的提示词，避免因意外关闭而丢失')).toBeVisible();
   });
 
   test('submit feedback shows validation error when disabled', async () => {

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -158,10 +158,15 @@ test.describe('Feedback Page E2E', () => {
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
 
     let dialogFired = false;
-    page.on('dialog', () => { dialogFired = true; });
-    await page.keyboard.press('Escape');
-    expect(dialogFired).toBe(false);
-    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
+    const onDialog = () => { dialogFired = true; };
+    page.on('dialog', onDialog);
+    try {
+      await page.keyboard.press('Escape');
+      expect(dialogFired).toBe(false);
+      await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
+    } finally {
+      page.off('dialog', onDialog);
+    }
   });
 
   test('hints are visible in the submit modal', async () => {
@@ -274,7 +279,7 @@ test.describe('Feedback Page E2E', () => {
     expect(captured[0].title).toBe('E2E mock submission');
     expect(captured[0].content).toContain('Mocked success-path');
     expect(captured[0].contact).toBe('e2e@test.com');
-  });;
+  });
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {
     await openFeedbackTab(page);

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -61,10 +61,14 @@ test.describe('Feedback Page E2E', () => {
   test.afterEach(async () => {
     const modalHeading = page.getByRole('heading', { name: '提交反馈' });
     if (await modalHeading.isVisible().catch(() => false)) {
-      // Accept any confirm dialog that fires (e.g. unsaved-content guard)
-      page.once('dialog', async (dialog) => { await dialog.accept(); });
-      await page.keyboard.press('Escape');
-      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+      // Click "取消" to close without triggering the unsaved-content guard.
+      const cancelBtn = page.getByRole('button', { name: '取消', exact: true });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+      } else {
+        await page.keyboard.press('Escape');
+      }
+      await modalHeading.waitFor({ state: 'hidden', timeout: 3_000 });
     }
   });
 
@@ -111,148 +115,82 @@ test.describe('Feedback Page E2E', () => {
 
   test('Escape key closes the submit modal', async () => {
     await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-
-    // Press Escape
     await page.keyboard.press('Escape');
-
-    // Modal heading should no longer be visible
-    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
-      timeout: 2_000,
-    });
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
   });
 
-  test('unsaved content shows confirm dialog on Escape — dismiss keeps modal open', async () => {
+  test('unsaved content guard: dismiss keeps modal open, accept closes', async () => {
     await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
-    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-
-    // Fill title → hasUnsavedContent becomes true
+    const modalHeading = page.getByRole('heading', { name: '提交反馈' });
+    await expect(modalHeading).toBeVisible();
     await page.getByPlaceholder('简要描述你的问题或建议').fill('测试未保存拦截');
 
-    // Intercept the confirm dialog — dismiss it (return false)
-    let dialogMessage = '';
-    page.once('dialog', async (dialog) => {
-      dialogMessage = dialog.message();
-      await dialog.dismiss();
-    });
-    await page.keyboard.press('Escape');
+    let dismissCalled = false;
+    const onDialog = (dialog: any) => {
+      if (!dismissCalled) { dismissCalled = true; dialog.dismiss(); }
+      else { dialog.accept(); }
+    };
+    page.on('dialog', onDialog);
+    try {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(500);
+      expect(dismissCalled).toBe(true);
+      await expect(modalHeading).toBeVisible({ timeout: 2_000 });
 
-    expect(dialogMessage).toBe('放弃已填写的内容？');
-    // Modal should still be visible
-    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible({
-      timeout: 2_000,
-    });
-  });
-
-  test('unsaved content shows confirm dialog on Escape — accept closes modal', async () => {
-    await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
-    await headerBtn.click();
-    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-
-    await page.getByPlaceholder('简要描述你的问题或建议').fill('测试接受');
-
-    // Accept the confirm dialog
-    page.once('dialog', async (dialog) => {
-      await dialog.accept();
-    });
-    await page.keyboard.press('Escape');
-
-    // Modal should close
-    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
-      timeout: 2_000,
-    });
+      await page.getByPlaceholder('简要描述你的问题或建议').click();
+      await page.waitForTimeout(300);
+      await page.keyboard.press('Escape');
+      await expect(modalHeading).not.toBeVisible({ timeout: 5_000 });
+    } finally {
+      page.off('dialog', onDialog);
+    }
   });
 
   test('empty form closes normally on Escape without confirm', async () => {
     await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
 
-    // Leave form completely empty — no unsaved content
-    // Should close without firing a dialog
     let dialogFired = false;
     page.on('dialog', () => { dialogFired = true; });
     await page.keyboard.press('Escape');
-
     expect(dialogFired).toBe(false);
-    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
-      timeout: 2_000,
-    });
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
   });
 
   test('hints are visible in the submit modal', async () => {
     await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-
     await expect(page.getByText('日志将在提交时自动附加并发送到飞书')).toBeVisible();
     await expect(page.getByText('提示：建议先复制已填写的提示词，避免因意外关闭而丢失')).toBeVisible();
   });
 
   test('submit feedback shows validation error when disabled', async () => {
-    // E2E test config has feedback disabled by default, so a real submit
-    // surfaces the FEEDBACK_DISABLED error.  This verifies the modal handles
-    // errors gracefully.  Full success flow requires enabling feedback in
-    // the test config and is covered by the Python unit tests + the manual
-    // E2E verification (see PR description).
     await openFeedbackTab(page);
-
-    // Open modal
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
 
-    // Fill form with valid data
     await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E test title');
-    await page
-      .getByPlaceholder('请详细描述你的问题或建议...')
-      .fill('E2E test content - verifying the form submission path.');
+    await page.getByPlaceholder('请详细描述你的问题或建议...').fill('E2E test content');
 
-    // Submit
-    const submitButton = page
-      .locator('div.bg-\\[var\\(--surface\\)\\]')
-      .getByRole('button', { name: '提交', exact: true });
+    const submitButton = page.locator('div.bg-\\[var\\(--surface\\)\\]').getByRole('button', { name: '提交', exact: true });
     await submitButton.click();
 
-    // Feedback is disabled by default in E2E config → specific error must appear.
-    // Assert the FEEDBACK_DISABLED message is shown and "提交成功！" is absent.
     const errorBox = page.locator('[class*="bg-red-500"]');
     await expect(errorBox).toBeVisible({ timeout: 5_000 });
     await expect(errorBox).toContainText('反馈功能未启用');
     await expect(page.getByText('提交成功！')).not.toBeVisible();
-    // Modal stays open so the user can correct and retry
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-    // Close modal so afterEach Escape doesn't double-press
-    await page.keyboard.press('Escape');
+    // Close via cancel to bypass the unsaved-content guard
+    await page.getByRole('button', { name: '取消', exact: true }).click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible();
   });
 

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -130,6 +130,7 @@ test.describe('Feedback Page E2E', () => {
     await expect(modalHeading).toBeVisible();
     await page.getByPlaceholder('简要描述你的问题或建议').fill('测试未保存拦截');
 
+    // Esc: dismiss keeps open, accept closes
     let dismissCalled = false;
     const onDialog = (dialog: any) => {
       if (!dismissCalled) { dismissCalled = true; dialog.dismiss(); }
@@ -149,23 +150,66 @@ test.describe('Feedback Page E2E', () => {
     } finally {
       page.off('dialog', onDialog);
     }
+
+    // Overlay click: dismiss keeps open, accept closes
+    await headerBtn.click();
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('覆盖层点击测试');
+    await expect(modalHeading).toBeVisible();
+
+    let overlayDismissed = false;
+    const onDialog2 = (dialog: any) => {
+      if (!overlayDismissed) { overlayDismissed = true; dialog.dismiss(); }
+      else { dialog.accept(); }
+    };
+    page.on('dialog', onDialog2);
+    try {
+      // Click outside modal — the overlay is at fixed inset-0
+      await page.mouse.click(10, 10);
+      await page.waitForTimeout(500);
+      expect(overlayDismissed).toBe(true);
+      await expect(modalHeading).toBeVisible({ timeout: 2_000 });
+
+      await page.getByPlaceholder('简要描述你的问题或建议').click();
+      await page.waitForTimeout(300);
+      await page.mouse.click(10, 10);
+      await expect(modalHeading).not.toBeVisible({ timeout: 5_000 });
+    } finally {
+      page.off('dialog', onDialog2);
+    }
   });
 
-  test('empty form closes normally on Escape without confirm', async () => {
+  test('empty form closes on Escape and overlay click without confirm', async () => {
     await openFeedbackTab(page);
     const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
-    await headerBtn.click();
-    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+    const modalHeading = page.getByRole('heading', { name: '提交反馈' });
 
+    // Escape
+    await headerBtn.click();
+    await expect(modalHeading).toBeVisible();
     let dialogFired = false;
     const onDialog = () => { dialogFired = true; };
     page.on('dialog', onDialog);
     try {
       await page.keyboard.press('Escape');
       expect(dialogFired).toBe(false);
-      await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
+      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
     } finally {
       page.off('dialog', onDialog);
+    }
+
+    // Overlay click
+    await headerBtn.click();
+    await expect(modalHeading).toBeVisible();
+    let overlayDialog = false;
+    const onDialog2 = () => { overlayDialog = true; };
+    page.on('dialog', onDialog2);
+    try {
+      await page.mouse.click(10, 10);
+      await page.waitForTimeout(500);
+      expect(overlayDialog).toBe(false);
+      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+    } finally {
+      page.off('dialog', onDialog2);
     }
   });
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复
- [x] 🧪 测试

## 变更概述

修复反馈弹窗点击空白区域/Esc/关闭按钮时无确认丢失数据的问题（#595），通过 Radix DismissableLayer 事件初步拦截关闭。

## 背景/问题

此前两次尝试（#596 用 onOpenChange 拦截，#597 用 Modal handleOpenChange 拦截）均被用户验证无效。根因：Radix Dialog v1.1 内部有两层独立关闭路径——DismissableLayer（onInteractOutside/onEscapeKeyDown）和 Dialog Root（onOpenChange）。只拦截 onOpenChange 不够，DismissableLayer 层会先把内容从 DOM 移除。

## 变更内容

1. `Dialog.tsx` — 新增 `onBeforeClose` prop，在 `DialogPrimitive.Content` 上绑定 `onInteractOutside` 和 `onEscapeKeyDown` 处理器。当 guard 返回 true 时调用 `e.preventDefault()`，从 DismissableLayer 层阻止关闭
2. `Modal.tsx` — 将 `onBeforeClose` 透传给 `DialogContent`（不再在 Modal 层重复拦截，避免 confirm 弹两次）
3. `FeedbackPage.tsx` — X 关闭按钮也加上 `onBeforeClose()` 保护，与 overlay/Escape 行为一致
4. `feedback.spec.ts` — 9 个 e2e 测试覆盖：未保存内容弹窗（取消保留/确认关闭）、空表单直接关闭、提示文案可见等

## 日志/验证证据

```
$ npx playwright test --project=electron feedback.spec.ts
  9 passed (34s)
```

## 测试情况

- E2E 9/9 通过（含连续两轮 18/18 稳定性验证）
- TypeScript 编译通过


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added confirmation dialog on close with unsaved content to prevent data loss

- Added "logs will be attached" and "copy prompt" hints before submission

- Refactored modal close interception using `onBeforeClose` in shared Dialog component

- Added E2E tests covering guard behavior and hints visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Close Attempted"] --> B{"Unsaved Content?"}
  B -- "Yes" --> C["Show Confirm Dialog"]
  C -- "Cancel" --> D["Stay Open"]
  C -- "OK" --> E["Close Modal"]
  B -- "No" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Modal.tsx</strong><dd><code>Add onBeforeClose prop to shared Modal component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/components/shared/Modal.tsx

<ul><li>Added optional <code>onBeforeClose</code> prop to the <code>Modal</code> component<br> <li> Passed the prop directly to <code>DialogContent</code> for interception</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/597/files#diff-b732296ffdb284ca321e181eee2976e582487b718db61caf3530e79a2d8e8458">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Implement onBeforeClose guard in DialogContent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/components/ui/Dialog.tsx

<ul><li>Added <code>onBeforeClose</code> prop to <code>DialogContent</code><br> <li> Bound <code>onInteractOutside</code> and <code>onEscapeKeyDown</code> handlers<br> <li> Prevent close when guard returns true by calling <code>e.preventDefault()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/597/files#diff-efab55df73122c79435ae4e36c6af357740a48b488cea915ee9f67e47f2ebbd8">+37/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FeedbackPage.tsx</strong><dd><code>Replace modal close logic with onBeforeClose guard for feedback</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx

<ul><li>Removed old <code>handleModalOpenChange</code> and manual Escape listener<br> <li> Implemented <code>onBeforeClose</code> callback with <code>window.confirm</code> for unsaved <br>content<br> <li> Extended <code>hasUnsavedContent</code> to include contact field<br> <li> Wired guard into modal and close button</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/597/files#diff-fede6e3b7129e73dbfdf22f1a44058e02ebcbd90f27476bd17a96ddb154a0dfa">+8/-27</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>feedback.spec.ts</strong><dd><code>Add E2E tests for unsaved-content guard and hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/feedback.spec.ts

<ul><li>Added tests for unsaved-content guard: dismiss keeps open, accept <br>closes<br> <li> Added test for empty form closing without confirm dialog<br> <li> Added test verifying hint visibility ("日志将在提交时自动附加" and copy <br>suggestion)<br> <li> Improved <code>afterEach</code> teardown to close modal via "取消" button</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/597/files#diff-91d4d5b1923c01aa2dbe89a65393adb8acd8915b191940e073c32eb917ada4ea">+115/-38</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

