### PR TITLE
fix: httpx 流式断连归为 TRANSIENT，触发重试 + 正确提示（#675）

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -267,6 +267,22 @@ def classify_error(exc: BaseException) -> ErrorKind:
     except ImportError:
         pass
 
+    # httpx is the shared transport under openai/anthropic SDKs. Mid-stream
+    # connection drops surface as raw httpx errors (ReadError etc.) with empty
+    # messages that string-matching can't classify — treat them as TRANSIENT so
+    # with_retry re-runs instead of surfacing a generic "internal error"
+    # (observed: 22-tool turn died on httpx.ReadError with no retry).
+    try:
+        import httpx
+
+        # httpx 0.28 hierarchy: ReadError→NetworkError→TransportError→…,
+        # timeouts share TimeoutException. Both cover the connect/read/write
+        # failure modes of a streaming LLM call.
+        if isinstance(exc, (httpx.NetworkError, httpx.TimeoutException)):
+            return ErrorKind.TRANSIENT
+    except (ImportError, AttributeError):
+        pass
+
     try:
         import anthropic
 

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -125,6 +125,47 @@ def test_classify_error_httpx_transport_errors_transient() -> None:
         assert classify_error(exc) == ErrorKind.TRANSIENT, exc
 
 
+async def test_with_retry_retries_httpx_readerror_then_succeeds() -> None:
+    """TRANSIENT httpx.ReadError must actually trigger a retry — the #675
+    regression (classified FATAL → no retry → misleading 'internal error')."""
+    import httpx
+
+    calls = 0
+    retries = []
+
+    async def factory() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ReadError("connection reset by peer")
+        return "ok"
+
+    result = await with_retry(
+        factory,
+        max_attempts=3,
+        sleep=lambda _: asyncio.sleep(0),
+        on_retry=lambda attempt, kind, delay: retries.append((attempt, kind)),
+    )
+    assert result == "ok"
+    assert calls == 2  # failed once, retried once, succeeded
+    assert retries == [(1, ErrorKind.TRANSIENT)]
+
+
+async def test_with_retry_does_not_retry_fatal_error() -> None:
+    """A FATAL-classified error must NOT be retried (control case)."""
+
+    calls = 0
+
+    async def factory() -> str:
+        nonlocal calls
+        calls += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError):
+        await with_retry(factory, max_attempts=3, sleep=lambda _: asyncio.sleep(0))
+    assert calls == 1  # raised immediately, no retry
+
+
 @pytest.mark.parametrize("message", [
     # OpenAI style
     "You exceeded your current quota, please check your plan and billing details",

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -109,6 +109,22 @@ def test_classify_error_payment_required_status_402() -> None:
     assert classify_error(_StatusError("upstream response", status_code=402)) == ErrorKind.PAYMENT_REQUIRED
 
 
+def test_classify_error_httpx_transport_errors_transient() -> None:
+    """httpx transport errors (mid-stream drops/timeouts) must be TRANSIENT so
+    with_retry re-runs instead of surfacing a generic "internal error" (#675)."""
+    import httpx
+
+    for exc in (
+        httpx.ReadError("connection reset"),
+        httpx.ConnectError("connect failed"),
+        httpx.WriteError("write failed"),
+        httpx.ReadTimeout("read timed out"),
+        httpx.ConnectTimeout("connect timed out"),
+        httpx.PoolTimeout("no free pool"),
+    ):
+        assert classify_error(exc) == ErrorKind.TRANSIENT, exc
+
+
 @pytest.mark.parametrize("message", [
     # OpenAI style
     "You exceeded your current quota, please check your plan and billing details",

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -119,6 +119,7 @@ def test_classify_error_httpx_transport_errors_transient() -> None:
         httpx.ConnectError("connect failed"),
         httpx.WriteError("write failed"),
         httpx.ReadTimeout("read timed out"),
+        httpx.WriteTimeout("write timed out"),
         httpx.ConnectTimeout("connect timed out"),
         httpx.PoolTimeout("no free pool"),
     ):


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 修复

## 变更概述
`classify_error`（`miqi/providers/resilience.py`）增加 httpx 底层传输异常识别：网络断连/超时从误分类 FATAL 改为 **TRANSIENT**。

## 背景/问题
#675：长任务（多工具调用）中 LLM 流式响应中途断连（`httpx.ReadError`，消息为空字符串）不匹配任何现有分类（openai/anthropic SDK 类型、HTTP 状态码、字符串关键词）→ 落到兜底 FATAL → with_retry 不重试 → 前端误报「处理消息时发生内部错误」。

实测：MOF-5 调研任务 22 个工具调用全部成功后，模型继续生成时连接被重置（BrokenResourceError）→ 整轮失败，用户误以为产品 bug。

## 变更内容
`miqi/providers/resilience.py` `classify_error` 增加（在 SDK 类型分支之后）：
```python
import httpx
if isinstance(exc, (httpx.NetworkError, httpx.TimeoutException)):
    return ErrorKind.TRANSIENT
```
- `httpx.NetworkError`：ReadError/ConnectError/WriteError 的基类（httpx 0.28 层级）
- `httpx.TimeoutException`：ReadTimeout/ConnectTimeout/PoolTimeout 的基类
- 兼容防御：`except (ImportError, AttributeError)`

## 日志/验证证据
```
分类断言（httpx 0.28.1）：
  httpx.ReadError('')      → transient ✓（之前 fatal）
  httpx.ConnectError('x')  → transient ✓
  httpx.ReadTimeout('t')   → transient ✓
  httpx.PoolTimeout('p')   → transient ✓

pytest tests/runtime/test_runtime_task_runner.py → 28 passed
pytest tests/runtime/ -k "task_runner or resilience" → 57 passed
```

## 风险与兼容性
- 仅影响异常分类路径（错误提示/重试决策），不影响正常调用
- TRANSIENT 会让 with_retry 多尝试重试（原 FATAL 直接失败）——对瞬时网络错误是期望行为
- 修复后重试仍失败时用户看到「模型服务暂时不可用或过载」而非误导性的「内部错误」

Closes #675


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reclassify `httpx.NetworkError` and `httpx.TimeoutException` as `TRANSIENT`.

- Trigger automatic retry for mid-stream HTTPX disconnects/timeouts.

- Prevent misleading "internal error" after retry exhaustion.

- Add regression tests for classification and retry behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["httpx.NetworkError / TimeoutException"] -- "classified" --> B["ErrorKind.TRANSIENT"]
  B -- "with_retry retries" --> C["Avoid misleading internal error"]
  D["Regression tests"] -- "validate" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resilience.py</strong><dd><code>Classify httpx transport errors as transient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/providers/resilience.py

<ul><li>Add guarded <code>httpx</code> import with <code>try/except (ImportError, </code><br><code>AttributeError)</code>.<br> <li> Recognize <code>httpx.NetworkError</code> and <code>httpx.TimeoutException</code> as <code>TRANSIENT</code>.<br> <li> Allow streaming transport failures to retry instead of falling through <br>to <code>FATAL</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/676/files#diff-50c32f0941d63bf7242c992961262e3e3666f7dc855b212a51881ac2922f338a">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_provider_resilience.py</strong><dd><code>Add regression tests for httpx retry classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_provider_resilience.py

<ul><li>Assert seven <code>httpx</code> transport/timeout exceptions classify as <code>TRANSIENT</code>.<br> <li> Verify <code>with_retry</code> retries <code>httpx.ReadError</code> once and then succeeds.<br> <li> Add control test confirming <code>FATAL</code> errors are not retried.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/676/files#diff-911b5386c9a0eedc23ab458d26a9beacc81c1190e26d97065464b325a53abf1e">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

