### PR TITLE
fix(desktop): 新建会话后发送消息无响应 — 重试期间连接提示 + 耗尽后错误气泡与重试按钮（#570）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -211,7 +211,7 @@ interface Message {
   toolData?: unknown;
   /** Original tool-call arguments (e.g. web_fetch's url) — real references */
   toolArgs?: unknown;
-  action?: 'open-provider-settings';
+  action?: 'open-provider-settings' | 'retry-load';
   actionLabel?: string;
   /** When true the message is collapsed by default (user can click to expand) */
   collapsed?: boolean;
@@ -1690,6 +1690,9 @@ export function ChatConsole({
   const [customTitle, setCustomTitle] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState(false);
   const [clockTick, setClockTick] = useState(() => Date.now());
+  // #570: bump to force a manual reload of the current session's history
+  // (used by the "重试" button on the load-failure error bubble).
+  const [retryTick, setRetryTick] = useState(0);
   const [input, setInput] = useState('');
   const [executionPolicy, setExecutionPolicy] = useState<ExecutionPolicy>('edit');
   const [streaming, setStreaming] = useState(false);
@@ -2274,7 +2277,29 @@ export function ChatConsole({
           '[ChatConsole] Failed to load session data after retries, last error:',
           lastErr
         );
+        // #570: exhausted retries used to be silent — the spinner was swapped
+        // for the blank empty state with no explanation.  Surface an explicit
+        // error so the user knows the session failed to load.
         setHistoryLoaded(true);
+        setMessages([
+          {
+            role: 'error',
+            content:
+              '会话加载失败：无法连接后台服务，请稍后重试或重启应用。',
+            action: 'retry-load',
+            actionLabel: '重试',
+            timestamp: Date.now(),
+          },
+        ]);
+        // #480: keep trying in the background — a slow-starting bridge will
+        // eventually satisfy sessions.get, and the successful load() overwrites
+        // this error bubble via setMessages(merged) below.  Guards against a
+        // permanent dead-end when the user's only reload trigger (runtimeReadyKey,
+        // event-driven with no polling) fired once while the bridge was still
+        // warming up.
+        const t = setTimeout(() => {
+          if (currentSessionRef.current === sessionKey) load();
+        }, 10_000);
         return;
       }
 
@@ -2553,8 +2578,9 @@ export function ChatConsole({
     };
     load();
     // loadTrigger lets the parent force a reload (e.g. after bridge becomes ready)
+    // retryTick lets the "重试" button force a reload after load exhaustion.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionKey, loadTrigger]);
+  }, [sessionKey, loadTrigger, retryTick]);
 
   // Scroll to bottom: (a) unconditionally after opening a session,
   // (b) during streaming only if the user hasn't manually scrolled up.
@@ -4761,8 +4787,9 @@ export function ChatConsole({
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-2">
               {!historyLoaded ? (
-                <div className="flex items-center justify-center min-h-[300px]">
+                <div className="flex flex-col items-center justify-center min-h-[300px] gap-2.5">
                   <Loader2 size={16} className="animate-spin text-text-faint" />
+                  <p className="text-xs text-text-faint">正在连接…</p>
                 </div>
               ) : messages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-center gap-4">
@@ -4835,6 +4862,7 @@ export function ChatConsole({
                         onCopy={(text) => handleCopy(text, i)}
                         isCopied={copiedIdx === i}
                         onRetry={() => handleRetry(group.msg)}
+                        onRetryLoad={() => setRetryTick((t) => t + 1)}
                         onRegenerate={() => handleRegenerate(group.msg)}
                         onOpenProviderSettings={onOpenProviderSettings}
                         onDownloadPaper={handleDownloadPaper}
@@ -5922,6 +5950,7 @@ function MessageBubble({
   onCopy,
   isCopied,
   onRetry,
+  onRetryLoad,
   onRegenerate,
   onOpenProviderSettings,
   onDownloadPaper,
@@ -5943,6 +5972,8 @@ function MessageBubble({
   onCopy: (text: string) => void;
   isCopied: boolean;
   onRetry?: () => void;
+  /** #570: reload the current session's history (the error bubble's 重试 button). */
+  onRetryLoad?: () => void;
   onRegenerate?: () => void;
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
@@ -6265,6 +6296,20 @@ function MessageBubble({
           }}
         >
           <div className="whitespace-pre-wrap break-words">{msg.content}</div>
+          {msg.action === 'retry-load' && onRetryLoad && (
+            <button
+              type="button"
+              onClick={onRetryLoad}
+              className="mt-3 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors"
+              style={{
+                background: 'var(--danger)',
+                color: 'var(--danger-bg)',
+              }}
+            >
+              <RefreshCw size={13} />
+              {msg.actionLabel ?? '重试'}
+            </button>
+          )}
           {msg.action === 'open-provider-settings' && onOpenProviderSettings && (
             <button
               type="button"

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -13,10 +13,9 @@
  *   npx playwright test --config=playwright.config.ts --project=electron -g "regression-480"
  */
 
-import { _electron as electron, test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import {
-  APPS_DESKTOP,
   LLM_TIMEOUT,
   waitForInputReady,
   sendMessage,
@@ -25,6 +24,7 @@ import {
   getSidebarSessionItems,
   createNewConversation,
   launchElectronApp,
+  relaunchElectronApp,
   closeElectronApp,
   waitForBridgeInitialized,
 } from './helpers/electron-setup';
@@ -85,39 +85,13 @@ test.describe('Regression #480: Session loads on startup', () => {
       await closeElectronApp(electronApp); // no miqiHome arg → keep data
       await new Promise((r) => setTimeout(r, 3000));
 
-      const env: Record<string, string | undefined> = { ...process.env };
-      env.MIQI_HOME = miqiHome;
-      delete env.ELECTRON_RUN_AS_NODE;
-
-      const app2 = await electron.launch({
-        args: [APPS_DESKTOP],
-        executablePath: require('electron') as string,
-        env: env as Record<string, string>,
-        chromiumSandbox: false,
-      });
-
-      let page2: Page | undefined;
-      for (let i = 0; i < 100; i++) {
-        const windows = app2.windows();
-        for (const w of windows) {
-          try {
-            const info = await w.evaluate(() => ({
-              t: document.title,
-              w: window.outerWidth,
-            }));
-            if (info.w > 500 && info.t === 'MiQi Desktop') {
-              page2 = w;
-              break;
-            }
-          } catch {
-            /* window not ready */
-          }
-        }
-        if (page2) break;
-        await new Promise((r) => setTimeout(r, 100));
-      }
-      if (!page2) page2 = await app2.firstWindow();
-      await page2.waitForLoadState('domcontentloaded');
+      // relaunchElectronApp reuses the same home dir and — unlike a manual
+      // electron.launch({ env: { ...process.env } }) — re-probes/clears a broken
+      // MIQI_PYTHON_PATH so the relaunched bridge uses the repo venv instead of
+      // dying at startup (#480 restart-recovery E2E).
+      const fixture2 = await relaunchElectronApp(miqiHome);
+      const app2 = fixture2.electronApp;
+      let page2 = fixture2.page;
 
       // ── Phase 3: Wait for UI + bridge ready ─────────────────────
       try {

--- a/apps/desktop/tests/e2e/repro-570-silent-send.spec.ts
+++ b/apps/desktop/tests/e2e/repro-570-silent-send.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Repro/regression test for issue #570 — [ChatConsole] new session + send →
+ * UI completely silent.
+ *
+ * The bug (fixed in this change):
+ *   `ChatConsole.load()` retries `sessions.get` 10× with exponential backoff
+ *   (500ms → 10s).  When the bridge is not running, `sendSafe` (bridge.ts:763)
+ *   returns null every time.  Pre-fix, the retry window showed only a bare
+ *   `Loader2` spinner (historyLoaded stays false, ChatConsole.tsx:4552) with
+ *   no "正在连接…" text, and after exhaustion (ChatConsole.tsx:2270) the code
+ *   only `console.warn`ed + `setHistoryLoaded(true)`, swapping the spinner for
+ *   the blank empty state — no error bubble, the user saw silence.
+ *
+ * The fix: a "正在连接…" hint during the retry window, and an explicit
+ * "会话加载失败…" error message after the retries are exhausted.
+ *
+ * This is a REGRESSION test — it asserts the DESIRED behaviour (connecting
+ * hint + explicit error), so it FAILED on pre-fix code and passes now.
+ *
+ * Trigger: set `MIQI_PYTHON_PATH` to a python that passes launchElectronApp's
+ * `import sys` probe but cannot actually boot the bridge (system Python 3.14
+ * without the venv deps — no httpx).  `findBridgeExecutable` (bridge.ts:113)
+ * picks it first, the bridge dies at startup, `sessions.get` returns null,
+ * and the 10× retry runs on every session open.
+ *
+ * Note on reload: `launchElectronApp` waits ~60s for the bridge, which already
+ * consumes the initial session's ~57s retry window.  So the test reloads the
+ * renderer to start a FRESH retry cycle under its control.
+ *
+ * Run:
+ *   cd apps/desktop
+ *   npm run build
+ *   PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+ *     MIQI_PYTHON_PATH="C:\Users\Guo\AppData\Local\Python\pythoncore-3.14-64\python.exe" \
+ *     npx playwright test --config=playwright.config.ts --project=electron \
+ *       repro-570-silent-send --reporter=list
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+// The full retry window: 500+1000+2000+4000+8000+10000*5 ≈ 57s.
+const RETRY_WINDOW_MS = 57_000;
+
+test.describe('Repro #570: silent UI on session open with no bridge', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp).catch(() => {});
+  });
+
+  test('dead bridge → connecting hint during retry, explicit error after exhaustion', async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+
+    // Capture renderer console so we can PROVE the retry loop ran — it only
+    // ever surfaces in the console, never in the UI (that's the bug).
+    const consoleLines: string[] = [];
+    page.on('console', (msg) => consoleLines.push(msg.text()));
+
+    // Reload the renderer so ChatConsole remounts and starts a FRESH 10×
+    // retry under our control (launchElectronApp's ~60s bridge-wait already
+    // consumed the initial session's retry window).
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page
+      .locator('[data-testid="chat-input-container"]')
+      .waitFor({ state: 'attached', timeout: 15_000 });
+
+    // ── Desired #1: during the ~57s retry window the UI should show a
+    //    connecting/loading hint ("正在连接…").  Sample across the window —
+    //    pre-fix code showed only a bare spinner with zero explanation. ──
+    const samples: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      samples.push((await page.locator('main').textContent()) ?? '');
+      await page.waitForTimeout(3000);
+    }
+    expect(
+      samples.join('\n'),
+      'during the 10× retry the UI should show a connecting/loading explanation',
+    ).toMatch(/连接|加载|重试|connecting|loading/i);
+
+    // ── Desired #2: after the retries are exhausted the user should get an
+    //    explicit error message (pre-fix code swapped the spinner for the
+    //    blank empty state with no error at all). ──
+    await page.waitForTimeout(RETRY_WINDOW_MS);
+    const afterText = (await page.locator('main').textContent()) ?? '';
+    expect(
+      afterText,
+      'after 10 exhausted retries the UI should show an explicit error message',
+    ).toMatch(/加载失败|连接失败|重试失败|会话加载失败|出错|失败|error/i);
+
+    // ── Desired #3: the error bubble is not a dead end — its "重试" button
+    //    must trigger a fresh load (a new "Load attempt 1/10" console log),
+    //    so a user (or the #480 slow-start path) can recover once the bridge
+    //    comes back. ──
+    const attemptsBefore = consoleLines.filter((l) =>
+      /Load attempt \d+\/10 returned null/.test(l),
+    ).length;
+    const retryBtn = page.getByRole('button', { name: '重试' });
+    await retryBtn.click({ timeout: 5_000 });
+    await page.waitForTimeout(1000);
+    const attemptsAfter = consoleLines.filter((l) =>
+      /Load attempt \d+\/10 returned null/.test(l),
+    ).length;
+    expect(
+      attemptsAfter,
+      'clicking 重试 on the error bubble should trigger a fresh load() attempt',
+    ).toBeGreaterThan(attemptsBefore);
+
+    // The retry loop DID run (proven via console) and, thanks to the #570
+    // fix, the UI now surfaced a connecting hint during the window and an
+    // explicit error after it exhausted.
+    const loadAttemptLines = consoleLines.filter((l) =>
+      /Load attempt \d+\/10 returned null/.test(l),
+    );
+    expect(
+      loadAttemptLines.length,
+      'ChatConsole.load() retry loop ran (proven via console logs)',
+    ).toBeGreaterThan(0);
+    console.log(
+      `[e2e] Retry loop ran ${loadAttemptLines.length} attempts before exhaustion — ` +
+        `UI showed connecting hint + error after fix, 重试 button re-triggered load. ` +
+        `First: ${loadAttemptLines[0]}`,
+    );
+  });
+});

--- a/apps/desktop/tests/e2e/repro-570-silent-send.spec.ts
+++ b/apps/desktop/tests/e2e/repro-570-silent-send.spec.ts
@@ -4,10 +4,10 @@
  *
  * The bug (fixed in this change):
  *   `ChatConsole.load()` retries `sessions.get` 10× with exponential backoff
- *   (500ms → 10s).  When the bridge is not running, `sendSafe` (bridge.ts:763)
- *   returns null every time.  Pre-fix, the retry window showed only a bare
- *   `Loader2` spinner (historyLoaded stays false, ChatConsole.tsx:4552) with
- *   no "正在连接…" text, and after exhaustion (ChatConsole.tsx:2270) the code
+ *   (500ms → 10s).  When the bridge is not running, `sessions.get` returns
+ *   null every time.  Pre-fix, the retry window showed only a bare `Loader2`
+ *   spinner (historyLoaded stays false, ChatConsole.tsx:4552) with no
+ *   "正在连接…" text, and after exhaustion (ChatConsole.tsx:2270) the code
  *   only `console.warn`ed + `setHistoryLoaded(true)`, swapping the spinner for
  *   the blank empty state — no error bubble, the user saw silence.
  *
@@ -17,21 +17,25 @@
  * This is a REGRESSION test — it asserts the DESIRED behaviour (connecting
  * hint + explicit error), so it FAILED on pre-fix code and passes now.
  *
- * Trigger: set `MIQI_PYTHON_PATH` to a python that passes launchElectronApp's
- * `import sys` probe but cannot actually boot the bridge (system Python 3.14
- * without the venv deps — no httpx).  `findBridgeExecutable` (bridge.ts:113)
- * picks it first, the bridge dies at startup, `sessions.get` returns null,
- * and the 10× retry runs on every session open.
+ * Trigger: patch the main-process `sessions:get` IPC handler to return null
+ * (via electronApp.evaluate), so every `window.miqi.sessions.get` invoke hits
+ * the patched handler and returns null — the exact "backend unavailable" state
+ * the retry loop guards against.  This is environment-independent (no reliance
+ * on a specific broken python), so it runs identically on Windows dev machines
+ * and Linux CI.  contextBridge freezes window.miqi.* in the renderer, so a
+ * page.evaluate override would be silently dropped — patching ipcMain in the
+ * main process is the working approach (same pattern as
+ * workspace-file-read-edit.spec.ts for dialog:openDirectory).
  *
- * Note on reload: `launchElectronApp` waits ~60s for the bridge, which already
- * consumes the initial session's ~57s retry window.  So the test reloads the
- * renderer to start a FRESH retry cycle under its control.
+ * Note on reload: the app is launched with a HEALTHY bridge, so the session
+ * loads normally at first.  The test patches sessions:get → null, then reloads
+ * the renderer so ChatConsole remounts and runs a FRESH 10× retry under the
+ * patched handler (which survives reload — ipcMain is in the main process).
  *
  * Run:
  *   cd apps/desktop
  *   npm run build
  *   PLAYWRIGHT_SKIP_WEB_SERVER=1 \
- *     MIQI_PYTHON_PATH="C:\Users\Guo\AppData\Local\Python\pythoncore-3.14-64\python.exe" \
  *     npx playwright test --config=playwright.config.ts --project=electron \
  *       repro-570-silent-send --reporter=list
  */
@@ -45,6 +49,7 @@ import {
 
 // The full retry window: 500+1000+2000+4000+8000+10000*5 ≈ 57s.
 const RETRY_WINDOW_MS = 57_000;
+const SESSIONS_GET = 'sessions:get';
 
 test.describe('Repro #570: silent UI on session open with no bridge', () => {
   let electronApp: ElectronApplication;
@@ -54,7 +59,7 @@ test.describe('Repro #570: silent UI on session open with no bridge', () => {
     await closeElectronApp(electronApp).catch(() => {});
   });
 
-  test('dead bridge → connecting hint during retry, explicit error after exhaustion', async () => {
+  test('unavailable backend → connecting hint during retry, explicit error after exhaustion', async () => {
     const fixture = await launchElectronApp();
     electronApp = fixture.electronApp;
     page = fixture.page;
@@ -64,9 +69,19 @@ test.describe('Repro #570: silent UI on session open with no bridge', () => {
     const consoleLines: string[] = [];
     page.on('console', (msg) => consoleLines.push(msg.text()));
 
+    // ── Make the backend unavailable: patch the main-process IPC handler so
+    //    `sessions.get` returns null.  contextBridge freezes window.miqi.* in
+    //    the renderer, so this must be done in the main process (electronApp
+    //    .evaluate) — ipcMain survives renderer reloads, so the patch stays
+    //    active after the reload below. ──
+    await electronApp.evaluate(async ({ ipcMain: ipc }, channel: string) => {
+      ipc.removeHandler(channel);
+      ipc.handle(channel, async () => null);
+    }, SESSIONS_GET);
+
     // Reload the renderer so ChatConsole remounts and starts a FRESH 10×
-    // retry under our control (launchElectronApp's ~60s bridge-wait already
-    // consumed the initial session's retry window).
+    // retry under the patched handler (the initial mount already loaded the
+    // session successfully with the healthy bridge).
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #570：新建会话后发送消息，前端全程无响应 —— 重试期间现在显示「正在连接…」提示，耗尽后显示明确的错误气泡 + 可操作的「重试」按钮。

## 背景/问题

Issue #570：新建会话后发送消息，UI 无任何响应。根因在 `ChatConsole.load()` 的 10 次重试（`sessions.get` 指数退避，500ms→10s，约 57s 窗口）：重试期间只渲染裸 `Loader2` spinner，无任何文字说明（`historyLoaded` 保持 false）；耗尽后代码仅 `console.warn` + `setHistoryLoaded(true)`，把 spinner 换成空白空态——没有任何错误提示，用户全程看到的是"静默"。

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 重试窗口内显示「正在连接…」连接提示（修复静默）
  - 重试耗尽后渲染明确错误气泡「会话加载失败：无法连接后台服务，请稍后重试或重启应用。」（`action: 'retry-load'` + `actionLabel: '重试'`）
  - 耗尽分支自调度 10s 后重试 `load()`（`currentSessionRef.current === sessionKey` 守卫），bridge 慢启动时可自动恢复——同时避免 #480 重启恢复路径被永久卡死
  - Message 类型扩展 `action?: 'open-provider-settings' | 'retry-load'`，错误气泡带「重试」按钮（`retryTick` state + effect 依赖 `[sessionKey, loadTrigger, retryTick]`）
- `apps/desktop/tests/e2e/repro-570-silent-send.spec.ts`（新增）
  - 回归测试：断言连接提示、耗尽后的错误气泡、「重试」按钮点击后重新触发 `Load attempt 1/10`
- `apps/desktop/tests/e2e/regression-480-startup-history.spec.ts`
  - 重启阶段改用 `relaunchElectronApp`，避免手写 `electron.launch({ env: {...process.env} })` 把坏 `MIQI_PYTHON_PATH` 带进重启的 app 导致 bridge 死亡

## 日志/验证证据

```
[ChatConsole] Load attempt 1/10 returned null, retrying in 500ms…
[ChatConsole] Load attempt 2/10 returned null, retrying in 1000ms…
[ChatConsole] Failed to load session data after retries, last error: Error: …
（重试耗尽 → UI 显示错误气泡）
```

## 测试情况

- 单元测试：`npm test` → 11 文件 / 153 测试全过
- E2E：`repro-570-silent-send`（坏 Python 模拟 bridge 死）→ 通过，重试 17 次后 UI 显示连接提示 + 错误气泡，点击「重试」重新触发 load
- E2E：`regression-480-startup-history`（正常 Python）→ 2 个测试全过，重启后历史可加载，不回归

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/55a0e0e8-348d-44a9-91a2-949b28055fd3" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/00fb3e1d-5763-42a0-ac39-a7450759f2f2" />


## 后续计划


- 无


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add "正在连接…" hint during session load retries

- Show explicit retryable "会话加载失败…" error bubble after exhaustion

- Auto-retry after 10s and manual "重试" button

- Add E2E regression tests for #570 and #480


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChatConsole.load retries sessions.get"] -- "during retries" --> B["show '正在连接…' hint"]
  A -- "retries exhausted" --> C["insert error bubble with retry button"]
  C -- "button click" --> D["retryTick++ triggers load"]
  C -- "10s timeout" --> A
  E["repro-570 E2E patches sessions:get to null"] --> A
  F["regression-480 uses relaunchElectronApp"] --> G["stable restart path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Surface load failures and add retry UX in ChatConsole</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Extends <code>Message.action</code> with <code>'retry-load'</code> and adds <code>retryTick</code> state.<br> <li> On retry exhaustion, inserts an error bubble with a <code>重试</code> action and <br>schedules automatic retry after 10s.<br> <li> Shows <code>正在连接…</code> text under the spinner while history is not loaded.<br> <li> Passes <code>onRetryLoad</code> to <code>MessageBubble</code> and renders a <code>RefreshCw</code> retry <br>button.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/669/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+48/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>regression-480-startup-history.spec.ts</strong><dd><code>Use relaunchElectronApp for stable #480 restart test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/regression-480-startup-history.spec.ts

<ul><li>Replaces manual <code>electron.launch</code> with <code>relaunchElectronApp(miqiHome)</code>.<br> <li> Avoids leaking broken <code>MIQI_PYTHON_PATH</code> into the relaunched app.<br> <li> Removes now-unused <code>_electron as electron</code> and <code>APPS_DESKTOP</code> imports.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/669/files#diff-747a811277a39c83a94a4b3a78a8702e9bb76364dfb253375e8d55b0e99d5bbf">+9/-35</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repro-570-silent-send.spec.ts</strong><dd><code>Add E2E regression for silent ChatConsole load failure</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/repro-570-silent-send.spec.ts

<ul><li>Patches main-process <code>sessions:get</code> handler to return null via <br><code>electronApp.evaluate</code>.<br> <li> Reloads renderer to run a fresh 10x retry window.<br> <li> Asserts connecting hint, explicit error after exhaustion, and that the <br>retry button re-triggers load.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/669/files#diff-ff5b97935aacaf4c81b5bace98fd88881975a5093ef546fc3e9a492a0576a5e6">+148/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

