### PR TITLE
fix(desktop): reuse empty session when creating a new one

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { RuntimeProvider, useRuntime } from './contexts/RuntimeContext';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { Sidebar } from './components/Sidebar';
@@ -24,6 +24,7 @@ import { PermissionsPage } from './features/permissions/PermissionsPage';
 import { PluginMarket } from './features/plugins/PluginMarket';
 import { SessionExplorer } from './features/sessions/SessionExplorer';
 import { WorkspacePage } from './features/workspace/WorkspacePage';
+import { shouldCreateNewSession } from './lib/sessionNewSession';
 
 type NavId =
   | 'chat'
@@ -55,6 +56,7 @@ function AppShell() {
     }
   });
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
+  const [currentSessionEmpty, setCurrentSessionEmpty] = useState(true);
   const [runtimeReadyKey, setRuntimeReadyKey] = useState(0);
   const [needsSetup, setNeedsSetup] = useState<boolean | null>(() => {
     // Blocking python.check() stalls the render tree on cold starts
@@ -124,9 +126,15 @@ function AppShell() {
     try { localStorage.setItem('miqi:configReady', 'true'); } catch { /* ignore */ }
   };
 
+  const handleSessionEmptyChange = useCallback((isEmpty: boolean) => {
+    setCurrentSessionEmpty(isEmpty);
+  }, []);
+
   const handleNewSession = () => {
     if (activeNav !== 'chat') setActiveNav('chat');
+    if (!shouldCreateNewSession(currentSessionEmpty)) return;
     const newKey = `desktop:${Date.now()}`;
+    setCurrentSessionEmpty(true);
     setSessionKey(newKey);
     setSessionRefreshKey((k) => k + 1);
   };
@@ -245,6 +253,7 @@ function AppShell() {
               <Sidebar
                 currentSession={sessionKey}
                 onSessionSelect={(key) => {
+                  setCurrentSessionEmpty(true);
                   setSessionKey(key);
                   setActiveNav('chat');
                   setSessionRefreshKey((k) => k + 1);
@@ -270,7 +279,9 @@ function AppShell() {
                     key={sessionKey}
                     sessionKey={sessionKey}
                     loadTrigger={runtimeReadyKey}
+                    onSessionEmptyChange={handleSessionEmptyChange}
                     onNewSession={(newKey) => {
+                      setCurrentSessionEmpty(true);
                       setSessionKey(newKey);
                       setSessionRefreshKey((k) => k + 1);
                     }}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1053,6 +1053,7 @@ function extractTrackedFilesFromMessages(rawMsgs: any[]): TrackedFile[] {
 export function ChatConsole({
   sessionKey = DEFAULT_SESSION,
   loadTrigger,
+  onSessionEmptyChange,
   onNewSession,
   onChatFinished,
   onOpenProviderSettings,
@@ -1061,6 +1062,7 @@ export function ChatConsole({
   sessionKey?: string;
   /** Increment to force a session history reload (e.g. after bridge becomes ready) */
   loadTrigger?: number;
+  onSessionEmptyChange?: (isEmpty: boolean) => void;
   onNewSession?: (newKey: string) => void;
   onChatFinished?: () => void;
   onOpenProviderSettings?: () => void;
@@ -1075,6 +1077,10 @@ export function ChatConsole({
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
+
+  useEffect(() => {
+    onSessionEmptyChange?.(messages.length === 0);
+  }, [messages, onSessionEmptyChange]);
   const [downloadingPaperId, setDownloadingPaperId] = useState<string | null>(null);
   const [panelOpen, setPanelOpen] = useState(true);
   const [panelWidth, setPanelWidth] = useState(280);

--- a/apps/desktop/src/renderer/lib/sessionNewSession.ts
+++ b/apps/desktop/src/renderer/lib/sessionNewSession.ts
@@ -1,0 +1,3 @@
+export function shouldCreateNewSession(currentSessionEmpty: boolean): boolean {
+  return !currentSessionEmpty;
+}

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -181,6 +181,12 @@ test.describe('Regression #480: Session loads on startup', () => {
 
       // ── Step 2: Create session B ──────────────────────────────
       await createNewConversation(page);
+      const markerB = `SWB_${Date.now()}`;
+      await typeAndSend(page, `只回答${markerB}`);
+      await waitForResponseComplete(page, 240_000);
+      await expect(
+        page.locator('main').getByText(markerB, { exact: false }).first(),
+      ).toBeVisible({ timeout: 10_000 });
       // Wait for sidebar to show both sessions
       await page.waitForTimeout(3000);
       await expect

--- a/apps/desktop/tests/sessionNewSession.test.ts
+++ b/apps/desktop/tests/sessionNewSession.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldCreateNewSession } from '../src/renderer/lib/sessionNewSession';
+
+describe('shouldCreateNewSession', () => {
+  it('reuses an empty session instead of creating a new one', () => {
+    expect(shouldCreateNewSession(true)).toBe(false);
+  });
+
+  it('creates a new session after a real conversation', () => {
+    expect(shouldCreateNewSession(false)).toBe(true);
+  });
+});


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

点“+”新建会话时，如果当前会话还没有真实对话，就复用当前会话，不再无限创建空会话。

## 背景/问题

当前侧边栏“+”每次都会生成 `desktop:${Date.now()}` 新 key，即使当前会话没有任何消息也可以一直点出新空会话；这些空会话不展示在侧边栏，但会不断重置聊天区域，体验不合理。

## 变更内容

- `apps/desktop/src/renderer/App.tsx`：通过 ChatConsole 上报当前会话是否为空；空会话时点“+”只切回聊天页，不生成新 key。
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：新增 `onSessionEmptyChange` 回调，按 `messages` 是否为空上报。
- 新增 `sessionNewSession.ts` 策略函数与单元测试。

## 日志/验证证据

```
$ npx vitest run tests/sessionNewSession.test.ts
✓ tests/sessionNewSession.test.ts (2 tests) 2ms

$ npm run build
✓ built in 6.14s
```

## 测试情况

- 单元测试 2 passed
- `npm run build` 通过
- 行为：空会话点“+”不新建；有真实消息后点“+”才新建

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/be75e6ba-c593-4f6e-a9e9-3e56d440db18" />

Fixes #615


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevent infinite empty session creation on '+' click

- Track whether the current session contains any messages

- Add `shouldCreateNewSession` utility to decide session reuse

- Update e2e test to align with the new reuse logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
    ChatConsole["ChatConsole tracks messages"] -- "onSessionEmptyChange callback" --> AppState["App state: currentSessionEmpty"]
    AppState -- "used in handleNewSession" --> Decision{"shouldCreateNewSession?"}
    Decision -- "true" --> NewSession["Create new session"]
    Decision -- "false" --> Stay["Stay in current session (reuse)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Add empty session tracking and reuse logic to AppShell</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/App.tsx

<ul><li>Import <code>shouldCreateNewSession</code> utility<br> <li> Introduce <code>currentSessionEmpty</code> state to track session emptiness<br> <li> Guard <code>handleNewSession</code> to reuse empty session instead of creating a <br>new key<br> <li> Pass <code>onSessionEmptyChange</code> to <code>ChatConsole</code> and reset emptiness on <br>session selection/new creation</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/614/files#diff-4b03b04efb7537be2e18ba0418bc81886c910207148cec6f9e92c88208fc58dd">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Report session emptiness to parent component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Accept <code>onSessionEmptyChange</code> prop<br> <li> Call <code>onSessionEmptyChange</code> via <code>useEffect</code> whenever <code>messages</code> array <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/614/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sessionNewSession.ts</strong><dd><code>Extract new session creation logic into separate utility</code>&nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/lib/sessionNewSession.ts

<ul><li>Provide <code>shouldCreateNewSession</code> function returning <code>false</code> when session <br>is empty</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/614/files#diff-4c69d5fbe800e63fe813508bff87d901d02ba04bc11c05fc9898605419f62bee">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessionNewSession.test.ts</strong><dd><code>Unit tests for session reuse decision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/sessionNewSession.test.ts

<ul><li>Unit tests for <code>shouldCreateNewSession</code>: reuse empty session, create <br>after real conversation</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/614/files#diff-09f25a809dc1484aa42b3958ee2747a209202e402f9d6de0fc11362fdbd78eac">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>regression-480-startup-history.spec.ts</strong><dd><code>Adapt e2e test to empty session reuse logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/regression-480-startup-history.spec.ts

<ul><li>Send a message in session B before asserting sidebar session count<br> <li> Ensures the e2e test is compatible with the new empty‑session reuse <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/614/files#diff-747a811277a39c83a94a4b3a78a8702e9bb76364dfb253375e8d55b0e99d5bbf">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

