### PR TITLE
feat(chat): 图片附件 OCR 提取 + 内联显示 + 跨 session 保持（#659）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1552,11 +1552,19 @@ export function ChatConsole({
       (m.attachments ?? []).filter((a) => a.type === 'image' && !a.dataUrl)
     );
     if (pendingImages.length === 0) return;
-    void Promise.all(
-      pendingImages.map(async (att) => {
+    // Bound concurrent restores — an unbounded Promise.all would fire one IPC
+    // read per historical image at once, spiking bridge/renderer memory on
+    // sessions with many large images (CodeRabbit #661 review).
+    const CONCURRENCY = 3;
+    let cursor = 0;
+    const worker = async () => {
+      while (!cancelled) {
+        const idx = cursor++;
+        if (idx >= pendingImages.length) return;
+        const att = pendingImages[idx];
         try {
           const res = await window.miqi.files.read(att.name, activeKey);
-          if (cancelled || !res?.data_base64) return;
+          if (cancelled || !res?.data_base64) continue;
           const mime = res.mime_type || 'image/png';
           const dataUrl = `data:${mime};base64,${res.data_base64}`;
           setMessages((prev) =>
@@ -1576,7 +1584,10 @@ export function ChatConsole({
         } catch {
           // Image file missing on disk — keep the placeholder chip.
         }
-      })
+      }
+    };
+    void Promise.all(
+      Array.from({ length: Math.min(CONCURRENCY, pendingImages.length) }, () => worker())
     );
     return () => {
       cancelled = true;
@@ -5153,15 +5164,27 @@ function MessageBubble({
             {/* image attachments */}
             {msg.attachments
               ?.filter((a) => a.type === 'image')
-              .map((att, i) => (
-                <img
-                  key={i}
-                  src={att.dataUrl}
-                  alt={att.name}
-                  className="rounded-xl max-w-[280px] max-h-[200px] object-cover"
-                  style={{ border: '1px solid var(--border-subtle)' }}
-                />
-              ))}
+              .map((att, i) =>
+                att.dataUrl ? (
+                  <img
+                    key={i}
+                    src={att.dataUrl}
+                    alt={att.name}
+                    className="rounded-xl max-w-[280px] max-h-[200px] object-cover"
+                    style={{ border: '1px solid var(--border-subtle)' }}
+                  />
+                ) : (
+                  // Restoring / read-failed image — placeholder instead of a
+                  // broken <img> (same fallback as the composer, CodeRabbit #661).
+                  <div
+                    key={i}
+                    className="flex h-24 w-24 shrink-0 items-center justify-center rounded-xl"
+                    style={{ border: '1px solid var(--border-subtle)', background: 'var(--surface-muted)' }}
+                  >
+                    <Image size={18} style={{ color: 'var(--info)' }} />
+                  </div>
+                )
+              )}
             {/* text attachments */}
             {msg.attachments
               ?.filter((a) => a.type === 'text')

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1523,9 +1523,13 @@ export function ChatConsole({
   // Lazily re-read image attachments after session load: the sender embeds
   // only "[Image: name]" in the persisted content; the actual bytes live in
   // the session files dir and are fetched on demand (#659).
+  // NOTE: use the sessionKey PROP (render-time value), not
+  // currentSessionRef.current — the ref updates in an effect that runs AFTER
+  // render, so on session switch the lazy-load would read the previous
+  // session's key and fail to find the image files.
   useEffect(() => {
-    const sessionKey = currentSessionRef.current;
-    if (!historyLoaded || !sessionKey) return;
+    const activeKey = sessionKey;
+    if (!historyLoaded || !activeKey) return;
     let cancelled = false;
     const pendingImages = messages.flatMap((m) =>
       (m.attachments ?? []).filter((a) => a.type === 'image' && !a.dataUrl)
@@ -1534,7 +1538,7 @@ export function ChatConsole({
     void Promise.all(
       pendingImages.map(async (att) => {
         try {
-          const res = await window.miqi.files.read(att.name, sessionKey);
+          const res = await window.miqi.files.read(att.name, activeKey);
           if (cancelled || !res?.data_base64) return;
           const mime = res.mime_type || 'image/png';
           const dataUrl = `data:${mime};base64,${res.data_base64}`;
@@ -1561,7 +1565,7 @@ export function ChatConsole({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [historyLoaded]);
+  }, [historyLoaded, sessionKey]);
   const [panelOpen, setPanelOpen] = useState(true);
   const [panelWidth, setPanelWidth] = useState(280);
   const panelResizing = useRef(false);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -160,6 +160,23 @@ interface FileChip {
   category: ReturnType<typeof getDocCategory>;
 }
 
+const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\]]+)\]/g;
+
+/** Extract image attachments from the "[Image: name]" placeholder the sender
+ *  embeds. dataUrl stays undefined — it is re-read from the session files dir
+ *  lazily after load (#659). */
+function extractImageAttachmentsFromContent(content: string): Attachment[] | undefined {
+  const names = [...content.matchAll(IMAGE_PLACEHOLDER_RES)].map((m) => m[1].trim());
+  if (names.length === 0) return undefined;
+  return names.map((name) => ({
+    name,
+    type: 'image' as const,
+    dataUrl: undefined,
+    size: 0,
+    status: 'pending' as const,
+  }));
+}
+
 function extractFileChips(content: string): { cleanContent: string; chips: FileChip[] } {
   const chips: FileChip[] = [];
   let clean = content;
@@ -171,6 +188,9 @@ function extractFileChips(content: string): { cleanContent: string; chips: FileC
       return '';
     });
   }
+  // Image placeholders are rendered as inline previews via attachments,
+  // never as raw "[Image: name]" text (#659).
+  clean = clean.replace(IMAGE_PLACEHOLDER_RES, '');
   return { cleanContent: clean.trim(), chips };
 }
 
@@ -1007,11 +1027,19 @@ export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
           : undefined;
       const hasContent = m.content && String(m.content).trim().length > 0;
       if (m.role === 'user' || hasContent || reasoningContent) {
+        const contentStr = messageContentToString(m.content);
+        // Restore image attachments from the "[Image: name]" placeholder the
+        // sender embeds (dataUrl is not persisted — it is re-read from the
+        // session files dir lazily after load, see loadSession #659).
+        const attachments = m.role === 'user'
+          ? extractImageAttachmentsFromContent(contentStr)
+          : undefined;
         result.push({
           role: m.role as 'user' | 'assistant',
-          content: messageContentToString(m.content),
+          content: contentStr,
           reasoning: reasoningContent,
           timestamp: ts,
+          attachments,
         });
       }
     } else if (m.role === 'subagent') {
@@ -1491,6 +1519,49 @@ export function ChatConsole({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [downloadingPaperId, setDownloadingPaperId] = useState<string | null>(null);
+
+  // Lazily re-read image attachments after session load: the sender embeds
+  // only "[Image: name]" in the persisted content; the actual bytes live in
+  // the session files dir and are fetched on demand (#659).
+  useEffect(() => {
+    const sessionKey = currentSessionRef.current;
+    if (!historyLoaded || !sessionKey) return;
+    let cancelled = false;
+    const pendingImages = messages.flatMap((m) =>
+      (m.attachments ?? []).filter((a) => a.type === 'image' && !a.dataUrl)
+    );
+    if (pendingImages.length === 0) return;
+    void Promise.all(
+      pendingImages.map(async (att) => {
+        try {
+          const res = await window.miqi.files.read(att.name, sessionKey);
+          if (cancelled || !res?.data_base64) return;
+          const mime = res.mime_type || 'image/png';
+          const dataUrl = `data:${mime};base64,${res.data_base64}`;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.attachments?.some((a) => a === att)
+                ? {
+                    ...m,
+                    attachments: m.attachments.map((a) =>
+                      a === att
+                        ? { ...a, dataUrl, status: 'done' as const, size: res.size }
+                        : a
+                    ),
+                  }
+                : m
+            )
+          );
+        } catch {
+          // Image file missing on disk — keep the placeholder chip.
+        }
+      })
+    );
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [historyLoaded]);
   const [panelOpen, setPanelOpen] = useState(true);
   const [panelWidth, setPanelWidth] = useState(280);
   const panelResizing = useRef(false);
@@ -2727,8 +2798,19 @@ export function ChatConsole({
       const key =
         activeThreadId === 'main' ? currentSessionRef.current : `desktop:${activeThreadId}`;
       const chatAttachments = sentAttachments
-        .filter((a) => a.type === 'document' && a.dataBase64)
-        .map((a) => ({ name: a.name, data_base64: a.dataBase64, mime_type: a.mimeType }));
+        .filter(
+          (a) =>
+            (a.type === 'document' && a.dataBase64) ||
+            (a.type === 'image' && a.dataUrl)
+        )
+        .map((a) => ({
+          name: a.name,
+          data_base64:
+            a.type === 'image' && a.dataUrl
+              ? a.dataUrl.split(',')[1] ?? a.dataUrl
+              : a.dataBase64,
+          mime_type: a.mimeType,
+        }));
 
       // Mark all doc attachments as parsing
       if (sentAttachments.some((a) => a.type === 'document')) {
@@ -3747,7 +3829,16 @@ export function ChatConsole({
                             {cat.label}
                           </span>
                         ) : att.type === 'image' ? (
-                          <Image size={14} className="shrink-0" style={{ color: 'var(--info)' }} />
+                          att.dataUrl ? (
+                            <img
+                              src={att.dataUrl}
+                              alt={att.name}
+                              className="h-12 w-12 shrink-0 rounded object-cover"
+                              style={{ border: '1px solid var(--border-subtle)' }}
+                            />
+                          ) : (
+                            <Image size={14} className="shrink-0" style={{ color: 'var(--info)' }} />
+                          )
                         ) : (
                           <FileText size={14} className="shrink-0 text-text-faint" />
                         )}

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -151,6 +151,38 @@ describe('sessionMsgsToUi', () => {
     expect(messages[0].role).toBe('progress');
     expect(messages[0].reasoning).toBe('a long chain of thought');
   });
+
+  it('restores image attachments from [Image: name] placeholders (#659)', () => {
+    const messages = sessionMsgsToUi([
+      {
+        role: 'user',
+        content: '看看这张图\n\n[Image: screenshot.png]\n[Image: chart.jpg]',
+        timestamp: '2026-07-08T01:00:01.000Z',
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    const atts = messages[0].attachments ?? [];
+    expect(atts).toHaveLength(2);
+    expect(atts[0]).toMatchObject({
+      name: 'screenshot.png',
+      type: 'image',
+      status: 'pending',
+    });
+    expect(atts[0].dataUrl).toBeUndefined(); // lazily re-read after load
+    expect(atts[1].name).toBe('chart.jpg');
+  });
+
+  it('does not attach anything when the user message has no [Image:] placeholder', () => {
+    const messages = sessionMsgsToUi([
+      {
+        role: 'user',
+        content: 'plain question without images',
+        timestamp: '2026-07-08T01:00:01.000Z',
+      },
+    ]);
+    expect(messages[0].attachments).toBeUndefined();
+  });
 });
 
 describe('appendReasoningDelta', () => {

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -62,6 +62,8 @@ def parse_document(
     if suffix in _PDF_SUFFIXES:
         return _parse_pdf(file_path, max_chars=max_chars, force_ocr=force_ocr,
                           extract_charts=extract_charts)
+    elif suffix in _IMAGE_SUFFIXES:
+        return _parse_image(file_path, max_chars=max_chars)
     elif suffix in _DOCX_SUFFIXES:
         return _parse_docx(file_path, max_chars=max_chars)
     elif suffix in _PPTX_SUFFIXES:
@@ -174,6 +176,10 @@ _SH_SUFFIXES = {".sh", ".bash"}
 _TXT_SUFFIXES = {".txt", ".text"}
 _RTF_SUFFIXES = {".rtf"}
 
+_IMAGE_SUFFIXES = {
+    ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff", ".tif", ".ico",
+}
+
 _ALL_DOCUMENT_SUFFIXES = (
     _PDF_SUFFIXES | _DOCX_SUFFIXES | _PPTX_SUFFIXES |
     _XLSX_SUFFIXES | _MD_SUFFIXES | _HTML_SUFFIXES |
@@ -181,7 +187,7 @@ _ALL_DOCUMENT_SUFFIXES = (
     _YAML_SUFFIXES | _ENV_SUFFIXES | _LOG_SUFFIXES |
     _SQL_SUFFIXES | _INI_SUFFIXES | _TOML_SUFFIXES |
     _HTACCESS_SUFFIXES | _SH_SUFFIXES | _TXT_SUFFIXES |
-    _RTF_SUFFIXES
+    _RTF_SUFFIXES | _IMAGE_SUFFIXES
 )
 
 
@@ -209,6 +215,15 @@ def _get_suffix(file_path: Path | str) -> str:
 
 _SUFFIX_TO_MIME: dict[str, str] = {
     ".pdf": "application/pdf",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".bmp": "image/bmp",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".ico": "image/x-icon",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -410,6 +425,78 @@ def _pdf_ocr(file_path: Path) -> str:
     except Exception as exc:
         logger.error(f"OCR pipeline failed: {exc}")
         return ""
+
+
+# ── Images (OCR) ─────────────────────────────────────────────────────────
+
+def _image_ocr(file_path: Path) -> str:
+    """OCR a single image with tesseract (chi_sim+eng).
+
+    Shares the tessdata resolution of _pdf_ocr so custom installs work.
+    Returns "" (never raises) when tesseract is missing or fails.
+    """
+    _tessdata_prefix = os.environ.get("TESSDATA_PREFIX", "")
+    if not _tessdata_prefix:
+        for _candidate in (
+            "/usr/share/tesseract-ocr/4.00",
+            "/usr/share/tesseract-ocr",
+            str(Path.home() / ".local" / "share" / "tessdata"),
+        ):
+            if Path(_candidate, "tessdata", "eng.traineddata").exists() or \
+               Path(_candidate, "eng.traineddata").exists():
+                _tessdata_prefix = _candidate
+                break
+
+    _env = dict(os.environ)
+    if _tessdata_prefix:
+        _env["TESSDATA_PREFIX"] = _tessdata_prefix
+
+    try:
+        result = subprocess.run(
+            ["tesseract", str(file_path), "stdout", "-l", "chi_sim+eng"],
+            capture_output=True, text=True, timeout=60, env=_env,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except FileNotFoundError:
+        logger.warning("tesseract not found, image OCR unavailable")
+    except subprocess.TimeoutExpired:
+        logger.warning("image OCR timed out")
+    except Exception as exc:
+        logger.warning(f"image OCR failed: {exc}")
+    return ""
+
+
+def _parse_image(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[str, Any]:
+    """Parse an image: OCR text (tesseract, chi_sim+eng) + basic metadata.
+
+    Falls back to metadata-only when tesseract is unavailable. The text is
+    prefixed with an image header (size/format) so the model understands it
+    is describing an image.
+    """
+    result: dict[str, Any] = {
+        "text": "", "page_count": 1, "size_bytes": file_path.stat().st_size,
+        "mime_type": _SUFFIX_TO_MIME.get(file_path.suffix.lower(), "image/octet-stream"),
+        "ocr_used": False, "parse_ms": 0, "charts": [],
+    }
+    _t0 = time.time()
+    try:
+        from PIL import Image as _PILImage
+        with _PILImage.open(file_path) as img:
+            width, height = img.size
+            fmt = img.format or ""
+        header = f"[图片] {file_path.name} ({width}x{height}, {fmt})\n"
+        ocr_text = _image_ocr(file_path)
+        if ocr_text:
+            result["ocr_used"] = True
+            result["text"] = (header + ocr_text)[:max_chars]
+        else:
+            result["text"] = header + "（图片未提取到文字：tesseract 不可用或图中无文字）"
+        result["parse_ms"] = int((time.time() - _t0) * 1000)
+    except Exception as exc:
+        logger.warning(f"image parse failed for {file_path}: {exc}")
+        result["text"] = f"[图片] {file_path.name}（解析失败: {exc}）"
+    return result
 
 
 # ── Chart & Table extraction ────────────────────────────────────────────────

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -506,11 +506,11 @@ def _parse_image(file_path: Path, max_chars: int = MAX_CONTEXT_CHARS) -> dict[st
             result["ocr_used"] = True
             result["text"] = (header + ocr_text)[:max_chars]
         else:
-            result["text"] = header + "（图片未提取到文字：tesseract 不可用或图中无文字）"
+            result["text"] = (header + "（图片未提取到文字：tesseract 不可用或图中无文字）")[:max_chars]
         result["parse_ms"] = int((time.time() - _t0) * 1000)
     except Exception as exc:
         logger.warning(f"image parse failed for {file_path}: {exc}")
-        result["text"] = f"[图片] {file_path.name}（解析失败: {exc}）"
+        result["text"] = (f"[图片] {file_path.name}（解析失败: {exc}）")[:max_chars]
     return result
 
 

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -430,11 +430,26 @@ def _pdf_ocr(file_path: Path) -> str:
 # ── Images (OCR) ─────────────────────────────────────────────────────────
 
 def _image_ocr(file_path: Path) -> str:
-    """OCR a single image with tesseract (chi_sim+eng).
+    """OCR a single image.
 
-    Shares the tessdata resolution of _pdf_ocr so custom installs work.
-    Returns "" (never raises) when tesseract is missing or fails.
+    Prefers RapidOCR (pure-Python ONNX runtime, no system binary, strong
+    zh/en accuracy) and falls back to tesseract (chi_sim+eng) when RapidOCR
+    is not installed. Returns "" (never raises) when no engine is available.
     """
+    # Engine 1: RapidOCR — onnxruntime, no system dependency (#659).
+    try:
+        from rapidocr_onnxruntime import RapidOCR
+
+        _engine = RapidOCR()
+        result, _ = _engine(str(file_path))
+        if result:
+            lines = [line[1] for line in result if len(line) > 1 and line[1].strip()]
+            if lines:
+                return "\n".join(lines)
+    except Exception as exc:
+        logger.warning(f"RapidOCR unavailable for {file_path}: {exc}")
+
+    # Engine 2: tesseract (chi_sim+eng) — needs the system binary.
     _tessdata_prefix = os.environ.get("TESSDATA_PREFIX", "")
     if not _tessdata_prefix:
         for _candidate in (

--- a/miqi/runtime/file_handlers.py
+++ b/miqi/runtime/file_handlers.py
@@ -220,10 +220,22 @@ _ALLOWED_NAMES: set[str] = {
 
 _BINARY_VIEWABLE_SUFFIXES: set[str] = {
     ".pdf",
+    # Images — 附件内联显示 + 跨 session 恢复 (#659)，与 document_parser
+    # 的 _SUFFIX_TO_MIME 保持一致
+    ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff", ".tif", ".ico",
 }
 
 _SUFFIX_TO_MIME: dict[str, str] = {
     ".pdf": "application/pdf",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".bmp": "image/bmp",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".ico": "image/x-icon",
 }
 
 _TREE_SKIP_SUFFIXES: set[str] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "mcp>=1.28.1,<2.0.0",
     "json-repair>=0.60.1,<1.0.0",
     "lark-oapi>=1.5.0,<2.0.0",
+    "rapidocr-onnxruntime>=1.4.4,<2.0.0",
     "tzdata>=2024.1 ; sys_platform == 'win32'",
     "pyinstaller>=6.20.0",
     "pyyaml>=6.0.3",

--- a/tests/documents/test_image_parser.py
+++ b/tests/documents/test_image_parser.py
@@ -63,5 +63,5 @@ def test_parse_image_bmp(bmp_image: Path) -> None:
 
 
 def test_parse_image_missing_file_raises(tmp_path: Path) -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         parse_document(tmp_path / "nope.png", max_chars=500)

--- a/tests/documents/test_image_parser.py
+++ b/tests/documents/test_image_parser.py
@@ -1,0 +1,67 @@
+"""Tests for image parsing (OCR) in document_parser (#659)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from miqi.documents.document_parser import (
+    is_supported_document,
+    parse_document,
+)
+
+
+@pytest.fixture
+def png_image(tmp_path: Path) -> Path:
+    """A small valid PNG (1x1 red pixel) — no tesseract needed for metadata."""
+    from PIL import Image
+
+    img = Image.new("RGB", (1, 1), (255, 0, 0))
+    p = tmp_path / "pixel.png"
+    img.save(p)
+    return p
+
+
+@pytest.fixture
+def bmp_image(tmp_path: Path) -> Path:
+    from PIL import Image
+
+    img = Image.new("RGB", (2, 2), (0, 0, 255))
+    p = tmp_path / "pixel.bmp"
+    img.save(p)
+    return p
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp", ".tiff", ".tif", ".ico"],
+)
+def test_image_suffixes_are_supported(tmp_path: Path, suffix: str) -> None:
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 4), "white")
+    p = tmp_path / f"img{suffix}"
+    img.save(p, format="PNG" if suffix in (".png", ".ico") else None)
+    assert is_supported_document(p)
+
+
+def test_parse_image_returns_metadata_and_header(png_image: Path) -> None:
+    result = parse_document(png_image, max_chars=500)
+    assert result["page_count"] == 1
+    assert result["size_bytes"] > 0
+    assert "png" in result["mime_type"].lower()
+    assert "[图片] pixel.png (1x1" in result["text"]
+    # tesseract may or may not be installed; either way text is non-empty
+    # (OCR text or the graceful-degradation note).
+    assert result["text"].strip()
+
+
+def test_parse_image_bmp(bmp_image: Path) -> None:
+    result = parse_document(bmp_image, max_chars=500)
+    assert "[图片] pixel.bmp (2x2" in result["text"]
+
+
+def test_parse_image_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(Exception):
+        parse_document(tmp_path / "nope.png", max_chars=500)

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -391,3 +391,50 @@ def test_appserver_has_all_file_handlers():
         assert hasattr(file_handlers, name), f"Missing handler: {name}"
         handler = getattr(file_handlers, name)
         assert callable(handler), f"Handler {name} is not callable"
+
+
+@pytest.mark.asyncio
+async def test_files_read_image_returns_base64_and_mime(fake_config, fake_provider, tmp_path):
+    """files.read on an image returns base64 + image mime — OCR 附件恢复链路 (#659)."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_read_handler
+
+    sm, ws = _setup_session("img-reader", "client-1")
+    files_dir = ws / "sessions" / "img-reader" / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    # Minimal PNG: 8-byte signature + 16 zero bytes payload
+    (files_dir / "photo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+
+    registry = ClientSessionRegistry()
+    result = await files_read_handler(
+        "req-img",
+        {"path": "photo.png", "session_key": "img-reader"},
+        "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["is_binary"] is True
+    assert r["mime_type"] == "image/png"
+    assert r["data_base64"].startswith("iVBORw0KGgo")  # PNG magic bytes
+    assert r["size"] == 24
+
+
+@pytest.mark.asyncio
+async def test_files_read_image_jpg_mime(fake_config, fake_provider, tmp_path):
+    """files.read on a .jpg maps to image/jpeg (#659)."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_read_handler
+
+    sm, ws = _setup_session("jpg-reader", "client-1")
+    files_dir = ws / "sessions" / "jpg-reader" / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    (files_dir / "shot.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 8)
+
+    registry = ClientSessionRegistry()
+    result = await files_read_handler(
+        "req-jpg",
+        {"path": "shot.jpg", "session_key": "jpg-reader"},
+        "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["is_binary"] is True
+    assert r["mime_type"] == "image/jpeg"

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.11.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
### **User description**
## 类型

- [x] ✨ 新功能

## 变更概述

图片附件（jpg/png/bmp 等）支持 OCR 提取文字 + 聊天内联显示缩略图 + 切换 session 后图片保持显示。

## 背景/问题

聊天发送图片有三个缺陷（Issue #659）：

- **图片内容不进模型**：发送时只嵌 `[Image: 文件名]` 文本占位，图片数据完全不传给后端，非多模态模型看不到图、无法读取图中文字/表格
- **聊天里不显示图片**：附件渲染为图标 chip（Image 图标 + 文件名），不是图片本身
- **切换 session 图片变文字**：持久化内容只有 `[Image: name]` 占位文本，恢复视图不解析，dataUrl 未持久化——切走再回来图片变成纯文字

## 变更内容

- `miqi/documents/document_parser.py`：新增 `_parse_image`（PIL 读图 + tesseract OCR chi_sim+eng，复用现有 PDF OCR 的 tessdata 查找，tesseract 缺失时优雅降级为图片元数据）；`_IMAGE_SUFFIXES`（jpg/jpeg/png/bmp/gif/webp/tiff/tif/ico）接入 `is_supported_document`/`parse_document`/mime 映射
- `apps/desktop/.../ChatConsole.tsx`：
  - `chat.send` 附件 payload 纳入 image 类型（base64 传递）——此前被完全丢弃
  - 附件 chip 对 image 渲染内联缩略图（48px object-cover）
  - session 恢复：`[Image: name]` 占位 → pending 图片附件；懒加载 effect 用 `files.read(name, sessionKey)` 从会话文件目录读回 base64 → dataUrl → **切换 session 图片保持显示**
  - `extractFileChips` 从渲染内容清除 `[Image:]` 占位文本

## 日志/验证证据
```
# 本地实测：造带文字图片 → parse_document
supported: True
text: [图片] test_ocr.png (400x120, PNG)
（图片未提取到文字：tesseract 不可用或图中无文字）   ← 无 tesseract 时优雅降级

# tesseract 可用时（生产/装了 tesseract 的环境）：
[图片] screenshot.png (1920x1080, PNG)
Hello MiQi OCR 12345   ← OCR 提取的文字嵌入消息给模型
```

## 测试情况

- 后端 `tests/documents/test_image_parser.py`（新增 12 个用例：后缀支持×9、元数据/头部、bmp、缺失文件）→ pytest 39 passed
- 前端 `chatConsoleMessages.test.ts`（新增 2 个用例：[Image:] 恢复成附件、无占位不生成）→ vitest **153 passed**（11 文件）
- `tsc --noEmit -p tsconfig.web.json` → 0 错误

## 截图

<img width="1264" height="821" alt="87f20eb4af482a8551c7dbc72fd1fdf0" src="https://github.com/user-attachments/assets/f5e4afb0-476c-45b2-a43c-2e2825b9d14a" />
___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Backend: image parsing with OCR (RapidOCR primary, tesseract fallback) and metadata header

- Backend: file_handlers support reading image bytes for inline previews

- Frontend: ChatConsole sends image base64 data, renders inline thumbnails, and restores images from session files

- Tests: validate image parser, file read, and UI placeholder restoration


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User sends image"] --> B["Frontend: attach base64 to chat.send"]
  B --> C["Backend: parse_document → _parse_image → OCR (RapidOCR/tesseract)"]
  C --> D["Model receives OCR text + metadata"]
  D --> E["Message stored with [Image: name]"]
  E --> F["Session restore: frontend reads image bytes from files dir"]
  F --> G["Inline thumbnail displayed in chat"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>document_parser.py</strong><dd><code>Add image OCR parsing with RapidOCR/tesseract fallback</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-42edcb3bdb887cb051f706bfd568845779b60340f9abe99d076b3e04b1f11d2e">+103/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>file_handlers.py</strong><dd><code>Register image file types for binary viewing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-964d156c94744321a6e8772a9cf54af6287bb0c4f025ff8b9c1c9e268d57acf8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx</strong><dd><code>Implement image attachment send, inline preview, and session restore</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+131/-13</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_image_parser.py</strong><dd><code>Add tests for image document parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-4c95a996118cd0b8bd10b1f15d211fca165e1d46de754690619f7aaf8b3d4185">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_file_handlers.py</strong><dd><code>Test files.read for image binary data and MIME</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-6bb6e15521eac99b07571045e809f309ba3a9690e2b4be5ac4480823c32c55dc">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chatConsoleMessages.test.ts</strong><dd><code>Add UI tests for image attachment restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-57e0a1418353c85e7343af5e7874362a47020346334f769495a023896b252032">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add RapidOCR dependency for image OCR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/661/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

