### PR TITLE
fix(ci): use dynaconf SECTION.KEY env format for PR Agent pr_reviewer

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -28,8 +28,11 @@ jobs:
           # Post each review as a fresh comment and publish code suggestions
           # as inline diff comments — instead of collapsing everything into a
           # single persistent comment that's easy to miss.
-          github_action_config.pr_reviewer.persistent_comment: "false"
-          github_action_config.pr_reviewer.inline_code_comments: "true"
+          # NOTE: env keys map to the [pr_reviewer] TOML section via dynaconf
+          # (SECTION.KEY), so the correct names are PR_REVIEWER.* — NOT
+          # github_action_config.pr_reviewer.* (which dynaconf ignores).
+          PR_REVIEWER.PERSISTENT_COMMENT: "false"
+          PR_REVIEWER.INLINE_CODE_COMMENTS: "true"
           github_action_config.pr_actions: '["opened", "reopened", "synchronize", "ready_for_review", "review_requested"]'
           github_action_config.handle_push_trigger: "true"
           github_action_config.push_commands: '["/review", "/describe", "/improve"]'


### PR DESCRIPTION
### **User description**
## Summary
- PR #627 tried to make PR Agent post inline code comments instead of a single persistent review comment, using `github_action_config.pr_reviewer.persistent_comment` and `github_action_config.pr_reviewer.inline_code_comments`.
- Those env keys never applied: PR Agent's config loader (dynaconf `env_loader`) maps environment variables to TOML sections by name, so the correct format is `PR_REVIEWER.PERSISTENT_COMMENT` and `PR_REVIEWER.INLINE_CODE_COMMENTS`.
- This PR fixes the key names so the setting actually takes effect — reviews will be posted as fresh comments with inline diff suggestions instead of one persistent comment.

## Test plan
- [ ] Merge, then open/update a PR and confirm PR Agent posts inline code comments on the diff
- [ ] Confirm no persistent comment is created on the PR thread


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PR Agent env variable names so review settings take effect

- Replace `github_action_config.pr_reviewer.*` with `PR_REVIEWER.*` to match dynaconf SECTION.KEY format

- Add comment explaining the mapping to avoid future mistakes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Previous config: github_action_config.pr_reviewer.*"] -- "ignored by dynaconf" --> B["Settings not applied"]
  C["Fix: PR_REVIEWER.*"] -- "mapped to TOML section" --> D["Fresh comment + inline suggestions enabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Fix PR Agent env keys to dynaconf format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Replace incorrect env keys <br><code>github_action_config.pr_reviewer.persistent_comment</code> and <br><code>github_action_config.pr_reviewer.inline_code_comments</code> with the correct <br><code>PR_REVIEWER.PERSISTENT_COMMENT</code> and <code>PR_REVIEWER.INLINE_CODE_COMMENTS</code>.<br> <li> Add a comment block explaining that PR Agent uses dynaconf env_loader <br>and expects <code>SECTION.KEY</code> format (e.g., <code>PR_REVIEWER.PERSISTENT_COMMENT</code>), <br>so previous keys were silently ignored.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/630/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

