### PR TITLE
fix(desktop): 修复 develop typecheck 4 个类型错误（bridge timeout / WEB_CHECK_URL / WSL execFile input）(#652)

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -854,7 +854,7 @@ export class BridgeManager extends EventEmitter {
     };
 
     return new Promise((resolve, reject) => {
-      let timeout: ReturnType<typeof setTimeout>;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       const timeoutMessage =
         timeoutMode === 'inactivity'
           ? `Request ${method} timed out after ${timeoutMs}ms without bridge events`

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1,5 +1,5 @@
 import { electron } from '../../shared/electron';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
@@ -1685,6 +1685,38 @@ for m in ("pydantic", "httpx", "loguru"):
 
   const execFileAsync = promisify(execFile);
 
+  /** promisified spawn with stdin input — execFile's options don't accept
+   *  `input`, but the WSL search probe feeds a bash script via stdin. */
+  const spawnWithInput = (
+    cmd: string,
+    args: string[],
+    opts: { input?: string; timeout?: number } = {},
+  ): Promise<{ stdout: string }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(cmd, args, { windowsHide: true });
+      let stdout = '';
+      const timer = setTimeout(() => {
+        child.kill();
+        reject(new Error(`spawn ${cmd} timed out`));
+      }, opts.timeout ?? 10_000);
+      child.stdout?.on('data', (d: Buffer) => {
+        stdout += d.toString('utf8');
+      });
+      // Keep the stderr pipe drained so a chatty probe can't deadlock the child.
+      child.stderr?.on('data', () => {});
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve({ stdout });
+        else reject(new Error(`spawn ${cmd} exited ${code}`));
+      });
+      if (opts.input) child.stdin.write(opts.input);
+      child.stdin.end();
+    });
+
   async function findFileInWsl(
     relPath: string
   ): Promise<{ wslAbsPath: string; distro: string } | null> {
@@ -1722,9 +1754,9 @@ for m in ("pydantic", "httpx", "loguru"):
 
     for (const distro of distros) {
       try {
-        const { stdout } = await execFileAsync('wsl.exe', ['-d', distro, '--', 'bash'], {
-          ...execOpts,
+        const { stdout } = await spawnWithInput('wsl.exe', ['-d', distro, '--', 'bash'], {
           input: searchScript,
+          timeout: execOpts.timeout,
         });
         if (stdout?.trim()) return { wslAbsPath: stdout.trim(), distro };
       } catch {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -96,6 +96,9 @@ export const IPC = {
   FILES_OPEN_CONTAINING_FOLDER: 'files:openContainingFolder',
   DOCUMENTS_PARSE: 'documents:parse',
 
+  // Web URL HEAD-check (查看来源 dead-link 过滤)
+  WEB_CHECK_URL: 'web:checkUrl',
+
   // Python check
   PYTHON_CHECK: 'python:check',
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 develop 分支 `npm run typecheck` 的 4 个 TypeScript 类型错误（bridge.ts timeout 未赋值 ×2、ipc/index.ts WEB_CHECK_URL 缺失 + execFile `input` 选项不合法）。

## 背景/问题

develop 最新代码（#637 等）引入 4 个 tsc 错误：`bridge.ts` 的 `clearTimeout(timeout)` 在 `let timeout;` 未初始化时被引用（TS2454 ×2）；`ipc/index.ts` 使用了不存在的 `IPC.WEB_CHECK_URL` 常量（TS2339）；`execFileAsync` 的 options 传了仅 `execFileSync`/`spawn` 支持的 `input` 字段（TS2769）。CI（desktop-ci.yml）只跑 vitest 不跑 typecheck，因此一直未被发现（issue #652）。

## 变更内容

- `apps/desktop/src/shared/ipc.ts`：补上缺失的 `WEB_CHECK_URL: 'web:checkUrl'` 常量（handler 已注册，通道名与 renderer 侧约定一致）
- `apps/desktop/src/main/bridge.ts`：`let timeout` 声明补 `| undefined`——`clearTimeout` 接受 undefined，运行时行为不变（armTimeout 总在 clearTimeout 前调用）
- `apps/desktop/src/main/ipc/index.ts`：新增 `spawnWithInput`（promisified spawn，支持 stdin input + 超时 + stderr 排空），替换 WSL 文件搜索探测里非法的 `execFileAsync(..., { input })` 调用——`input` 语义保持（bash 脚本经 stdin 喂给 wsl.exe）

## 日志/验证证据

```
修复前（develop 24e9094c）：
$ npm run typecheck
src/main/bridge.ts(895,22): error TS2454: Variable 'timeout' is used before being assigned.
src/main/bridge.ts(909,22): error TS2454: Variable 'timeout' is used before being assigned.
src/main/ipc/index.ts(344,22): error TS2339: Property 'WEB_CHECK_URL' does not exist ...
src/main/ipc/index.ts(1727,11): error TS2769: No overload matches this call. (execFile options 不接受 'input')

修复后：
$ npm run typecheck   → exit 0（typecheck:node + typecheck:web 全部通过）
```

## 测试情况

- `npm run typecheck`：0 错误（修复前 4 个）
- vitest：134 passed（9 个测试文件），无回归
- WSL 探测路径：`spawnWithInput` 与原 `execFileAsync + input` 语义一致（stdin 喂脚本），仅实现方式从 execFile 改为 spawn

## 截图

无需截图（纯类型/主进程内部改动，无 UI 变化）。


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `timeout` uninitialized variable error in `bridge.ts` by adding `| undefined`

- Add missing `WEB_CHECK_URL` constant to IPC dictionary in `ipc.ts`

- Replace illegal `execFile` `input` option with `spawnWithInput` helper for WSL file search

- Drain stderr in new spawn helper to prevent deadlocks during probe


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Typecheck errors (develop branch)"] --> B["bridge.ts: timeout used before assigned"]
  A --> C["ipc/index.ts: WEB_CHECK_URL missing"]
  A --> D["ipc/index.ts: execFile input illegal"]
  B --> E["Add <code>| undefined</code> to timeout type"]
  C --> F["Add <code>WEB_CHECK_URL</code> to IPC constants"]
  D --> G["Create <code>spawnWithInput</code> helper, replace <code>execFile</code>"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bridge.ts</strong><dd><code>Fix timeout variable type in bridge.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/main/bridge.ts

<ul><li>Add <code>| undefined</code> to <code>timeout</code> declaration to prevent TS2454 error<br> <li> <code>clearTimeout</code> accepts undefined, preserving runtime behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/653/files#diff-3831bb05dca22108d2c79dd6107f2c6f0c8d74feb31aa38f0b33c2e7048a5b5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Replace execFile with spawn for WSL file search input</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/main/ipc/index.ts

<ul><li>Import <code>spawn</code> from <code>child_process</code><br> <li> Add <code>spawnWithInput</code> promisified helper supporting stdin and timeout<br> <li> Replace illegal <code>execFileAsync</code> call with <code>spawnWithInput</code> for WSL file <br>search<br> <li> Drain stderr to avoid potential deadlocks</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/653/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ipc.ts</strong><dd><code>Add missing WEB_CHECK_URL IPC constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/shared/ipc.ts

<ul><li>Add <code>WEB_CHECK_URL: 'web:checkUrl'</code> constant to IPC channel map<br> <li> Resolves TS2339 error where the constant was missing</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/653/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

