### PR TITLE
fix(desktop): guard console writes against EPIPE when stdout pipe is broken

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -114,17 +114,29 @@ export function main(): void {
   const formatLogArgs = (args: unknown[]) =>
     args.map((arg) => (typeof arg === 'string' ? arg : inspect(arg, { depth: 4 }))).join(' ');
 
+  // When stdout is a pipe whose reader has gone away (e.g. the app was
+  // spawned by another process that exited), writing to it throws EPIPE and
+  // would crash the main process as an uncaught exception. Swallow it — the
+  // log file is the durable record; the console is best-effort.
+  const safeConsoleWrite = (fn: (...args: unknown[]) => void, args: unknown[]): void => {
+    try {
+      fn(...args);
+    } catch {
+      // stdout/stderr pipe is broken (EPIPE) — drop the write silently.
+    }
+  };
+
   console.log = (...args: unknown[]) => {
     writeMainProcessLog('INFO', formatLogArgs(args), bridgeManager?.getProjectRoot());
-    return originalConsoleLog(...args);
+    safeConsoleWrite(originalConsoleLog, args);
   };
   console.warn = (...args: unknown[]) => {
     writeMainProcessLog('WARN', formatLogArgs(args), bridgeManager?.getProjectRoot());
-    return originalConsoleWarn(...args);
+    safeConsoleWrite(originalConsoleWarn, args);
   };
   console.error = (...args: unknown[]) => {
     writeMainProcessLog('ERROR', formatLogArgs(args), bridgeManager?.getProjectRoot());
-    return originalConsoleError(...args);
+    safeConsoleWrite(originalConsoleError, args);
   };
 
   app.whenReady().then(() => {


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 Electron 主进程在 stdout 管道被关闭后写 console 抛 EPIPE、反复弹出崩溃对话框的问题。

## 背景/问题

**现象**：当 MiQi 桌面版由脚本/其他程序启动、且启动方退出导致 stdout 管道断开后，主进程对 stdout 的写操作抛 `EPIPE: broken pipe`，变成未捕获异常，弹出 "A JavaScript error occurred in the main process — Uncaught Exception: Error: EPIPE: broken pipe" 崩溃对话框；bridge 每输出一行 stderr 日志就弹一次，应用可能直接退出。

**根因**：`apps/desktop/src/main/index.ts` 重写 `console.log/warn/error` 转发到原始 console 时未包 try/catch（文件写入 `writeMainProcessLog` 已有保护，console 转发没有）；`apps/desktop/src/main/bridge.ts` 的 stderr data handler 在 I/O 回调里调用 `console.log`，EPIPE 无处捕获，成为主进程未捕获异常。

**影响**：所有"由脚本/其他程序启动"的使用方式，在父进程退出后都会反复弹窗、可能崩溃。

## 变更内容

- `apps/desktop/src/main/index.ts`：新增 `safeConsoleWrite` 辅助函数（try/catch 包裹原始 console 写，捕获 EPIPE 静默丢弃）；`console.log/warn/error` 三个重写均改走 `safeConsoleWrite`。日志文件（`writeMainProcessLog`）不受影响，仍是持久记录；终端输出变为 best-effort。
- 覆盖范围：三个重写 → bridge stderr handler 调用的也是被重写的 `console.log`，一并被保护。

## 日志/验证证据

```
修复前（stdout 管道断开时，崩溃弹窗内容）：
A JavaScript error occurred in the main process
Uncaught Exception:Error: EPIPE: broken pipe, write
  at Socket. write (node:internal/net:63:18)
  at writeOrBuffer (node:internal/streams/writable:572:12)
  at _write (node:internal/streams/writable:501:10)
  at Writable.write (node:internal/streams/writable:510:10)
  at console.value (node:internal/console/constructor:303:16)
  at console.log (node:internal/console/constructor:405:26)
  at Socket.<anonymous> (D:\Desktop\539\MiQi\apps\desktop\out\main\index.js:2227:19)
  at Socket.emit (node:events:519:28)
  at addChunk (node:internal/streams/readable:561:12)
  at console.log (D:\Desktop\539\MiQi\apps\desktop\out\main\index.js:2828:12)

修复后（stdout 管道断开，不再抛异常、不弹窗）：
（无输出/无异常 —— 写失败被静默捕获，日志文件照常写入）
```

## 测试情况

- `npm run build`（electron-vite build）通过，构建产物 `out/main/index.js` 已包含 `safeConsoleWrite` 保护。
- 本地复现：父进程 stdout 管道关闭后，修复前第一条日志即崩溃；修复后不再抛异常。
- `typecheck:node` 无新增错误（`bridge.ts:895/909`、`ipc/index.ts:1717` 为既有错误，与本改动无关）。

## 截图

无需截图（无 UI 变更，纯主进程日志健壮性修复）。

Closes #634
