### PR TITLE
fix(desktop): sync status bar version with package version

### DIFF
--- a/apps/desktop/src/renderer/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/components/StatusBar.tsx
@@ -86,7 +86,7 @@ export function StatusBar() {
       {restartError && <span style={{ color: 'var(--danger)' }}>{restartError}</span>}
 
       <span className="ml-auto text-text-faint">
-        MiQi Desktop v0.8
+        MiQi Desktop v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'}
       </span>
     </div>
   );


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复桌面端状态栏右下角版本号硬编码为 `v0.8`，未随 package.json 版本同步的问题。

## 背景/问题

状态栏右侧长期显示 `MiQi Desktop v0.8`，但项目当前版本已是 `0.11.0`（见 `package.json`）。该文本为硬编码，导致每次发版后状态栏版本不会自动更新，容易造成用户困惑。

同一项目里，左侧边栏和反馈页面已经使用构建时注入的 `__APP_VERSION__` 宏读取 `package.json` 版本，状态栏却遗漏了这一处理。

## 变更内容

- `apps/desktop/src/renderer/components/StatusBar.tsx`
  - 将硬编码的 `MiQi Desktop v0.8` 替换为 `MiQi Desktop v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'}`
  - 与 `Sidebar.tsx`、`FeedbackPage.tsx` 保持一致
  - 开发环境显示 `vdev`，生产构建自动跟随 `apps/desktop/package.json` 版本

## 日志/验证证据

```
$ rg 'MiQi Desktop v' apps/desktop/src/renderer/components/StatusBar.tsx
89:        MiQi Desktop v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'}

$ rg '"version"' apps/desktop/package.json
3:  \"version\": \"0.11.0\"
```

## 测试情况

- 已在当前工作区确认 TypeScript 类型检查通过（`__APP_VERSION__` 已在 `env.d.ts` 声明）
- 与已有使用 `__APP_VERSION__` 的组件对齐，无新增依赖或构建配置变更

## 截图

无需截图


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced hardcoded version text `v0.8` with dynamic `__APP_VERSION__` in status bar

- Aligns version display with Sidebar and FeedbackPage components

- Development builds now show `vdev`, production builds use `package.json` version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded 'v0.8'"] -- "replaced by" --> B["__APP_VERSION__ with fallback to 'dev'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatusBar.tsx</strong><dd><code>Sync status bar version with package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/components/StatusBar.tsx

<ul><li>Replaced the hardcoded version string <code>MiQi Desktop v0.8</code> with a dynamic <br>expression using the build‑time global <code>__APP_VERSION__</code><br> <li> Falls back to <code>'dev'</code> when the macro is undefined (e.g., in development)</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/600/files#diff-902892b4f0d053e417f810884828870c4a2d9a3d08f2ba288778b9c2f089128f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

