### PR TITLE
Fix first-message send lag and duplicate submissions

### DIFF
--- a/src/renderer/src/hooks/useSendMessage.ts
+++ b/src/renderer/src/hooks/useSendMessage.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef, useState } from 'react';
+
+export type ChatRole = 'user' | 'assistant';
+
+export interface ChatMessage {
+  id: string;
+  role: ChatRole;
+  content: string;
+  status?: 'sending' | 'sent' | 'failed';
+  createdAt: number;
+}
+
+export interface UseSendMessageOptions {
+  appendMessage: (message: ChatMessage) => void;
+  sendMessageToBackend: (content: string) => Promise<void>;
+  clearInput?: () => void;
+  onFailed?: (messageId: string, error: unknown) => void;
+  ensureConversationReady?: () => Promise<void> | void;
+  onSettled?: () => void;
+}
+
+export function useSendMessage(options: UseSendMessageOptions) {
+  const {
+    appendMessage,
+    sendMessageToBackend,
+    clearInput,
+    onFailed,
+    ensureConversationReady,
+    onSettled,
+  } = options;
+
+  const [isSending, setIsSending] = useState(false);
+  const sendingRef = useRef(false);
+
+  const sendMessage = useCallback(
+    async (rawContent: string) => {
+      const content = rawContent.trim();
+      if (!content) return;
+
+      // Prevent duplicate submissions while the first request is still being prepared.
+      if (sendingRef.current) return;
+
+      const tempId = `local-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+      // Optimistically render the user bubble immediately so the UI stays responsive.
+      sendingRef.current = true;
+      setIsSending(true);
+      clearInput?.();
+
+      appendMessage({
+        id: tempId,
+        role: 'user',
+        content,
+        status: 'sending',
+        createdAt: Date.now(),
+      });
+
+      // Prepare the conversation in the background, but never block the optimistic UI update.
+      const readyPromise = ensureConversationReady?.();
+
+      try {
+        await Promise.resolve(readyPromise);
+        await sendMessageToBackend(content);
+      } catch (error) {
+        onFailed?.(tempId, error);
+      } finally {
+        sendingRef.current = false;
+        setIsSending(false);
+        onSettled?.();
+      }
+    },
+    [appendMessage, clearInput, ensureConversationReady, onFailed, onSettled, sendMessageToBackend]
+  );
+
+  return { sendMessage, isSending };
+}


### PR DESCRIPTION
Closes #364

### What changed
- Render the user message immediately on submit instead of waiting for conversation initialization or backend preparation.
- Add a lightweight send lock to prevent repeated clicks / Enter presses from submitting the same message multiple times.
- Keep conversation preparation asynchronous so the UI feedback is not blocked.

### Why
This removes the visible gap between pressing Send and seeing the user bubble, which was causing users to repeat the action and create duplicate messages/tasks.

### Notes
- The fix is intentionally focused on UI responsiveness and duplicate prevention.
- Failed sends are still surfaced through the existing failure callback.