### PR TITLE
feat: 论文卡片「下载 PDF」直接下载（#667）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1894,6 +1894,27 @@ for m in ("pydantic", "httpx", "loguru"):
     }
   });
 
+  // #667: 直接下载（论文 PDF 等）——webContents.downloadURL 走 Electron 下载器
+  ipcMain.handle(IPC.DOWNLOADS_DOWNLOAD, async (event, payload: unknown) => {
+    const p = payload as { url?: string; filename?: string };
+    const url = p?.url ?? '';
+    if (!/^https?:\/\//i.test(url)) return { ok: false, error: 'invalid url' };
+    const win = electron.BrowserWindow.fromWebContents(event.sender);
+    if (!win) return { ok: false, error: 'no window' };
+    if (p.filename) {
+      const safe = p.filename.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120);
+      win.webContents.session.once('will-download', (_e, item) => {
+        try {
+          item.setSavePath(join(electron.app.getPath('downloads'), safe));
+        } catch {
+          // fall back to default download path
+        }
+      });
+    }
+    win.webContents.downloadURL(url);
+    return { ok: true };
+  });
+
   // -- Document parsing -----------------------------------------------------
   ipcMain.handle(IPC.DOCUMENTS_PARSE, async (_event, payload: unknown) => {
     return bridge.sendSafe('documents.parse', payload as Record<string, unknown>);

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1895,24 +1895,53 @@ for m in ("pydantic", "httpx", "loguru"):
   });
 
   // #667: 直接下载（论文 PDF 等）——webContents.downloadURL 走 Electron 下载器
+  // 按发起方 webContents 关联 will-download（session 是全局的，其他窗口/
+  // 并发下载会串文件名），等 DownloadItem 的 done 事件后按真实结果返回，
+  // 避免渲染层把取消/失败当作成功（CodeRabbit #668 review）。
   ipcMain.handle(IPC.DOWNLOADS_DOWNLOAD, async (event, payload: unknown) => {
     const p = payload as { url?: string; filename?: string };
     const url = p?.url ?? '';
     if (!/^https?:\/\//i.test(url)) return { ok: false, error: 'invalid url' };
     const win = electron.BrowserWindow.fromWebContents(event.sender);
     if (!win) return { ok: false, error: 'no window' };
-    if (p.filename) {
-      const safe = p.filename.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120);
-      win.webContents.session.once('will-download', (_e, item) => {
+    const safe = p.filename
+      ? p.filename.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120)
+      : undefined;
+    const session = win.webContents.session;
+    return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const finish = (ok: boolean, error?: string) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        session.removeListener('will-download', onWillDownload);
+        resolve({ ok, error });
+      };
+      const onWillDownload = (
+        _e: Electron.Event,
+        item: Electron.DownloadItem,
+        wc: Electron.WebContents
+      ) => {
+        // Only the initiating webContents's downloads get our filename.
+        if (wc !== win.webContents) return;
         try {
-          item.setSavePath(join(electron.app.getPath('downloads'), safe));
+          if (safe) item.setSavePath(join(electron.app.getPath('downloads'), safe));
         } catch {
           // fall back to default download path
         }
-      });
-    }
-    win.webContents.downloadURL(url);
-    return { ok: true };
+        item.once('done', (_ev, state) => {
+          finish(state === 'completed', state === 'completed' ? undefined : `download ${state}`);
+        });
+      };
+      session.once('will-download', onWillDownload);
+      win.webContents.downloadURL(url);
+      // Guard: if will-download never fires (e.g. the URL navigates instead
+      // of downloading), don't leave the renderer hanging forever.
+      timer = setTimeout(() => {
+        finish(false, 'download did not start');
+      }, 60_000);
+    });
   });
 
   // -- Document parsing -----------------------------------------------------

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -353,6 +353,12 @@ const api = {
       ipcRenderer.invoke(IPC.FILES_OPEN_CONTAINING_FOLDER, { path }),
   },
 
+  // -- Direct downloads (issue #667: paper PDF etc.) -----------------------
+  downloads: {
+    download: (url: string, filename?: string): Promise<{ ok: boolean; error?: string }> =>
+      ipcRenderer.invoke(IPC.DOWNLOADS_DOWNLOAD, { url, filename }),
+  },
+
   // -- Document parsing ----------------------------------------------------
   documents: {
     parse: (path: string, sessionKey?: string, options?: { forceOcr?: boolean; preview?: boolean }): Promise<DocumentsParseResult> =>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2811,6 +2811,18 @@ export function ChatConsole({
   const handleDownloadPaper = useCallback(
     (paper: PaperItem) => {
       const title = (paper.title || 'this paper').trim();
+      // #667: 有开放 PDF 直链 → 直接下载（Electron downloadURL，零 token 零 AI）
+      const directUrl = paper.open_access_pdf_url || paper.pdf_url ||
+        (paper.arxiv_id ? `https://arxiv.org/pdf/${paper.arxiv_id}` : '');
+      if (directUrl) {
+        setDownloadingPaperId(paper.id || null);
+        const filename = `${(paper.arxiv_id || 'paper')}.pdf`;
+        window.miqi.downloads
+          .download(directUrl, filename)
+          .finally(() => setDownloadingPaperId(null));
+        return;
+      }
+      // 无直链：fallback 让 AI 下载
       const pid = paper.arxiv_id || paper.id || paper.doi || title;
       const instruction = `请下载论文《${title}》的 PDF 文件。paperId: ${pid}`;
       setDownloadingPaperId(paper.id || null);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2811,40 +2811,65 @@ export function ChatConsole({
   const handleDownloadPaper = useCallback(
     (paper: PaperItem) => {
       const title = (paper.title || 'this paper').trim();
-      // #667: 有开放 PDF 直链 → 直接下载（Electron downloadURL，零 token 零 AI）
-      const directUrl = paper.open_access_pdf_url || paper.pdf_url ||
-        (paper.arxiv_id ? `https://arxiv.org/pdf/${paper.arxiv_id}` : '');
+      const filenameBase =
+        paper.arxiv_id || paper.id || paper.doi ||
+        title.replace(/[\\/:*?"<>|]/g, '_').slice(0, 80) || 'paper';
+      // #667: 有开放 PDF 直链 → 直接下载（Electron downloadURL，零 token 零 AI）。
+      // 只接受有效的 HTTP(S) URL——无效直链不阻断后续候选/fallback
+      // （CodeRabbit #668 review）。
+      const candidates = [
+        paper.open_access_pdf_url,
+        paper.pdf_url,
+        paper.arxiv_id ? `https://arxiv.org/pdf/${paper.arxiv_id}` : '',
+      ].filter((u): u is string => !!u && /^https?:\/\//i.test(u));
+      const directUrl = candidates[0];
       if (directUrl) {
         setDownloadingPaperId(paper.id || null);
-        const filename = `${(paper.arxiv_id || 'paper')}.pdf`;
+        const filename = `${filenameBase}.pdf`;
+        const fallback = () => {
+          setDownloadingPaperId(null);
+          aiDownload(paper, title);
+        };
         window.miqi.downloads
           .download(directUrl, filename)
-          .finally(() => setDownloadingPaperId(null));
+          .then((res) => {
+            if (res?.ok) {
+              setDownloadingPaperId(null);
+            } else {
+              fallback();
+            }
+          })
+          .catch(() => fallback());
         return;
       }
       // 无直链：fallback 让 AI 下载
-      const pid = paper.arxiv_id || paper.id || paper.doi || title;
-      const instruction = `请下载论文《${title}》的 PDF 文件。paperId: ${pid}`;
-      setDownloadingPaperId(paper.id || null);
-      // Set input and trigger send on next tick so React state propagates
-      setInput(instruction);
-      setTimeout(() => {
-        const text = instruction.trim();
-        if (!text) return;
-        // Direct send: bypasses the input-state read in handleSend since
-        // we just set it. We inline the send logic here for simplicity.
-        window.miqi.chat
-          .send(text, sessionKey)
-          .then(() => {
-            setDownloadingPaperId(null);
-          })
-          .catch(() => {
-            setDownloadingPaperId(null);
-          });
-      }, 0);
+      aiDownload(paper, title);
     },
     [sessionKey]
   );
+
+  // Fallback: ask the AI to download the paper.
+  const aiDownload = (paper: PaperItem, title: string) => {
+    const pid = paper.arxiv_id || paper.id || paper.doi || title;
+    const instruction = `请下载论文《${title}》的 PDF 文件。paperId: ${pid}`;
+    setDownloadingPaperId(paper.id || null);
+    // Set input and trigger send on next tick so React state propagates
+    setInput(instruction);
+    setTimeout(() => {
+      const text = instruction.trim();
+      if (!text) return;
+      // Direct send: bypasses the input-state read in handleSend since
+      // we just set it. We inline the send logic here for simplicity.
+      window.miqi.chat
+        .send(text, sessionKey)
+        .then(() => {
+          setDownloadingPaperId(null);
+        })
+        .catch(() => {
+          setDownloadingPaperId(null);
+        });
+    }, 0);
+  };
 
   /** Auto-resize textarea to fit content */
   const adjustTextareaHeight = useCallback(() => {

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -34,6 +34,7 @@ export interface PaperItem {
   reference_count?: number | null;
   is_open_access?: boolean;
   open_access_pdf_url?: string;
+  pdf_url?: string; // #667: 直接下载直链
   source?: string;
   source_url?: string;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -94,6 +94,7 @@ export const IPC = {
   FILES_ACCEPT: 'files:accept',
   FILES_OPEN_EXTERNAL: 'files:openExternal',
   FILES_OPEN_CONTAINING_FOLDER: 'files:openContainingFolder',
+  DOWNLOADS_DOWNLOAD: 'downloads:download', // #667: 直接下载（论文 PDF 等）
   DOCUMENTS_PARSE: 'documents:parse',
 
   // Web URL HEAD-check (查看来源 dead-link 过滤)

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.11.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 改进

## 变更概述
论文搜索结果卡片（paper_search）的「下载 PDF」按钮从"发消息让 AI 下载"改为**直接下载**：有 PDF 直链时前端直接触发 Electron 下载器（`webContents.downloadURL` → 系统下载目录），秒下、零 token、零 AI 参与。

## 背景/问题
#667：原实现点「下载 PDF」→ 把"请下载论文《xxx》的 PDF"作为一条新消息发送给 AI → 模型重新跑一轮 turn 下载。问题：
1. 不是直接下载——绕一圈，慢（几秒到几十秒）
2. 消耗 token（一轮完整 LLM 调用）
3. 不可靠（模型可能下载失败/路径不对/卡住）
4. "下载中…"状态实际在等 AI 回复，用户感知混乱

## 变更内容
- `shared/ipc.ts`：新增 `DOWNLOADS_DOWNLOAD: 'downloads:download'` 通道
- `main/ipc/index.ts`：`downloads:download` handler → 校验 URL（仅 http/https）→ `webContents.downloadURL(url)`；可选 filename 走 `will-download` 设置保存路径到系统下载目录
- `preload`：暴露 `window.miqi.downloads.download(url, filename?)`
- `ChatConsole.handleDownloadPaper`：有直链（`open_access_pdf_url` / `pdf_url` / `arxiv_id` 拼 `https://arxiv.org/pdf/{id}`）→ IPC 直接下载；无直链保留原 AI 下载逻辑作 fallback
- `PaperSearchResult.tsx`：PaperItem 类型补 `pdf_url` 字段

## 日志/验证证据
```
# 前端：
cd apps/desktop && vitest run → 151 passed / 11 files
tsc --noEmit web + node → 0 errors
```

## 风险与兼容性
- 仅 http/https URL 允许下载（防任意协议）；filename 做非法字符清洗 + 长度截断
- 无直链论文走原 AI 下载逻辑（行为不变）

Closes #667


___

### **PR Type**
Enhancement


___

### **Description**
- Paper search cards now support direct PDF downloads via Electron’s downloader when an open-access URL is available.

- New IPC channel `downloads:download` handles URL validation, filename sanitization, and Electron `webContents.downloadURL`.

- Preload script exposes `window.miqi.downloads.download()` for direct download triggering.

- Fallback to the previous AI-based download is preserved if no direct URL exists or the download fails.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["User clicks Download PDF"] --> B{"Has direct PDF URL?"}
  B -- Yes --> C["IPC downloads:download"]
  C --> D["Main process: validate URL, set filename"]
  D --> E["Electron downloader"]
  E --> F["Download complete"]
  B -- No --> G["Fallback: AI download via chat"]
  G --> H["AI fetches PDF"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Implement direct-download IPC handler using Electron downloader</code></dd></summary>
<hr>

apps/desktop/src/main/ipc/index.ts

<ul><li>Added IPC handler for <code>downloads:download</code> channel.<br> <li> Validates URL (http/https only), sanitizes filename, and triggers <br><code>webContents.downloadURL</code>.<br> <li> Associates <code>will-download</code> event with the initiating window, waits for <br><code>done</code> event to resolve success/failure, with a 60-second timeout.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/668/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Expose downloads API in preload for direct downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/preload/index.ts

<ul><li>Exposed <code>window.miqi.downloads.download(url, filename?)</code> via IPC invoke.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/668/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Add direct-download path with AI fallback to paper download handler</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Refactored <code>handleDownloadPaper</code> to attempt direct download first if a <br>valid PDF URL is available from <code>open_access_pdf_url</code>, <code>pdf_url</code>, or <br><code>arxiv_id</code>.<br> <li> On download failure or missing URL, reverts to the original AI chat <br>fallback (<code>aiDownload</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/668/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+55/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PaperSearchResult.tsx</strong><dd><code>Add pdf_url field to PaperItem type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx

<ul><li>Added optional <code>pdf_url</code> field to <code>PaperItem</code> interface for direct <br>download support.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/668/files#diff-52e59847eb62dd0bb9d1ee24db1fd1c43b6e0208ed08b4c942a5bb5d417afa9b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipc.ts</strong><dd><code>Add direct-download IPC channel constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/shared/ipc.ts

<ul><li>Registered <code>DOWNLOADS_DOWNLOAD: 'downloads:download'</code> IPC channel <br>constant.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/668/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

