### PR TITLE
fix(sandbox): P0 稳定性 — stop() 真杀流式子进程 + 状态文件自愈（#472）

### DIFF
--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -148,6 +148,11 @@ class BwrapCommandHandle:
     async def kill(self) -> None:
         """Kill the running command.
 
+        No-op when the process has already exited and been reaped: killing
+        the stale process group is both pointless and dangerous — its pgid
+        (the group-leader pid) may have been recycled for an unrelated
+        process group, and `killpg` would signal innocent processes (#472).
+
         On native Linux, tries SIGTERM then SIGKILL against the process group
         (bwrap creates a PID namespace but the outer bwrap process itself is
         in the process group created with ``start_new_session=True``).
@@ -158,6 +163,8 @@ class BwrapCommandHandle:
 
         After calling this, call :meth:`cleanup` to release temporary resources.
         """
+        if self._process.returncode is not None:
+            return
         if self._pgid is not None:
             # Native Linux — kill the process group (bwrap + children)
             try:

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1701,6 +1701,30 @@ class BwrapSandbox:
             return await BwrapSandbox._find_bwrap_native() is not None
 
     @staticmethod
+    async def _communicate_or_kill(
+        proc: asyncio.subprocess.Process, timeout: float = 15.0
+    ) -> bytes:
+        """``communicate()`` with a timeout; on timeout kill + await the process.
+
+        A timed-out ``rm``/``test`` subprocess would otherwise keep running as
+        an orphaned WSL wrapper — exactly what this PR is meant to eliminate.
+        """
+        try:
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            return stderr
+        except asyncio.TimeoutError:
+            logger.warning("Sandbox subprocess timed out — killing it")
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                pass
+            raise
+
+    @staticmethod
     async def _rm_rf_retry(linux_dir: str, wsl_distro: str = "") -> bool:
         """Remove a directory tree with retries and post-delete verification.
 
@@ -1728,7 +1752,7 @@ class BwrapSandbox:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=15.0)
+                stderr_bytes = await BwrapSandbox._communicate_or_kill(proc)
                 if proc.returncode != 0:
                     logger.warning(
                         "rm -rf {} failed (attempt {}/3): {}",
@@ -1743,13 +1767,17 @@ class BwrapSandbox:
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
-                    await asyncio.wait_for(check.communicate(), timeout=15.0)
+                    await BwrapSandbox._communicate_or_kill(check)
                     if check.returncode != 0:
                         return True
                     logger.warning(
                         "rm -rf {} reported success but path still exists (attempt {}/3)",
                         linux_dir, attempt + 1,
                     )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "rm -rf {} timed out (attempt {}/3)", linux_dir, attempt + 1
+                )
             except Exception as exc:
                 logger.warning(
                     "rm -rf {} failed (attempt {}/3): {}", linux_dir, attempt + 1, exc
@@ -1759,7 +1787,10 @@ class BwrapSandbox:
         logger.warning("Failed to remove {} after 3 attempts", linux_dir)
         return False
 
-    async def cleanup_dir(linux_dir: str, wsl_distro: str = "") -> bool:
+    @staticmethod
+    async def cleanup_dir(
+        linux_dir: str, wsl_distro: str = "", expected_root: str = ""
+    ) -> bool:
         """Remove a sandbox directory from the Linux/WSL filesystem.
 
         This is used by SandboxManager to clean up stale sandboxes from
@@ -1768,6 +1799,10 @@ class BwrapSandbox:
         Args:
             linux_dir: Absolute path inside Linux/WSL to remove.
             wsl_distro: WSL distribution name (auto-detect if empty).
+            expected_root: The configured sandbox root (native ``sandbox_base_dir``
+                or WSL ``wsl_base_dir``).  When provided, ``linux_dir`` must be
+                at or below this root (boundary-safe); when empty, the legacy
+                fixed-prefix guard is applied instead.
 
         Returns:
             True if the directory is gone, False if cleanup failed.
@@ -1776,13 +1811,22 @@ class BwrapSandbox:
             logger.warning("Refusing to cleanup non-absolute path: {}", linux_dir)
             return False
 
-        # Safety: only allow paths under known sandbox prefixes
-        _ALLOWED_PREFIXES = ("/tmp/miqi-sandboxes/", "/tmp/miqi-sandbox")
-        if not any(linux_dir.startswith(p) for p in _ALLOWED_PREFIXES):
-            logger.warning(
-                "Refusing to cleanup path outside allowed prefixes: {}", linux_dir
-            )
-            return False
+        if expected_root:
+            root = expected_root.rstrip("/")
+            if not (linux_dir == root or linux_dir.startswith(root + "/")):
+                logger.warning(
+                    "Refusing to cleanup path outside expected root {}: {}",
+                    root, linux_dir,
+                )
+                return False
+        else:
+            # Legacy guard — only allow paths under known sandbox prefixes
+            _ALLOWED_PREFIXES = ("/tmp/miqi-sandboxes/", "/tmp/miqi-sandbox")
+            if not any(linux_dir.startswith(p) for p in _ALLOWED_PREFIXES):
+                logger.warning(
+                    "Refusing to cleanup path outside allowed prefixes: {}", linux_dir
+                )
+                return False
 
         ok = await BwrapSandbox._rm_rf_retry(linux_dir, wsl_distro)
         if ok:

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -1080,28 +1080,26 @@ class BwrapSandbox:
         """Stop any running bwrap process and clean up sandbox directories."""
         self._running = False
 
-        # Clean up any streaming handles not manually cleaned up
+        # Kill any streaming commands still running, then release their temp
+        # resources.  Previously this only called cleanup() (script-file
+        # removal), leaving the wsl.exe → bash → bwrap process chain alive
+        # when a long-running command was in flight — the real source of
+        # orphan WSL processes after stop() (#472).
         for handle in getattr(self, '_streaming_handles', []):
+            try:
+                await handle.kill()
+            except Exception:
+                pass
             try:
                 await handle.cleanup()
             except Exception:
                 pass
         self._streaming_handles = []
 
-        # Kill any running process
-        if self._process and self._process.returncode is None:
-            try:
-                self._process.kill()
-                await asyncio.wait_for(self._process.wait(), timeout=5.0)
-            except (asyncio.TimeoutError, ProcessLookupError):
-                pass
-            self._process = None
-
-        # Clean up sandbox filesystem inside Linux/WSL
-        rc, _, err = await self._run_linux_command(
-            f"rm -rf '{self._linux_base_dir}'"
-        )
-        if rc == 0:
+        # Clean up sandbox filesystem inside Linux/WSL — retry + verify the
+        # directory is actually gone so failures surface instead of silently
+        # leaking disk (#472).
+        if await BwrapSandbox._rm_rf_retry(self._linux_base_dir, self._detected_distro):
             logger.info("Sandbox cleaned up: {}", self._linux_base_dir)
             append_workspace_log(
                 self._log_workspace,
@@ -1110,10 +1108,10 @@ class BwrapSandbox:
                 source="sandbox",
             )
         else:
-            logger.warning("Failed to clean sandbox {}: {}", self._linux_base_dir, err)
+            logger.warning("Failed to clean sandbox {}", self._linux_base_dir)
             append_workspace_log(
                 self._log_workspace,
-                f"Sandbox cleanup failed session={self.session_key} error={err}",
+                f"Sandbox cleanup failed session={self.session_key} path={self._linux_base_dir}",
                 level="WARNING",
                 source="sandbox",
             )
@@ -1703,7 +1701,65 @@ class BwrapSandbox:
             return await BwrapSandbox._find_bwrap_native() is not None
 
     @staticmethod
-    async def cleanup_dir(linux_dir: str, wsl_distro: str = "") -> None:
+    async def _rm_rf_retry(linux_dir: str, wsl_distro: str = "") -> bool:
+        """Remove a directory tree with retries and post-delete verification.
+
+        ``rm -rf`` can fail transiently in WSL (file locks, slow tmpfs, the
+        WSL server momentarily restarting); retry with exponential backoff
+        (0.5s/1s/2s, 3 attempts) and confirm the path is actually gone before
+        reporting success.  Paths are passed as argv (never through a shell),
+        so there is no quoting-injection surface (#472).
+        """
+        if _is_windows():
+            distro = wsl_distro
+            if not distro:
+                distro = await BwrapSandbox._detect_wsl_distro() or ""
+            if not distro:
+                logger.warning("No WSL distro available for cleanup of {}", linux_dir)
+                return False
+            prefix = ["wsl.exe", "-d", distro, "--"]
+        else:
+            prefix = []
+
+        for attempt in range(3):
+            try:
+                proc = await _create_subprocess_exec(
+                    *prefix, "rm", "-rf", linux_dir,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=15.0)
+                if proc.returncode != 0:
+                    logger.warning(
+                        "rm -rf {} failed (attempt {}/3): {}",
+                        linux_dir, attempt + 1,
+                        stderr_bytes.decode("utf-8", errors="replace").strip(),
+                    )
+                else:
+                    # Verify the path is actually gone — test -e returns 0 if it
+                    # still exists, so success means "removed".
+                    check = await _create_subprocess_exec(
+                        *prefix, "test", "-e", linux_dir,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    await asyncio.wait_for(check.communicate(), timeout=15.0)
+                    if check.returncode != 0:
+                        return True
+                    logger.warning(
+                        "rm -rf {} reported success but path still exists (attempt {}/3)",
+                        linux_dir, attempt + 1,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "rm -rf {} failed (attempt {}/3): {}", linux_dir, attempt + 1, exc
+                )
+            if attempt < 2:
+                await asyncio.sleep(0.5 * (2 ** attempt))
+        logger.warning("Failed to remove {} after 3 attempts", linux_dir)
+        return False
+
+    async def cleanup_dir(linux_dir: str, wsl_distro: str = "") -> bool:
         """Remove a sandbox directory from the Linux/WSL filesystem.
 
         This is used by SandboxManager to clean up stale sandboxes from
@@ -1712,10 +1768,13 @@ class BwrapSandbox:
         Args:
             linux_dir: Absolute path inside Linux/WSL to remove.
             wsl_distro: WSL distribution name (auto-detect if empty).
+
+        Returns:
+            True if the directory is gone, False if cleanup failed.
         """
         if not linux_dir or not linux_dir.startswith("/"):
             logger.warning("Refusing to cleanup non-absolute path: {}", linux_dir)
-            return
+            return False
 
         # Safety: only allow paths under known sandbox prefixes
         _ALLOWED_PREFIXES = ("/tmp/miqi-sandboxes/", "/tmp/miqi-sandbox")
@@ -1723,38 +1782,14 @@ class BwrapSandbox:
             logger.warning(
                 "Refusing to cleanup path outside allowed prefixes: {}", linux_dir
             )
-            return
+            return False
 
-        if _is_windows():
-            # Run via WSL
-            distro = wsl_distro
-            if not distro:
-                distro = await BwrapSandbox._detect_wsl_distro() or ""
-            if not distro:
-                logger.warning("No WSL distro available for cleanup of {}", linux_dir)
-                return
-            prefix = ["wsl.exe", "-d", distro, "--"]
+        ok = await BwrapSandbox._rm_rf_retry(linux_dir, wsl_distro)
+        if ok:
+            logger.debug("Cleaned up directory: {}", linux_dir)
         else:
-            prefix = []
-
-        try:
-            process = await _create_subprocess_exec(
-                *prefix, "rm", "-rf", linux_dir,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(), timeout=15.0
-            )
-            if process.returncode == 0:
-                logger.debug("Cleaned up directory: {}", linux_dir)
-            else:
-                stderr = stderr_bytes.decode("utf-8", errors="replace")
-                logger.warning(
-                    "Failed to cleanup {}: {}", linux_dir, stderr.strip()
-                )
-        except Exception as exc:
-            logger.warning("Failed to cleanup {}: {}", linux_dir, exc)
+            logger.warning("Failed to cleanup {} after retries", linux_dir)
+        return ok
 
     @property
     def is_running(self) -> bool:

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -29,6 +29,7 @@ Usage:
     await manager.destroy("feishu:oc_123")
 """
 
+import asyncio
 import json
 import os
 import tempfile
@@ -40,7 +41,7 @@ from typing import Any
 
 from loguru import logger
 
-from miqi.sandbox.bwrap import BwrapSandbox, BwrapSandboxError
+from miqi.sandbox.bwrap import BwrapSandbox, BwrapSandboxError, _create_subprocess_exec, _is_windows
 
 
 class SandboxManager:
@@ -160,19 +161,77 @@ class SandboxManager:
         except Exception as exc:
             logger.warning("Failed to save sandbox state: {}", exc)
 
-    def _load_state(self) -> dict[str, Any] | None:
+    def _load_state(self) -> tuple[dict[str, Any] | None, bool]:
         """Read the persisted sandbox state from disk.
 
-        Returns the parsed JSON payload, or None if no valid state file exists.
+        Returns a ``(state, damaged)`` tuple:
+        - ``state``: the parsed JSON payload, or None if no state exists.
+        - ``damaged``: True when a state file exists but could not be parsed
+          (corrupt / truncated).  Callers should rebuild from a filesystem
+          scan instead of trusting the file (#472).
         """
         if not self._state_file.exists():
-            return None
+            return None, False
         try:
             with open(self._state_file, encoding="utf-8") as f:
-                return json.load(f)
+                return json.load(f), False
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to read sandbox state: {}", exc)
-            return None
+            return None, True
+
+    async def _cleanup_orphan_scan(self) -> int:
+        """Scan the sandbox base dir for leftover sandbox directories.
+
+        Used when the state file is missing or corrupt: instead of trusting
+        the (possibly lost) registration, enumerate whatever is under the
+        sandbox base dir in Linux/WSL and remove every entry.  This closes
+        the "orphan directory lost from state" leak (#472).
+        """
+        if _is_windows():
+            distro = self.wsl_distro
+            if not distro:
+                distro = await BwrapSandbox._detect_wsl_distro() or ""
+            if not distro:
+                logger.warning("No WSL distro available for orphan scan")
+                return 0
+            proc = await _create_subprocess_exec(
+                "wsl.exe", "-d", distro, "--", "sh", "-c",
+                f"ls -d {self.wsl_base_dir}/*/ 2>/dev/null || true",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        else:
+            proc = await _create_subprocess_exec(
+                "sh", "-c",
+                f"ls -d {self.sandbox_base_dir}/*/ 2>/dev/null || true",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        try:
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except asyncio.TimeoutError:
+            logger.warning("Sandbox orphan scan timed out")
+            proc.kill()
+            return 0
+
+        dirs = [
+            line.rstrip("/").strip()
+            for line in out.decode("utf-8", errors="replace").splitlines()
+            if line.strip()
+        ]
+        cleaned = 0
+        for linux_dir in dirs:
+            try:
+                if await BwrapSandbox.cleanup_dir(linux_dir, self.wsl_distro):
+                    cleaned += 1
+                    logger.info("Orphan scan cleaned sandbox: {}", linux_dir)
+                else:
+                    logger.warning("Orphan scan failed to remove: {}", linux_dir)
+            except Exception as exc:
+                logger.warning("Orphan scan error on {}: {}", linux_dir, exc)
+        if cleaned:
+            logger.info("Sandbox orphan scan complete: {} removed", cleaned)
+        return cleaned
 
     async def cleanup_stale(self) -> int:
         """Clean up sandbox directories left from a previous bridge run.
@@ -182,7 +241,22 @@ class SandboxManager:
 
         Returns the number of stale sandboxes cleaned up.
         """
-        state = self._load_state()
+        state, damaged = self._load_state()
+        if damaged:
+            # Corrupt state file — the registered entries are unrecoverable.
+            # Rebuild from a filesystem scan so orphaned directories are not
+            # permanently lost, then drop the corrupt file (#472).
+            logger.warning(
+                "Sandbox state file corrupt — falling back to directory scan"
+            )
+            cleaned = await self._cleanup_orphan_scan()
+            try:
+                if self._state_file.exists():
+                    self._state_file.unlink()
+            except OSError as exc:
+                logger.warning("Failed to remove corrupt state file: {}", exc)
+            return cleaned
+
         if state is None:
             return 0
 
@@ -193,6 +267,7 @@ class SandboxManager:
             return 0
 
         cleaned = 0
+        failures = 0
         for entry in entries:
             linux_base_dir = entry.get("linux_base_dir")
             if not linux_base_dir:
@@ -200,23 +275,37 @@ class SandboxManager:
 
             # Use BwrapSandbox's static cleanup helper
             try:
-                await BwrapSandbox.cleanup_dir(
+                if await BwrapSandbox.cleanup_dir(
                     linux_base_dir,
                     wsl_distro=self.wsl_distro,
-                )
-                cleaned += 1
-                logger.info(
-                    "Cleaned up stale sandbox: {} ({})",
-                    entry.get("session_key", "?"), linux_base_dir,
-                )
+                ):
+                    cleaned += 1
+                    logger.info(
+                        "Cleaned up stale sandbox: {} ({})",
+                        entry.get("session_key", "?"), linux_base_dir,
+                    )
+                else:
+                    failures += 1
+                    logger.warning(
+                        "Failed to clean stale sandbox {} ({})",
+                        entry.get("session_key", "?"), linux_base_dir,
+                    )
             except Exception as exc:
+                failures += 1
                 logger.warning(
                     "Failed to clean stale sandbox {}: {}",
                     entry.get("session_key", "?"), exc,
                 )
 
-        # Clear the state file — all listed sandboxes have been handled
-        self._clear_state_file()
+        if failures == 0:
+            # All listed sandboxes handled — safe to drop the state file.
+            self._clear_state_file()
+        else:
+            # Keep the state file so failed directories are retried on the
+            # next startup instead of being silently forgotten (#472).
+            logger.warning(
+                "{} stale sandbox(s) failed cleanup — state kept for retry", failures
+            )
         logger.info("Stale sandbox cleanup complete: {} removed", cleaned)
         return cleaned
 

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -161,31 +161,61 @@ class SandboxManager:
         except Exception as exc:
             logger.warning("Failed to save sandbox state: {}", exc)
 
+    @staticmethod
+    def _validate_state(data: Any) -> bool:
+        """Validate the loaded sandbox state schema.
+
+        Requires a top-level dict, a ``sandboxes`` list, and a non-empty
+        ``linux_base_dir`` string on every entry.  A syntactically-valid file
+        with the wrong shape (e.g. ``[]``) is treated as damaged so callers
+        fall back to orphan recovery instead of crashing or skipping cleanup.
+        """
+        if not isinstance(data, dict):
+            return False
+        entries = data.get("sandboxes")
+        if not isinstance(entries, list):
+            return False
+        for entry in entries:
+            if not isinstance(entry, dict):
+                return False
+            base = entry.get("linux_base_dir")
+            if not isinstance(base, str) or not base:
+                return False
+        return True
+
     def _load_state(self) -> tuple[dict[str, Any] | None, bool]:
         """Read the persisted sandbox state from disk.
 
         Returns a ``(state, damaged)`` tuple:
         - ``state``: the parsed JSON payload, or None if no state exists.
         - ``damaged``: True when a state file exists but could not be parsed
-          (corrupt / truncated).  Callers should rebuild from a filesystem
-          scan instead of trusting the file (#472).
+          (corrupt / truncated / schema-invalid).  Callers should rebuild from
+          a filesystem scan instead of trusting the file (#472).
         """
         if not self._state_file.exists():
             return None, False
         try:
             with open(self._state_file, encoding="utf-8") as f:
-                return json.load(f), False
+                data = json.load(f)
+            if not SandboxManager._validate_state(data):
+                logger.warning("Sandbox state file has invalid schema")
+                return None, True
+            return data, False
         except (json.JSONDecodeError, OSError) as exc:
             logger.warning("Failed to read sandbox state: {}", exc)
             return None, True
 
-    async def _cleanup_orphan_scan(self) -> int:
+    async def _cleanup_orphan_scan(self) -> tuple[int, bool]:
         """Scan the sandbox base dir for leftover sandbox directories.
 
         Used when the state file is missing or corrupt: instead of trusting
         the (possibly lost) registration, enumerate whatever is under the
         sandbox base dir in Linux/WSL and remove every entry.  This closes
         the "orphan directory lost from state" leak (#472).
+
+        Returns ``(cleaned, completed)`` — ``completed`` is False when the
+        scan itself could not run (WSL unavailable, timeout) or when any
+        removal failed, so callers know not to drop the damaged state file.
         """
         if _is_windows():
             distro = self.wsl_distro
@@ -193,17 +223,16 @@ class SandboxManager:
                 distro = await BwrapSandbox._detect_wsl_distro() or ""
             if not distro:
                 logger.warning("No WSL distro available for orphan scan")
-                return 0
+                return 0, False
             proc = await _create_subprocess_exec(
-                "wsl.exe", "-d", distro, "--", "sh", "-c",
-                f"ls -d {self.wsl_base_dir}/*/ 2>/dev/null || true",
+                "wsl.exe", "-d", distro, "--",
+                "find", self.wsl_base_dir, "-mindepth", "1", "-maxdepth", "1", "-type", "d",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
         else:
             proc = await _create_subprocess_exec(
-                "sh", "-c",
-                f"ls -d {self.sandbox_base_dir}/*/ 2>/dev/null || true",
+                "find", str(self.sandbox_base_dir), "-mindepth", "1", "-maxdepth", "1", "-type", "d",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -211,27 +240,42 @@ class SandboxManager:
             out, _ = await asyncio.wait_for(proc.communicate(), timeout=20.0)
         except asyncio.TimeoutError:
             logger.warning("Sandbox orphan scan timed out")
-            proc.kill()
-            return 0
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                pass
+            return 0, False
 
-        dirs = [
-            line.rstrip("/").strip()
-            for line in out.decode("utf-8", errors="replace").splitlines()
-            if line.strip()
-        ]
+        dirs = [line.strip() for line in out.decode("utf-8", errors="replace").splitlines() if line.strip()]
         cleaned = 0
+        completed = True
         for linux_dir in dirs:
             try:
-                if await BwrapSandbox.cleanup_dir(linux_dir, self.wsl_distro):
+                if await BwrapSandbox.cleanup_dir(
+                    linux_dir, self.wsl_distro,
+                    expected_root=self._sandbox_root(),
+                ):
                     cleaned += 1
                     logger.info("Orphan scan cleaned sandbox: {}", linux_dir)
                 else:
+                    completed = False
                     logger.warning("Orphan scan failed to remove: {}", linux_dir)
             except Exception as exc:
+                completed = False
                 logger.warning("Orphan scan error on {}: {}", linux_dir, exc)
         if cleaned:
             logger.info("Sandbox orphan scan complete: {} removed", cleaned)
-        return cleaned
+        return cleaned, completed
+
+    def _sandbox_root(self) -> str:
+        """The expected sandbox root for cleanup validation (native or WSL)."""
+        if _is_windows():
+            return self.wsl_base_dir
+        return str(self.sandbox_base_dir)
 
     async def cleanup_stale(self) -> int:
         """Clean up sandbox directories left from a previous bridge run.
@@ -245,16 +289,23 @@ class SandboxManager:
         if damaged:
             # Corrupt state file — the registered entries are unrecoverable.
             # Rebuild from a filesystem scan so orphaned directories are not
-            # permanently lost, then drop the corrupt file (#472).
+            # permanently lost.  Only drop the corrupt file when the scan
+            # actually completed; otherwise keep it so the next startup
+            # retries instead of silently forgetting the orphans (#472).
             logger.warning(
                 "Sandbox state file corrupt — falling back to directory scan"
             )
-            cleaned = await self._cleanup_orphan_scan()
-            try:
-                if self._state_file.exists():
-                    self._state_file.unlink()
-            except OSError as exc:
-                logger.warning("Failed to remove corrupt state file: {}", exc)
+            cleaned, completed = await self._cleanup_orphan_scan()
+            if completed:
+                try:
+                    if self._state_file.exists():
+                        self._state_file.unlink()
+                except OSError as exc:
+                    logger.warning("Failed to remove corrupt state file: {}", exc)
+            else:
+                logger.warning(
+                    "Orphan scan incomplete — keeping corrupt state file for retry"
+                )
             return cleaned
 
         if state is None:
@@ -278,6 +329,7 @@ class SandboxManager:
                 if await BwrapSandbox.cleanup_dir(
                     linux_base_dir,
                     wsl_distro=self.wsl_distro,
+                    expected_root=self._sandbox_root(),
                 ):
                     cleaned += 1
                     logger.info(

--- a/tests/sandbox/test_sandbox_stability.py
+++ b/tests/sandbox/test_sandbox_stability.py
@@ -382,3 +382,43 @@ async def test_cleanup_dir_respects_expected_root(monkeypatch):
         await BwrapSandbox.cleanup_dir("/etc/passwd", expected_root="/data/sandboxes")
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_kill_noop_after_process_reaped(monkeypatch):
+    """kill() on an already-reaped process must not signal the stale pgid —
+    the pgid may have been recycled for an unrelated process group (#472)."""
+    from miqi.sandbox.bwrap import BwrapCommandHandle
+
+    handle = BwrapCommandHandle(_fake_proc(0), pgid=999)
+    import os as _os
+
+    killpg = MagicMock()
+    monkeypatch.setattr(_os, "killpg", killpg, raising=False)
+    terminate = MagicMock()
+    monkeypatch.setattr(handle._process, "terminate", terminate)
+
+    await handle.kill()
+
+    killpg.assert_not_called()
+    terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_kill_signals_pgid_while_running(monkeypatch):
+    """kill() on a running process (returncode None) still signals the pgid."""
+    from miqi.sandbox.bwrap import BwrapCommandHandle
+
+    import signal as _signal
+
+    proc = _fake_proc(None)  # still running
+    handle = BwrapCommandHandle(proc, pgid=999)
+    import os as _os
+
+    killpg = MagicMock()
+    monkeypatch.setattr(_os, "killpg", killpg, raising=False)
+    proc.wait = AsyncMock(return_value=0)
+
+    await handle.kill()
+
+    killpg.assert_called_once_with(999, _signal.SIGTERM)

--- a/tests/sandbox/test_sandbox_stability.py
+++ b/tests/sandbox/test_sandbox_stability.py
@@ -136,6 +136,27 @@ async def test_load_state_valid_file(tmp_path):
     assert state == {"sandboxes": []}
 
 
+@pytest.mark.asyncio
+async def test_load_state_invalid_schema_treated_as_damaged(tmp_path):
+    """A syntactically valid but schema-invalid file (e.g. `[]`) must be
+    treated as damaged so orphan recovery runs instead of crashing on
+    state.get(...) (CodeRabbit)."""
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text("[]", encoding="utf-8")
+    state, damaged = m._load_state()
+    assert state is None
+    assert damaged is True
+
+    # malformed entry (missing linux_base_dir) also counts as damaged
+    m._state_file.write_text(
+        json.dumps({"sandboxes": [{"session_key": "x"}]}), encoding="utf-8"
+    )
+    state, damaged = m._load_state()
+    assert state is None
+    assert damaged is True
+
+
 # ── cleanup_stale: self-healing ──────────────────────────────────────────
 
 @pytest.mark.asyncio
@@ -144,14 +165,31 @@ async def test_cleanup_stale_corrupt_state_uses_orphan_scan(tmp_path, monkeypatc
     m._state_file.parent.mkdir(parents=True, exist_ok=True)
     m._state_file.write_text("{corrupt", encoding="utf-8")
 
-    scan = AsyncMock(return_value=2)
+    scan = AsyncMock(return_value=(2, True))
     monkeypatch.setattr(m, "_cleanup_orphan_scan", scan)
 
     cleaned = await m.cleanup_stale()
 
     scan.assert_awaited_once()
     assert cleaned == 2
-    assert not m._state_file.exists()  # corrupt file dropped
+    assert not m._state_file.exists()  # corrupt file dropped after complete scan
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_keeps_corrupt_state_when_scan_incomplete(tmp_path, monkeypatch):
+    """A damaged state file survives an incomplete orphan scan so the next
+    startup retries instead of forgetting the orphans (#472 / CodeRabbit)."""
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text("{corrupt", encoding="utf-8")
+
+    scan = AsyncMock(return_value=(1, False))  # cleaned 1, but incomplete
+    monkeypatch.setattr(m, "_cleanup_orphan_scan", scan)
+
+    cleaned = await m.cleanup_stale()
+
+    assert cleaned == 1
+    assert m._state_file.exists()  # kept for retry
 
 
 @pytest.mark.asyncio
@@ -196,18 +234,61 @@ async def test_cleanup_stale_clears_state_when_all_succeed(tmp_path, monkeypatch
 @pytest.mark.asyncio
 async def test_orphan_scan_removes_dirs(tmp_path, monkeypatch):
     m = _make_manager(tmp_path)
-    proc = _fake_proc(0, out=b"/tmp/miqi-sandboxes/a/\n/tmp/miqi-sandboxes/b/\n")
+    proc = _fake_proc(0, out=b"/tmp/miqi-sandboxes/a\n/tmp/miqi-sandboxes/b\n")
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
+    with patch(
+        "miqi.sandbox.manager._create_subprocess_exec",
+        return_value=proc,
+    ) as spawn, patch(
+        "miqi.sandbox.manager.BwrapSandbox.cleanup_dir",
+        AsyncMock(return_value=True),
+    ):
+        cleaned, completed = await m._cleanup_orphan_scan()
+
+    assert cleaned == 2
+    assert completed is True
+    # find is invoked via argv (no sh -c string interpolation)
+    find_call = spawn.await_args.args
+    assert "find" in find_call
+    assert "sh" not in find_call
+
+
+@pytest.mark.asyncio
+async def test_orphan_scan_incomplete_on_failed_removal(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    proc = _fake_proc(0, out=b"/tmp/miqi-sandboxes/a\n")
     monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
     with patch(
         "miqi.sandbox.manager._create_subprocess_exec",
         return_value=proc,
     ), patch(
         "miqi.sandbox.manager.BwrapSandbox.cleanup_dir",
-        AsyncMock(return_value=True),
+        AsyncMock(return_value=False),
     ):
-        cleaned = await m._cleanup_orphan_scan()
+        cleaned, completed = await m._cleanup_orphan_scan()
 
-    assert cleaned == 2
+    assert cleaned == 0
+    assert completed is False
+
+
+@pytest.mark.asyncio
+async def test_orphan_scan_timeout_kills_and_waits(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
+    with patch(
+        "miqi.sandbox.manager._create_subprocess_exec",
+        return_value=proc,
+    ):
+        cleaned, completed = await m._cleanup_orphan_scan()
+
+    assert cleaned == 0
+    assert completed is False
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited_once()
 
 
 # ── _rm_rf_retry: retry + verify ────────────────────────────────────────
@@ -246,3 +327,58 @@ async def test_rm_rf_retry_gives_up_after_3_attempts(monkeypatch):
         AsyncMock(side_effect=procs),
     )
     assert await BwrapSandbox._rm_rf_retry("/tmp/miqi-sandboxes/x") is False
+
+
+@pytest.mark.asyncio
+async def test_rm_rf_retry_timeout_kills_and_waits(monkeypatch):
+    """A timed-out rm subprocess must be killed and awaited before the retry
+    loop moves on — otherwise the WSL wrapper leaks (CodeRabbit)."""
+    timed_out = AsyncMock()
+    timed_out.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+    timed_out.kill = MagicMock()
+    timed_out.wait = AsyncMock()
+
+    ok_proc = _fake_proc(0)
+    verify_gone = _fake_proc(1)
+
+    monkeypatch.setattr("miqi.sandbox.bwrap._is_windows", lambda: False)
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap._create_subprocess_exec",
+        AsyncMock(side_effect=[timed_out, ok_proc, verify_gone]),
+    )
+
+    # attempt 1 times out (killed+awaited), attempt 2 succeeds
+    assert await BwrapSandbox._rm_rf_retry("/tmp/miqi-sandboxes/x") is True
+    timed_out.kill.assert_called_once()
+    timed_out.wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dir_respects_expected_root(monkeypatch):
+    """Paths outside the configured sandbox root are rejected; paths under it
+    pass through (CodeRabbit — no fixed /tmp allowlist)."""
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap.BwrapSandbox._rm_rf_retry", AsyncMock(return_value=True)
+    )
+
+    # custom root accepts children
+    assert (
+        await BwrapSandbox.cleanup_dir(
+            "/data/sandboxes/sess_1", expected_root="/data/sandboxes"
+        )
+        is True
+    )
+    # root itself is accepted (boundary)
+    assert (
+        await BwrapSandbox.cleanup_dir("/data/sandboxes", expected_root="/data/sandboxes")
+        is True
+    )
+    # sibling / parent / unrelated paths are rejected
+    assert (
+        await BwrapSandbox.cleanup_dir("/data/sandboxes2/sess_1", expected_root="/data/sandboxes")
+        is False
+    )
+    assert (
+        await BwrapSandbox.cleanup_dir("/etc/passwd", expected_root="/data/sandboxes")
+        is False
+    )

--- a/tests/sandbox/test_sandbox_stability.py
+++ b/tests/sandbox/test_sandbox_stability.py
@@ -1,0 +1,248 @@
+"""Unit tests for the #472 P0 sandbox stability fixes.
+
+Covers the two "止血" changes (no real WSL/bwrap needed — all subprocess
+calls are mocked):
+
+1. ``BwrapSandbox.stop()`` really kills streaming handles before cleanup
+   (previously only cleanup() ran, leaving wsl.exe -> bash -> bwrap chains
+   alive — the source of orphan WSL processes).
+2. State-file self-healing:
+   - ``_load_state`` distinguishes missing / corrupt / valid files
+   - corrupt state falls back to a directory orphan scan
+   - a failed stale-dir cleanup keeps the state file (retried next start)
+3. ``_rm_rf_retry`` retries with backoff and verifies the dir is actually gone.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from miqi.sandbox.bwrap import BwrapSandbox
+from miqi.sandbox.manager import SandboxManager
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _make_manager(tmp_path: Path) -> SandboxManager:
+    return SandboxManager(
+        workspace=tmp_path,
+        sandbox_base_dir=tmp_path / "sandboxes",
+        wsl_base_dir="/tmp/miqi-sandboxes",
+    )
+
+
+def _make_sandbox() -> BwrapSandbox:
+    """Instance without __init__ side effects (no real WSL interaction)."""
+    sb = BwrapSandbox.__new__(BwrapSandbox)
+    sb._running = True
+    sb._streaming_handles = []
+    sb._linux_base_dir = "/tmp/miqi-sandboxes/test_key"
+    sb._detected_distro = "TestDistro"
+    sb.session_key = "test_key"
+    sb._log_workspace = None
+    return sb
+
+
+def _fake_proc(returncode: int, out: bytes = b"") -> AsyncMock:
+    p = AsyncMock()
+    p.returncode = returncode
+    p.communicate = AsyncMock(return_value=(out, b""))
+    return p
+
+
+# ── stop(): kill streaming handles before cleanup ───────────────────────
+
+@pytest.mark.asyncio
+async def test_stop_kills_streaming_handles_before_cleanup(monkeypatch):
+    sb = _make_sandbox()
+    handle = MagicMock()
+    handle.kill = AsyncMock()
+    handle.cleanup = AsyncMock()
+    sb._streaming_handles = [handle]
+    monkeypatch.setattr(BwrapSandbox, "_rm_rf_retry", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap.append_workspace_log", lambda *a, **k: None
+    )
+
+    await sb.stop()
+
+    handle.kill.assert_awaited_once()
+    handle.cleanup.assert_awaited_once()
+    # kill must happen before cleanup (kill releases the process; cleanup
+    # removes the temp script file).
+    assert handle.method_calls[0] == call.kill()
+    assert handle.method_calls[1] == call.cleanup()
+    assert sb._streaming_handles == []
+
+
+@pytest.mark.asyncio
+async def test_stop_continues_cleanup_when_kill_raises(monkeypatch):
+    sb = _make_sandbox()
+    handle = MagicMock()
+    handle.kill = AsyncMock(side_effect=RuntimeError("boom"))
+    handle.cleanup = AsyncMock()
+    sb._streaming_handles = [handle]
+    monkeypatch.setattr(BwrapSandbox, "_rm_rf_retry", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap.append_workspace_log", lambda *a, **k: None
+    )
+
+    await sb.stop()  # must not raise
+
+    handle.cleanup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_reports_rm_failure(monkeypatch):
+    sb = _make_sandbox()
+    monkeypatch.setattr(BwrapSandbox, "_rm_rf_retry", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap.append_workspace_log", lambda *a, **k: None
+    )
+
+    await sb.stop()  # must not raise; failure is logged, not silent
+
+
+# ── _load_state: missing / corrupt / valid ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_load_state_missing_file(tmp_path):
+    m = _make_manager(tmp_path)
+    state, damaged = m._load_state()
+    assert state is None
+    assert damaged is False
+
+
+@pytest.mark.asyncio
+async def test_load_state_corrupt_file(tmp_path):
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text("{ not valid json !!!", encoding="utf-8")
+    state, damaged = m._load_state()
+    assert state is None
+    assert damaged is True
+
+
+@pytest.mark.asyncio
+async def test_load_state_valid_file(tmp_path):
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text(json.dumps({"sandboxes": []}), encoding="utf-8")
+    state, damaged = m._load_state()
+    assert damaged is False
+    assert state == {"sandboxes": []}
+
+
+# ── cleanup_stale: self-healing ──────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_corrupt_state_uses_orphan_scan(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text("{corrupt", encoding="utf-8")
+
+    scan = AsyncMock(return_value=2)
+    monkeypatch.setattr(m, "_cleanup_orphan_scan", scan)
+
+    cleaned = await m.cleanup_stale()
+
+    scan.assert_awaited_once()
+    assert cleaned == 2
+    assert not m._state_file.exists()  # corrupt file dropped
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_keeps_state_on_failure(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text(
+        json.dumps({"sandboxes": [{"linux_base_dir": "/tmp/miqi-sandboxes/a"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.BwrapSandbox.cleanup_dir",
+        AsyncMock(return_value=False),
+    )
+
+    cleaned = await m.cleanup_stale()
+
+    assert cleaned == 0
+    # State file kept so the failed dir is retried next startup (#472).
+    assert m._state_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stale_clears_state_when_all_succeed(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    m._state_file.parent.mkdir(parents=True, exist_ok=True)
+    m._state_file.write_text(
+        json.dumps({"sandboxes": [{"linux_base_dir": "/tmp/miqi-sandboxes/a"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.BwrapSandbox.cleanup_dir",
+        AsyncMock(return_value=True),
+    )
+
+    cleaned = await m.cleanup_stale()
+
+    assert cleaned == 1
+    assert not m._state_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_orphan_scan_removes_dirs(tmp_path, monkeypatch):
+    m = _make_manager(tmp_path)
+    proc = _fake_proc(0, out=b"/tmp/miqi-sandboxes/a/\n/tmp/miqi-sandboxes/b/\n")
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
+    with patch(
+        "miqi.sandbox.manager._create_subprocess_exec",
+        return_value=proc,
+    ), patch(
+        "miqi.sandbox.manager.BwrapSandbox.cleanup_dir",
+        AsyncMock(return_value=True),
+    ):
+        cleaned = await m._cleanup_orphan_scan()
+
+    assert cleaned == 2
+
+
+# ── _rm_rf_retry: retry + verify ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rm_rf_retry_success(monkeypatch):
+    # rm succeeds (rc=0), then test -e fails (rc=1) -> path gone -> True
+    procs = [_fake_proc(0), _fake_proc(1)]
+    monkeypatch.setattr("miqi.sandbox.bwrap._is_windows", lambda: False)
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap._create_subprocess_exec",
+        AsyncMock(side_effect=procs),
+    )
+    assert await BwrapSandbox._rm_rf_retry("/tmp/miqi-sandboxes/x") is True
+
+
+@pytest.mark.asyncio
+async def test_rm_rf_retry_retries_then_succeeds(monkeypatch):
+    # rm fails once (rc=2), then succeeds (rc=0), verify gone (test rc=1)
+    procs = [_fake_proc(2), _fake_proc(0), _fake_proc(1)]
+    monkeypatch.setattr("miqi.sandbox.bwrap._is_windows", lambda: False)
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap._create_subprocess_exec",
+        AsyncMock(side_effect=procs),
+    )
+    assert await BwrapSandbox._rm_rf_retry("/tmp/miqi-sandboxes/x") is True
+
+
+@pytest.mark.asyncio
+async def test_rm_rf_retry_gives_up_after_3_attempts(monkeypatch):
+    # rm always fails -> False after 3 attempts
+    procs = [_fake_proc(2), _fake_proc(2), _fake_proc(2)]
+    monkeypatch.setattr("miqi.sandbox.bwrap._is_windows", lambda: False)
+    monkeypatch.setattr(
+        "miqi.sandbox.bwrap._create_subprocess_exec",
+        AsyncMock(side_effect=procs),
+    )
+    assert await BwrapSandbox._rm_rf_retry("/tmp/miqi-sandboxes/x") is False


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

#472 P0 止血：`stop()` 真正杀死流式子进程（消除孤儿 WSL 进程链）+ 沙箱状态文件自愈（损坏重建、失败保留、rm -rf 重试校验）。

## 背景/问题

#472 审计（评论区 7/30 结论）定位沙箱稳定性真问题集中在"收尾"：

- **问题 1（最严重）**：`stop()` 对 streaming handles 只调 `cleanup()`（删脚本文件），不 `kill()`；`self._process` 死代码块（start 从未赋值）永不执行 → session 后台长命令（`wsl.exe → bash → bwrap` 链）在归档/淘汰/销毁时**不杀进程**，`--die-with-parent` 因 bash 未死而失效 → 孤儿 WSL 进程直到 bridge 重启。
- **问题 2**：`_load_state` 无法区分"无文件/损坏"；损坏时 `cleanup_stale` 直接 return，孤儿目录与 state 永久失联；单条清理失败仍无条件清 state → 残留目录从登记中抹掉，永久泄漏；`rm -rf` 无重试无校验。

## 变更内容

`miqi/sandbox/bwrap.py`：
- `stop()`：对每个 streaming handle **先 `await handle.kill()` 再 `cleanup()`**；删除从不执行的 `self._process` 死代码块；目录删除改用 `_rm_rf_retry`。
- 新增 `_rm_rf_retry()`：指数退避重试 3 次（0.5s/1s/2s）+ 删除后 `test -e` 校验路径确实消失；argv 传参（无 shell）无注入面。
- `cleanup_dir()`：改用 `_rm_rf_retry`，返回 `bool` 让调用方感知失败。

`miqi/sandbox/manager.py`：
- `_load_state()` → 返回 `(state, damaged)` 三态（缺失/损坏/正常）。
- 损坏时降级 `_cleanup_orphan_scan()`：直接扫描 sandbox base dir 枚举残留目录逐个清理（不再依赖可能丢失的登记），并删除损坏 state 文件。
- `cleanup_stale()`：单条失败不再无条件清 state，**保留文件下次启动重试**；全部成功才清。

`tests/sandbox/test_sandbox_stability.py`（新增 13 个用例，mock 子进程无需真实 WSL）：
- stop 对 handle kill 先于 cleanup / kill 抛异常仍 cleanup / rm 失败仅告警
- _load_state 三态 / 损坏时 orphan scan / 失败保留 state / 全成功清 state / orphan scan 枚举清理
- _rm_rf_retry 成功 / 重试后成功 / 3 次放弃

## 日志/验证证据

```
# 本地验证（Windows + WSL 环境）
$ PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/sandbox/test_sandbox_stability.py -q
  13 passed          # 新增 P0 单测

$ PYTHONPATH=. .venv/Scripts/python.exe -m pytest tests/sandbox/ tests/execution/ -q
  463 passed in 290.25s   # 全量沙箱 + execution 回归

# 修复前行为（代码审查确认）：
# stop() → handle.cleanup() 仅删脚本文件；self._process 恒为 None → 杀进程块死代码
# _load_state 损坏 → cleanup_stale return 0 → 孤儿目录永久失联
```

## 测试情况

- 新增 13 个纯逻辑单测（mock `_create_subprocess_exec`/`_is_windows`，跨平台可跑）全过
- `tests/sandbox/` + `tests/execution/`：463 passed 无回归
- 未改前端，vitest 不受影响

## 截图

无需截图（后端稳定性修复）。

## 后续（本 PR 不含，按 #472 审计 P1-P3 分 PR 推进）

- P1：LRU 驱逐替代 FIFO、`_creating` 看门狗、`_install_lock` 上提
- P2：`health_check()` + degraded 标记、结构化指标（参考 xai-grok-sandbox 的 SandboxEvent 模式）
- P3：并发/驱逐/故障注入单测补全


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- `stop()` kills streaming handles before cleanup, eliminating orphan WSL process chains.

- State file self-healing: corrupt state triggers orphan directory scan, retains file on incomplete cleanup.

- `_rm_rf_retry()` with exponential backoff, post-delete `test -e` verification, and no-shell argv.

- `cleanup_dir()` gains `expected_root` boundary check and returns success boolean.

- New `_communicate_or_kill()` helper ensures timed-out subprocesses are properly killed.

- 13 new unit tests cover stop, state healing, orphan scan, retry, and boundary scenarios.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  stop["stop()"] --> kill_handles["kill streaming handles"]
  kill_handles --> cleanup_handles["cleanup temp scripts"]
  stop --> rm_dir["retry+verify directory removal"]
  state_file["state file"] --> load_state["_load_state"]
  load_state --> missing["missing"]
  load_state --> valid["valid"]
  load_state --> damaged["damaged/corrupt"]
  damaged --> orphan_scan["orphan directory scan"]
  orphan_scan --> cleanup["cleanup each dir"]
  cleanup --> keep_state["keep state on failure"]
  orphan_scan --> rm_state["delete state on complete"]
  rm_rf["_rm_rf_retry"] --> backoff["exponential backoff (0.5/1/2s)"]
  rm_rf --> verify["test -e verification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bwrap.py</strong><dd><code>Kill streaming handles in stop(), retry+verify rm -rf, root boundary </code><br><code>check</code></dd></summary>
<hr>

miqi/sandbox/bwrap.py

<ul><li>Added early return in <code>kill()</code> when process already reaped to avoid <br>signaling recycled pgid.<br> <li> Modified <code>stop()</code> to kill each streaming handle before cleanup, <br>preventing orphan WSL processes.<br> <li> Removed dead <code>self._process</code> code block that never executed.<br> <li> Implemented <code>_rm_rf_retry()</code> with three attempts, exponential backoff, <br>and post-delete <code>test -e</code> verification.<br> <li> Added <code>_communicate_or_kill()</code> helper to kill timed-out subprocesses.<br> <li> Updated <code>cleanup_dir()</code> to accept <code>expected_root</code> boundary check and <br>return bool.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/657/files#diff-d7d5a8260ce597977133c8f4a9bd8e5de7698df9a1fc925cdcc8e22aee7cdb2b">+140/-54</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manager.py</strong><dd><code>State file self-healing with orphan scan and failure retention</code></dd></summary>
<hr>

miqi/sandbox/manager.py

<ul><li><code>_load_state()</code> now returns a <code>(state, damaged)</code> tuple to distinguish <br>missing/corrupt/valid.<br> <li> Added <code>_validate_state()</code> for schema validation of loaded state.<br> <li> Implemented <code>_cleanup_orphan_scan()</code> to recover orphan directories from <br>corrupt state.<br> <li> <code>cleanup_stale()</code> delegates to orphan scan on damaged state, and retains <br>state file on failures.<br> <li> Added <code>_sandbox_root()</code> to supply expected root for cleanup boundary.<br> <li> State file is only deleted when all stale directories are successfully <br>cleaned.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/657/files#diff-4ba4fb086c91c1958f0af2a0228609261cb4fdb078919a1f345c018bf3691361">+157/-16</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sandbox_stability.py</strong><dd><code>Unit tests for sandbox stability fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sandbox/test_sandbox_stability.py

<ul><li>New test file with 13 unit tests covering stop() kill-before-cleanup, <br>state loading, orphan scan, rm -rf retry, and boundary checks.<br> <li> Tests stop() order of operations and exception handling, state <br>corruption fallback, orphan scan timeout, cleanup_dir root validation, <br>and process reaped kill guard.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/657/files#diff-26e825492cd2aa3f4c75433202404028975888925bf13cc0cd06e57b96e7084c">+424/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

