### PR TITLE
fix(sandbox): allow tools.extra_roots and .skills in file tool whitelist (#567)

### DIFF
--- a/docs/backend/tools.md
+++ b/docs/backend/tools.md
@@ -229,7 +229,7 @@ get_document_category(path) → "pdf" | "word" | "ppt" | "excel" | ...
 
 ## 安全机制
 
-1. **工作区隔离**：文件操作默认限制在 `workspace` 目录（`restrict_to_workspace: true`）
+1. **工作区隔离**：文件操作受 `workspace` 目录约束（由 `restrict_to_workspace` 控制），WSL 沙箱下默认放行 `memory/`、`skills/`、`.skills/` 与配置文件；`tools.extra_roots` 可显式授权 workspace 外目录
 2. **危险命令审批**：39 种危险命令模式需用户确认（`miqi/agent/command_approval.py`）
 3. **bwrap 沙箱**：LANDLOCK 文件系统规则，FIFO 驱逐（最多 10 个）
 4. **快照保护**：文件写入前自动创建原始内容快照，支持回滚

--- a/docs/backend/tools.md
+++ b/docs/backend/tools.md
@@ -84,11 +84,11 @@ class ToolResult:
 
 | 工具 | 功能 | 安全限制 |
 |------|------|----------|
-| `read_file` | 读取文件内容 | 仅限工作区 |
-| `write_file` | 写入/创建文件 | 自动创建快照 |
-| `edit_file` | 精确字符串替换 | 仅限工作区 |
-| `list_dir` | 列出目录 | 仅限工作区 |
-| `apply_patch` | Unified Diff 补丁应用 | 版本快照 |
+| `read_file` | 读取文件内容 | 工作区 + `memory/`/`skills/`/`.skills/`；`tools.extra_roots` 可额外授权；config.json 仅只读 |
+| `write_file` | 写入/创建文件 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，自动创建快照 |
+| `edit_file` | 精确字符串替换 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写 |
+| `list_dir` | 列出目录 | 工作区 + 默认共享目录 + `tools.extra_roots` |
+| `apply_patch` | Unified Diff 补丁应用 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，版本快照 |
 
 ### 办公文档工具
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,7 @@ MiQi Desktop 的全局配置存储在 `~/.miqi/config.json` 中。
   },
   "tools": {
     "restrict_to_workspace": true,
+    "extra_roots": [],
     "web": {
       "search": {
         "provider": "ddgs",
@@ -127,6 +128,7 @@ shows a persistent warning in the top bar.
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `restrict_to_workspace` | bool | true | 文件操作限制在工作区 |
+| `extra_roots` | array | [] | 文件工具额外允许的根目录（支持 workspace 外目录，WSL 沙箱白名单） |
 | `web.search.provider` | string | "ddgs" | 搜索引擎 (ddgs/brave/hybrid) |
 | `web.search.apiKey` | string | "" | Brave Search API Key，仅 brave/hybrid 使用 |
 | `web.search.maxResults` | int | 5 | 最大搜索结果数量 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ MiQi Desktop 的全局配置存储在 `~/.miqi/config.json` 中。
     }
   },
   "tools": {
-    "restrict_to_workspace": true,
+    "restrict_to_workspace": false,
     "extra_roots": [],
     "web": {
       "search": {
@@ -127,7 +127,7 @@ shows a persistent warning in the top bar.
 
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
-| `restrict_to_workspace` | bool | true | 文件操作限制在工作区 |
+| `restrict_to_workspace` | bool | false | 文件操作限制在工作区 |
 | `extra_roots` | array | [] | 文件工具额外允许的根目录（支持 workspace 外目录，WSL 沙箱白名单） |
 | `web.search.provider` | string | "ddgs" | 搜索引擎 (ddgs/brave/hybrid) |
 | `web.search.apiKey` | string | "" | Brave Search API Key，仅 brave/hybrid 使用 |

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -368,7 +368,11 @@ class ApplyPatchTool(Tool):
 
         # Native / no sandbox
         file_path = _resolve_path(
-            path, self._workspace, self._allowed_dir, self._sandbox_manager
+            path,
+            self._workspace,
+            self._allowed_dir,
+            self._sandbox_manager,
+            shared_roots=self._shared_roots,
         )
         snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
 

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -485,6 +485,7 @@ def _resolve_path(
     workspace: Path | None = None,
     allowed_dir: Path | None = None,
     sandbox_manager=None,
+    shared_roots: Iterable[Path] | None = None,
 ) -> Path:
     """Resolve path against workspace (if relative) and enforce directory restriction.
 
@@ -492,6 +493,10 @@ def _resolve_path(
     operations are automatically redirected to the sandbox's workspace
     directory. This ensures each conversation's AI only accesses its
     own isolated filesystem.
+
+    When *allowed_dir* is set, paths inside *shared_roots* are also
+    accepted so ``tools.extra_roots`` and workspace memory/skills roots
+    keep working on native paths, not only WSL sandbox paths.
     """
     p = Path(path).expanduser()
     if not p.is_absolute() and workspace:
@@ -529,7 +534,16 @@ def _resolve_path(
         try:
             resolved.relative_to(allowed_dir.resolve())
         except ValueError:
-            raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
+            allowed = False
+            for root in shared_roots or []:
+                try:
+                    resolved.relative_to(Path(root).resolve())
+                    allowed = True
+                    break
+                except ValueError:
+                    continue
+            if not allowed:
+                raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
     return resolved
 
 
@@ -654,7 +668,11 @@ class ReadFileTool(Tool):
             # Native sandbox or no sandbox — use local filesystem
             try:
                 file_path = _resolve_path(
-                    path, self._workspace, self._allowed_dir, self._sandbox_manager
+                    path,
+                    self._workspace,
+                    self._allowed_dir,
+                    self._sandbox_manager,
+                    shared_roots=self._shared_roots,
                 )
                 if not file_path.exists():
                     return f"Error: File not found: {path}"
@@ -760,7 +778,11 @@ class WriteFileTool(Tool):
             # Native sandbox or no sandbox — use local filesystem
             try:
                 file_path = _resolve_path(
-                    path, self._workspace, self._allowed_dir, self._sandbox_manager
+                    path,
+                    self._workspace,
+                    self._allowed_dir,
+                    self._sandbox_manager,
+                    shared_roots=self._shared_roots,
                 )
                 # Snapshot original content before first write (enables non-git diff/revert)
                 snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
@@ -884,13 +906,17 @@ class EditFileTool(Tool):
             # Native sandbox or no sandbox — use local filesystem
             try:
                 file_path = _resolve_path(
-                    path, self._workspace, self._allowed_dir, self._sandbox_manager
+                    path,
+                    self._workspace,
+                    self._allowed_dir,
+                    self._sandbox_manager,
+                    shared_roots=self._shared_roots,
                 )
                 if not file_path.exists():
                     return f"Error: File not found: {path}"
 
                 # Snapshot original content before first edit (enables non-git diff/revert)
-                snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
+                _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
 
                 content = file_path.read_text(encoding="utf-8")
 
@@ -1005,7 +1031,11 @@ class ListDirTool(Tool):
             # Native sandbox or no sandbox — use local filesystem
             try:
                 dir_path = _resolve_path(
-                    path, self._workspace, self._allowed_dir, self._sandbox_manager
+                    path,
+                    self._workspace,
+                    self._allowed_dir,
+                    self._sandbox_manager,
+                    shared_roots=self._shared_roots,
                 )
                 if not dir_path.exists():
                     return f"Error: Directory not found: {path}"

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -331,7 +331,8 @@ def _canonicalize_wsl_mnt_path(
         roots_str = ", ".join(str(r) for r in roots) if roots else "<none>"
         raise PermissionError(
             f"Path '{host_str}' (normalized: '{normalized}') resolves to '{resolved}' "
-            f"which is outside all legal roots [{roots_str}]"
+            f"which is outside all legal roots [{roots_str}]. "
+            "Add the directory to tools.extra_roots in the MiQi config to allow access."
         )
 
     resolved_str = str(resolved).replace("\\", "/")

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -500,6 +500,7 @@ class ToolsConfig(Base):
     exec: ExecToolConfig = Field(default_factory=ExecToolConfig)
     papers: PapersToolConfig = Field(default_factory=PapersToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
+    extra_roots: list[str] = Field(default_factory=list)  # Additional filesystem roots allowed by file tools
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -86,16 +86,26 @@ def create_runtime_tool_registry(
         _write_workspace = _work_dir
 
     # Host-global shared roots the system prompt legitimately directs the
-    # agent to read/write (issue #516): memory/ (MEMORY.md, LTM_SNAPSHOT, …)
-    # and skills/ (<name>/SKILL.md).  These live outside the per-session
-    # files dir, so without them the WSL sandbox containment check wrongly
-    # rejects memory/skill paths.  Per-session isolation is unaffected: only
-    # these two global dirs are whitelisted, never another session's files.
+    # agent to read/write (issue #516): memory/ (MEMORY.md, LTM_SNAPSHOT, ...)
+    # and skills/ (<name>/SKILL.md), plus the .skills/ layout used by some
+    # clients (issue #567).  These live outside the per-session files dir,
+    # so without them the WSL sandbox containment check wrongly rejects
+    # memory/skill paths.  Per-session isolation is unaffected: only these
+    # shared dirs are whitelisted, never another session's files.
+    tools_cfg = getattr(config, "tools", None)
     _shared_roots: list[Path] = []
-    for _sub in ("memory", "skills"):
+    for _sub in ("memory", "skills", ".skills"):
         _shared_dir = workspace / _sub
         _shared_dir.mkdir(parents=True, exist_ok=True)
         _shared_roots.append(_shared_dir)
+
+    # User-configured extra roots (issue #567): explicit authorization for
+    # directories outside the workspace, e.g. C:\Users\<user>\Desktop\work.
+    _extra_roots_cfg = getattr(tools_cfg, "extra_roots", None) or []
+    for _raw_root in _extra_roots_cfg:
+        if not isinstance(_raw_root, str) or not _raw_root.strip():
+            continue
+        _shared_roots.append(Path(_raw_root).expanduser().resolve())
 
     # Read-only whitelist for the host config file (issue #553): agents may
     # inspect settings, but write/edit/patch tools keep rejecting it so the
@@ -103,7 +113,6 @@ def create_runtime_tool_registry(
     _read_shared_roots = [*_shared_roots, get_config_path()]
 
     # Resolve config sections
-    tools_cfg = getattr(config, "tools", None)
     restrict_to_workspace = getattr(tools_cfg, "restrict_to_workspace", False) if tools_cfg is not None else False
 
     exec_cfg = getattr(tools_cfg, "exec", None) if tools_cfg is not None else None

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -9,11 +9,54 @@ Registration order is kept stable so model tool specs remain deterministic.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from miqi.agent.tools.registry import ToolRegistry
 from miqi.paths import get_config_path
+
+_log = logging.getLogger(__name__)
+
+
+def _is_protected_extra_root(root: Path, workspace: Path) -> bool:
+    """Return True when *root* would make protected paths writable.
+
+    User-configured extra roots must never cover the host config file or
+    per-session files, otherwise a broad root (e.g. ``~/.miqi`` or the
+    workspace itself) could bypass read-only config handling and session
+    isolation.
+    """
+    config = get_config_path().resolve()
+    sessions = (workspace / "sessions").resolve()
+    if config.is_relative_to(root):
+        return True
+    if sessions.is_relative_to(root) or root.is_relative_to(sessions):
+        return True
+    return False
+
+
+def _resolve_default_shared_dir(workspace: Path, sub: str) -> Path | None:
+    """Create/validate a workspace-owned shared root.
+
+    Returns the resolved directory, or ``None`` when the directory is (or
+    points through a symlink to) a path outside the workspace.  External
+    skill/memory locations must be authorized explicitly with
+    ``tools.extra_roots``.
+    """
+    shared_dir = workspace / sub
+    try:
+        shared_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        _log.warning("Skipping shared root %s: cannot create directory", shared_dir)
+        return None
+    resolved = shared_dir.resolve()
+    try:
+        resolved.relative_to(workspace.resolve())
+    except ValueError:
+        _log.warning("Skipping shared root %s: resolves outside workspace", shared_dir)
+        return None
+    return resolved
 
 
 def create_runtime_tool_registry(
@@ -95,17 +138,24 @@ def create_runtime_tool_registry(
     tools_cfg = getattr(config, "tools", None)
     _shared_roots: list[Path] = []
     for _sub in ("memory", "skills", ".skills"):
-        _shared_dir = workspace / _sub
-        _shared_dir.mkdir(parents=True, exist_ok=True)
-        _shared_roots.append(_shared_dir)
+        _shared_dir = _resolve_default_shared_dir(workspace, _sub)
+        if _shared_dir is not None:
+            _shared_roots.append(_shared_dir)
 
     # User-configured extra roots (issue #567): explicit authorization for
     # directories outside the workspace, e.g. C:\Users\<user>\Desktop\work.
-    _extra_roots_cfg = getattr(tools_cfg, "extra_roots", None) or []
+    _extra_roots_cfg = getattr(tools_cfg, "extra_roots", []) if tools_cfg is not None else []
     for _raw_root in _extra_roots_cfg:
         if not isinstance(_raw_root, str) or not _raw_root.strip():
             continue
-        _shared_roots.append(Path(_raw_root).expanduser().resolve())
+        _root = Path(_raw_root).expanduser().resolve(strict=False)
+        if _is_protected_extra_root(_root, workspace):
+            _log.warning(
+                "Ignoring tools.extra_roots entry %s: covers protected config/session paths",
+                _root,
+            )
+            continue
+        _shared_roots.append(_root)
 
     # Read-only whitelist for the host config file (issue #553): agents may
     # inspect settings, but write/edit/patch tools keep rejecting it so the

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -1,5 +1,7 @@
 """Tests for runtime tool registry factory (Phase 22)."""
 
+from pathlib import Path
+
 import pytest
 
 
@@ -277,6 +279,7 @@ def test_sandbox_manager_none_does_not_break_tools(fake_config, tmp_path):
 def test_sandbox_manager_wired_through_services_from_config(fake_config):
     """RuntimeServices.from_config passes sandbox_manager to tool registry."""
     from unittest.mock import MagicMock
+
     from miqi.runtime.services import RuntimeServices
 
     sandbox_manager = MagicMock()
@@ -291,3 +294,27 @@ def test_sandbox_manager_wired_through_services_from_config(fake_config):
         tool = services.tool_registry.get(tool_name)
         assert tool is not None
         assert tool._sandbox_manager is sandbox_manager
+
+
+def test_file_tools_receive_dot_skills_and_configured_extra_roots(fake_config, tmp_path):
+    """tools.extra_roots and workspace/.skills flow into file tool shared roots."""
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    extra_root = tmp_path.parent / "authorized-work"
+    extra_root.mkdir()
+    fake_config.tools.extra_roots = [str(extra_root)]
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path,
+    )
+    expected = {
+        (tmp_path / "memory").resolve(),
+        (tmp_path / "skills").resolve(),
+        (tmp_path / ".skills").resolve(),
+        extra_root.resolve(),
+    }
+    for tool_name in ("read_file", "write_file", "edit_file", "list_dir", "apply_patch"):
+        tool = registry.get(tool_name)
+        assert tool is not None
+        roots = {Path(p).resolve() for p in tool._shared_roots}
+        assert expected.issubset(roots), f"{tool_name} missing shared roots: {expected - roots}"

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -376,7 +376,7 @@ def test_factory_skips_default_shared_symlink_outside_workspace(fake_config, tmp
     """A symlinked default shared dir resolving outside workspace is not auto-registered."""
     from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
 
-    external = tmp_path / "external"
+    external = tmp_path.parent / f"external-{tmp_path.name}"
     external.mkdir()
     link = tmp_path / ".skills"
     link.symlink_to(external, target_is_directory=True)

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -1,5 +1,6 @@
 """Tests for runtime tool registry factory (Phase 22)."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -300,7 +301,7 @@ def test_file_tools_receive_dot_skills_and_configured_extra_roots(fake_config, t
     """tools.extra_roots and workspace/.skills flow into file tool shared roots."""
     from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
 
-    extra_root = tmp_path.parent / "authorized-work"
+    extra_root = tmp_path.parent / f"authorized-{tmp_path.name}"
     extra_root.mkdir()
     fake_config.tools.extra_roots = [str(extra_root)]
 
@@ -318,3 +319,99 @@ def test_file_tools_receive_dot_skills_and_configured_extra_roots(fake_config, t
         assert tool is not None
         roots = {Path(p).resolve() for p in tool._shared_roots}
         assert expected.issubset(roots), f"{tool_name} missing shared roots: {expected - roots}"
+
+
+@pytest.mark.asyncio
+async def test_factory_native_file_tools_respect_extra_roots_when_restricted(fake_config, tmp_path):
+    """tools.extra_roots must also work for native paths under workspace restriction."""
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    extra_root = tmp_path.parent / f"authorized-{tmp_path.name}"
+    extra_root.mkdir()
+    target = extra_root / "report.txt"
+    target.write_text("ok", encoding="utf-8")
+    fake_config.tools.extra_roots = [str(extra_root)]
+    fake_config.tools.restrict_to_workspace = True
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path,
+    )
+
+    read = registry.get("read_file")
+    result = await read.execute(path=str(target))
+    assert result == "ok"
+
+    write = registry.get("write_file")
+    out = extra_root / "out.txt"
+    result = await write.execute(path=str(out), content="hello")
+    assert "Successfully wrote" in result
+    assert out.read_text(encoding="utf-8") == "hello"
+
+    list_dir = registry.get("list_dir")
+    result = await list_dir.execute(path=str(extra_root))
+    assert "report.txt" in result
+
+
+def test_factory_rejects_extra_roots_covering_protected_paths(fake_config, tmp_path):
+    """Config/session ancestors must not be registered as writable extra roots."""
+    from miqi.paths import get_config_path
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    (tmp_path / "sessions").mkdir()
+    fake_config.tools.extra_roots = [
+        str(tmp_path),
+        str(get_config_path().parent),
+    ]
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path,
+    )
+    roots = {Path(p).resolve() for p in registry.get("write_file")._shared_roots}
+    assert tmp_path.resolve() not in roots
+    assert get_config_path().parent.resolve() not in roots
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges on Windows")
+def test_factory_skips_default_shared_symlink_outside_workspace(fake_config, tmp_path):
+    """A symlinked default shared dir resolving outside workspace is not auto-registered."""
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    external = tmp_path / "external"
+    external.mkdir()
+    link = tmp_path / ".skills"
+    link.symlink_to(external, target_is_directory=True)
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path,
+    )
+    roots = {Path(p).resolve() for p in registry.get("read_file")._shared_roots}
+    assert link.resolve() not in roots
+
+
+def test_resolve_path_allows_shared_roots_with_native_sandbox(tmp_path):
+    """Native sandbox path resolution also honors shared roots when restricted."""
+    from unittest.mock import MagicMock
+
+    from miqi.agent.tools.filesystem import _resolve_path
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    extra = tmp_path / "extra"
+    extra.mkdir()
+    target = extra / "a.txt"
+    target.write_text("x", encoding="utf-8")
+
+    sandbox = MagicMock()
+    sandbox.is_running = True
+    sandbox.workspace_path = str(tmp_path / "sandbox-ws")
+    manager = MagicMock()
+    manager.active_sandbox = sandbox
+
+    result = _resolve_path(
+        str(target),
+        workspace=ws,
+        allowed_dir=ws,
+        sandbox_manager=manager,
+        shared_roots=[extra],
+    )
+    assert result == target.resolve()

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -174,7 +174,7 @@ class TestCanonicalizeWslMntPath:
         ws.mkdir()
         other = tmp_path / "other"
         other.mkdir()
-        with pytest.raises(PermissionError, match="tools.extra_roots"):
+        with pytest.raises(PermissionError, match=r"tools\.extra_roots"):
             _canonicalize_wsl_mnt_path(_as_mnt_path(other, "file.txt"), ws)
 
 

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -4,9 +4,7 @@ Tests _resolve_sandbox_path, _canonicalize_wsl_mnt_path, and
 _sandbox_to_host_path. WSL-specific containment tests are Windows-only;
 logic tests run everywhere.
 """
-import os
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -168,6 +166,16 @@ class TestCanonicalizeWslMntPath:
         mnt = _as_mnt_path(host_memory, "..", "evil.txt")
         with pytest.raises(PermissionError, match="outside"):
             _canonicalize_wsl_mnt_path(mnt, session_ws, extra_roots=[host_memory])
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_permission_error_mentions_extra_roots_config(self, tmp_path):
+        """The rejection message points users to tools.extra_roots (issue #567)."""
+        ws = tmp_path / "sub"
+        ws.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        with pytest.raises(PermissionError, match="tools.extra_roots"):
+            _canonicalize_wsl_mnt_path(_as_mnt_path(other, "file.txt"), ws)
 
 
 # ── _resolve_sandbox_path ────────────────────────────────────────────────


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

WSL 沙箱文件工具白名单支持 `tools.extra_roots` 配置与 `workspace/.skills` 目录，并优化越权报错提示。

## 背景/问题

Issue #567：`tool_registry_factory.py` 将文件工具白名单硬编码为 `memory`/`skills` 两个根目录，`.skills` 等合法共享目录以及用户通过配置授权的 workspace 外目录会被 WSL 沙箱路径检查拒绝；`skills/extraRoots/set` 只作用于技能列表，不流入文件工具白名单；`PermissionError` 只列出合法根，未说明如何扩展。

## 变更内容

- `miqi/config/schema.py`：`ToolsConfig` 新增 `extra_roots` 配置项。
- `miqi/runtime/tool_registry_factory.py`：默认白名单加入 `workspace/.skills`，并将 `tools.extra_roots` 解析后流入所有文件工具的 `shared_roots`。
- `miqi/agent/tools/filesystem.py`：越权报错增加 `tools.extra_roots` 配置提示。
- 测试：补充文件工具 shared_roots 接线与报错提示用例。
- 文档：更新 `docs/configuration.md` 与 `docs/backend/tools.md`。

## 日志/验证证据

```
$ uv run pytest tests/runtime/test_tool_registry_factory.py tests/sandbox/test_wsl_sandbox_path_mapping.py -q
........................................                                 [100%]
40 passed in 1.71s
```

## 测试情况

已运行上述 40 个相关测试，全部通过。

## 截图

<img width="1264" height="1000" alt="image" src="https://github.com/user-attachments/assets/e85e679b-ac81-49d2-a79f-d94b645ed69d" />
<img width="1264" height="1000" alt="image" src="https://github.com/user-attachments/assets/cef29783-56a3-46bf-ac5d-9eca40f0e7d2" />


Closes #567


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Allow `workspace/.skills` and `tools.extra_roots` in file tool whitelist
  - `.skills` directory automatically added to shared roots
  - User-configured extra roots from config now honored

- Improve `PermissionError` to suggest `tools.extra_roots` for authorization

- Harden extra root validation (reject symlinks outside workspace, protect config/session paths)

- Make native path resolution respect `shared_roots` when workspace is restricted

- Update documentation (config schema, tools security table) and add comprehensive tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config (extra_roots)"] --> B["ToolRegistryFactory"]
  B --> C["Workspace/.skills auto-added"]
  B --> D["Validate extra roots (reject protected paths)"]
  B --> E["Construct shared_roots list"]
  E --> F["File tools (read/write/edit/list/patch)"]
  F --> G["Native _resolve_path uses shared_roots"]
  F --> H["WSL containment allows shared_roots"]
  H --> I["Improved PermissionError (point to config)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>apply_patch.py</strong><dd><code>Pass shared_roots to _resolve_path for patch apply</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-55c4775c822bbd6942ead6b0e254f2740b7658ef37a0cd6acb19423f6fceba64">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>filesystem.py</strong><dd><code>Allow shared_roots in native resolution and improve error message</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+38/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_registry_factory.py</strong><dd><code>Build shared_roots with .skills, extra_roots, and validation</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-bba7bdac87ba258004e88a6416dd357e77b6ab0c025e4c8134808fbcc37e2eac">+69/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>schema.py</strong><dd><code>Add extra_roots field to ToolsConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-647e6744d678afbea4bbc195c7d3767222891145736755bb7f5016a81f0da3ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_tool_registry_factory.py</strong><dd><code>Test extra roots, native resolution, and protected path rejection</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-cff948657ad1cde008668a0a7eb25c696683f9617be95503514386c9f4a4937c">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_wsl_sandbox_path_mapping.py</strong><dd><code>Test error message references tools.extra_roots config</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-78b5181b165bbad81de1a66f652928946f7591f6e7749456c67ac45e78d80c0b">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>tools.md</strong><dd><code>Update file tool security restrictions and safety mechanism</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-603ae6a307b42fd52fc54502a11424dffa4eca2065fa98e782f0914aede6e901">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>configuration.md</strong><dd><code>Document extra_roots and update configuration example</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/611/files#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

