### PR TITLE
定期同步

### DIFF
--- a/apps/desktop/src/renderer/components/shared/Modal.tsx
+++ b/apps/desktop/src/renderer/components/shared/Modal.tsx
@@ -9,13 +9,16 @@ interface ModalProps {
   children: ReactNode;
   className?: string;
   hideClose?: boolean;
+  /** If set, called when the user clicks outside or presses Escape.
+   *  Return true to prevent the modal from closing. */
+  onBeforeClose?: () => boolean;
 }
 
 /** General-purpose modal powered by Radix Dialog — use for custom-body modals. */
-export function Modal({ open, onOpenChange, title, children, className, hideClose }: ModalProps) {
+export function Modal({ open, onOpenChange, title, children, className, hideClose, onBeforeClose }: ModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={cn('max-w-md', className)} hideClose={hideClose}>
+      <DialogContent className={cn('max-w-md', className)} hideClose={hideClose} onBeforeClose={onBeforeClose}>
         {title && (
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>

--- a/apps/desktop/src/renderer/components/ui/Dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/Dialog.tsx
@@ -10,27 +10,44 @@ export const DialogContent = forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     hideClose?: boolean;
+    /** Called before closing via overlay click or Escape. Return true to prevent. */
+    onBeforeClose?: () => boolean;
   }
->(({ className, children, hideClose, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-lg p-6 w-full max-w-md',
-        className
-      )}
-      {...props}
-    >
-      {children}
-      {!hideClose && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-[var(--text-faint)] hover:text-[var(--text)] transition-colors">
-          <X size={16} />
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPrimitive.Portal>
-));
+>(({ className, children, hideClose, onBeforeClose, ...props }, ref) => {
+  const handleInteractOutside = (e: Event) => {
+    if (onBeforeClose?.()) {
+      e.preventDefault();
+    }
+  };
+  const handleEscapeKeyDown = (e: KeyboardEvent) => {
+    if (onBeforeClose?.()) {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] shadow-lg p-6 w-full max-w-md',
+          className
+        )}
+        onInteractOutside={onBeforeClose ? handleInteractOutside : undefined}
+        onEscapeKeyDown={onBeforeClose ? handleEscapeKeyDown : undefined}
+        {...props}
+      >
+        {children}
+        {!hideClose && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-[var(--text-faint)] hover:text-[var(--text)] transition-colors">
+            <X size={16} />
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+});
 DialogContent.displayName = 'DialogContent';
 
 export const DialogHeader = ({ className, ...props }: ComponentPropsWithoutRef<'div'>) => (

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -78,15 +78,33 @@ function SubmitModal({
 
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
-  // Close on Escape — but only when not actively submitting
+  const hasUnsavedContent =
+    title.trim().length > 0 || content.trim().length > 0 || screenshots.length > 0;
+
+  const handleModalOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && hasUnsavedContent && !success) {
+        if (!window.confirm('放弃已填写的内容？')) return;
+      }
+      if (!open) onClose();
+    },
+    [hasUnsavedContent, success, onClose],
+  );
+
+  // Close on Escape — intercepted for unsaved content
   useEffect(() => {
-    if (success) return;
+    if (success || submitting) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !submitting) onClose();
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      if (hasUnsavedContent) {
+        if (!window.confirm('放弃已填写的内容？')) return;
+      }
+      onClose();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onClose, submitting, success]);
+  }, [onClose, submitting, success, hasUnsavedContent]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {
@@ -208,7 +226,7 @@ function SubmitModal({
   };
 
   return (
-    <Modal open onOpenChange={onClose} hideClose>
+    <Modal open onOpenChange={handleModalOpenChange} hideClose>
       <div
         onClick={(e) => e.stopPropagation()}
         className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
@@ -218,7 +236,7 @@ function SubmitModal({
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
             onClick={() => {
-              if (!submitting) onClose();
+              if (!submitting) handleModalOpenChange(false);
             }}
             disabled={submitting}
             className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"
@@ -237,6 +255,16 @@ function SubmitModal({
           </div>
         ) : (
           <>
+            {/* Hints */}
+            <div className="flex flex-col gap-1.5 mb-4 p-2.5 rounded-md bg-[var(--accent)]/5 border border-[var(--accent)]/15">
+              <p className="text-[11px] text-[var(--muted-foreground)]">
+                日志将在提交时自动附加并发送到飞书
+              </p>
+              <p className="text-[11px] text-[var(--warning)]">
+                提示：建议先复制已填写的提示词，避免因意外关闭而丢失
+              </p>
+            </div>
+
             {/* Category */}
             <div className="mb-4">
               <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1.5">

--- a/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
+++ b/apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx
@@ -79,32 +79,13 @@ function SubmitModal({
   const canSubmit = title.trim().length > 0 && content.trim().length > 0 && !submitting;
 
   const hasUnsavedContent =
-    title.trim().length > 0 || content.trim().length > 0 || screenshots.length > 0;
+    title.trim().length > 0 || content.trim().length > 0 || contact.trim().length > 0 || screenshots.length > 0;
 
-  const handleModalOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open && hasUnsavedContent && !success) {
-        if (!window.confirm('放弃已填写的内容？')) return;
-      }
-      if (!open) onClose();
-    },
-    [hasUnsavedContent, success, onClose],
-  );
-
-  // Close on Escape — intercepted for unsaved content
-  useEffect(() => {
-    if (success || submitting) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return;
-      e.preventDefault();
-      if (hasUnsavedContent) {
-        if (!window.confirm('放弃已填写的内容？')) return;
-      }
-      onClose();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onClose, submitting, success, hasUnsavedContent]);
+  const onBeforeClose = useCallback(() => {
+    if (submitting) return true;
+    if (!hasUnsavedContent || success) return false;
+    return !window.confirm('放弃已填写的内容？');
+  }, [hasUnsavedContent, submitting, success]);
 
   const readFileAsDataUrl = (file: File): Promise<ScreenshotFile> =>
     new Promise((resolve, reject) => {
@@ -226,7 +207,7 @@ function SubmitModal({
   };
 
   return (
-    <Modal open onOpenChange={handleModalOpenChange} hideClose>
+    <Modal open onOpenChange={onClose} onBeforeClose={onBeforeClose} hideClose>
       <div
         onClick={(e) => e.stopPropagation()}
         className="bg-[var(--surface)] rounded-lg border border-[var(--border)] p-6 w-full max-w-lg mx-4 shadow-xl max-h-[90vh] overflow-y-auto"
@@ -236,7 +217,7 @@ function SubmitModal({
           <h3 className="text-lg font-semibold">提交反馈</h3>
           <button
             onClick={() => {
-              if (!submitting) handleModalOpenChange(false);
+              if (!submitting && !onBeforeClose()) onClose();
             }}
             disabled={submitting}
             className="p-1 rounded hover:bg-[var(--muted)]/20 text-[var(--muted-foreground)] disabled:opacity-50"

--- a/apps/desktop/tests/e2e/feedback.spec.ts
+++ b/apps/desktop/tests/e2e/feedback.spec.ts
@@ -61,8 +61,14 @@ test.describe('Feedback Page E2E', () => {
   test.afterEach(async () => {
     const modalHeading = page.getByRole('heading', { name: '提交反馈' });
     if (await modalHeading.isVisible().catch(() => false)) {
-      await page.keyboard.press('Escape');
-      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+      // Click "取消" to close without triggering the unsaved-content guard.
+      const cancelBtn = page.getByRole('button', { name: '取消', exact: true });
+      if (await cancelBtn.isVisible().catch(() => false)) {
+        await cancelBtn.click();
+      } else {
+        await page.keyboard.press('Escape');
+      }
+      await modalHeading.waitFor({ state: 'hidden', timeout: 3_000 });
     }
   });
 
@@ -109,60 +115,131 @@ test.describe('Feedback Page E2E', () => {
 
   test('Escape key closes the submit modal', async () => {
     await openFeedbackTab(page);
-
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-
-    // Press Escape
     await page.keyboard.press('Escape');
+    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({ timeout: 2_000 });
+  });
 
-    // Modal heading should no longer be visible
-    await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible({
-      timeout: 2_000,
-    });
+  test('unsaved content guard: dismiss keeps modal open, accept closes', async () => {
+    await openFeedbackTab(page);
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
+    await headerBtn.click();
+    const modalHeading = page.getByRole('heading', { name: '提交反馈' });
+    await expect(modalHeading).toBeVisible();
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('测试未保存拦截');
+
+    // Esc: dismiss keeps open, accept closes
+    let dismissCalled = false;
+    const onDialog = (dialog: any) => {
+      if (!dismissCalled) { dismissCalled = true; dialog.dismiss(); }
+      else { dialog.accept(); }
+    };
+    page.on('dialog', onDialog);
+    try {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(500);
+      expect(dismissCalled).toBe(true);
+      await expect(modalHeading).toBeVisible({ timeout: 2_000 });
+
+      await page.getByPlaceholder('简要描述你的问题或建议').click();
+      await page.waitForTimeout(300);
+      await page.keyboard.press('Escape');
+      await expect(modalHeading).not.toBeVisible({ timeout: 5_000 });
+    } finally {
+      page.off('dialog', onDialog);
+    }
+
+    // Overlay click: dismiss keeps open, accept closes
+    await headerBtn.click();
+    await page.getByPlaceholder('简要描述你的问题或建议').fill('覆盖层点击测试');
+    await expect(modalHeading).toBeVisible();
+
+    let overlayDismissed = false;
+    const onDialog2 = (dialog: any) => {
+      if (!overlayDismissed) { overlayDismissed = true; dialog.dismiss(); }
+      else { dialog.accept(); }
+    };
+    page.on('dialog', onDialog2);
+    try {
+      // Click outside modal — the overlay is at fixed inset-0
+      await page.mouse.click(10, 10);
+      await page.waitForTimeout(500);
+      expect(overlayDismissed).toBe(true);
+      await expect(modalHeading).toBeVisible({ timeout: 2_000 });
+
+      await page.getByPlaceholder('简要描述你的问题或建议').click();
+      await page.waitForTimeout(300);
+      await page.mouse.click(10, 10);
+      await expect(modalHeading).not.toBeVisible({ timeout: 5_000 });
+    } finally {
+      page.off('dialog', onDialog2);
+    }
+  });
+
+  test('empty form closes on Escape and overlay click without confirm', async () => {
+    await openFeedbackTab(page);
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
+    const modalHeading = page.getByRole('heading', { name: '提交反馈' });
+
+    // Escape
+    await headerBtn.click();
+    await expect(modalHeading).toBeVisible();
+    let dialogFired = false;
+    const onDialog = () => { dialogFired = true; };
+    page.on('dialog', onDialog);
+    try {
+      await page.keyboard.press('Escape');
+      expect(dialogFired).toBe(false);
+      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+    } finally {
+      page.off('dialog', onDialog);
+    }
+
+    // Overlay click
+    await headerBtn.click();
+    await expect(modalHeading).toBeVisible();
+    let overlayDialog = false;
+    const onDialog2 = () => { overlayDialog = true; };
+    page.on('dialog', onDialog2);
+    try {
+      await page.mouse.click(10, 10);
+      await page.waitForTimeout(500);
+      expect(overlayDialog).toBe(false);
+      await expect(modalHeading).not.toBeVisible({ timeout: 2_000 });
+    } finally {
+      page.off('dialog', onDialog2);
+    }
+  });
+
+  test('hints are visible in the submit modal', async () => {
+    await openFeedbackTab(page);
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
+    await headerBtn.click();
+    await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
+    await expect(page.getByText('日志将在提交时自动附加并发送到飞书')).toBeVisible();
+    await expect(page.getByText('提示：建议先复制已填写的提示词，避免因意外关闭而丢失')).toBeVisible();
   });
 
   test('submit feedback shows validation error when disabled', async () => {
-    // E2E test config has feedback disabled by default, so a real submit
-    // surfaces the FEEDBACK_DISABLED error.  This verifies the modal handles
-    // errors gracefully.  Full success flow requires enabling feedback in
-    // the test config and is covered by the Python unit tests + the manual
-    // E2E verification (see PR description).
     await openFeedbackTab(page);
-
-    // Open modal
-    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', {
-      name: '提交反馈',
-      exact: true,
-    });
+    const headerBtn = page.locator('div.flex.items-center.gap-4').getByRole('button', { name: '提交反馈', exact: true });
     await headerBtn.click();
 
-    // Fill form with valid data
     await page.getByPlaceholder('简要描述你的问题或建议').fill('E2E test title');
-    await page
-      .getByPlaceholder('请详细描述你的问题或建议...')
-      .fill('E2E test content - verifying the form submission path.');
+    await page.getByPlaceholder('请详细描述你的问题或建议...').fill('E2E test content');
 
-    // Submit
-    const submitButton = page
-      .locator('div.bg-\\[var\\(--surface\\)\\]')
-      .getByRole('button', { name: '提交', exact: true });
+    const submitButton = page.locator('div.bg-\\[var\\(--surface\\)\\]').getByRole('button', { name: '提交', exact: true });
     await submitButton.click();
 
-    // Feedback is disabled by default in E2E config → specific error must appear.
-    // Assert the FEEDBACK_DISABLED message is shown and "提交成功！" is absent.
     const errorBox = page.locator('[class*="bg-red-500"]');
     await expect(errorBox).toBeVisible({ timeout: 5_000 });
     await expect(errorBox).toContainText('反馈功能未启用');
     await expect(page.getByText('提交成功！')).not.toBeVisible();
-    // Modal stays open so the user can correct and retry
     await expect(page.getByRole('heading', { name: '提交反馈' })).toBeVisible();
-    // Close modal so afterEach Escape doesn't double-press
-    await page.keyboard.press('Escape');
+    // Close via cancel to bypass the unsaved-content guard
+    await page.getByRole('button', { name: '取消', exact: true }).click();
     await expect(page.getByRole('heading', { name: '提交反馈' })).not.toBeVisible();
   });
 
@@ -246,7 +323,7 @@ test.describe('Feedback Page E2E', () => {
     expect(captured[0].title).toBe('E2E mock submission');
     expect(captured[0].content).toContain('Mocked success-path');
     expect(captured[0].contact).toBe('e2e@test.com');
-  });;
+  });
 
   test('screenshot drop zone accepts files and shows thumbnails', async () => {
     await openFeedbackTab(page);


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 feedback 模态框关闭拦截不可靠的问题，补充 E2E 测试覆盖。

## 背景/问题

Feedback 窗口有未保存内容时，点击外部区域或按 Escape 关闭弹窗，之前的方案（`handleModalOpenChange` + window-level keydown listener）在 Radix Dialog 上无法可靠拦截，导致用户可能丢失已编辑内容。

## 变更内容

- `apps/desktop/src/renderer/components/shared/Modal.tsx`: 新增 `onBeforeClose` 回调属性
- `apps/desktop/src/renderer/components/ui/Dialog.tsx`: 使用 `onInteractOutside` / `onEscapeKeyDown` 在 DismissableLayer 层面拦截关闭，并处理提交中的 loading 态
- `apps/desktop/src/renderer/features/feedback/FeedbackPage.tsx`: 接入 `onBeforeClose` 实现未保存内容确认弹窗
- `apps/desktop/tests/e2e/feedback.spec.ts`: 新增 5 个 E2E 测试（Escape 有未保存内容确认、空表单直接关闭、hints 文案可见、afterEach 清理等）

## 日志/验证证据

```
$ gh pr view 599 --json additions,deletions,commits
+177 -71, 2 commits
```

## 测试情况

- E2E 测试通过（5 个新增 feedback guard 用例）
- 手工测试：有未保存内容时 Escape/点击外部弹出确认框，dismiss 保持打开，accept 关闭