### PR TITLE
fix(desktop): 未配置 API Key 时提示准确错误并引导去设置配置 (#617)

### DIFF
--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeUiMessage } from './sanitizeUiMessage';
+
+describe('sanitizeUiMessage', () => {
+  it('maps a wrapped NO_API_KEY chat:send failure to a provider-config hint, not a runtime error (#617)', () => {
+    const wrapped =
+      "Error invoking remote method 'chat:send': No API key configured — set one in Settings > Models (NO_API_KEY)";
+    expect(sanitizeUiMessage(wrapped)).toBe('未配置 API Key，请前往 设置 > 模型 配置后再试。');
+  });
+
+  it('maps the raw backend no-api-key message', () => {
+    expect(
+      sanitizeUiMessage('No API key configured. Set one in your config file under the providers section.')
+    ).toBe('未配置 API Key，请前往 设置 > 模型 配置后再试。');
+  });
+
+  it('maps no_api_key code appended to the message', () => {
+    expect(sanitizeUiMessage("No API key configured (NO_API_KEY)")).toBe(
+      '未配置 API Key，请前往 设置 > 模型 配置后再试。'
+    );
+  });
+
+  it('keeps mapping genuine bridge-down signals to the runtime hint', () => {
+    expect(sanitizeUiMessage('Bridge not running')).toBe('运行时未启动或正在重启，请稍后再试。');
+    expect(
+      sanitizeUiMessage("Error invoking remote method 'chat:send': Bridge process exited")
+    ).toBe('运行时未启动或正在重启，请稍后再试。');
+    expect(
+      sanitizeUiMessage("Error invoking remote method 'chat:send': Bridge stopped — request cancelled")
+    ).toBe('运行时未启动或正在重启，请稍后再试。');
+  });
+
+  it('does NOT mask other chat:send failures as a runtime problem (#617)', () => {
+    const rateLimited =
+      "Error invoking remote method 'chat:send': 429 Too Many Requests (RATE_LIMITED)";
+    expect(sanitizeUiMessage(rateLimited)).toContain('429');
+    expect(sanitizeUiMessage(rateLimited)).not.toContain('运行时未启动');
+  });
+
+  it('maps turn-in-progress errors', () => {
+    expect(sanitizeUiMessage('A turn is already in progress')).toBe(
+      '上一个任务还在进行中，请稍候片刻或新开一个会话。'
+    );
+  });
+
+  it('maps provider test / connection / timeout errors', () => {
+    expect(sanitizeUiMessage('provider test failed')).toBe(
+      '连接测试失败，请检查 API Key、API Base、模型名称或网络。'
+    );
+    expect(sanitizeUiMessage('Connection error: refused')).toBe(
+      '连接模型服务失败，请检查网络或 API Base。'
+    );
+    expect(sanitizeUiMessage('Request chat.send timed out after 30000ms')).toBe(
+      '请求超时，请稍后重试。'
+    );
+  });
+
+  it('still strips paths, URLs and long tokens from unknown errors', () => {
+    const raw =
+      'Error invoking remote method \'chat:send\': boom at C:\\Users\\test\\data.json https://example.com/api token' +
+      'A'.repeat(48);
+    const out = sanitizeUiMessage(raw);
+    expect(out).toContain('[path]');
+    expect(out).toContain('[url]');
+    expect(out).toContain('[token]');
+  });
+});

--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
@@ -42,9 +42,29 @@ export function sanitizeUiMessage(raw: string): string {
   if (lower.includes('turn is already in progress') || lower.includes('turn_in_progress')) {
     return '上一个任务还在进行中，请稍候片刻或新开一个会话。';
   }
+  // Missing/invalid provider credential — must be checked BEFORE the bridge
+  // checks: Electron wraps every chat:send failure as "Error invoking remote
+  // method 'chat:send': …", so the real cause would otherwise be swallowed and
+  // misreported as a runtime problem (#617).
+  if (
+    lower.includes('no api key') ||
+    lower.includes('no_api_key') ||
+    lower.includes('api key not configured')
+  ) {
+    return '未配置 API Key，请前往 设置 > 模型 配置后再试。';
+  }
+  // Only treat genuine bridge-down signals as "runtime not started". The
+  // generic "error invoking remote method 'chat:send'" prefix appears on ANY
+  // chat:send failure (provider errors, rate limits, …) and must not be used
+  // as a bridge-down signal by itself (#617).
   if (
     lower.includes('bridge not running') ||
-    lower.includes("error invoking remote method 'chat:send'")
+    lower.includes('bridge is not running') ||
+    lower.includes('bridge process exited') ||
+    lower.includes('bridge process error') ||
+    lower.includes('bridge initialization failed') ||
+    lower.includes('bridge stopped') ||
+    lower.includes('bridge restarted')
   ) {
     return '运行时未启动或正在重启，请稍后再试。';
   }


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

未配置 API Key 时发送消息，界面不再误报"运行时未启动或正在重启"，改为准确提示未配置 API Key 并引导前往 设置 > 模型 配置。

## 背景/问题

Issue #617（P0）：未配置任何 API Key 时发送消息，界面红色提示"运行时未启动或正在重启，请稍后再试。"，而 bridge 日志实际错误是 `No API key configured`，bridge 进程本身运行正常。

**根因**：`apps/desktop/src/renderer/lib/sanitizeUiMessage.ts` 中，Electron 会把任何 `chat:send` 失败包装成 `Error invoking remote method 'chat:send': <真实错误>`。原代码把包含该前缀的消息一律映射为"运行时未启动或正在重启"——但该前缀出现在**所有** `chat:send` 失败上（NO_API_KEY、限流、模型 404 等），真实错误在显示前就被吞掉，误导用户以为是 bridge 崩溃。

## 变更内容

- `apps/desktop/src/renderer/lib/sanitizeUiMessage.ts`：
  1. 新增 NO_API_KEY 分支（在 bridge 判断之前）：匹配 `no api key` / `no_api_key` / `api key not configured` → 提示「未配置 API Key，请前往 设置 > 模型 配置后再试。」。该文案含 `api key`，会被 `ChatConsole.isProviderConfigurationProblem` 识别，渲染带「去配置模型」按钮的错误气泡，点击直达 Settings > Models。
  2. 收窄 bridge-down 判断：移除过宽的 `error invoking remote method 'chat:send'` 匹配，仅对真正的 bridge 信号（`bridge not running` / `bridge process exited` / `bridge stopped` 等）提示"运行时未启动"；其他 `chat:send` 失败（限流、模型错误等）不再被误报。
- `apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts`（新增）：8 个单测覆盖上述映射。

## 日志/验证证据

```
$ npx vitest run src/renderer/lib/sanitizeUiMessage.test.ts
 ✓ src/renderer/lib/sanitizeUiMessage.test.ts (8 tests) 6ms

 Test Files  1 passed (1)
      Tests  8 passed (8)

$ npx vitest run
 Test Files  11 passed (11)
      Tests  151 passed (151)

# 修复前（#617 原始日志，bridge 实际正常）：
# [WARNING] [bridge] miqi.runtime.app_server:dispatch:376 | AppServer: error dispatching chat.send ... : No API key configured — set one in Settings > Models
# 界面却显示：运行时未启动或正在重启，请稍后再试。
```

## 测试情况

- 新增 `sanitizeUiMessage.test.ts` 8 用例全部通过：NO_API_KEY（IPC 包装 / 原始后端消息 / `(NO_API_KEY)` 后缀）→ 配置提示；真实 bridge 故障（`Bridge not running`、`Bridge process exited`、`Bridge stopped`）→ 运行时提示；429 限流等其他 `chat:send` 失败不再被掩码；turn-in-progress / provider test / connection / timeout 映射不变；路径/URL/token 脱敏不变。
- 全量 `npx vitest run`：11 个文件 151 个测试全部通过。
- `npm run typecheck` 无新增错误（`src/main/ipc/index.ts`、`src/main/bridge.ts` 的 4 个错误为 develop 上已存在，与本次改动无关）。

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/7118c54c-82ff-4cda-b18c-963f6b9a7b68" />


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Detect missing API key: show specific error message guiding to Settings > Models instead of misleading "runtime not started".

- Narrow bridge-down detection: only treat genuine bridge signals as runtime errors, preventing false positives for other `chat:send` failures.

- Add unit tests: verify correct mapping for NO_API_KEY, rate limiting, bridge-down, turn-in-progress, and provider connection errors.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw wrapped error (chat:send)"] --> B["sanitizeUiMessage"]
  B --> C{"Contains 'no api key'?"}
  C -- yes --> D["Show: '未配置 API Key，请前往 设置 > 模型 配置后再试。'"]
  C -- no --> E{"Contains genuine bridge-down signal?"}
  E -- yes --> F["Show: '运行时未启动或正在重启，请稍后再试。'"]
  E -- no --> G["Show sanitized generic error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitizeUiMessage.ts</strong><dd><code>Refine error message mapping for missing API key and bridge-down </code><br><code>signals</code></dd></summary>
<hr>

apps/desktop/src/renderer/lib/sanitizeUiMessage.ts

<ul><li>Add early check for "no api key" patterns and return a user-friendly <br>message with a configuration hint.<br> <li> Narrow the bridge-down condition to match only genuine bridge signals <br>(e.g., "bridge not running", "bridge process exited"), removing the <br>overbroad "Error invoking remote method 'chat:send'" catch-all.<br> <li> Keep sanitization for unknown errors (paths, URLs, tokens) intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/654/files#diff-a91242fe31e4015b97b1b409d59f1a6e24ea988c7045e914fcc503413661ff5f">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitizeUiMessage.test.ts</strong><dd><code>Add unit tests for sanitizeUiMessage error mapping (#617)</code></dd></summary>
<hr>

apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts

<ul><li>Add test for wrapped and raw NO_API_KEY errors mapping to the <br>provider-config hint.<br> <li> Verify that genuine bridge-down signals still return the runtime hint.<br> <li> Ensure other chat:send failures (e.g., rate limiting) are not masked <br>as runtime problems.<br> <li> Test turn-in-progress and provider connection/timeout error mappings.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/654/files#diff-e56b0a0947b344fe8277b0f101969d77a4031f654285195d78e66ab6c5bce993">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

