### PR TITLE
fix(desktop): AI 流式回复期间允许提前输入并支持中断重发（#542）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1455,7 +1455,11 @@ const TURN_ABORT_SETTLE_MS = 3000;
 /** Fallback for aborted events WITHOUT a turn_id (legacy/mock bridges): a
  *  stale aborted event from a superseded turn arriving this soon after a new
  *  send started is dropped. Bridges that emit turn ids use the authoritative
- *  activeTurnIdRef match instead — no time window involved (#542). */
+ *  activeTurnIdRef match instead — no time window involved (#542).
+ *  LIMITATION: under this fallback, a legitimately fast backend abort of the
+ *  NEW turn within the window is also dropped, leaving streaming=true until
+ *  the 60s watchdog fires. Production bridges all emit turn ids, so this is
+ *  degradation protection, not a correctness guarantee. */
 const TURN_TERMINAL_GRACE_MS = 500;
 
 export function ChatConsole({
@@ -2455,9 +2459,11 @@ export function ChatConsole({
     const sendCleanup = () => {
       if (watchdogTimer) {
         clearInterval(watchdogTimer);
+        // Identity check BEFORE nulling the local — the shared ref may
+        // already point at a replacement turn's watchdog.
+        if (watchdogTimerRef.current === watchdogTimer) watchdogTimerRef.current = null;
         watchdogTimer = null;
       }
-      if (watchdogTimerRef.current === watchdogTimer) watchdogTimerRef.current = null;
       // NOTE: cleanupListeners() is deliberately NOT called here.
       // The typewriter completing does not mean the turn is over —
       // another final may still arrive (e.g. tool-call then final-text).
@@ -2644,6 +2650,11 @@ export function ChatConsole({
       // turn's turn_started has not arrived yet (activeTurnIdRef is null),
       // any tagged terminal event is by definition stale. The superseded
       // turn's lifecycle promise is settled by its own closure.
+      //
+      // BACKEND CONTRACT: turn_started (task_runner.py emits TurnStartedEvent
+      // before any model call) always precedes every terminal event of a turn.
+      // If that ever changes (e.g. an error emitted before turn creation),
+      // this strict-match logic silently drops the legitimate event.
       if (data.turn_id && data.turn_id !== activeTurnIdRef.current) {
         return;
       }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2639,9 +2639,12 @@ export function ChatConsole({
       if (data.session_key && data.session_key !== currentSessionRef.current) return;
       // Final from a superseded turn (e.g. a pre-abort final racing a quick
       // resend): the backend's turn id is authoritative — drop it so the
-      // replacement turn's UI state is untouched (#542). The superseded
+      // replacement turn's UI state is untouched (#542). Strict match: a
+      // tagged event must equal the active turn id; while the replacement
+      // turn's turn_started has not arrived yet (activeTurnIdRef is null),
+      // any tagged terminal event is by definition stale. The superseded
       // turn's lifecycle promise is settled by its own closure.
-      if (data.turn_id && activeTurnIdRef.current && data.turn_id !== activeTurnIdRef.current) {
+      if (data.turn_id && data.turn_id !== activeTurnIdRef.current) {
         return;
       }
       clearFinalCleanupTimer();
@@ -2780,9 +2783,8 @@ export function ChatConsole({
       if (data.session_key && data.session_key !== currentSessionRef.current) return;
       // Error from a superseded turn (e.g. an abort-induced error racing a
       // quick resend): drop it so the replacement turn's UI state is
-      // untouched (#542). The superseded turn's lifecycle promise is
-      // settled by its own closure.
-      if (data.turn_id && activeTurnIdRef.current && data.turn_id !== activeTurnIdRef.current) {
+      // untouched (#542). Strict match — see the final listener.
+      if (data.turn_id && data.turn_id !== activeTurnIdRef.current) {
         return;
       }
       streamErrorHandled = true;
@@ -2808,7 +2810,10 @@ export function ChatConsole({
       // The backend's turn id is authoritative; the grace window is only a
       // fallback for bridges that don't emit turn ids (legacy/mocks).
       if (_data.turn_id) {
-        if (activeTurnIdRef.current && _data.turn_id !== activeTurnIdRef.current) {
+        // Strict match — a tagged event must equal the active turn id; while
+        // the replacement turn's turn_started has not arrived yet (ref is
+        // null), any tagged terminal event is by definition stale.
+        if (_data.turn_id !== activeTurnIdRef.current) {
           return;
         }
       } else if (Date.now() - currentSendStartedAtRef.current < TURN_TERMINAL_GRACE_MS) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1445,6 +1445,22 @@ function extractTrackedFilesFromMessages(rawMsgs: any[]): TrackedFile[] {
 }
 
 /* ─── Main component ─────────────────────────────────────────────── */
+
+/** Upper bound for waiting on a superseded turn's chat.send to settle after
+ *  abort(). Normal aborts resolve in well under a second (the send promise
+ *  settles at the abort terminal event); the bound only guards against a
+ *  wedged backend stalling interrupt-and-resend indefinitely. */
+const TURN_ABORT_SETTLE_MS = 3000;
+
+/** Terminal events from a superseded turn arriving this soon after a new
+ *  send started are stale and dropped. The awaited-old-promise design already
+ *  consumes the superseded turn's terminal before new listeners register; this
+ *  guard only covers the bounded-timeout fallback (wedged backend). Only the
+ *  aborted event needs it — a stale final/error cannot be emitted for an
+ *  aborted turn, and gating final/error would drop a legitimately fast
+ *  terminal event of the new turn (e.g. an immediate provider error). */
+const TURN_TERMINAL_GRACE_MS = 500;
+
 export function ChatConsole({
   sessionKey = DEFAULT_SESSION,
   loadTrigger,
@@ -1650,6 +1666,22 @@ export function ChatConsole({
   const previewJustClosed = useRef(false);
   const unsubsRef = useRef<Array<() => void>>([]);
   const finalCleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Shared across handleSend closures: a new send aborts the previous turn's
+  // typewriter reveal (its RAF is closure-local and otherwise leaks a ghost
+  // assistant bubble into the next turn).
+  const revealAnimIdRef = useRef<number | null>(null);
+  // Timestamp of the newest handleSend start. A stale aborted event from a
+  // superseded turn arriving within TURN_TERMINAL_GRACE_MS of it is dropped
+  // (see the onAborted guard in handleSend).
+  const currentSendStartedAtRef = useRef(0);
+  // The live turn's watchdog interval. Shared across closures so an interrupt
+  // (handleAbort / interrupt-and-resend) can stop the superseded turn's timer —
+  // its own sendCleanup never runs because its listeners are already removed.
+  const watchdogTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // The current turn's chat.send promise. Interrupt-and-resend awaits the
+  // superseded turn's promise (which settles at its terminal event) so its
+  // terminal event is consumed before the new turn registers listeners.
+  const sendPromiseRef = useRef<Promise<unknown> | null>(null);
   const liveReasoningTsRef = useRef<number | null>(null);
   const shareFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentSessionRef = useRef(sessionKey);
@@ -2092,6 +2124,18 @@ export function ChatConsole({
 
   const handleAbort = useCallback(async () => {
     cleanupListeners();
+    if (revealAnimIdRef.current !== null) {
+      cancelAnimationFrame(revealAnimIdRef.current);
+      revealAnimIdRef.current = null;
+    }
+    if (watchdogTimerRef.current !== null) {
+      clearInterval(watchdogTimerRef.current);
+      watchdogTimerRef.current = null;
+    }
+    // The aborted turn's send promise is stale from here on — do not let a
+    // later interrupt-and-resend await it (its terminal event was already
+    // consumed by the orphan-forwarding path).
+    sendPromiseRef.current = null;
     try {
       await window.miqi.chat.abort(currentSessionRef.current);
     } catch {
@@ -2188,14 +2232,46 @@ export function ChatConsole({
     // If a reveal animation is still running from the previous response,
     // cancel it and abort the in-flight request so we can start fresh.
     if (streaming) {
+      if (revealAnimIdRef.current !== null) {
+        cancelAnimationFrame(revealAnimIdRef.current);
+        revealAnimIdRef.current = null;
+      }
+      if (watchdogTimerRef.current !== null) {
+        clearInterval(watchdogTimerRef.current);
+        watchdogTimerRef.current = null;
+      }
       cleanupListeners();
       setStreaming(false);
+      const oldSendPromise = sendPromiseRef.current;
       try {
-        await window.miqi.chat.abort();
+        // Pass the session key — without it the backend resolves no session
+        // and rejects the abort with UNAUTHORIZED, leaving the old stream
+        // running while the new turn starts.
+        await window.miqi.chat.abort(currentSessionRef.current);
       } catch {
         /* ignore */
       }
+      // Wait for the superseded turn's chat.send to settle. It resolves at
+      // that turn's terminal event (aborted/final/error), so the old turn's
+      // terminal event is consumed before the new turn registers listeners —
+      // and the backend's drain task has exited, so the new chat.send is not
+      // rejected with TURN_IN_PROGRESS. Bounded so a wedged backend cannot
+      // stall interrupt-and-resend (see TURN_ABORT_SETTLE_MS).
+      if (oldSendPromise) {
+        try {
+          await Promise.race([
+            oldSendPromise,
+            new Promise<void>((resolve) => setTimeout(resolve, TURN_ABORT_SETTLE_MS)),
+          ]);
+        } catch {
+          /* ignore */
+        }
+      }
     }
+    // Stamp this turn now (BEFORE any await below) so listeners registered
+    // later can drop terminal events from the superseded turn.
+    const sendStartedAt = Date.now();
+    currentSendStartedAtRef.current = sendStartedAt;
 
     // Generate a client-side req_id so we can abort this specific request
     const reqId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -2320,6 +2396,7 @@ export function ChatConsole({
         ];
       });
       animId = requestAnimationFrame(revealNext);
+      revealAnimIdRef.current = animId;
     };
 
     // Track last progress event time for watchdog
@@ -2351,12 +2428,14 @@ export function ChatConsole({
         appendWatchdogMsg('⚠️ 后端 60s 无响应，可中止并检查运行日志。');
       }
     }, 5_000); // check every 5s
+    watchdogTimerRef.current = watchdogTimer;
 
     const sendCleanup = () => {
       if (watchdogTimer) {
         clearInterval(watchdogTimer);
         watchdogTimer = null;
       }
+      if (watchdogTimerRef.current === watchdogTimer) watchdogTimerRef.current = null;
       // NOTE: cleanupListeners() is deliberately NOT called here.
       // The typewriter completing does not mean the turn is over —
       // another final may still arrive (e.g. tool-call then final-text).
@@ -2677,6 +2756,10 @@ export function ChatConsole({
 
     const unsubAborted = window.miqi.chat.onAborted((_data: ChatAborted) => {
       if (_data.session_key && _data.session_key !== currentSessionRef.current) return;
+      // Stale terminal event from a superseded turn: stop-then-quick-send
+      // orphans the old aborted event, which would otherwise drop
+      // streaming=false and append a spurious "已停止。" bubble mid-reply.
+      if (Date.now() - currentSendStartedAtRef.current < TURN_TERMINAL_GRACE_MS) return;
       if (animId !== null) cancelAnimationFrame(animId);
       setStreaming(false);
       setCurrentReqId(null);
@@ -2753,6 +2836,7 @@ export function ChatConsole({
         chatAttachments.length > 0 ? chatAttachments : undefined,
         workspace ?? undefined
       );
+      sendPromiseRef.current = sendPromise;
 
       // Mark as done after a tick — server parsing is synchronous, already complete
       if (sentAttachments.some((a) => a.type === 'document')) {
@@ -2774,6 +2858,7 @@ export function ChatConsole({
 
       await sendPromise;
     } catch (e: any) {
+      sendPromiseRef.current = null;
       if (animId !== null) cancelAnimationFrame(animId);
       if (streamErrorHandled) {
         setStreaming(false);
@@ -3827,7 +3912,6 @@ export function ChatConsole({
                   rows={1}
                   allowResize={true}
                   className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
-                  disabled={streaming}
                   style={{ color: 'var(--text)', fieldSizing: 'content' }}
                 />
                 {/* Icon row at the bottom — no text, like DeepSeek */}
@@ -3835,7 +3919,6 @@ export function ChatConsole({
                   <ExecutionPolicySelector
                     policy={executionPolicy}
                     onChange={setExecutionPolicy}
-                    disabled={streaming}
                     onOpenApprovals={onOpenApprovals}
                   />
                   {/* AI disclaimer — centered in the mode row, fades when typing */}
@@ -3855,7 +3938,7 @@ export function ChatConsole({
                   >
                     <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
                   </button>
-                  {streaming ? (
+                  {streaming && !input.trim() && attachments.length === 0 ? (
                     <button
                       onClick={handleAbort}
                       title="停止生成"
@@ -3868,8 +3951,8 @@ export function ChatConsole({
                     <button
                       onClick={handleSend}
                       disabled={!input.trim() && attachments.length === 0}
-                      title="发送"
-                      aria-label="发送"
+                      title={streaming ? '中断当前生成并发送' : '发送'}
+                      aria-label={streaming ? '中断当前生成并发送' : '发送'}
                       className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:brightness-110 hover:-translate-y-px active:scale-95 disabled:opacity-30 disabled:hover:brightness-100 disabled:hover:translate-y-0 disabled:shadow-none"
                       style={{
                         background:

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1452,13 +1452,10 @@ function extractTrackedFilesFromMessages(rawMsgs: any[]): TrackedFile[] {
  *  wedged backend stalling interrupt-and-resend indefinitely. */
 const TURN_ABORT_SETTLE_MS = 3000;
 
-/** Terminal events from a superseded turn arriving this soon after a new
- *  send started are stale and dropped. The awaited-old-promise design already
- *  consumes the superseded turn's terminal before new listeners register; this
- *  guard only covers the bounded-timeout fallback (wedged backend). Only the
- *  aborted event needs it — a stale final/error cannot be emitted for an
- *  aborted turn, and gating final/error would drop a legitimately fast
- *  terminal event of the new turn (e.g. an immediate provider error). */
+/** Fallback for aborted events WITHOUT a turn_id (legacy/mock bridges): a
+ *  stale aborted event from a superseded turn arriving this soon after a new
+ *  send started is dropped. Bridges that emit turn ids use the authoritative
+ *  activeTurnIdRef match instead — no time window involved (#542). */
 const TURN_TERMINAL_GRACE_MS = 500;
 
 export function ChatConsole({
@@ -1670,18 +1667,28 @@ export function ChatConsole({
   // typewriter reveal (its RAF is closure-local and otherwise leaks a ghost
   // assistant bubble into the next turn).
   const revealAnimIdRef = useRef<number | null>(null);
-  // Timestamp of the newest handleSend start. A stale aborted event from a
-  // superseded turn arriving within TURN_TERMINAL_GRACE_MS of it is dropped
-  // (see the onAborted guard in handleSend).
+  // Timestamp of the newest handleSend start. Fallback guard for terminal
+  // events WITHOUT a turn_id (legacy/mock bridges) arriving from a superseded
+  // turn — the turn_id path is authoritative (see the onAborted guard).
   const currentSendStartedAtRef = useRef(0);
+  // Backend-issued turn id of the active turn, learned from the turn_started
+  // progress event. Terminal events tagged with a different turn id are
+  // dropped — a session key cannot distinguish two turns in one session.
+  const activeTurnIdRef = useRef<string | null>(null);
   // The live turn's watchdog interval. Shared across closures so an interrupt
   // (handleAbort / interrupt-and-resend) can stop the superseded turn's timer —
   // its own sendCleanup never runs because its listeners are already removed.
   const watchdogTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  // The current turn's chat.send promise. Interrupt-and-resend awaits the
-  // superseded turn's promise (which settles at its terminal event) so its
-  // terminal event is consumed before the new turn registers listeners.
-  const sendPromiseRef = useRef<Promise<unknown> | null>(null);
+  // The current turn's FULL lifecycle (threads.start + chat.send + terminal
+  // event), registered before any await that can be superseded. The next
+  // send awaits the superseded turn's lifecycle so its terminal event is
+  // consumed before new listeners register — and the backend drain task has
+  // exited, so the new chat.send is not rejected with TURN_IN_PROGRESS.
+  // Kept after a manual stop (only cleared by the owning handleSend in its
+  // identity-checked finally) so stop-then-quick-send still serializes.
+  const lifecycleRef = useRef<{ id: number; promise: Promise<void> } | null>(null);
+  // Monotonic id for lifecycleRef identity checks.
+  const turnSeqRef = useRef(0);
   const liveReasoningTsRef = useRef<number | null>(null);
   const shareFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentSessionRef = useRef(sessionKey);
@@ -2132,10 +2139,9 @@ export function ChatConsole({
       clearInterval(watchdogTimerRef.current);
       watchdogTimerRef.current = null;
     }
-    // The aborted turn's send promise is stale from here on — do not let a
-    // later interrupt-and-resend await it (its terminal event was already
-    // consumed by the orphan-forwarding path).
-    sendPromiseRef.current = null;
+    // Keep the lifecycle promise in place — a stop-then-quick-send must still
+    // await the aborted turn's settlement so its terminal event (and the
+    // backend drain task) cannot race the replacement send.
     try {
       await window.miqi.chat.abort(currentSessionRef.current);
     } catch {
@@ -2231,6 +2237,7 @@ export function ChatConsole({
 
     // If a reveal animation is still running from the previous response,
     // cancel it and abort the in-flight request so we can start fresh.
+    const supersededLifecycle = lifecycleRef.current;
     if (streaming) {
       if (revealAnimIdRef.current !== null) {
         cancelAnimationFrame(revealAnimIdRef.current);
@@ -2242,7 +2249,6 @@ export function ChatConsole({
       }
       cleanupListeners();
       setStreaming(false);
-      const oldSendPromise = sendPromiseRef.current;
       try {
         // Pass the session key — without it the backend resolves no session
         // and rejects the abort with UNAUTHORIZED, leaving the old stream
@@ -2251,27 +2257,43 @@ export function ChatConsole({
       } catch {
         /* ignore */
       }
-      // Wait for the superseded turn's chat.send to settle. It resolves at
-      // that turn's terminal event (aborted/final/error), so the old turn's
-      // terminal event is consumed before the new turn registers listeners —
-      // and the backend's drain task has exited, so the new chat.send is not
-      // rejected with TURN_IN_PROGRESS. Bounded so a wedged backend cannot
-      // stall interrupt-and-resend (see TURN_ABORT_SETTLE_MS).
-      if (oldSendPromise) {
-        try {
-          await Promise.race([
-            oldSendPromise,
-            new Promise<void>((resolve) => setTimeout(resolve, TURN_ABORT_SETTLE_MS)),
-          ]);
-        } catch {
-          /* ignore */
-        }
+    }
+    // Wait for the superseded turn's FULL lifecycle (threads.start + chat.send
+    // + terminal event) to settle — even when a manual stop happened earlier,
+    // or while a threads.start was still pending. It resolves at that turn's
+    // terminal event, so the old turn's terminal event is consumed before the
+    // new turn registers listeners — and the backend's drain task has exited,
+    // so the new chat.send is not rejected with TURN_IN_PROGRESS. Bounded so a
+    // wedged backend cannot stall interrupt-and-resend (see TURN_ABORT_SETTLE_MS).
+    if (supersededLifecycle) {
+      try {
+        await Promise.race([
+          supersededLifecycle.promise,
+          new Promise<void>((resolve) => setTimeout(resolve, TURN_ABORT_SETTLE_MS)),
+        ]);
+      } catch {
+        /* ignore */
       }
     }
+    // This turn's lifecycle — registered BEFORE any await (threads.start,
+    // chat.send) so a subsequent interrupt-and-resend can always serialize
+    // against it, even mid thread-init.
+    const turnId = ++turnSeqRef.current;
+    let resolveLifecycle: () => void = () => {};
+    const lifecyclePromise = new Promise<void>((resolve) => {
+      resolveLifecycle = resolve;
+    });
+    const lifecycle = { id: turnId, promise: lifecyclePromise };
+    lifecycleRef.current = lifecycle;
+    const settleLifecycle = () => {
+      if (lifecycleRef.current?.id === turnId) lifecycleRef.current = null;
+      resolveLifecycle();
+    };
     // Stamp this turn now (BEFORE any await below) so listeners registered
     // later can drop terminal events from the superseded turn.
     const sendStartedAt = Date.now();
     currentSendStartedAtRef.current = sendStartedAt;
+    activeTurnIdRef.current = null;
 
     // Generate a client-side req_id so we can abort this specific request
     const reqId = `req_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -2477,6 +2499,16 @@ export function ChatConsole({
         return;
       }
 
+      // ── Turn start (turn lifecycle) ─────────────────────────────────
+      // The backend announces the active turn id when it starts. Terminal
+      // events (final/aborted/error) tagged with a different turn id are
+      // stale and dropped — see the guards in the final/aborted/error
+      // listeners (#542).
+      if (data.stream === 'turn' && typeof data.turn_id === 'string') {
+        activeTurnIdRef.current = data.turn_id;
+        return;
+      }
+
       // ── Live reasoning stream (thinking models) ──────────────────────
       // Append every delta to the LAST live thinking bubble in the message
       // list. The scan is deliberately state-driven (not a closure-local
@@ -2605,6 +2637,13 @@ export function ChatConsole({
 
     const unsubFinal = window.miqi.chat.onFinal((data: ChatFinal) => {
       if (data.session_key && data.session_key !== currentSessionRef.current) return;
+      // Final from a superseded turn (e.g. a pre-abort final racing a quick
+      // resend): the backend's turn id is authoritative — drop it so the
+      // replacement turn's UI state is untouched (#542). The superseded
+      // turn's lifecycle promise is settled by its own closure.
+      if (data.turn_id && activeTurnIdRef.current && data.turn_id !== activeTurnIdRef.current) {
+        return;
+      }
       clearFinalCleanupTimer();
       if (animId !== null) {
         cancelAnimationFrame(animId);
@@ -2739,6 +2778,13 @@ export function ChatConsole({
 
     const unsubError = window.miqi.chat.onError((data: ChatError) => {
       if (data.session_key && data.session_key !== currentSessionRef.current) return;
+      // Error from a superseded turn (e.g. an abort-induced error racing a
+      // quick resend): drop it so the replacement turn's UI state is
+      // untouched (#542). The superseded turn's lifecycle promise is
+      // settled by its own closure.
+      if (data.turn_id && activeTurnIdRef.current && data.turn_id !== activeTurnIdRef.current) {
+        return;
+      }
       streamErrorHandled = true;
       if (animId !== null) cancelAnimationFrame(animId);
       const message = sanitizeUiMessage(data.message);
@@ -2759,7 +2805,15 @@ export function ChatConsole({
       // Stale terminal event from a superseded turn: stop-then-quick-send
       // orphans the old aborted event, which would otherwise drop
       // streaming=false and append a spurious "已停止。" bubble mid-reply.
-      if (Date.now() - currentSendStartedAtRef.current < TURN_TERMINAL_GRACE_MS) return;
+      // The backend's turn id is authoritative; the grace window is only a
+      // fallback for bridges that don't emit turn ids (legacy/mocks).
+      if (_data.turn_id) {
+        if (activeTurnIdRef.current && _data.turn_id !== activeTurnIdRef.current) {
+          return;
+        }
+      } else if (Date.now() - currentSendStartedAtRef.current < TURN_TERMINAL_GRACE_MS) {
+        return;
+      }
       if (animId !== null) cancelAnimationFrame(animId);
       setStreaming(false);
       setCurrentReqId(null);
@@ -2836,7 +2890,6 @@ export function ChatConsole({
         chatAttachments.length > 0 ? chatAttachments : undefined,
         workspace ?? undefined
       );
-      sendPromiseRef.current = sendPromise;
 
       // Mark as done after a tick — server parsing is synchronous, already complete
       if (sentAttachments.some((a) => a.type === 'document')) {
@@ -2857,10 +2910,11 @@ export function ChatConsole({
       }
 
       await sendPromise;
+      settleLifecycle();
     } catch (e: any) {
-      sendPromiseRef.current = null;
       if (animId !== null) cancelAnimationFrame(animId);
       if (streamErrorHandled) {
+        settleLifecycle();
         setStreaming(false);
         sendCleanup();
         cleanupListeners();
@@ -2880,6 +2934,7 @@ export function ChatConsole({
           { role: 'error' as const, content: errMsg, timestamp: Date.now() },
         ]);
       }
+      settleLifecycle();
       setStreaming(false);
       sendCleanup();
       cleanupListeners();

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -765,8 +765,10 @@ export interface TrackedFileInfo {
 // ---------------------------------------------------------------------------
 
 export interface ChatProgress {
-  text: string;
-  tool_hint: boolean;
+  /** Text content — absent for pure-lifecycle events like stream:'turn'. */
+  text?: string;
+  /** Tool-hint flag — absent for pure-lifecycle events like stream:'turn'. */
+  tool_hint?: boolean;
   stream?: 'stdout' | 'stderr' | 'reasoning' | 'turn';
   delta?: string;
   tool_call_id?: string;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -767,7 +767,7 @@ export interface TrackedFileInfo {
 export interface ChatProgress {
   text: string;
   tool_hint: boolean;
-  stream?: 'stdout' | 'stderr' | 'reasoning';
+  stream?: 'stdout' | 'stderr' | 'reasoning' | 'turn';
   delta?: string;
   tool_call_id?: string;
   /** Original tool-call arguments (e.g. web_fetch's url) — carried on the
@@ -783,6 +783,9 @@ export interface ChatProgress {
   file?: string;
   stage?: string;
   message?: string;
+  /** Backend-issued turn id — carried on turn_started progress so the
+   *  frontend can drop terminal events from superseded turns (#542). */
+  turn_id?: string;
 }
 
 export interface ChatFinal {
@@ -795,6 +798,9 @@ export interface ChatFinal {
   /** Session key for frontend-side event filtering (fix #212).  Optional
    *  for backward compatibility; see ChatProgress.session_key. */
   session_key?: string;
+  /** Backend-issued turn id — lets the frontend drop a final event from a
+   *  superseded turn (#542). */
+  turn_id?: string;
 }
 
 export interface ChatError {
@@ -804,6 +810,8 @@ export interface ChatError {
   /** Session key for frontend-side event filtering (fix #212).  Optional
    *  for backward compatibility; see ChatProgress.session_key. */
   session_key?: string;
+  /** Backend-issued turn id (#542). */
+  turn_id?: string;
 }
 
 export interface ChatAborted {
@@ -811,6 +819,9 @@ export interface ChatAborted {
   /** Session key for frontend-side event filtering (fix #212).  Optional
    *  for backward compatibility; see ChatProgress.session_key. */
   session_key?: string;
+  /** Backend-issued turn id — lets the frontend drop an aborted event from
+   *  a superseded turn instead of stopping the replacement turn (#542). */
+  turn_id?: string;
 }
 
 export interface ChatSubagentResult {

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1012,6 +1012,7 @@ class BridgeRuntimeLoop:
                     final_payload = {
                         "content": event.content,
                         "aborted": False,
+                        "turn_id": event.turn_id,
                         "tool_calls": event.tool_calls,
                     }
                     if event.reasoning:
@@ -1032,6 +1033,7 @@ class BridgeRuntimeLoop:
                     await _emit_terminal("error", {
                         "message": event.message,
                         "code": event.error_kind or "ERROR",
+                        "turn_id": event.turn_id,
                     })
                     break
 
@@ -1043,6 +1045,7 @@ class BridgeRuntimeLoop:
                             "content": "",
                             "aborted": False,
                             "status": "completed",
+                            "turn_id": event.turn_id,
                         })
                     break
 
@@ -1071,11 +1074,20 @@ class BridgeRuntimeLoop:
                     })
                     continue
 
+                # Turn lifecycle: the turn_id lets the frontend correlate
+                # terminal events (final/aborted/error) with the active turn
+                # and drop stale events from superseded turns (#542).
+                if isinstance(event, TurnStartedEvent):
+                    await _emit("progress", {
+                        "stream": "turn",
+                        "turn_id": event.turn_id,
+                    })
+                    continue
+
                 # Internal runtime events that should never appear in
                 # the chat message stream.  See Issue #35.
                 if isinstance(event, (
                     AgentMessageDeltaEvent,   # streaming delta; final content via AgentMessageEvent
-                    TurnStartedEvent,          # turn lifecycle; not chat content
                     ApprovalResolvedEvent,     # approval lifecycle; not chat content
                     ExecCommandBeginEvent,     # exec lifecycle; rendered via ToolCallBeginEvent
                     ExecCommandEndEvent,       # exec lifecycle; rendered via ToolCallEndEvent


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

AI 流式回复期间输入框不再被禁用，用户可提前键入下一条 prompt；点击发送自动中断当前生成并发送新消息。

## 背景/问题

Issue #542：AI 流式回复时 textarea 被 `disabled={streaming}` 锁定（ChatConsole.tsx），用户只能干等或点停止。handleSend 中已有的"中断并重发"逻辑（line 1293-1301）因此成为死代码。深入审计后发现该逻辑即使放开输入框也无法正确工作：abort 缺少 session key 会被后端以 UNAUTHORIZED 拒绝、旧 turn 的 aborted 终态事件会被新 turn 监听器误收导致新回复被置为"已停止"、旧 turn 的 reveal 动画与 watchdog 定时器泄漏、后端 TURN_IN_PROGRESS 会拒绝快速重发。

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 移除 textarea 与 ExecutionPolicySelector 的 `disabled={streaming}`
  - Send/Abort 按钮智能切换：流式+无输入 → Abort；流式+有输入 → Send（中断当前生成并发送，title 提示"中断当前生成并发送"）
  - 中断路径：abort 补传 session key；等待旧 send promise settle（在其终态事件处 resolve，消除陈旧终态事件竞态 + TURN_IN_PROGRESS 拒绝）后注册新监听器，带 3s 兜底上限
  - 新增共享 ref 取消旧 turn 的 typewriter reveal 动画（`revealAnimIdRef`）与 watchdog 定时器（`watchdogTimerRef`），防止幽灵 assistant 气泡与"后端无响应"误报泄漏到新 turn
  - `onAborted` 增加 500ms 陈旧终态事件兜底（stop 后快速重发的 orphan-forwarding 场景）

## 日志/验证证据

```
$ npx tsc --noEmit -p tsconfig.web.json
EXIT: 0

$ npx vitest run
Test Files  11 passed (11)
Tests       151 passed (151)
```

## 测试情况

- `tsc --noEmit -p tsconfig.web.json` 通过
- `vitest run` 151/151 通过（含 BridgeManager aborted terminal event 测试）
- 现有 E2E 无断言流式中输入框禁用，`waitForResponseComplete` 依赖 Thinking… 指示器与文本稳定性，不受影响
- 建议人工验证：发起对话后输入框可输入；流式+有输入时按钮变 Send，点击后旧回复停止、新消息发出

## 截图

无需截图（无视觉布局变化，仅交互行为变更）


___

### **PR Type**
Bug fix


___

### **Description**
- Keep input enabled during AI streaming, allowing user to pre-type next prompt

- Send button now interrupts current generation and starts new request when input present

- Backend attaches `turn_id` to terminal events so frontend can discard stale responses

- Properly serialise turn lifecycles to avoid race conditions after abort-and-resend


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User types new prompt during streaming"] --> B["Send button appears"]
  B --> C["Abort current turn (with session key)"]
  C --> D["Cancel reveal animation & watchdog"]
  D --> E["Wait for old turn lifecycle to settle (3s cap)"]
  E --> F["Start new turn"]
  F --> G["Backend emits turn_started with turn_id"]
  G --> H["Old terminal events dropped via turn_id match"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loop.py</strong><dd><code>Add turn_id to backend terminal events and forward turn lifecycle</code></dd></summary>
<hr>

miqi/bridge/loop.py

<ul><li>Emit <code>turn_id</code> in final, error, and aborted terminal events for frontend <br>correlation<br> <li> Forward <code>TurnStartedEvent</code> as a progress event with <code>stream: "turn"</code> and <br><code>turn_id</code><br> <li> Filter out TurnStartedEvent from the internal-event skip list so it <br>reaches the frontend</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/660/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ipc.ts</strong><dd><code>Extend IPC types with turn_id and turn lifecycle stream</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/shared/ipc.ts

<ul><li>Add optional <code>turn_id</code> fields to <code>ChatProgress</code>, <code>ChatFinal</code>, <code>ChatError</code>, <br><code>ChatAborted</code> interfaces<br> <li> Make <code>text</code> and <code>tool_hint</code> optional in <code>ChatProgress</code> to support <br>pure-lifecycle events<br> <li> Add <code>"turn"</code> to the <code>stream</code> union type for <code>ChatProgress</code></ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/660/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Enable input during streaming and implement robust turn event </code><br><code>isolation</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Remove <code>disabled={streaming}</code> from textarea and <code>ExecutionPolicySelector</code><br> <li> Show Abort button only when streaming and no input/attachments; <br>otherwise show Send button with title “中断当前生成并发送”<br> <li> Manage shared refs for turn lifecycle: <code>revealAnimIdRef</code>, <br><code>watchdogTimerRef</code>, <code>activeTurnIdRef</code>, <code>lifecycleRef</code>, <code>turnSeqRef</code><br> <li> In <code>handleAbort</code>: cancel reveal animation, clear watchdog, keep <br>lifecycle promise for later serialisation<br> <li> In <code>handleSend</code>: if streaming, abort with session key, wait for <br>superseded turn lifecycle to settle (3s timeout), then create new turn <br>lifecycle and reset freshness timestamps<br> <li> Listeners for <code>turn_started</code> progress update <code>activeTurnIdRef</code>; on <br>final/aborted/error, strictly drop events whose <code>turn_id</code> does not match <br>the current turn or (legacy fallback) arrive within a 500ms grace <br>window<br> <li> Adjust send cleanup to avoid clearing a replacement turn’s watchdog</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/660/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+160/-6</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

