### PR TITLE
fix(sandbox): bind custom workspace into sandbox for exec/file consistency

### DIFF
--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -207,7 +207,12 @@ class BridgeState:
             try:
                 from miqi.session.manager import SessionManager
                 sm = SessionManager(config.workspace_path)
-                session = sm.get_or_create(key, client_id=client_id)
+                # The sandbox key is namespaced `client_id:session_key` (e.g.
+                # `miqi-desktop:desktop:xxx`); the session metadata is stored
+                # under the bare session_key (`desktop:xxx`).  Strip the first
+                # colon segment regardless of whether client_id is passed.
+                bare_key = key.split(":", 1)[1] if ":" in key else key
+                session = sm.get_or_create(bare_key, client_id=client_id)
                 return session.metadata.get("workspace")
             except Exception:
                 return None

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -209,15 +209,14 @@ class BridgeState:
                 sm = SessionManager(config.workspace_path)
                 # The sandbox key is namespaced `client_id:session_key` (e.g.
                 # `miqi-desktop:desktop:xxx`); the session metadata is stored
-                # under the bare session_key (`desktop:xxx`).  Strip ONLY an
-                # exact `client_id:` prefix — a raw key like `desktop:xxx`
-                # must be kept intact.
-                prefix = f"{client_id}:" if client_id is not None else ""
-                bare_key = (
-                    key[len(prefix):]
-                    if prefix and key.startswith(prefix)
-                    else key
-                )
+                # under the bare session_key (`desktop:xxx`).  The resolver
+                # may be called without client_id, so strip the known client
+                # prefix `miqi-desktop:` when present, and otherwise keep the
+                # key intact (a raw key like `desktop:xxx` must not be split).
+                _CLIENT_PREFIX = "miqi-desktop:"
+                bare_key = key
+                if key.startswith(_CLIENT_PREFIX):
+                    bare_key = key[len(_CLIENT_PREFIX):]
                 session = sm.get_or_create(bare_key, client_id=client_id)
                 return session.metadata.get("workspace")
             except Exception:

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -209,9 +209,15 @@ class BridgeState:
                 sm = SessionManager(config.workspace_path)
                 # The sandbox key is namespaced `client_id:session_key` (e.g.
                 # `miqi-desktop:desktop:xxx`); the session metadata is stored
-                # under the bare session_key (`desktop:xxx`).  Strip the first
-                # colon segment regardless of whether client_id is passed.
-                bare_key = key.split(":", 1)[1] if ":" in key else key
+                # under the bare session_key (`desktop:xxx`).  Strip ONLY an
+                # exact `client_id:` prefix — a raw key like `desktop:xxx`
+                # must be kept intact.
+                prefix = f"{client_id}:" if client_id is not None else ""
+                bare_key = (
+                    key[len(prefix):]
+                    if prefix and key.startswith(prefix)
+                    else key
+                )
                 session = sm.get_or_create(bare_key, client_id=client_id)
                 return session.metadata.get("workspace")
             except Exception:

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1030,8 +1030,21 @@ class BwrapSandbox:
                     linux_workspace,
                 )
 
-        # Always use per-sandbox workspace — no shared host workspace bind mount
-        self._linux_workspace = None
+        # If the session uses a CUSTOM workspace (the user picked a project
+        # directory in the workspace picker), bind-mount it into the sandbox
+        # so exec and the file tools operate on the SAME directory.  The
+        # default workspace keeps the per-session private sandbox dir
+        # (Issue #221 isolation).
+        from miqi.agent.tools.filesystem import _is_default_workspace
+        if linux_workspace and not _is_default_workspace(self.workspace):
+            self._linux_workspace = linux_workspace
+            logger.info(
+                "Sandbox will bind-mount custom workspace {} → /home/miqi/workspace",
+                linux_workspace,
+            )
+        else:
+            # Always use per-sandbox workspace — no shared host workspace bind mount
+            self._linux_workspace = None
 
         self._running = True
         logger.info(
@@ -1490,11 +1503,15 @@ class BwrapSandbox:
         args.extend(["--bind", self.sandbox_home, "/home/miqi"])
 
         # ── Workspace mount ────────────────────────────────────────
-        # Always use the per-sandbox workspace directory for full
-        # session isolation. Do NOT bind-mount the shared host
-        # workspace, which would let any sandbox see all sessions'
-        # files (Issue #221).
-        args.extend(["--bind", self.sandbox_workspace, "/home/miqi/workspace"])
+        # Default workspace: use the per-sandbox workspace directory for
+        # full session isolation (Issue #221).  Custom workspace: bind-mount
+        # the user's project directory so exec and file tools see the same
+        # files (consistency), while the session-key still isolates the
+        # sandbox from other sessions.
+        if self._linux_workspace:
+            args.extend(["--bind", self._linux_workspace, "/home/miqi/workspace"])
+        else:
+            args.extend(["--bind", self.sandbox_workspace, "/home/miqi/workspace"])
 
         # ── /etc/resolv.conf ─────────────────────────────────────────
         # /etc is already ro-bind-mounted from host (share_net=True),

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1036,7 +1036,16 @@ class BwrapSandbox:
         # default workspace keeps the per-session private sandbox dir
         # (Issue #221 isolation).
         from miqi.agent.tools.filesystem import _is_default_workspace
-        if linux_workspace and not _is_default_workspace(self.workspace):
+        if not _is_default_workspace(self.workspace):
+            # A custom workspace MUST be bind-mounted so exec and the file
+            # tools operate on the same directory.  If it can't be resolved
+            # to an accessible Linux path, fail startup instead of silently
+            # falling back to the (empty) private sandbox dir — that would
+            # make exec and file tools modify different directories.
+            if not linux_workspace:
+                raise BwrapSandboxError(
+                    f"Custom workspace is not accessible from the sandbox: {self.workspace}"
+                )
             self._linux_workspace = linux_workspace
             logger.info(
                 "Sandbox will bind-mount custom workspace {} → /home/miqi/workspace",

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1046,6 +1046,14 @@ class BwrapSandbox:
                 raise BwrapSandboxError(
                     f"Custom workspace is not accessible from the sandbox: {self.workspace}"
                 )
+            # Defensive: the resolved path must actually exist on the Linux
+            # side (test -d) before binding — a stale/non-empty-but-missing
+            # path would make bwrap fail with an obscure error.
+            rc_exists, _, _ = await self._run_linux_command(f"test -d '{linux_workspace}'")
+            if rc_exists != 0:
+                raise BwrapSandboxError(
+                    f"Custom workspace does not exist on the Linux side: {linux_workspace}"
+                )
             self._linux_workspace = linux_workspace
             logger.info(
                 "Sandbox will bind-mount custom workspace {} → /home/miqi/workspace",

--- a/tests/sandbox/test_workspace_bind_mount.py
+++ b/tests/sandbox/test_workspace_bind_mount.py
@@ -1,0 +1,52 @@
+"""Unit tests for sandbox workspace bind-mount behavior (#PR).
+
+Custom workspace → bind-mount the user's project dir into /home/miqi/workspace
+so exec and file tools operate on the SAME directory.
+Default workspace → keep the per-session private sandbox dir.
+"""
+from pathlib import Path
+
+from miqi.sandbox.bwrap import BwrapSandbox
+
+
+def _make_sandbox(workspace: Path, *, custom: bool) -> BwrapSandbox:
+    sb = BwrapSandbox(
+        session_key="desktop:test123",
+        workspace=workspace,
+        sandbox_base_dir=Path("/tmp/miqi-sandboxes"),
+        wsl_distro="Ubuntu",
+        wsl_base_dir="/tmp/miqi-sandboxes",
+    )
+    sb._bwrap_path = "/usr/bin/bwrap"
+    # Simulate start(): custom workspace resolves to a Linux path that gets
+    # bind-mounted; default leaves _linux_workspace None.
+    if custom:
+        sb._linux_workspace = str(workspace).replace("\\", "/")
+    else:
+        sb._linux_workspace = None
+    return sb
+
+
+def _bind_mounts(args: list[str]) -> list[tuple[str, str]]:
+    """Extract (src, dest) pairs from the flat bwrap arg list."""
+    pairs = []
+    for i, a in enumerate(args[:-1]):
+        if a == "--bind":
+            pairs.append((args[i + 1], args[i + 2]))
+    return pairs
+
+
+def test_default_workspace_binds_private_sandbox_dir():
+    sb = _make_sandbox(Path("/home/user/.miqi/workspace"), custom=False)
+    args = sb._build_bwrap_args("echo hi")
+    mounts = _bind_mounts(args)
+    # Should bind the private sandbox_workspace, NOT any host path.
+    assert (sb.sandbox_workspace, "/home/miqi/workspace") in mounts
+
+
+def test_custom_workspace_binds_real_project_dir():
+    sb = _make_sandbox(Path("/mnt/c/git-program/auto_display_light"), custom=True)
+    args = sb._build_bwrap_args("echo hi")
+    mounts = _bind_mounts(args)
+    # Should bind the real custom workspace into /home/miqi/workspace.
+    assert ("/mnt/c/git-program/auto_display_light", "/home/miqi/workspace") in mounts


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

沙箱模式下，自定义 workspace 的 exec 和文件工具访问不一致——exec 在沙箱私有空目录，文件工具在宿主自定义目录。改为将自定义 workspace bind-mount 进沙箱，两者一致。

## 背景/问题

当用户选择自定义工作目录（如 `C:\git-program\auto_display_light`）且沙箱开启时：
- 文件工具（read_file/write_file）正确访问宿主自定义目录
- 但 exec 的工作目录 `/home/miqi/workspace` 是沙箱私有**空**目录（不 bind 宿主工作区，Issue #221 隔离）

导致 AI 用 `ls` 看不到工作区文件，exec 和文件工具行为不一致。

## 变更内容

- `miqi/bridge/server.py` — sandbox workspace resolver 剥离 `client_id:` 前缀再查 session metadata（之前读错 session 拿不到自定义 workspace）
- `miqi/sandbox/bwrap.py` — 自定义 workspace 时 bind-mount 到 `/home/miqi/workspace`；默认 workspace 保持 per-session 隔离（Issue #221）
- `tests/sandbox/test_workspace_bind_mount.py` — 新增单测验证 bind 行为

## 日志/验证证据

```
E2E 探针（sandbox ON + 自定义 workspace）修复前：
[test] AI ls: A目录为空，没有文件。

修复后：
[test] AI ls: Ahello.txt、logs、memory、sessions、skills
[test] AI read hello.txt: ASANDBOX_WS_MARKER
[test] write_file 落盘宿主自定义 workspace: true
```

## 测试情况

- `tests/sandbox/`：35 passed（含新增 2 个 bind 单测）
- E2E 探针验证：exec `ls` 能看到工作区文件，read/write 正常

## 截图

<img width="1264" height="821" alt="01-sandbox-workspace-consistency" src="https://github.com/user-attachments/assets/2ccbec68-b333-4162-b132-132d0988f8b7" />


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix server.py to correctly resolve custom workspace by stripping the `miqi-desktop:` prefix

- In bwrap.py, bind-mount custom workspace into sandbox so exec and file tools share the same directory

- Default workspace retains per-session private sandbox isolation

- Add unit tests verifying default and custom workspace bind-mount logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Server strips client_id prefix"] --> B["Session workspace metadata resolved"]
  B --> C{"Is default workspace?"}
  C -- No --> D["Bind-mount custom workspace\ninto /home/miqi/workspace"]
  C -- Yes --> E["Use private per-session workspace"]
  D --> F["Exec and file tools\nsee same directory"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Strip client prefix from sandbox workspace resolver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/bridge/server.py

<ul><li>Strip <code>miqi-desktop:</code> prefix from sandbox key before looking up session <br>metadata for workspace resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/629/files#diff-1b1073a8a8a93d566dbcd6ecb2c5aaae27e4e6a806936824e96366eacbe6236f">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bwrap.py</strong><dd><code>Bind-mount custom workspace into sandbox for consistency</code>&nbsp; </dd></summary>
<hr>

miqi/sandbox/bwrap.py

<ul><li>When a custom (non-default) workspace is used, resolve its Linux path, <br>verify it exists, and bind-mount it into <code>/home/miqi/workspace</code><br> <li> Default workspace continues to use the private per-session sandbox <br>directory (Issue #221 isolation)<br> <li> Fail startup if the custom workspace cannot be resolved or does not <br>exist, preventing silent fallback to an empty private directory</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/629/files#diff-d7d5a8260ce597977133c8f4a9bd8e5de7698df9a1fc925cdcc8e22aee7cdb2b">+41/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workspace_bind_mount.py</strong><dd><code>Add unit tests for workspace bind-mount behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sandbox/test_workspace_bind_mount.py

<ul><li>Add test verifying default workspace binds the private sandbox <br>directory<br> <li> Add test verifying custom workspace binds the real project directory <br>into <code>/home/miqi/workspace</code></ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/629/files#diff-3bc4fdcae2b14dc12e3fe81390f72332cd289862855a4576a1e050ff460ac433">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

