### PR TITLE
fix(sandbox): preinstall python3/pip in WSL sandbox distro (#566)

### DIFF
--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -1268,7 +1268,9 @@ class ExecTool(Tool):
             # Allow exact match (workspace itself) or paths under workspace.
             # Reject sibling directories like /workspace-evil/ that prefix-match.
             if canonical_host != canonical_ws and canonical_ws not in canonical_host.parents:
-                logger.warning("exec [mirror] rejected: path escapes workspace: {}", host_path)
+                # Expected for non-workspace paths (e.g. /tmp package
+                # installs); the mirror is only for workspace artifacts.
+                logger.debug("exec [mirror] rejected: path escapes workspace: {}", host_path)
                 return
         except Exception as exc:
             logger.warning("exec [mirror] path resolution failed: {}", exc)

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -69,11 +69,14 @@ _install_lock = threading.Lock()
 #: the old `which bwrap`-only probe and never reach the dependency
 #: installer, leaving the agent to retry failed pip installs forever
 #: (issue #566).  Requiring the full toolchain up front makes such a
-#: distro fall through to auto-install instead.
+#: distro fall through to auto-install instead.  python3-venv and unzip
+#: are part of the installed package set, so they are probed too.
 _WSL_READY_CMD = (
     "which bwrap >/dev/null 2>&1 && "
     "python3 -V >/dev/null 2>&1 && "
-    "python3 -m pip --version >/dev/null 2>&1"
+    "python3 -m pip --version >/dev/null 2>&1 && "
+    "python3 -m venv --help >/dev/null 2>&1 && "
+    "unzip -v >/dev/null 2>&1"
 )
 """Serialize _ensure_wsl_deps to prevent concurrent apt-get.
 
@@ -754,15 +757,20 @@ class BwrapSandbox:
 
         # Serialize installation: if another thread is already running
         # apt-get (e.g. sandbox manager background init), poll-wait for
-        # bwrap to become available instead of launching a second apt-get.
-        # This avoids concurrent apt-get processes racing on dpkg lock.
+        # the toolchain to become available instead of launching a second
+        # apt-get. This avoids concurrent apt-get processes racing on
+        # dpkg lock.
         if not _install_lock.acquire(blocking=False):
             logger.info(
                 "Concurrent apt-get detected in WSL distro '{}' — waiting...",
                 distro,
             )
-            for i in range(180):
+            # Bounded by real elapsed time (180 s), not loop iterations:
+            # each iteration also awaits a subprocess with its own timeout.
+            deadline = time.monotonic() + 180.0
+            while time.monotonic() < deadline:
                 await asyncio.sleep(1)
+                recheck = None
                 try:
                     recheck = await _create_subprocess_exec(
                         "wsl.exe", "-d", distro, "--", "bash", "-c",
@@ -770,15 +778,37 @@ class BwrapSandbox:
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
-                    await asyncio.wait_for(recheck.communicate(), timeout=5.0)
+                    try:
+                        await asyncio.wait_for(
+                            recheck.communicate(), timeout=5.0,
+                        )
+                    except asyncio.TimeoutError:
+                        # Probe timed out — terminate and reap the WSL
+                        # process so it cannot leak past this loop.
+                        try:
+                            recheck.kill()
+                            await asyncio.wait_for(
+                                recheck.wait(), timeout=5.0,
+                            )
+                        except (asyncio.TimeoutError, ProcessLookupError, OSError):
+                            pass
+                        recheck = None
+                        continue
                     if recheck.returncode == 0:
                         logger.info(
-                            "bwrap installed by concurrent thread in WSL "
-                            "distro '{}' after ~{}s", distro, i + 1,
+                            "bwrap/python3/pip installed by concurrent "
+                            "thread in WSL distro '{}' after ~{:.0f}s",
+                            distro, time.monotonic() - deadline + 180.0,
                         )
                         return True
                 except (asyncio.TimeoutError, OSError):
                     pass
+                finally:
+                    if recheck is not None and recheck.returncode is None:
+                        try:
+                            recheck.kill()
+                        except (ProcessLookupError, OSError):
+                            pass
             logger.warning(
                 "Timed out waiting for concurrent apt-get in WSL distro '{}'",
                 distro,
@@ -839,9 +869,20 @@ class BwrapSandbox:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                _stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(), timeout=180.0,
-                )
+                try:
+                    _stdout, stderr = await asyncio.wait_for(
+                        proc.communicate(), timeout=180.0,
+                    )
+                except asyncio.TimeoutError:
+                    # Kill the wsl.exe wrapper before releasing the lock —
+                    # an orphaned apt-get would keep holding the dpkg lock
+                    # and deadlock the next installer.
+                    try:
+                        proc.kill()
+                        await asyncio.wait_for(proc.wait(), timeout=5.0)
+                    except (asyncio.TimeoutError, ProcessLookupError, OSError):
+                        pass
+                    raise
                 stderr = stderr.decode("utf-8", errors="replace") if stderr else ""
 
                 if proc.returncode != 0:

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -710,22 +710,33 @@ class BwrapSandbox:
 
     @staticmethod
     async def _ensure_wsl_deps(distro: str) -> bool:
-        """Install required packages in a WSL distro and verify bwrap.
+        """Install required packages in a WSL distro and verify bwrap + Python.
 
-        Installs: bubblewrap, coreutils, rsync.
+        Installs: bubblewrap, coreutils, rsync, python3, python3-pip,
+        python3-venv, unzip.
 
-        Returns True if bwrap is available after installation, False otherwise.
+        Returns True if bwrap and python3/pip are available after
+        installation, False otherwise.
         """
-        # Quick check: skip if bwrap already installed
+        _ready_cmd = (
+            "which bwrap >/dev/null 2>&1 && "
+            "python3 -V >/dev/null 2>&1 && "
+            "python3 -m pip --version >/dev/null 2>&1"
+        )
+
+        # Quick check: skip if bwrap and python3/pip already installed
         try:
             check = await _create_subprocess_exec(
-                "wsl.exe", "-d", distro, "--", "bash", "-c", "which bwrap",
+                "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             await asyncio.wait_for(check.communicate(), timeout=30.0)
             if check.returncode == 0:
-                logger.info("bwrap already installed in WSL distro '{}'", distro)
+                logger.info(
+                    "bwrap and python3/pip already installed in WSL distro '{}'",
+                    distro,
+                )
                 return True
         except (asyncio.TimeoutError, OSError):
             pass
@@ -743,8 +754,7 @@ class BwrapSandbox:
                 await asyncio.sleep(1)
                 try:
                     recheck = await _create_subprocess_exec(
-                        "wsl.exe", "-d", distro, "--", "bash", "-c",
-                        "which bwrap",
+                        "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -804,7 +814,8 @@ class BwrapSandbox:
             install_cmd = (
                 "export DEBIAN_FRONTEND=noninteractive; "
                 "apt-get update -qq 2>/dev/null; "
-                "apt-get install -y -qq bubblewrap coreutils rsync"
+                "apt-get install -y -qq bubblewrap coreutils rsync "
+                "python3 python3-pip python3-venv unzip"
             )
             if use_sudo:
                 install_cmd = f"sudo bash -c '{install_cmd}'"
@@ -856,7 +867,7 @@ class BwrapSandbox:
         # Verify bwrap is now available
         try:
             verify = await _create_subprocess_exec(
-                "wsl.exe", "-d", distro, "--", "bash", "-c", "which bwrap",
+                "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -871,7 +882,8 @@ class BwrapSandbox:
             pass
 
         logger.warning(
-            "Dependencies installed but bwrap still not found in WSL distro '{}'",
+            "Dependencies installed but bwrap or python3/pip still missing "
+            "in WSL distro '{}'",
             distro,
         )
         return False
@@ -893,8 +905,9 @@ class BwrapSandbox:
                         distro = await self._detect_wsl_distro(install_distro)
             if not distro:
                 raise BwrapSandboxError(
-                    "No WSL distribution with bwrap found. "
-                    "Install bubblewrap in WSL: apt install bubblewrap"
+                    "No WSL distribution with bwrap and python3/pip found. "
+                    "Install bubblewrap, python3, python3-pip in WSL: "
+                    "apt install bubblewrap python3 python3-pip"
                 )
             self._detected_distro = distro
             self._bwrap_path = "/usr/bin/bwrap"  # Always available if WSL detection passed

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -71,8 +71,11 @@ _install_lock = threading.Lock()
 #: (issue #566).  Requiring the full toolchain up front makes such a
 #: distro fall through to auto-install instead.  python3-venv and unzip
 #: are part of the installed package set, so they are probed too.
+#: bwrap is probed at the exact path start() uses (/usr/bin/bwrap on
+#: Debian/Ubuntu), not via `which`, so readiness implies the execution
+#: path the sandbox will actually invoke exists.
 _WSL_READY_CMD = (
-    "which bwrap >/dev/null 2>&1 && "
+    "test -x /usr/bin/bwrap && "
     "python3 -V >/dev/null 2>&1 && "
     "python3 -m pip --version >/dev/null 2>&1 && "
     "python3 -m venv --help >/dev/null 2>&1 && "
@@ -745,7 +748,15 @@ class BwrapSandbox:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(check.communicate(), timeout=30.0)
+            try:
+                await asyncio.wait_for(check.communicate(), timeout=30.0)
+            except asyncio.TimeoutError:
+                try:
+                    check.kill()
+                    await asyncio.wait_for(check.wait(), timeout=5.0)
+                except (asyncio.TimeoutError, ProcessLookupError, OSError):
+                    pass
+                raise
             if check.returncode == 0:
                 logger.info(
                     "bwrap and python3/pip already installed in WSL distro '{}'",
@@ -837,9 +848,17 @@ class BwrapSandbox:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                await asyncio.wait_for(
-                    check_nopass.communicate(), timeout=10.0,
-                )
+                try:
+                    await asyncio.wait_for(
+                        check_nopass.communicate(), timeout=10.0,
+                    )
+                except asyncio.TimeoutError:
+                    try:
+                        check_nopass.kill()
+                        await asyncio.wait_for(check_nopass.wait(), timeout=5.0)
+                    except (asyncio.TimeoutError, ProcessLookupError, OSError):
+                        pass
+                    raise
                 use_sudo = (check_nopass.returncode == 0)
             except (asyncio.TimeoutError, OSError):
                 pass

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -61,6 +61,20 @@ _auto_install_cache: dict[str, bool] = {}
 
 import threading
 _install_lock = threading.Lock()
+
+#: WSL distro readiness probe: bwrap + python3/pip toolchain.
+#:
+#: Used by _detect_wsl_distro / _find_any_wsl_distro and by
+#: _ensure_wsl_deps.  A distro that has bwrap but lacks pip would pass
+#: the old `which bwrap`-only probe and never reach the dependency
+#: installer, leaving the agent to retry failed pip installs forever
+#: (issue #566).  Requiring the full toolchain up front makes such a
+#: distro fall through to auto-install instead.
+_WSL_READY_CMD = (
+    "which bwrap >/dev/null 2>&1 && "
+    "python3 -V >/dev/null 2>&1 && "
+    "python3 -m pip --version >/dev/null 2>&1"
+)
 """Serialize _ensure_wsl_deps to prevent concurrent apt-get.
 
 When sandbox init is deferred to background (after the bridge ready
@@ -68,7 +82,7 @@ signal), a file_tool request may also trigger _ensure_wsl_deps via the
 lazy check in SandboxManager.get_or_create().  Without a lock two
 apt-get processes race on the dpkg lock and one fails.  This lock
 makes the second caller wait for the first install, then re-check with
-a quick ``which bwrap`` that succeeds immediately.
+a quick readiness probe that succeeds immediately.
 """
 
 
@@ -420,9 +434,10 @@ class BwrapSandbox:
 
     @staticmethod
     async def _detect_wsl_distro(preferred: str = "") -> str | None:
-        """Detect available WSL distribution with bwrap.
+        """Detect available WSL distribution with bwrap + python3/pip.
 
-        Returns the distro name if found, None if WSL/bwrap not available.
+        Returns the distro name if found, None if WSL or the toolchain
+        (bwrap + python3/pip) is not available.
         """
         if not _is_windows():
             return None
@@ -431,7 +446,8 @@ class BwrapSandbox:
         if preferred:
             try:
                 proc = await _create_subprocess_exec(
-                    "wsl.exe", "-d", preferred, "--", "bash", "-c", "which bwrap",
+                    "wsl.exe", "-d", preferred, "--", "bash", "-c",
+                    _WSL_READY_CMD,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -486,7 +502,8 @@ class BwrapSandbox:
                     continue
                 try:
                     check = await _create_subprocess_exec(
-                        "wsl.exe", "-d", distro, "--", "bash", "-c", "which bwrap",
+                        "wsl.exe", "-d", distro, "--", "bash", "-c",
+                        _WSL_READY_CMD,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -718,16 +735,10 @@ class BwrapSandbox:
         Returns True if bwrap and python3/pip are available after
         installation, False otherwise.
         """
-        _ready_cmd = (
-            "which bwrap >/dev/null 2>&1 && "
-            "python3 -V >/dev/null 2>&1 && "
-            "python3 -m pip --version >/dev/null 2>&1"
-        )
-
         # Quick check: skip if bwrap and python3/pip already installed
         try:
             check = await _create_subprocess_exec(
-                "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
+                "wsl.exe", "-d", distro, "--", "bash", "-c", _WSL_READY_CMD,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -754,7 +765,8 @@ class BwrapSandbox:
                 await asyncio.sleep(1)
                 try:
                     recheck = await _create_subprocess_exec(
-                        "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
+                        "wsl.exe", "-d", distro, "--", "bash", "-c",
+                        _WSL_READY_CMD,
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -830,16 +842,14 @@ class BwrapSandbox:
                 _stdout, stderr = await asyncio.wait_for(
                     proc.communicate(), timeout=180.0,
                 )
+                stderr = stderr.decode("utf-8", errors="replace") if stderr else ""
 
                 if proc.returncode != 0:
                     logger.info(
                         "  apt-get install completed in {:.0f}s (failed)",
                         time.monotonic() - _t0,
                     )
-                    err_msg = (
-                        stderr.decode("utf-8", errors="replace")[:300]
-                        if stderr else "unknown error"
-                    )
+                    err_msg = stderr[:300] or "unknown error"
                     if not use_sudo and (
                         "permission denied" in err_msg.lower()
                         or "are you root" in err_msg.lower()
@@ -848,7 +858,7 @@ class BwrapSandbox:
                             " (sudo is required but needs a password. "
                             "Configure passwordless sudo in the WSL distro "
                             "or run: wsl -d {0} -- sudo apt-get install "
-                            "bubblewrap coreutils rsync)".format(distro)
+                            "bubblewrap python3 python3-pip)".format(distro)
                         )
                     logger.warning(
                         "Failed to install dependencies in WSL distro "
@@ -864,10 +874,10 @@ class BwrapSandbox:
         finally:
             _install_lock.release()
 
-        # Verify bwrap is now available
+        # Verify bwrap + python3/pip are now available
         try:
             verify = await _create_subprocess_exec(
-                "wsl.exe", "-d", distro, "--", "bash", "-c", _ready_cmd,
+                "wsl.exe", "-d", distro, "--", "bash", "-c", _WSL_READY_CMD,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1633,7 +1633,8 @@ class BwrapSandbox:
         WSL distro has bwrap installed, this method will:
         1. Auto-create a dedicated sandbox distro (AIShadowSandbox)
            by exporting the first available distro
-        2. Install bubblewrap, coreutils, rsync into it
+        2. Install bubblewrap, coreutils, rsync, python3, python3-pip,
+           python3-venv, unzip into it
         """
         if _is_windows():
             distro = await BwrapSandbox._detect_wsl_distro(wsl_distro)

--- a/tests/sandbox/test_bwrap_auto_install.py
+++ b/tests/sandbox/test_bwrap_auto_install.py
@@ -110,6 +110,17 @@ async def test_wsl_sandbox_auto_install():
         assert rc == 0, f"write+read failed: rc={rc} stderr={stderr!r}"
         assert "isolated" in stdout
 
+        # Python/pip toolchain available inside sandbox (issue #566)
+        rc, stdout, stderr = await sandbox.run_command(
+            "python3 -V && python3 -m pip --version"
+        )
+        assert rc == 0, (
+            f"python3/pip missing inside sandbox: rc={rc} "
+            f"stderr={stderr!r} stdout={stdout!r}"
+        )
+        assert "Python" in stdout
+        assert "pip" in stdout
+
     finally:
         await sandbox.stop()
         assert not sandbox.is_running

--- a/tests/sandbox/test_wsl_detect_readiness.py
+++ b/tests/sandbox/test_wsl_detect_readiness.py
@@ -16,7 +16,7 @@ import subprocess
 
 import pytest
 
-from miqi.sandbox.bwrap import BwrapSandbox, _WSL_READY_CMD
+from miqi.sandbox.bwrap import _WSL_READY_CMD, BwrapSandbox
 
 pytestmark = [pytest.mark.wsl, pytest.mark.sandbox]
 

--- a/tests/sandbox/test_wsl_detect_readiness.py
+++ b/tests/sandbox/test_wsl_detect_readiness.py
@@ -102,9 +102,16 @@ async def test_detect_skips_distro_with_bwrap_but_no_python():
         pytest.skip(f"Could not locate pip package in '{distro}'")
 
     hidden = pip_dir + ".miqi-test-bak"
+    hid_ok = False
     try:
         rc = await _run_in_distro(distro, f"mv {pip_dir} {hidden}")
-        assert rc == 0, f"failed to hide pip in '{distro}'"
+        if rc != 0:
+            # WSL user may lack write permission to dist-packages
+            # (e.g. CI's non-root user) — skip instead of failing.
+            pytest.skip(
+                f"Cannot hide pip in '{distro}' (permissions); skipping"
+            )
+        hid_ok = True
         # Sanity: the distro really is missing pip now.
         assert not await _distro_ready(distro), "pip should be missing now"
 
@@ -113,11 +120,12 @@ async def test_detect_skips_distro_with_bwrap_but_no_python():
             f"detection accepted '{distro}' without pip — #566 regression"
         )
     finally:
-        rc = await _run_in_distro(distro, f"mv {hidden} {pip_dir}")
-        assert rc == 0, f"CRITICAL: failed to restore pip in '{distro}'"
-        assert await _distro_ready(distro), (
-            "distro should be ready after restore"
-        )
+        if hid_ok:
+            rc = await _run_in_distro(distro, f"mv {hidden} {pip_dir}")
+            assert rc == 0, f"CRITICAL: failed to restore pip in '{distro}'"
+            assert await _distro_ready(distro), (
+                "distro should be ready after restore"
+            )
 
 
 @pytest.mark.asyncio
@@ -162,12 +170,21 @@ async def test_detect_falls_back_to_another_distro_when_preferred_missing_pip():
     pip_dir = await _pip_module_dir(preferred)
     if not pip_dir:
         pytest.skip(f"Could not locate pip package in '{preferred}'")
-    ready_others = [d for d in distros if d != preferred]
+    # Only fully-ready distros are valid fallback targets; a distro that
+    # is itself missing pip must not satisfy the assertion.
+    ready_others = [
+        d for d in distros if d != preferred and await _distro_ready(d)
+    ]
 
     hidden = pip_dir + ".miqi-test-bak"
+    hid_ok = False
     try:
         rc = await _run_in_distro(preferred, f"mv {pip_dir} {hidden}")
-        assert rc == 0, f"failed to hide pip in '{preferred}'"
+        if rc != 0:
+            pytest.skip(
+                f"Cannot hide pip in '{preferred}' (permissions); skipping"
+            )
+        hid_ok = True
         found = await BwrapSandbox._detect_wsl_distro(preferred)
         assert found != preferred, (
             f"preferred distro '{preferred}' accepted without pip — #566 regression"
@@ -177,9 +194,10 @@ async def test_detect_falls_back_to_another_distro_when_preferred_missing_pip():
                 f"expected fallback to another ready distro, got {found!r}"
             )
     finally:
-        rc = await _run_in_distro(preferred, f"mv {hidden} {pip_dir}")
-        assert rc == 0, f"CRITICAL: failed to restore pip in '{preferred}'"
-        assert await _distro_ready(preferred), "distro should be ready after restore"
+        if hid_ok:
+            rc = await _run_in_distro(preferred, f"mv {hidden} {pip_dir}")
+            assert rc == 0, f"CRITICAL: failed to restore pip in '{preferred}'"
+            assert await _distro_ready(preferred), "distro should be ready after restore"
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_wsl_detect_readiness.py
+++ b/tests/sandbox/test_wsl_detect_readiness.py
@@ -1,0 +1,232 @@
+"""Real WSL integration tests for distro readiness detection (#566).
+
+Verifies, on real WSL, that distro detection requires the full toolchain
+(bwrap + python3/pip) and that auto-install installs the Python toolchain.
+
+Regression target: a distro that has bwrap but lacks pip used to pass
+the `which bwrap`-only probe, so the dependency installer never ran and
+agents retried failed pip installs forever (issue #566).
+
+These tests require a Windows runner with WSL and a bash-capable distro
+(same prereq as test_bwrap_auto_install.py); they skip when WSL is
+unavailable.
+"""
+import asyncio
+import subprocess
+
+import pytest
+
+from miqi.sandbox.bwrap import BwrapSandbox, _WSL_READY_CMD
+
+pytestmark = [pytest.mark.wsl, pytest.mark.sandbox]
+
+
+def _real_distros() -> list[str]:
+    """WSL distro names that can run bash (excluding docker-desktop)."""
+    try:
+        result = subprocess.run(
+            ["wsl.exe", "-l", "-q"], capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return []
+    distros = [
+        line.strip().replace("\x00", "")
+        for line in result.stdout.splitlines()
+        if line.strip().replace("\x00", "")
+        and "docker-desktop" not in line.lower()
+    ]
+    ready = []
+    for distro in distros:
+        try:
+            check = subprocess.run(
+                ["wsl.exe", "-d", distro, "--", "bash", "-c", "echo ok"],
+                capture_output=True, timeout=10,
+            )
+        except Exception:
+            continue
+        if check.returncode == 0:
+            ready.append(distro)
+    return ready
+
+
+async def _run_in_distro(distro: str, cmd: str) -> int:
+    """Run a command in a WSL distro; return exit code."""
+    proc = await asyncio.create_subprocess_exec(
+        "wsl.exe", "-d", distro, "--", "bash", "-c", cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await asyncio.wait_for(proc.communicate(), timeout=120.0)
+    return proc.returncode if proc.returncode is not None else -1
+
+
+async def _distro_ready(distro: str) -> bool:
+    """True if the distro currently passes the full readiness probe."""
+    return await _run_in_distro(distro, _WSL_READY_CMD) == 0
+
+
+async def _pip_module_dir(distro: str) -> str | None:
+    """Path of the pip package directory inside the distro, or None."""
+    proc = await asyncio.create_subprocess_exec(
+        "wsl.exe", "-d", distro, "--", "bash", "-c",
+        'python3 -c "import pip; print(pip.__file__)"',
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+    if proc.returncode != 0:
+        return None
+    path = stdout.decode("utf-8", errors="replace").strip()
+    if not path.endswith("/__init__.py"):
+        return None
+    return path[: -len("/__init__.py")]
+
+
+@pytest.mark.asyncio
+async def test_detect_skips_distro_with_bwrap_but_no_python():
+    """#566: hiding pip in a ready distro must make detection reject it.
+
+    Uses a real distro: temporarily moves the pip package away, verifies
+    the full-toolchain probe now fails, then asserts detection no longer
+    selects that distro.  The package is restored in a finally block.
+    """
+    distros = _real_distros()
+    if not distros:
+        pytest.skip("No real WSL distro available")
+    # Prefer a non-sandbox distro for the experiment.
+    distro = next((d for d in distros if d != "AIShadowSandbox"), distros[0])
+    if not await _distro_ready(distro):
+        pytest.skip(f"Distro '{distro}' is not fully ready; nothing to hide")
+    pip_dir = await _pip_module_dir(distro)
+    if not pip_dir:
+        pytest.skip(f"Could not locate pip package in '{distro}'")
+
+    hidden = pip_dir + ".miqi-test-bak"
+    try:
+        rc = await _run_in_distro(distro, f"mv {pip_dir} {hidden}")
+        assert rc == 0, f"failed to hide pip in '{distro}'"
+        # Sanity: the distro really is missing pip now.
+        assert not await _distro_ready(distro), "pip should be missing now"
+
+        found = await BwrapSandbox._detect_wsl_distro(distro)
+        assert found != distro, (
+            f"detection accepted '{distro}' without pip — #566 regression"
+        )
+    finally:
+        rc = await _run_in_distro(distro, f"mv {hidden} {pip_dir}")
+        assert rc == 0, f"CRITICAL: failed to restore pip in '{distro}'"
+        assert await _distro_ready(distro), (
+            "distro should be ready after restore"
+        )
+
+
+@pytest.mark.asyncio
+async def test_detect_accepts_fully_ready_distro():
+    """A distro with the full toolchain is selected and really is ready."""
+    found = await BwrapSandbox._detect_wsl_distro("")
+    if found is None:
+        pytest.skip("No fully-ready distro (auto-install path needed)")
+    assert await _distro_ready(found), (
+        f"detected distro '{found}' does not actually have bwrap + python3/pip"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_wsl_deps_installs_python_toolchain():
+    """Auto-install leaves a distro with the full toolchain, ready or not."""
+    distros = _real_distros()
+    if not distros:
+        pytest.skip("No real WSL distro available")
+    distro = distros[0]
+    ok = await BwrapSandbox._ensure_wsl_deps(distro)
+    assert ok, f"_ensure_wsl_deps failed on real distro '{distro}'"
+    assert await _distro_ready(distro), (
+        f"distro '{distro}' not ready after _ensure_wsl_deps"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_falls_back_to_another_distro_when_preferred_missing_pip():
+    """Preferred distro missing pip falls through to a fully ready one.
+
+    This exercises the start() flow: _detect_wsl_distro(preferred) must
+    reject a distro without pip even when it is explicitly preferred, and
+    find the fully-ready distro instead.
+    """
+    distros = _real_distros()
+    if not distros:
+        pytest.skip("No real WSL distro available")
+    preferred = next(
+        (d for d in distros if d != "AIShadowSandbox"), distros[0]
+    )
+    pip_dir = await _pip_module_dir(preferred)
+    if not pip_dir:
+        pytest.skip(f"Could not locate pip package in '{preferred}'")
+    ready_others = [d for d in distros if d != preferred]
+
+    hidden = pip_dir + ".miqi-test-bak"
+    try:
+        rc = await _run_in_distro(preferred, f"mv {pip_dir} {hidden}")
+        assert rc == 0, f"failed to hide pip in '{preferred}'"
+        found = await BwrapSandbox._detect_wsl_distro(preferred)
+        assert found != preferred, (
+            f"preferred distro '{preferred}' accepted without pip — #566 regression"
+        )
+        if ready_others:
+            assert found in ready_others or found == "AIShadowSandbox", (
+                f"expected fallback to another ready distro, got {found!r}"
+            )
+    finally:
+        rc = await _run_in_distro(preferred, f"mv {hidden} {pip_dir}")
+        assert rc == 0, f"CRITICAL: failed to restore pip in '{preferred}'"
+        assert await _distro_ready(preferred), "distro should be ready after restore"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_start_creates_working_session_with_python():
+    """Full lifecycle: sandbox.start() + python3/pip inside the sandbox.
+
+    This is the real end-to-end guarantee of #566 — once detection and
+    install pass, a sandbox session must actually run python3 and pip
+    inside the isolated environment.
+    """
+    distros = _real_distros()
+    if not distros:
+        pytest.skip("No real WSL distro available")
+    found = await BwrapSandbox._detect_wsl_distro("")
+    if found is None:
+        pytest.skip("No fully-ready distro (auto-install path needed)")
+    # Give the distro a chance to pass the full probe.
+    ok = await BwrapSandbox._ensure_wsl_deps(found)
+    assert ok, f"_ensure_wsl_deps failed on '{found}'"
+
+    import tempfile
+    from pathlib import Path
+
+    workspace = Path(tempfile.mkdtemp(prefix="miqi-wsl-readiness-"))
+    sandbox = BwrapSandbox(
+        session_key="test-wsl-readiness",
+        workspace=workspace,
+        share_net=True,
+        wsl_distro=found,
+        auto_install_deps=True,
+    )
+    try:
+        await sandbox.start()
+        assert sandbox.is_running
+
+        rc, stdout, stderr = await sandbox.run_command(
+            "python3 -V && python3 -m pip --version"
+        )
+        assert rc == 0, (
+            f"python3/pip missing inside sandbox: rc={rc} stderr={stderr!r} "
+            f"stdout={stdout!r}"
+        )
+        assert "Python" in stdout
+        assert "pip" in stdout
+    finally:
+        await sandbox.stop()
+        assert not sandbox.is_running
+
+    import shutil
+    shutil.rmtree(workspace, ignore_errors=True)


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

WSL 沙箱 AIShadowSandbox 自动安装并校验 python3 + pip/venv + unzip，缺失时快速失败并给出明确提示，避免 agent 反复重试安装依赖。

## 背景/问题

Issue #566：桌面会话的 WSL 沙箱发行版未预装 pip/Python 工具链，agent 尝试安装 matplotlib/numpy 等依赖时全部失败并反复重试，技能脚本无法运行，同时刷爆会话上下文。

## 变更内容

- `miqi/sandbox/bwrap.py`：`_ensure_wsl_deps` 安装 `python3`、`python3-pip`、`python3-venv`、`unzip`，快速检查和并发等待也校验 bwrap + python3/pip；安装后仍缺失时返回失败并给出明确提示。
- `miqi/agent/tools/shell.py`：workspace 外的 mirror 拒绝日志降为 debug，避免 `/tmp` 安装路径刷日志。
- `tests/sandbox/test_bwrap_auto_install.py`：沙箱启动后验证 `python3 -V && python3 -m pip --version`。

## 日志/验证证据

```
$ uv run pytest tests/sandbox/test_bwrap_auto_install.py -q
..                                                                       [100%]
2 passed in 57.42s
```

## 测试情况

- 真实 WSL 集成测试 2 passed：自动安装后沙箱内可运行 `python3 -V` 与 `python3 -m pip --version`。
- 改动仅涉及 WSL 依赖安装与日志级别，无 UI 变更。

## 截图

无 UI 视觉变更，无需截图

Fixes #566


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Distro detection now requires full toolchain (bwrap + python3/pip/venv/unzip) via `_WSL_READY_CMD`, preventing selection of distros missing pip

- `_ensure_wsl_deps` installs python3, python3-pip, python3-venv, unzip and improves subprocess handling (timeouts, killing orphaned apt-get)

- Downgrade mirror rejection log to debug to suppress `/tmp` install noise

- Add integration tests for readiness detection, pip hiding, and sandbox Python availability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Distro detection (wsl.exe)"] --> B{"_WSL_READY_CMD? (bwrap + python3/pip/venv/unzip)"}
  B -- "pass" --> C["Distro accepted as sandbox-ready"]
  B -- "fail" --> D["_ensure_wsl_deps: apt-get install python3,pip,venv,unzip"]
  D --> E["Verify ready command"]
  E --> C
  C --> F["Sandbox start with python/pip"]
  F --> G["python3 -V & pip --version inside sandbox"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bwrap.py</strong><dd><code>Require full toolchain in distro detection and install Python deps</code></dd></summary>
<hr>

miqi/sandbox/bwrap.py

<ul><li>Add <code>_WSL_READY_CMD</code> constant requiring bwrap, python3, pip, venv, unzip<br> <li> Use it in distro detection functions to reject distros missing <br>Python/pip<br> <li> Extend <code>_ensure_wsl_deps</code> to install python3, python3-pip, python3-venv, <br>unzip<br> <li> Replace loop count with deadline-based concurrent-install waiter and <br>kill orphaned processes on timeout<br> <li> Improve error/log messages for missing toolchain</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/616/files#diff-d7d5a8260ce597977133c8f4a9bd8e5de7698df9a1fc925cdcc8e22aee7cdb2b">+121/-37</a></td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell.py</strong><dd><code>Downgrade mirror rejection log to debug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/agent/tools/shell.py

<ul><li>Change <code>_mirror_downloaded_files</code> rejection log from warning to debug to <br>reduce noise for non-workspace paths (e.g., <code>/tmp</code> package installs)</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/616/files#diff-3cc5757485ddb3df794186684ead9e7294ad0648552d9d298091abdafc38ca92">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bwrap_auto_install.py</strong><dd><code>Add Python/pip verification in auto-install test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sandbox/test_bwrap_auto_install.py

<ul><li>Add verification that <code>python3 -V</code> and <code>pip --version</code> succeed inside the <br>sandbox after auto-install</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/616/files#diff-eb4e7b7685dc168179111c0866fd7528fd0c6d281e43deaa99b6ef34ec78ac89">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_wsl_detect_readiness.py</strong><dd><code>Add tests for WSL distro readiness with pip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sandbox/test_wsl_detect_readiness.py

<ul><li>Add real-WSL tests for distro readiness detection when pip is hidden<br> <li> Verify fallback to fully-ready distro when preferred distro lacks pip<br> <li> Test that <code>_ensure_wsl_deps</code> installs the full Python toolchain<br> <li> End-to-end test that <code>sandbox.start()</code> yields a working python3/pip <br>environment</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/616/files#diff-aa2af62c9637ed70845691b6fa4a23e0adbf95e1d8ce0b95feece8f530d07015">+250/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

