### PR TITLE
fix(desktop): dev 模式按 checkout 隔离 Chromium userData（#647）

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { inspect } from 'util';
+import { createHash } from 'node:crypto';
 import { electron } from '../shared/electron';
 import { registerIpcHandlers } from './ipc';
 import { BridgeManager } from './bridge';
@@ -138,6 +139,19 @@ export function main(): void {
     writeMainProcessLog('ERROR', formatLogArgs(args), bridgeManager?.getProjectRoot());
     safeConsoleWrite(originalConsoleError, args);
   };
+
+  // ── Dev-mode cache isolation ──────────────────────────────────────
+  // 多 checkout 并行开发（如 ziti 与 539 工作区）时，各实例共享同一个
+  // Chromium userData（%APPDATA%\miqi-desktop），会互相踩缓存：启动时
+  // disk_cache / Gpu Cache Creation failed 报错、前端 localStorage 串味
+  // （会话/配置互相覆盖）。开发模式下按仓库绝对路径 hash 出独立子目录
+  // （%APPDATA%\miqi-desktop-dev\ws-<hash>），每个工作区各用各的缓存。
+  // 打包版保持默认行为（单安装目录，无多实例问题）。
+  if (!app.isPackaged) {
+    const repoRoot = join(__dirname, '../../..');
+    const wsHash = createHash('md5').update(repoRoot).digest('hex').slice(0, 8);
+    app.setPath('userData', join(app.getPath('appData'), 'miqi-desktop-dev', `ws-${wsHash}`));
+  }
 
   app.whenReady().then(() => {
     bridgeManager = new BridgeManager();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -149,7 +149,7 @@ export function main(): void {
   // 打包版保持默认行为（单安装目录，无多实例问题）。
   if (!app.isPackaged) {
     const repoRoot = join(__dirname, '../../..');
-    const wsHash = createHash('md5').update(repoRoot).digest('hex').slice(0, 8);
+    const wsHash = createHash('sha256').update(repoRoot).digest('hex').slice(0, 16);
     app.setPath('userData', join(app.getPath('appData'), 'miqi-desktop-dev', `ws-${wsHash}`));
   }
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

开发模式下按 checkout 隔离 Chromium userData，修复多实例并行开发时的缓存互踩。

## 背景/问题

同时跑多个 MiQi dev 实例（不同 checkout，如 ziti 与 539 工作区）时，Electron 默认 userData 均为 %APPDATA%\miqi-desktop，实例间互相踩 Chromium 缓存：

- 现象：第二个启动的实例出现 disk_cache / Gpu Cache Creation failed 报错；localStorage（会话、UI 偏好、登录态）被另一实例覆盖
- 根因：dev 模式未隔离 userData，多个 Electron 实例竞争同一缓存目录
- 影响：报错随机（取决于启动顺序），易误判为代码 bug

## 变更内容

- apps/desktop/src/main/index.ts（+15 行）：开发模式（!app.isPackaged）下，取仓库绝对路径 sha256 前 16 位，userData 设为 %APPDATA%\miqi-desktop-dev\ws-<hash>；打包版保持默认行为
- 业务数据 ~/.miqi/（配置/会话/workspace）不受影响——隔离仅针对 Chromium 缓存层

## 日志/验证证据
```
修复前（多实例并行启动，第二个实例报错）：
[12188:0804/103251.278:ERROR:disk_cache_util.cc(231)] Unable to create cache
[12188:0804/103251.278:ERROR:gpu_process_host.cc(1018)] Gpu process crashed!
Gpu Cache Creation failed

修复后（隔离目录生成，报错消失）：
%APPDATA%\miqi-desktop-dev\ws-35e58e7c7d03fd1c\   ← 539 工作区（路径绑定，稳定）
%APPDATA%\miqi-desktop-dev\ws-<其他hash>\          ← 其他 checkout 各自独立
```

## 测试情况

- tsc -p tsconfig.node.json：零新增错误（4 个为 develop 基线）
- 本地验证：hash 目录正确生成（539 工作区 → ws-35e58e7c7d03fd1c）
- 多实例并行启动：GPU/磁盘缓存报错消失，各自独立 Cache/GPUCache/localStorage

## 截图

无需截图（无 UI 变更，属 Electron 主进程启动配置）


___

### **PR Type**
Bug fix


___

### **Description**
- Isolate Chromium userData per dev workspace using SHA-256 hash

- Prevent disk_cache and GPU cache creation errors on multi-instance dev

- Avoid localStorage cross-contamination between checkouts

- No change to packaged builds behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App is not packaged?"] -- "yes" --> B["Compute SHA-256 of repo root path"]
  B --> C["Set userData path to miqi-desktop-dev/ws-hash"]
  A -- "no" --> D["Use default userData path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Isolate Chromium userData in dev mode for multi-instance safety</code></dd></summary>
<hr>

apps/desktop/src/main/index.ts

<ul><li>Imports <code>createHash</code> from <code>node:crypto</code><br> <li> In dev mode (<code>!app.isPackaged</code>), computes SHA-256 hash of the repository <br>root path (16 hex chars)<br> <li> Sets <code>userData</code> path to <code>%APPDATA%\miqi-desktop-dev\ws-<hash></code> to isolate <br>Chromium caches per checkout<br> <li> Preserves default behavior for packaged builds</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/648/files#diff-5bf7db7b15749c034541a4a70a0cacf9816b4e214fd11cb5735c5ddb7ca4b1d8">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

