### PR TITLE
feat: surface local skills to the desktop agent (fixes #613)

### DIFF
--- a/miqi/agent/skills.py
+++ b/miqi/agent/skills.py
@@ -171,7 +171,10 @@ class SkillsLoader:
 
         return "\n\n---\n\n".join(parts) if parts else ""
 
-    def build_skills_summary(self) -> str:
+    def build_skills_summary(
+        self,
+        all_skills: list[dict[str, str]] | None = None,
+    ) -> str:
         """
         Build a summary of all skills (name, description, path, availability).
 
@@ -187,10 +190,17 @@ class SkillsLoader:
         agent can read them with relative paths. This matches the Claude
         Code / Cowork convention of `pdf/SKILL.md`-style locations.
 
+        Args:
+            all_skills: Optional pre-scanned skill list (list_skills output)
+                to reuse instead of scanning the filesystem again. Callers
+                that already hold a scan (e.g. for intent matching) pass it
+                here to avoid a duplicate directory scan per turn (#613).
+
         Returns:
             XML-formatted skills summary.
         """
-        all_skills = self.list_skills(filter_unavailable=False)
+        if all_skills is None:
+            all_skills = self.list_skills(filter_unavailable=False)
         if not all_skills:
             return ""
 

--- a/miqi/agent/skills.py
+++ b/miqi/agent/skills.py
@@ -152,6 +152,19 @@ class SkillsLoader:
 
         return None
 
+    def load_skill_by_path(self, path: str) -> str | None:
+        """
+        Load a skill's content from its indexed path.
+
+        Nested built-in skills can get a synthesized display name
+        (e.g. ``plugin-foo`` when ``foo`` collides) that has no matching
+        directory, so callers holding a skill record should load by path.
+        """
+        try:
+            return Path(path).read_text(encoding="utf-8")
+        except OSError:
+            return None
+
     def load_skills_for_context(self, skill_names: list[str]) -> str:
         """
         Load specific skills for inclusion in agent context.

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -247,6 +247,7 @@ def _canonicalize_wsl_mnt_path(
     mnt_path: str,
     workspace: Path | None,
     extra_roots: Iterable[Path] | None = None,
+    session_files_dir: Path | None = None,
 ) -> str:
     """Canonicalize a /mnt/<drive>/... path and verify workspace containment.
 
@@ -261,6 +262,14 @@ def _canonicalize_wsl_mnt_path(
     directories the system prompt legitimately directs the agent to read and
     write.  A path under another session's ``sessions/<other>/files`` is never
     in any root, so per-session isolation is preserved.
+
+    ``session_files_dir`` is the per-session files dir (when session
+    isolation is active, i.e. ``<workspace>/sessions/<key>/files``).  When
+    provided, a path that lives under *any* session's files dir must be the
+    current session's — a path under another session's files dir is rejected
+    even though it is inside *workspace*.  This lets read tools resolve
+    against the root workspace (the working directory the system prompt
+    tells the agent) while preserving session isolation (#613 follow-up).
 
     Returns *mnt_path* unchanged for non-/mnt/ paths or when no workspace
     is configured.
@@ -334,6 +343,28 @@ def _canonicalize_wsl_mnt_path(
             f"which is outside all legal roots [{roots_str}]. "
             "Add the directory to tools.extra_roots in the MiQi config to allow access."
         )
+
+    # Per-session isolation: when session isolation is active, a path under
+    # ANY session's files dir must be the current session's.  This allows
+    # read tools to resolve against the root workspace (the working dir the
+    # system prompt advertises) without opening another session's files.
+    if session_files_dir is not None:
+        sessions_root = session_files_dir.parents[1] if session_files_dir.parents else None
+        # sessions_root = <workspace>/sessions
+        if sessions_root is not None:
+            try:
+                resolved.relative_to(sessions_root)
+            except ValueError:
+                pass  # not under sessions/ — no isolation constraint
+            else:
+                try:
+                    resolved.relative_to(session_files_dir)
+                except ValueError:
+                    raise PermissionError(
+                        f"Path '{host_str}' resolves to '{resolved}' which is "
+                        f"inside another session's files dir — per-session "
+                        f"isolation forbids cross-session access."
+                    )
 
     resolved_str = str(resolved).replace("\\", "/")
     rm = _re.match(r"^([A-Za-z]):/(.+)$", resolved_str)
@@ -424,6 +455,7 @@ def _resolve_sandbox_path(
     workspace: Path | None,
     sandbox,
     extra_roots: Iterable[Path] | None = None,
+    session_files_dir: Path | None = None,
 ) -> str:
     """Resolve a path for use inside the sandbox.
 
@@ -443,7 +475,7 @@ def _resolve_sandbox_path(
         # WSL sandbox: use /mnt/ for direct host filesystem access (issue #474)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             result = f"/mnt/{drive}/{rest}"
-            result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots)
+            result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots, session_files_dir)
             _log.debug("Sandbox path: %s → %s (WSL /mnt/ direct)", original_path, result)
             return result
         # If the workspace matches this drive, compute relative path
@@ -472,7 +504,7 @@ def _resolve_sandbox_path(
                 drive = ws_match.group(1).lower()
                 ws_rest = ws_match.group(2).rstrip("/")
                 result = f"/mnt/{drive}/{ws_rest}/{path}"
-                result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots)
+                result = _canonicalize_wsl_mnt_path(result, workspace, extra_roots, session_files_dir)
                 _log.debug("Sandbox path: %s → %s (WSL relative /mnt/)", original_path, result)
                 return result
         # Compute the correct sandbox base path.
@@ -497,7 +529,7 @@ def _resolve_sandbox_path(
         if ws_str[1:2] == ":":
             # WSL sandbox: /mnt/ paths already access host filesystem directly (issue #474)
             if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-                result = _canonicalize_wsl_mnt_path(path, workspace, extra_roots)
+                result = _canonicalize_wsl_mnt_path(path, workspace, extra_roots, session_files_dir)
                 _log.debug("Sandbox path: %s → %s (WSL /mnt/ keep)", original_path, result)
                 return result
             drive = ws_str[0].lower()
@@ -679,9 +711,14 @@ class ReadFileTool(Tool):
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-            # WSL sandbox — route file operations through the sandbox
+            # WSL sandbox — route file operations through the sandbox.
+            # Read tools resolve against the ROOT workspace (the working dir
+            # the system prompt advertises), while session isolation is
+            # enforced separately via session_files_dir (#613 follow-up).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots
+                path, self._workspace, sandbox,
+                extra_roots=self._shared_roots,
+                session_files_dir=session_ws,
             )
             _log.info("read_file [sandbox]: %s → %s", path, sandbox_path)
             try:
@@ -1040,9 +1077,13 @@ class ListDirTool(Tool):
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-            # WSL sandbox — route file operations through the sandbox
+            # WSL sandbox — route file operations through the sandbox.
+            # Read tools resolve against the ROOT workspace, session
+            # isolation enforced via session_files_dir (#613 follow-up).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots
+                path, self._workspace, sandbox,
+                extra_roots=self._shared_roots,
+                session_files_dir=session_ws,
             )
             _log.info("list_dir [sandbox]: %s → %s", path, sandbox_path)
             try:

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -349,7 +349,15 @@ def _canonicalize_wsl_mnt_path(
     # read tools to resolve against the root workspace (the working dir the
     # system prompt advertises) without opening another session's files.
     if session_files_dir is not None:
-        sessions_root = session_files_dir.parents[1] if session_files_dir.parents else None
+        # Canonicalize once: resolved/workspace are canonical, so a relative
+        # or symlinked session_files_dir would make sessions_root lexical
+        # and let another session's canonical path skip the check.
+        try:
+            canonical_session_files_dir = session_files_dir.resolve()
+        except OSError:
+            canonical_session_files_dir = Path(session_files_dir).absolute()
+        parents = canonical_session_files_dir.parents
+        sessions_root = parents[1] if len(parents) >= 2 else None
         # sessions_root = <workspace>/sessions
         if sessions_root is not None:
             try:
@@ -358,7 +366,7 @@ def _canonicalize_wsl_mnt_path(
                 pass  # not under sessions/ — no isolation constraint
             else:
                 try:
-                    resolved.relative_to(session_files_dir)
+                    resolved.relative_to(canonical_session_files_dir)
                 except ValueError:
                     raise PermissionError(
                         f"Path '{host_str}' resolves to '{resolved}' which is "

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -368,10 +368,11 @@ def _canonicalize_wsl_mnt_path(
                 try:
                     resolved.relative_to(canonical_session_files_dir)
                 except ValueError:
+                    # Do NOT include the resolved path: it can reveal
+                    # another session's identifier and file layout.
                     raise PermissionError(
-                        f"Path '{host_str}' resolves to '{resolved}' which is "
-                        f"inside another session's files dir — per-session "
-                        f"isolation forbids cross-session access."
+                        "Path is inside another session's files dir — "
+                        "per-session isolation forbids cross-session access."
                     )
 
     resolved_str = str(resolved).replace("\\", "/")

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -10,6 +10,7 @@ import dataclasses
 import uuid
 import asyncio
 import inspect
+import re
 from typing import Any
 
 from loguru import logger
@@ -60,6 +61,47 @@ def _classify_chain(exc: BaseException):
             if cause_kind is not ErrorKind.FATAL:
                 return cause_kind
     return kind
+
+
+def _normalize_skill_ref(text: str) -> str:
+    """Normalize a skill reference for matching: lowercase, drop separators.
+
+    'mof-synthesis-price-agent', 'mof synthesis price agent' and
+    'mof_synthesis_price_agent' all normalize to 'mofsynthesispriceagent'.
+    """
+    return re.sub(r"[\s\-_]+", "", text.lower())
+
+
+def _match_skill_intent(
+    user_content: str,
+    skills: list[dict[str, str]],
+) -> list[str]:
+    """Return skill names referenced in the user message (#613).
+
+    Substring match on normalized names. *skills* is expected in
+    SkillsLoader.list_skills order (workspace before builtin), so the
+    first hit is the highest-priority match. Empty list when nothing
+    matches — the model then falls back to generic tool composition.
+
+    Only identifier-like names participate: names containing a separator
+    ('demo-agent', 'mof-synthesis-price-agent') or long single words
+    (>= 10 chars). Short common words such as 'weather' or 'pdf' would
+    false-positive on everyday language and are left to the LLM's own
+    judgment against the injected inventory.
+    """
+    if not user_content:
+        return []
+    normalized = _normalize_skill_ref(user_content)
+    hits = []
+    for s in skills:
+        name = s["name"]
+        if not (
+            "-" in name or "_" in name or " " in name or len(name) >= 10
+        ):
+            continue
+        if _normalize_skill_ref(name) in normalized:
+            hits.append(name)
+    return hits
 
 
 class TaskRunner:
@@ -556,6 +598,79 @@ class TaskRunner:
         }
         mode_prompt = _MODE_PROMPTS.get(turn.execution_policy, "")
         effective_system_prompt = mode_prompt + metadata.system_prompt if mode_prompt else metadata.system_prompt
+
+        # ── Local skill index (issue #613) ───────────────────────────
+        # Surface the workspace/builtin skill inventory in the system
+        # prompt so the model can discover local skills during planning
+        # instead of denying their existence from training priors
+        # ("没有名为 xxx 的现成 Agent"). Progressive disclosure: only
+        # name + description + location; the full SKILL.md is loaded on
+        # demand via skill_manage view / read_file. Best-effort: a scan
+        # failure must never break the turn.
+        try:
+            from miqi.agent.skills import SkillsLoader
+
+            loader = SkillsLoader(self.services.workspace)
+            # Single scan per turn, shared by the inventory summary and the
+            # intent matcher below (#613).
+            all_skills = loader.list_skills(filter_unavailable=False)
+            skills_summary = loader.build_skills_summary(
+                all_skills=all_skills
+            )
+            if skills_summary:
+                effective_system_prompt += (
+                    "\n\n# Local Skills\n\n"
+                    "The following skills are installed locally and can be "
+                    "invoked by name. If the user references one (e.g. "
+                    "\"use the <name> agent\"), load its full SKILL.md via "
+                    "`skill_manage` (action=view, name=<name>) or read_file "
+                    "on <location> BEFORE answering. "
+                    "Never claim a skill does not exist without checking "
+                    "this list first.\n\n"
+                    + skills_summary
+                )
+                logger.debug(
+                    "skill index: injected {} chars of skill inventory",
+                    len(skills_summary),
+                )
+            else:
+                logger.debug(
+                    "skill index: no local skills found for workspace {}",
+                    self.services.workspace,
+                )
+
+            # ── Skill intent match (issue #613) ──────────────────────
+            # When the user names a local skill, preload its full SKILL.md
+            # as context instead of letting the model judge existence from
+            # training priors. HIT/MISS is logged for observability.
+            hits = _match_skill_intent(msg.content, all_skills)
+            if hits:
+                matched = hits[0]
+                body = loader.load_skills_for_context([matched])
+                if body:
+                    effective_system_prompt += (
+                        "\n\n## Matched Local Skill: "
+                        + matched
+                        + "\n\n用户的请求命中了本地 Skill「"
+                        + matched
+                        + "」。直接使用该 Skill 的指令完成任务，"
+                        "不要声称其不存在。\n\n"
+                        + body
+                    )
+                logger.info(
+                    "skill index: HIT skill '{}' referenced in user message",
+                    matched,
+                )
+            else:
+                logger.debug(
+                    "skill index: MISS — {} skills indexed, none referenced",
+                    len(all_skills),
+                )
+        except Exception as exc:
+            logger.warning(
+                "skill index: injection skipped for workspace {}: {}",
+                self.services.workspace, exc,
+            )
 
         # ── Inject session workspace into the prompt ─────────────────────
         # The AI must know its working directory without needing `pwd`.

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -75,8 +75,8 @@ def _normalize_skill_ref(text: str) -> str:
 def _match_skill_intent(
     user_content: str,
     skills: list[dict[str, str]],
-) -> list[str]:
-    """Return skill names referenced in the user message (#613).
+) -> list[dict[str, str]]:
+    """Return matched skill records (with 'path') referenced in the message (#613).
 
     Substring match on normalized names. *skills* is expected in
     SkillsLoader.list_skills order (workspace before builtin), so the
@@ -88,19 +88,29 @@ def _match_skill_intent(
     (>= 10 chars). Short common words such as 'weather' or 'pdf' would
     false-positive on everyday language and are left to the LLM's own
     judgment against the injected inventory.
+
+    Returns records (not just names) so callers can load bodies by the
+    indexed ``path`` — a nested built-in may have a synthesized display
+    name (``plugin-foo``) with no matching directory to load from.
     """
     if not user_content:
         return []
     normalized = _normalize_skill_ref(user_content)
-    hits = []
-    for s in skills:
+    hits: list[dict[str, str]] = []
+    # Match longest names first so a shorter name that is a substring of a
+    # longer one (e.g. 'demo-agent' vs 'demo-agent-ex') cannot shadow it.
+    for s in sorted(skills, key=lambda r: len(r["name"]), reverse=True):
         name = s["name"]
         if not (
             "-" in name or "_" in name or " " in name or len(name) >= 10
         ):
             continue
-        if _normalize_skill_ref(name) in normalized:
-            hits.append(name)
+        # Reject empty normalized names: a directory named '---' (or any
+        # separator-only name) normalizes to '' — '' in normalized is always
+        # True, which would preload that skill on every message.
+        normalized_name = _normalize_skill_ref(name)
+        if normalized_name and normalized_name in normalized:
+            hits.append(s)
     return hits
 
 
@@ -646,20 +656,23 @@ class TaskRunner:
             hits = _match_skill_intent(msg.content, all_skills)
             if hits:
                 matched = hits[0]
-                body = loader.load_skills_for_context([matched])
+                # Load by the indexed path — a nested built-in can have a
+                # synthesized display name ('plugin-foo') with no matching
+                # directory, so name-based lookup would return nothing.
+                body = loader.load_skill_by_path(matched["path"])
                 if body:
                     effective_system_prompt += (
                         "\n\n## Matched Local Skill: "
-                        + matched
+                        + matched["name"]
                         + "\n\n用户的请求命中了本地 Skill「"
-                        + matched
+                        + matched["name"]
                         + "」。直接使用该 Skill 的指令完成任务，"
                         "不要声称其不存在。\n\n"
                         + body
                     )
                 logger.info(
                     "skill index: HIT skill '{}' referenced in user message",
-                    matched,
+                    matched["name"],
                 )
             else:
                 logger.debug(

--- a/tests/runtime/test_task_runner_history_integration.py
+++ b/tests/runtime/test_task_runner_history_integration.py
@@ -47,7 +47,7 @@ async def test_task_runner_persists_history_across_turns(
         seen_agent = False
         seen_complete = False
         while not (seen_agent and seen_complete):
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events_1.append(ev)
@@ -74,7 +74,7 @@ async def test_task_runner_persists_history_across_turns(
         seen_agent_2 = False
         seen_complete_2 = False
         while not (seen_agent_2 and seen_complete_2):
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events_2.append(ev)
@@ -159,7 +159,7 @@ async def test_task_runner_persists_tool_call_messages(
         seen_agent = False
         seen_complete = False
         while not (seen_agent and seen_complete):
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events.append(ev)
@@ -219,7 +219,7 @@ async def test_short_history_does_not_trigger_compact(
         events: list[object] = []
         seen_complete = False
         while not seen_complete:
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events.append(ev)
@@ -270,7 +270,7 @@ async def test_task_runner_auto_compacts_before_large_turn(
         events: list[object] = []
         seen_complete = False
         while not seen_complete:
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events.append(ev)
@@ -329,7 +329,7 @@ async def test_compaction_failure_does_not_crash_runtime(
         events: list[object] = []
         seen_complete = False
         while not seen_complete:
-            ev = await runtime.next_event(timeout=2)
+            ev = await runtime.next_event(timeout=15)
             if ev is None:
                 break
             events.append(ev)

--- a/tests/runtime/test_task_runner_skill_index.py
+++ b/tests/runtime/test_task_runner_skill_index.py
@@ -1,0 +1,217 @@
+"""TaskRunner injects the local skill inventory into the system prompt (#613).
+
+Regression test for: local skills were never surfaced to the model on the
+desktop runtime path (chat.send -> RuntimeSession.submit -> TaskRunner.handle),
+so the model denied the existence of installed skills from training priors
+("没有名为 xxx 的现成 Agent") instead of discovering them during planning.
+
+The fix: TaskRunner appends the workspace/builtin skill inventory
+(SkillsLoader.build_skills_summary) to the effective system prompt before
+handing it to TurnRunner, plus a no-denial rule telling the model to verify
+against the list before claiming a skill does not exist.
+"""
+
+import asyncio
+
+import pytest
+
+from miqi.agent.skills import SkillsLoader
+from miqi.protocol.commands import UserMessage
+from miqi.runtime.task_runner import TaskRunner
+
+
+@pytest.mark.asyncio
+async def test_task_runner_injects_local_skill_inventory_into_system_prompt(fake_services):
+    """A workspace skill appears by name + description in the turn's system prompt."""
+    skill_dir = fake_services.workspace / "skills" / "demo-agent"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: demo-agent\n"
+        "description: Demo agent for price synthesis and feasibility reports\n"
+        "---\n"
+        "\n"
+        "Run the synthesis pipeline: parse DOI, fetch prices, generate report.\n",
+        encoding="utf-8",
+    )
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(
+        content="can the demo-agent generate a feasibility report from a DOI?",
+        thread_id="cli:default",
+    ))
+
+    assert fake_services.turn_runner.run.await_count == 1
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+
+    # The skill inventory section must be present with name + description.
+    assert "Local Skills" in system_prompt
+    assert "<name>demo-agent</name>" in system_prompt
+    assert "Demo agent for price synthesis and feasibility reports" in system_prompt
+
+    # The no-denial rule must be present so the model verifies before denying.
+    assert "Never claim a skill does not exist" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_task_runner_skill_injection_skips_without_crashing(fake_services):
+    """No workspace skills dir -> turn still executes with the base prompt."""
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(content="hello", thread_id="cli:default"))
+
+    assert fake_services.turn_runner.run.await_count == 1
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+    # Base prompt still present and the turn executed normally.
+    assert "MiQi Desktop Agent" in system_prompt
+
+
+def _make_skill(workspace, name: str, description: str, body: str) -> None:
+    """Create a workspace skill at <workspace>/skills/<name>/SKILL.md."""
+    skill_dir = workspace / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_runner_preloads_matched_skill_body_on_intent_hit(fake_services):
+    """User message naming a local skill preloads its SKILL.md into the prompt."""
+    _make_skill(
+        fake_services.workspace,
+        "demo-agent",
+        "Demo agent for price synthesis",
+        "Run the synthesis pipeline: parse DOI, fetch prices, generate report.",
+    )
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(
+        content="can the demo-agent generate a feasibility report from a DOI?",
+        thread_id="cli:default",
+    ))
+
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+    # The matched skill's full body must be preloaded as context.
+    assert "Matched Local Skill: demo-agent" in system_prompt
+    assert "Run the synthesis pipeline: parse DOI, fetch prices, generate report." in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_task_runner_intent_match_normalizes_separators(fake_services):
+    """'demo agent' (spaces) matches skill 'demo-agent' (hyphens)."""
+    _make_skill(
+        fake_services.workspace,
+        "demo-agent",
+        "Demo agent for price synthesis",
+        "Run the synthesis pipeline: parse DOI, fetch prices, generate report.",
+    )
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(
+        content="can the demo agent generate a feasibility report?",
+        thread_id="cli:default",
+    ))
+
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+    assert "Matched Local Skill: demo-agent" in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_task_runner_intent_hit_logs_and_miss_skips_preload(fake_services, caplog):
+    """HIT logs the matched skill; a message without a skill ref preloads nothing."""
+    from loguru import logger as loguru_logger
+
+    _make_skill(
+        fake_services.workspace,
+        "demo-agent",
+        "Demo agent for price synthesis",
+        "Run the synthesis pipeline: parse DOI, fetch prices, generate report.",
+    )
+
+    messages: list[str] = []
+
+    def _sink(message):
+        messages.append(str(message.record["message"]))
+
+    handler_id = loguru_logger.add(_sink, level="DEBUG")
+    try:
+        events = asyncio.Queue()
+        runner = TaskRunner(services=fake_services, event_queue=events)
+
+        # HIT: message references the skill by name.
+        await runner.handle(UserMessage(
+            content="please use demo-agent for this",
+            thread_id="cli:default",
+        ))
+    finally:
+        loguru_logger.remove(handler_id)
+
+    assert any("skill index: HIT" in m and "demo-agent" in m for m in messages), (
+        f"expected a skill-index HIT log, got: {messages}"
+    )
+
+    # MISS: unrelated message -> no preload, no crash.
+    messages.clear()
+    handler_id = loguru_logger.add(_sink, level="DEBUG")
+    try:
+        events = asyncio.Queue()
+        runner = TaskRunner(services=fake_services, event_queue=events)
+
+        await runner.handle(UserMessage(
+            content="what is the weather today?",
+            thread_id="cli:default",
+        ))
+    finally:
+        loguru_logger.remove(handler_id)
+
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+    assert "Matched Local Skill" not in system_prompt
+    assert any("skill index: MISS" in m for m in messages), (
+        f"expected a skill-index MISS log, got: {messages}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_runner_scans_skills_once_per_turn(fake_services, monkeypatch):
+    """Skill discovery scans the filesystem once per turn, not twice (#613).
+
+    The inventory summary and the intent matcher must share a single
+    list_skills() pass; a second scan is pure waste on every message.
+    """
+    _make_skill(
+        fake_services.workspace,
+        "demo-agent",
+        "Demo agent for price synthesis",
+        "Run the synthesis pipeline: parse DOI, fetch prices, generate report.",
+    )
+
+    calls: list[int] = []
+    original = SkillsLoader.list_skills
+
+    def counting_list_skills(self, *args, **kwargs):
+        calls.append(1)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(SkillsLoader, "list_skills", counting_list_skills)
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(
+        content="please use demo-agent for this",
+        thread_id="cli:default",
+    ))
+
+    assert fake_services.turn_runner.run.await_count == 1
+    assert len(calls) == 1, f"expected exactly 1 skill scan, got {len(calls)}"
+
+

--- a/tests/runtime/test_task_runner_skill_index.py
+++ b/tests/runtime/test_task_runner_skill_index.py
@@ -56,6 +56,26 @@ async def test_task_runner_injects_local_skill_inventory_into_system_prompt(fake
 
 
 @pytest.mark.asyncio
+async def test_task_runner_separator_only_skill_name_not_matched(fake_services):
+    """A separator-only skill dir ('---') normalizes to '' and must NOT
+    match every message ('' in normalized is always True)."""
+    skill_dir = fake_services.workspace / "skills" / "---"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: ---\ndescription: separator-only\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+
+    await runner.handle(UserMessage(content="hello", thread_id="cli:default"))
+
+    system_prompt = fake_services.turn_runner.run.await_args.kwargs["system_prompt"]
+    assert "Matched Local Skill" not in system_prompt
+
+
+@pytest.mark.asyncio
 async def test_task_runner_skill_injection_skips_without_crashing(fake_services):
     """No workspace skills dir -> turn still executes with the base prompt."""
     events = asyncio.Queue()

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -296,6 +296,61 @@ class TestResolveSandboxPathWSL:
                 extra_roots=[host_memory],
             )
 
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_root_workspace_read_allowed_with_session_isolation(self, tmp_path):
+        """issue #613 follow-up: read tools resolve against the ROOT workspace
+        (the working dir the system prompt advertises); session isolation is
+        enforced via session_files_dir.  Root-workspace files must be readable
+        even when per-session isolation is active."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        session_ws = ws / "sessions" / "abc" / "files"
+        session_ws.mkdir(parents=True)
+        other_session = ws / "sessions" / "other" / "files"
+        other_session.mkdir(parents=True)
+        sb = _make_wsl_sandbox()
+
+        # Root workspace file: accepted (was rejected before the fix).
+        ok = _resolve_sandbox_path(
+            str(ws / "report.md"),
+            ws,
+            sb,
+            session_files_dir=session_ws,
+        )
+        assert "/report.md" in ok
+
+        # Own session dir: accepted.
+        ok_own = _resolve_sandbox_path(
+            str(session_ws / "x.txt"),
+            ws,
+            sb,
+            session_files_dir=session_ws,
+        )
+        assert "x.txt" in ok_own
+
+        # Other session dir: still rejected — isolation red line.
+        with pytest.raises(PermissionError, match="isolation"):
+            _resolve_sandbox_path(
+                str(other_session / "secret.md"),
+                ws,
+                sb,
+                session_files_dir=session_ws,
+            )
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_session_isolation_check_noop_without_session_files_dir(self, tmp_path):
+        """When session_files_dir is None (no session isolation), the
+        sessions/ dir is treated like any other workspace subdir."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        sb = _make_wsl_sandbox()
+        ok = _resolve_sandbox_path(
+            str(ws / "sessions" / "x" / "files" / "f.txt"),
+            ws,
+            sb,
+        )
+        assert "f.txt" in ok
+
 
 # ── _sandbox_to_host_path ────────────────────────────────────────────────
 


### PR DESCRIPTION
### **User description**
## 类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

本地 Skill 前置索引：桌面运行时每轮注入本地技能清单到系统提示词，用户消息点名技能时预载 SKILL.md 正文，修复模型误报"没有名为 xxx 的现成 Agent"。

## 背景/问题

**现象**：用户自然语言请求本地已安装的 Skill（如 `mof-synthesis-price-agent`）时，模型在规划阶段误报"没有名为 xxx 的现成 Agent"。

**根因**：桌面运行时路径（`chat.send` → `RuntimeSession.submit` → `TaskRunner.handle`）从未把本地 Skill 清单注入系统提示词，模型凭训练先验否认技能存在。

## 变更内容

- **`miqi/runtime/task_runner.py`**：每轮将 workspace/builtin Skill 清单注入 system prompt，并加"先查清单、未经核查不得否认"规则；意图匹配（用户点名技能名）命中即预载完整 SKILL.md 正文；HIT/MISS 日志
- **`miqi/agent/skills.py`**：`build_skills_summary(all_skills=None)` 支持复用调用方已持有的扫描结果
- **`miqi/agent/tools/filesystem.py`**：读工具（ReadFileTool/ListDirTool）解析基准改为根 workspace，session 隔离独立检查（`session_files_dir` 参数）——修复读根 workspace 文件的 PermissionError，保留跨 session 隔离
- **测试**：技能索引注入/命中预载/日志/单次扫描单测；sandbox 隔离测试

## 日志/验证证据

```
$ uv run pytest tests/runtime/test_task_runner_skill_index.py tests/sandbox/test_wsl_sandbox_path_mapping.py -q
.................................. [100%]
34 passed in 18.29s
```

运行时日志（本地 E2E）：

```
INFO  | miqi.runtime.task_runner - skill index: HIT skill 'demo-agent' referenced in user message
DEBUG | miqi.runtime.task_runner - skill index: MISS — N skills indexed, none referenced
```

## 测试情况

- 新增：`tests/runtime/test_task_runner_skill_index.py`（清单注入、命中预载、HIT/MISS 日志、单次扫描）
- sandbox：`tests/sandbox/test_wsl_sandbox_path_mapping.py`（根 workspace 读取放行、其他 session 拒绝）
- 回归：34 passed（runtime + sandbox）

## 截图

本地 E2E 实测：AI 感知技能需求并遵循技能规范（技能感知验证见 #643 的录屏）。

## 备注

触发词增强（自然语言触发技能预载）在 #643 中跟进。


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Inject local skill inventory into system prompt, with no‑denial rule

- Match skill names in user messages (normalized) and preload full SKILL.md

- Fix sandbox read tools to resolve against root workspace while preserving per‑session isolation

- Increase event‑drain timeout in integration tests to accommodate skill scan overhead


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["UserMessage"] --> B["TaskRunner.handle"]
    B --> C["SkillsLoader.list_skills (single scan)"]
    C --> D["build_skills_summary → inject into prompt"]
    B --> E["_match_skill_intent (normalized name)"]
    E -- hit --> F["load_skill_by_path → preload SKILL.md"]
    B --> G["Effective system prompt → TurnRunner.run"]
    H["Filesystem read tools"] --> I["_resolve_sandbox_path"]
    I --> J["session_files_dir enforcement (isolation)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task_runner.py</strong><dd><code>Add skill name matching and preload logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/task_runner.py

<ul><li>Introduce <code>_normalize_skill_ref</code> and <code>_match_skill_intent</code> for name‑based <br>skill discovery<br> <li> Inject local skill inventory (<code>SkillsLoader.build_skills_summary</code>) into <br>system prompt<br> <li> Preload full SKILL.md when a matched skill is detected in the user <br>message<br> <li> Guard against empty normalized names (e.g., skill dir <code>---</code> ) that would <br>otherwise match every message</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+128/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>skills.py</strong><dd><code>Support path‑based skill loading and scan reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/agent/skills.py

<ul><li>Add <code>load_skill_by_path</code> to load a skill’s content from its indexed path <br>(avoids name‑based lookup for nested built‑ins)<br> <li> Extend <code>build_skills_summary</code> with optional <code>all_skills</code> parameter to <br>reuse a single scan per turn</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-471dba4e296c4c858342f613776b8a057c8cfe3ac6a33d0917eba9ede2cabb94">+25/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filesystem.py</strong><dd><code>Fix sandbox read‑tool path resolution and session isolation</code></dd></summary>
<hr>

miqi/agent/tools/filesystem.py

<ul><li>Extend <code>_canonicalize_wsl_mnt_path</code> with <code>session_files_dir</code> for <br>per‑session isolation enforcement<br> <li> Update <code>_resolve_sandbox_path</code> to accept <code>session_files_dir</code> and propagate <br>it through WSL /mnt/ path handling<br> <li> Read tools (<code>ReadFileTool</code>, <code>ListDirTool</code>) now resolve paths against the <br>root workspace and enforce session isolation via <code>session_files_dir</code><br> <li> Catch <code>PermissionError</code> when a path belongs to another session and hide <br>the resolved path in error messages</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+57/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_runner_skill_index.py</strong><dd><code>Add unit tests for skill index injection and matching</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/runtime/test_task_runner_skill_index.py

<ul><li>New test module covering skill injection, name‑based matching, and <br>SKILL.md preload<br> <li> Verify inventory injection, no‑denial rule, separator normalization, <br>HIT/MISS logging<br> <li> Ensure single scan per turn and proper rejection of separator‑only <br>skill names</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-ec3b539cf4891bbf3cd89950b61ee15bba0e036547ecdb231869eb5d63153faa">+237/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_wsl_sandbox_path_mapping.py</strong><dd><code>Test sandbox session‑isolation enforcement with root‑workspace reads</code></dd></summary>
<hr>

tests/sandbox/test_wsl_sandbox_path_mapping.py

<ul><li>Add test for reading root workspace files when session isolation is <br>active<br> <li> Verify that own session directory is still allowed and other session <br>access is denied<br> <li> Test that session‑isolation check is a no‑op when <code>session_files_dir</code> is <br>None</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-78b5181b165bbad81de1a66f652928946f7591f6e7749456c67ac45e78d80c0b">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_runner_history_integration.py</strong><dd><code>Widen event‑drain timeout for skill scan overhead</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/runtime/test_task_runner_history_integration.py

<ul><li>Increase <code>next_event</code> timeout from 2s to 15s in all integration tests<br> <li> Prevents timing races caused by ~2.2s skill‑inventory scan at the <br>start of each turn</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/642/files#diff-fec032b026b079d1fb451c8bc37ac8081e4fe678fa0158dd124d0f6a4a5db0e6">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

