### PR TITLE
fix(tools): exact canonical match for default workspace detection

### DIFF
--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -372,16 +372,15 @@ def _is_default_workspace(path: Path | None) -> bool:
     if path is None:
         return True
     try:
-        import os
-        raw = str(path).replace("\\", "/")
-        default_raw = "~/.miqi/workspace"
-        if os.environ.get("MIQI_HOME", "").strip():
-            from miqi.paths import get_miqi_home
-            default_raw = str(get_miqi_home() / "workspace").replace("\\", "/")
-        else:
-            from pathlib import Path as _P
-            default_raw = str(_P(default_raw).expanduser()).replace("\\", "/")
-        return raw == default_raw or raw.endswith("/workspace")
+        # Resolve both the candidate and the default workspace to canonical
+        # absolute paths and compare exactly.  A loose `endswith("/workspace")`
+        # would misclassify any custom project dir that happens to end in
+        # `workspace` (e.g. /home/user/projects/workspace) as the default and
+        # wrongly enable per-session files isolation for it.
+        from miqi.paths import get_miqi_home
+        resolved = path.expanduser().resolve()
+        default = (get_miqi_home() / "workspace").resolve()
+        return resolved == default
     except Exception:
         return True
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 `_is_default_workspace` 的默认工作目录误判：任何以 `workspace` 结尾的路径都被当成默认目录，导致用户自定义的项目工作目录被错误地套用会话文件隔离。

## 背景/问题

`miqi/agent/tools/filesystem.py` 的 `_is_default_workspace` 用 `raw.endswith("/workspace")` 判断默认目录。这会把任何以 `workspace` 结尾的自定义目录（如 `/home/user/projects/workspace`）误判为默认工作区，从而错误地启用 `sessions/<key>/files` 隔离——隐藏了用户所选项目目录自己的文件（README.md、源码），AI 无法直接读取。

该问题由 PR Agent 在 #577 中提出（suggestion importance 7），但 #577 已合并，此修复未包含在内。

## 变更内容

- `miqi/agent/tools/filesystem.py` — `_is_default_workspace` 改为将候选路径和默认路径都 `resolve()` 成 canonical 绝对路径后精确比较，不再用宽松的 `endswith("/workspace")`。修复后自定义目录即使以 `workspace` 结尾也会被视为非默认，直接作为文件工具工作区。

## 日志/验证证据

```
$ uv run python -c "
from pathlib import Path
from miqi.agent.tools.filesystem import _is_default_workspace
import os
print('default:', _is_default_workspace(Path(os.path.join(os.environ.get('MIQI_HOME','~/.miqi'), 'workspace'))))
print('custom projects/workspace:', _is_default_workspace(Path('/home/user/projects/workspace')))
print('custom auto_display_light:', _is_default_workspace(Path('C:/git-program/auto_display_light')))
"

default: True
custom projects/workspace: False   # 修复前误判为 True
custom auto_display_light: False
```

## 测试情况

- `tests/runtime/test_tool_registry_factory.py` + `test_agent_control.py`：43 passed, 1 skipped
- 手动选择目录 E2E 验证：AI 报告 `C:\git-program\auto_display_light`（修复前会误判为默认目录导致隔离）

## 截图

见 #577 中「手动选择目录」的验证截图——修复后 AI 直接以所选目录为工作区。


___

### **PR Type**
Bug fix


___

### **Description**
- Replace loose `endswith("/workspace")` check with full path resolution and exact comparison

- Prevent misclassifying custom project directories (e.g. `.../projects/workspace`) as the default workspace

- Ensure file tools operate directly on the user-chosen workspace without per-session isolation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old: endswith('/workspace')"] -- "loose" --> misclassify["Misclassify custom dirs"]
  new["New: resolve & exact compare"] -- "exact" --> correct["Only default workspace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filesystem.py</strong><dd><code>Replace loose endswith check with canonical path resolution</code></dd></summary>
<hr>

miqi/agent/tools/filesystem.py

<ul><li>Canonical path resolution (<code>.expanduser().resolve()</code>) for both candidate <br>and default workspace<br> <li> Exact equality check instead of <code>endswith("/workspace")</code> to avoid false <br>positives<br> <li> Keep exception safety: on any error, default to treating path as <br>default workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/626/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+9/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

