### PR TITLE
fix(desktop): 点“+”复用空会话，不无限创建空会话（#615 回归修复）

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -73,6 +73,15 @@ function AppShell() {
   const [workspace, setWorkspace] = useState<string | null>(null);
   const [newSessionTrigger, setNewSessionTrigger] = useState(0);
   const pendingWorkspace = useRef<{ sessionKey: string; workspace: string } | null>(null);
+  // #615: guards for the "+" reuse-empty-session check — a lock prevents
+  // re-entrancy (double-click), the ref prevents acting on a stale request
+  // after the user already switched sessions mid-check.
+  const newSessionLockRef = useRef(false);
+  const sessionKeyRef = useRef(sessionKey);
+
+  useEffect(() => {
+    sessionKeyRef.current = sessionKey;
+  }, [sessionKey]);
 
   // Persist last active session so the app restores it on next launch
   useEffect(() => {
@@ -129,10 +138,37 @@ function AppShell() {
     try { localStorage.setItem('miqi:configReady', 'true'); } catch { /* ignore */ }
   };
 
-  const handleNewSession = () => {
+  const handleNewSession = async () => {
+    if (newSessionLockRef.current) return;
     if (activeNav !== 'chat') setActiveNav('chat');
-    // Pass through to ChatConsole's workspace picker via trigger counter
-    setNewSessionTrigger((k) => k + 1);
+    const requestedKey = sessionKey;
+    newSessionLockRef.current = true;
+    try {
+      // #615: reuse the current session when it has no real messages on disk
+      // — do NOT spawn endless empty sessions (regressed by the #577 rewrite).
+      // Query the backend (source of truth) instead of frontend state.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const detail = await Promise.race([
+            window.miqi.sessions.get(requestedKey),
+            new Promise<never>((_, reject) =>
+              setTimeout(() => reject(new Error('sessions.get timeout')), 1500)
+            ),
+          ]);
+          if (sessionKeyRef.current !== requestedKey) return; // switched mid-check
+          if (detail && Array.isArray(detail.messages) && detail.messages.length > 0) {
+            setNewSessionTrigger((k) => k + 1); // real conversation → create new session
+          }
+          return; // empty → reuse current session (stay on the chat page)
+        } catch {
+          if (sessionKeyRef.current !== requestedKey) return;
+          if (attempt < 2) await new Promise((r) => setTimeout(r, 250 * (attempt + 1)));
+        }
+      }
+      // Bridge unavailable — fall back to reuse, never to endless empty sessions.
+    } finally {
+      newSessionLockRef.current = false;
+    }
   };
 
   const handleSessionCreated = (newKey: string, workspace?: string | null) => {


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #615 回归：点「+」时若当前会话无真实消息则**复用当前会话**，不再无限创建空会话。

## 背景/问题

#615（8/6 提出）：侧边栏「+」每次点击都生成新的 `desktop:<timestamp>` session key，即使当前会话没有任何对话也会不断新建空会话，聊天区域反复重置。

原修复 #618（`f55331d3`，**8/7 合入**）实现"空会话复用"：点「+」时查询 `sessions.get`，磁盘无消息则复用当前会话。

**回归根因**：#577（workspace picker 重构，`7d77c6ad`，**8/8 合入**）整函数重写 `handleNewSession` 为 `setNewSessionTrigger(k+1)` → ChatConsole effect 直接 `createSession(null)` 无条件新建。git 合并时无冲突（整函数替换被当作干净覆盖），#618 的复用逻辑被**静默删除**，#615 回归（issue 的 `incomplete` 标签佐证）。

## 变更内容

`apps/desktop/src/renderer/App.tsx`：

- `handleNewSession` 恢复"空会话复用"检查（保留 #577 的 trigger 机制）：
  1. 点「+」→ 查询后端 `sessions.get`（磁盘真实消息为准，1.5s 超时 ×3 重试，bridge 冷启动兼容）
  2. 当前会话 `messages.length === 0`（或 bridge 不可用）→ **复用**：只切回聊天页，不新建、不重置
  3. 有真实消息 → `setNewSessionTrigger` 走原有新建链路
- 新增 `newSessionLockRef` 防双击重入；`sessionKeyRef` 防检查中途用户切换会话导致 stale 请求生效（#618 同款保护）

## 日志/验证证据

```
# 验证（本地 dev，App.tsx HMR 后）：
# 空会话连点「+」→ 聊天区不重置、不产生新 session key（复用）
# 发消息后点「+」→ 正常新建会话

# 回归证据链（git）：
# f55331d3 (8/7)  #618 修复：#618 的 handleNewSession = async + sessions.get 判空复用
# 7d77c6ad  (8/8)  #577 重构：重写 handleNewSession = setNewSessionTrigger(k+1)，复用逻辑消失
# develop 历史（--first-parent）中 7d77c6ad 在 f55331d3 之后 → #577 合入更晚，覆盖 #618
```


> 补充：#615 此前有两个修复 PR，均被 #577 覆盖——#614（8/6，第一版，前端状态判断 + `shouldCreateNewSession` helper）→ #618（8/7，第二版，重做：改后端 `sessions.get` 磁盘判断，删掉 #614 的 helper/测试）。本 PR 恢复的是第二版（#618）的后端判断逻辑（更可靠），并额外加了双击锁与 stale 请求保护。

## 测试情况

- `tsc --noEmit -p tsconfig.web.json`：0 错误
- `vitest run` 全量：143/143 通过
- backend pytest（流程性，未改 Python）：2748 passed, 20 skipped
- E2E 不涉及（`session-rename` 等 spec 不受影响；macOS E2E 稳定性修复见 #655）

## 截图

无需截图（行为修复，无 UI 变更）。


___

### **PR Type**
Bug fix


___

### **Description**
- Restore backend emptiness check before new session creation

- Add lock and stale-request guard for concurrent clicks

- Reuse current session if empty; create new only with messages

- Fix regression from workspace picker rewrite (#577)


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Click '+'"] --> Lock["Check re-entrancy lock"]
  Lock --> Fetch["Query sessions.get (timeout + retry)"]
  Fetch --> Stale{"Session still current?"}
  Stale -- No --> Abort["Abort (stale request)"]
  Stale -- Yes --> Check{"Has messages?"}
  Check -- Yes --> Create["Trigger new session"]
  Check -- No --> Reuse["Reuse current session"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Restore empty-session reuse check and add concurrency guards</code></dd></summary>
<hr>

apps/desktop/src/renderer/App.tsx

<ul><li>Add async backend query for current session messages with timeout and <br>retries<br> <li> Implement newSessionLockRef and sessionKeyRef to avoid re-entrancy and <br>stale responses<br> <li> Reuse current session if the backend returns no messages; otherwise <br>trigger new session creation</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/656/files#diff-4b03b04efb7537be2e18ba0418bc81886c910207148cec6f9e92c88208fc58dd">+39/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

