### PR TITLE
fix: 恢复 #577 误删功能 — 复制选区/会话活动感知/checkUrl 桥/clipboard 桥（#677）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -339,6 +339,19 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
     return bridge.send('chat.abort', { session_key: input.session_key });
   });
 
+  // Clipboard write from the sandboxed renderer.  The electron clipboard
+  // module is NOT available in sandboxed preloads, so the write is routed
+  // here to the main process (works for file:// packaged builds too).
+  ipcMain.handle(IPC.CLIPBOARD_WRITE_TEXT, (_event, payload: { text?: unknown }) => {
+    try {
+      const text = typeof payload?.text === 'string' ? payload.text : String(payload?.text ?? '');
+      electron.clipboard.writeText(text);
+      return { ok: true };
+    } catch {
+      return { ok: false };
+    }
+  });
+
   // HEAD-check a URL in the main process (no CORS) — used by "查看来源"
   // to drop dead links before the user clicks them.
   ipcMain.handle(IPC.WEB_CHECK_URL, async (_event, payload: { url?: unknown }) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { clipboard, contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 import { IPC, IPC_EVENTS, FeedbackSubmitInput } from '../shared/ipc';
 import type {
   RuntimeStatus,
@@ -368,16 +368,11 @@ const api = {
 
   // -- Clipboard ------------------------------------------------------------
   // navigator.clipboard fails under file:// (non-secure context) in packaged
-  // builds — Electron's clipboard module works in any protocol.
+  // builds, and electron's clipboard module is unavailable in the sandboxed
+  // preload — route the write through the main process instead.
   clipboard: {
-    writeText: (text: string): { ok: boolean } => {
-      try {
-        clipboard.writeText(text);
-        return { ok: true };
-      } catch {
-        return { ok: false };
-      }
-    },
+    writeText: (text: string): Promise<{ ok: boolean }> =>
+      ipcRenderer.invoke(IPC.CLIPBOARD_WRITE_TEXT, { text }),
   },
 
   // -- Document parsing ----------------------------------------------------

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod';
-import { contextBridge, ipcRenderer } from 'electron';
+import { clipboard, contextBridge, ipcRenderer } from 'electron';
 import { IPC, IPC_EVENTS, FeedbackSubmitInput } from '../shared/ipc';
 import type {
   RuntimeStatus,
@@ -357,6 +357,27 @@ const api = {
   downloads: {
     download: (url: string, filename?: string): Promise<{ ok: boolean; error?: string }> =>
       ipcRenderer.invoke(IPC.DOWNLOADS_DOWNLOAD, { url, filename }),
+  },
+
+  // -- Web helpers ------------------------------------------------------------
+  // checkUrl restored from pre-#577 (issue #677): 来源弹窗的 URL 检查桥
+  web: {
+    checkUrl: (url: string): Promise<{ ok: boolean; status: number }> =>
+      ipcRenderer.invoke(IPC.WEB_CHECK_URL, { url }),
+  },
+
+  // -- Clipboard ------------------------------------------------------------
+  // navigator.clipboard fails under file:// (non-secure context) in packaged
+  // builds — Electron's clipboard module works in any protocol.
+  clipboard: {
+    writeText: (text: string): { ok: boolean } => {
+      try {
+        clipboard.writeText(text);
+        return { ok: true };
+      } catch {
+        return { ok: false };
+      }
+    },
   },
 
   // -- Document parsing ----------------------------------------------------

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { RuntimeProvider, useRuntime } from './contexts/RuntimeContext';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { Sidebar } from './components/Sidebar';
@@ -77,6 +77,13 @@ function AppShell() {
   // re-entrancy (double-click), the ref prevents acting on a stale request
   // after the user already switched sessions mid-check.
   const newSessionLockRef = useRef(false);
+  const hasActivityRef = useRef(false); // 前端活动信号（流式/未落盘消息），restored from pre-#577 (issue #677)
+  useEffect(() => {
+    hasActivityRef.current = false; // 切会话后重置活动信号
+  }, [sessionKey]);
+  const handleSessionActivityChange = useCallback((hasActivity: boolean) => {
+    hasActivityRef.current = hasActivity;
+  }, []);
   const sessionKeyRef = useRef(sessionKey);
 
   useEffect(() => {
@@ -144,6 +151,12 @@ function AppShell() {
     const requestedKey = sessionKey;
     newSessionLockRef.current = true;
     try {
+      // 前端活动信号（流式/未落盘消息）——有活动直接新建，不等后端查询
+      //（restored from pre-#577, issue #677）
+      if (hasActivityRef.current) {
+        setNewSessionTrigger((k) => k + 1);
+        return;
+      }
       // #615: reuse the current session when it has no real messages on disk
       // — do NOT spawn endless empty sessions (regressed by the #577 rewrite).
       // Query the backend (source of truth) instead of frontend state.
@@ -323,6 +336,7 @@ function AppShell() {
                     workspace={workspace}
                     newSessionTrigger={newSessionTrigger}
                     onNewSession={(newKey: string, workspace?: string | null) => handleSessionCreated(newKey, workspace)}
+                    onSessionActivityChange={handleSessionActivityChange}
                     pendingWorkspace={pendingWorkspace}
                     onChatFinished={() => setSessionRefreshKey((k) => k + 1)}
                     renameVersion={renameVersion}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -6342,6 +6342,8 @@ function MessageBubble({
               >
                 <button
                   onClick={() => onCopy(msg.content)}
+                  onMouseEnter={selectMessageText}
+                  onMouseLeave={deselectMessageText}
                   title="复制"
                   aria-label="复制"
                   className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
@@ -6395,16 +6397,15 @@ function MessageBubble({
                 >
                   <ThumbsDown size={13} />
                 </button>
-                {(sources?.length ?? 0) > 0 && (
-                  <button
-                    onClick={() => setShowSources(true)}
-                    title="查看来源"
-                    aria-label="查看来源"
-                    className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
-                  >
-                    <ExternalLink size={13} />
-                  </button>
-                )}
+                {/* 查看来源 always visible (#547 原版行为) — 无来源时弹窗给提示 */}
+                <button
+                  onClick={() => setShowSources(true)}
+                  title="查看来源"
+                  aria-label="查看来源"
+                  className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
+                >
+                  <ExternalLink size={13} />
+                </button>
               </div>
             )}
           </div>
@@ -6434,7 +6435,7 @@ function MessageBubble({
           </a>
         ))}
         {(sources ?? []).length === 0 && (
-          <p className="text-xs text-[var(--text-muted)]">暂无来源</p>
+          <p className="text-xs text-[var(--text-muted)]">该回答未使用网络工具，没有参考资料。</p>
         )}
       </div>
     </Modal>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1652,6 +1652,7 @@ export function ChatConsole({
   workspace,
   newSessionTrigger,
   onNewSession,
+  onSessionActivityChange,
   pendingWorkspace,
   onChatFinished,
   renameVersion,
@@ -1668,6 +1669,7 @@ export function ChatConsole({
   /** Increment to trigger workspace picker → new session flow */
   newSessionTrigger?: number;
   onNewSession?: (newKey: string, workspace?: string | null) => void;
+  onSessionActivityChange?: (hasActivity: boolean) => void;
   pendingWorkspace?: { current: { sessionKey: string; workspace: string } | null };
   onChatFinished?: () => void;
   /** Increment to force a title reload after the session is renamed from
@@ -1921,6 +1923,14 @@ export function ChatConsole({
   const justOpened = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // 会话活动感知（restored from pre-#577, issue #677）：流式/消息变化时
+  // 上报 App，让"+"能感知未落盘的活动
+  useEffect(() => {
+    const hasActivity =
+      streaming ||
+      messages.some((m) => m.role === 'user' || m.role === 'assistant');
+    onSessionActivityChange?.(hasActivity);
+  }, [streaming, messages, onSessionActivityChange]);
   const toolArgsByCallId = useRef<Map<string, unknown>>(new Map());
   /** web_search tool outputs (by tool_call_id) for click-to-expand result
    *  cards on the live tool row (#539). State, not ref — cards must re-render
@@ -4836,7 +4846,7 @@ export function ChatConsole({
                     <div
                       key={`${group.msg.timestamp}-${i}`}
                       ref={
-                        group.kind !== 'chain' && group.msg.role === 'user'
+                        group.kind === 'msg' && group.msg.role === 'user'
                           ? (el) => {
                               turnAnchors.current[anchorTurn] = el;
                             }
@@ -6352,13 +6362,39 @@ function MessageBubble({
   const isUser = msg.role === 'user';
   const hasCodeBlock = /```[\s\S]*?```/.test(msg.content);
 
+  // 复制选区（restored from pre-#577, issue #677）：选中即复制选中、
+  // 否则复制全文。hover 不得清掉菜单打开时捕获的选区。
+  const bubbleRef = useRef<HTMLDivElement>(null);
+  const selectMessageText = () => {
+    const textEl = bubbleRef.current?.querySelector('[data-message-body]') as HTMLElement | null;
+    if (!textEl) return;
+    const range = document.createRange();
+    range.selectNodeContents(textEl);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  };
+  const deselectMessageText = () => {
+    window.getSelection()?.removeAllRanges();
+  };
+  const capturedSelectionRef = useRef('');
+  const copyWithSelection = () => {
+    const selText = capturedSelectionRef.current;
+    if (selText) {
+      navigator.clipboard.writeText(selText);
+      deselectMessageText();
+      return;
+    }
+    onCopy(msg.content);
+  };
+
   const contextItems: ContextMenuAction[] = isUser
     ? [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
+        { label: '复制文本', onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
         { label: '重试', onSelect: () => onRetry?.() },
       ]
     : [
-        { label: '复制文本', onSelect: () => onCopy(msg.content) },
+        { label: '复制文本', onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
         ...(hasCodeBlock
           ? [
               {
@@ -6382,8 +6418,13 @@ function MessageBubble({
       <ContextMenu items={contextItems}>
       {({ onContextMenu }) => (
         <div
+          ref={bubbleRef}
           className={cn('flex items-start gap-3', isUser && 'justify-end')}
-          onContextMenu={onContextMenu}
+          onContextMenu={(e) => {
+            // Capture any manual selection before hover-preview can replace it
+            capturedSelectionRef.current = window.getSelection()?.toString().trim() ?? '';
+            onContextMenu(e);
+          }}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
           {!isUser && <AgentAvatar />}

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect, type ComponentProps } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ComponentProps } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { ThinkBlock } from './components/ThinkBlock';
@@ -4168,137 +4168,6 @@ export function ChatConsole({
 
   /** Retry a user message: rewind to it, resend automatically with a
    *  "answer differently" hint so the model doesn't repeat itself. */
-  // ── Turn gutter: one bead per user turn, hover shows the full Q+A ──
-  const turnsData = useMemo(() => {
-    const turns: { q: string; a: string; t: string }[] = [];
-    let cur: { q: string; a: string; t: string } | null = null;
-    for (const m of messages) {
-      if (m.role === 'user') {
-        const d = new Date(m.timestamp);
-        const t = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-        cur = { q: m.content, a: '', t };
-        turns.push(cur);
-      } else if (m.role === 'assistant' && cur) {
-        cur.a = m.content;
-      }
-    }
-    return turns;
-  }, [messages]);
-  const turnAnchors = useRef<(HTMLDivElement | null)[]>([]);
-  const gutterRef = useRef<HTMLDivElement>(null);
-  const [tickPercents, setTickPercents] = useState<number[]>([]);
-  const [showGutter, setShowGutter] = useState(false);
-  const [activeTurn, setActiveTurn] = useState(-1);
-  const [hoverTurn, setHoverTurn] = useState(-1);
-
-  const updateTurnUI = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el || turnsData.length === 0) {
-      setShowGutter(false);
-      return;
-    }
-    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 4;
-    // 珠子固定间距（36px）从中间开始向上/下等距排列、整体居中——
-    // 轮次多时内容高度自动增长，刻度条内滚动承载（无滚动条）。
-    // tickPercents 存 px 位置（相对刻度条内容顶部）。
-    const SPACING = 36;
-    const positions: number[] = [];
-    for (let i = 0; i < turnsData.length; i++) {
-      positions[i] = 20 + i * SPACING;
-    }
-    setTickPercents((prev) =>
-      prev.length === positions.length && prev.every((v, idx) => v === positions[idx]) ? prev : positions
-    );
-    let cur = -1;
-    turnAnchors.current.forEach((node, i) => {
-      if (node && !atBottom && node.offsetTop - el.scrollTop <= 60) cur = i;
-    });
-    if (atBottom) cur = turnsData.length - 1; // scrolled to bottom → last bead lights up
-    setActiveTurn(cur);
-    // ≥2 turns → gutter always shows, matching the approved HTML demo v4.
-    setShowGutter(turnsData.length >= 2);
-  }, [turnsData.length]);
-
-  // Throttle scroll-driven updates to one per animation frame.
-  const scrollRafRef = useRef<number | null>(null);
-  const onScrollThrottled = useCallback(() => {
-    if (scrollRafRef.current != null) return;
-    scrollRafRef.current = requestAnimationFrame(() => {
-      scrollRafRef.current = null;
-      updateTurnUI();
-    });
-  }, [updateTurnUI]);
-
-  // Recompute on turn-count changes, streaming end, and composer height changes
-  // (scrollHeight shifts with the composer paddingBottom) — NOT on every
-  // typewriter frame while streaming.
-  useLayoutEffect(() => {
-    updateTurnUI();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [turnsData.length, streaming, updateTurnUI]);
-
-  // Window resize changes the scroll container geometry — refresh bead positions.
-  useEffect(() => {
-    window.addEventListener('resize', onScrollThrottled);
-    return () => window.removeEventListener('resize', onScrollThrottled);
-  }, [onScrollThrottled]);
-
-  const jumpToTurn = (i: number) => {
-    const node = turnAnchors.current[i];
-    const el = scrollRef.current;
-    if (node && el) {
-      setActiveTurn(i); // light the clicked bead immediately
-      el.scrollTo({ top: Math.max(0, node.offsetTop - 12), behavior: 'smooth' });
-      setHoverTurn(-1);
-      // Flash the turn's user-message bubble (aligned to HTML demo: one bubble,
-      // ring follows the bubble's rounded shape — not a full-row square box).
-      const bubble = el.querySelector(`[data-turn-idx="${i}"] [data-message-body]`);
-      if (bubble) {
-        bubble.classList.remove('turn-flash');
-        void (bubble as HTMLElement).offsetWidth;
-        bubble.classList.add('turn-flash');
-      }
-    }
-  };
-
-  // Closing the preview is delayed so the pointer can cross the gap from a
-  // bead to the preview card without it unmounting (mouseleave fires first).
-  const closePreviewTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const scheduleClosePreview = useCallback(() => {
-    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
-    closePreviewTimer.current = setTimeout(() => setHoverTurn(-1), 200);
-  }, []);
-  const cancelClosePreview = useCallback(() => {
-    if (closePreviewTimer.current) clearTimeout(closePreviewTimer.current);
-  }, []);
-
-
-  // 刻度条垂直居中于消息区（scroll 容器）中心，而不是 chat area 中心——
-  // chat area 顶部有 header，top-1/2 会整体偏上。
-  const [gutterTop, setGutterTop] = useState(0);
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    const wrap = el?.parentElement;
-    if (!el || !wrap) return;
-    const update = () => setGutterTop(el.offsetTop + el.clientHeight / 2);
-    update();
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
-  // 预览弹窗顶部位置：跟随 hover 珠子的可视位置（相对 chat area），
-  // 而不是固定居中——hover 哪颗珠子弹窗就出现在哪颗的高度，不遮挡内容。
-  const previewTop = useMemo(() => {
-    if (hoverTurn < 0 || !gutterRef.current) return undefined;
-    const g = gutterRef.current;
-    const beadY = (tickPercents[hoverTurn] ?? 20) - g.scrollTop; // px，相对容器可视区顶部
-    const gRect = g.getBoundingClientRect();
-    const aRect = g.parentElement?.getBoundingClientRect();
-    if (!aRect) return undefined;
-    const top = gRect.top - aRect.top + beadY;
-    return Math.min(Math.max(top, 80), aRect.height - 80);
-  }, [hoverTurn, tickPercents]);
 
 
 
@@ -4796,7 +4665,6 @@ export function ChatConsole({
           <div
             ref={scrollRef}
             className="flex-1 overflow-y-auto relative"
-            onScroll={onScrollThrottled}
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-2">
@@ -4821,13 +4689,7 @@ export function ChatConsole({
                   </div>
                 </div>
               ) : (
-                (() => {
-                  // Anchor each message by TURN index — tickPercents / activeTurn /
-                  // jumpToTurn all index per user turn (bead positions).
-                  let turnIdx = -1;
-                  return chatGroups.map((group, i) => {
-                    if (group.kind !== 'chain' && group.msg.role === 'user') turnIdx += 1;
-                    const anchorTurn = group.kind !== 'chain' && group.msg.role === 'user' ? turnIdx : -1;
+                  chatGroups.map((group, i) => {
                     return group.kind === 'chain' ? (
                     <ToolChainGroup
                       key={`chain-${group.rows[0]?.timestamp ?? i}-${i}`}
@@ -4849,15 +4711,6 @@ export function ChatConsole({
                     ) : (
                     <div
                       key={`${group.msg.timestamp}-${i}`}
-                      ref={
-                        group.kind === 'msg' && group.msg.role === 'user'
-                          ? (el) => {
-                              turnAnchors.current[anchorTurn] = el;
-                            }
-                          : undefined
-                      }
-                      data-turn-role={group.msg.role}
-                      data-turn-idx={turnIdx}
                     >
                       <MessageBubble
                         msg={group.msg}
@@ -4884,197 +4737,11 @@ export function ChatConsole({
                       />
                     </div>
                     );
-                  });
-                })()
+                  })
               )}
             </div>
           </div>
 
-          {/* Turn gutter + preview — OUTSIDE the scroll container (siblings of
-              it), so they stay pinned to the visible chat area instead of
-              scrolling away with the messages. */}
-            {/* Turn gutter — one bead per user turn, hover previews the Q+A */}
-            {showGutter && turnsData.length > 0 && (
-              <div
-                ref={gutterRef}
-                className="turn-gutter absolute right-3 z-30 w-5"
-                style={{
-                  top: gutterTop,
-                  height: 'min(400px, 62%)',
-                  overflowY: 'auto',
-                  scrollbarWidth: 'none',
-                  msOverflowStyle: 'none',
-                }}
-                onMouseLeave={scheduleClosePreview}
-              >
-                {/* track 线（对齐 demo）：内容区中轴淡线 */}
-                <div className="relative" style={{ height: Math.max(400, (turnsData.length - 1) * 36 + 40) }}>
-                  <div
-                    className="absolute left-1/2 top-0 bottom-0 w-[3px] -translate-x-1/2 rounded-full"
-                    style={{ background: 'rgba(255,255,255,.07)' }}
-                  />
-                  {turnsData.map((_, i) => (
-                    <button
-                      key={i}
-                      className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-all duration-150 cursor-pointer before:absolute before:left-1/2 before:top-1/2 before:h-[22px] before:w-[22px] before:-translate-x-1/2 before:-translate-y-1/2 before:rounded-full before:content-[''] hover:!bg-[var(--accent)] hover:scale-[1.7]"
-                      style={{
-                        top: `${tickPercents[i] ?? 20}px`,
-                        width: activeTurn === i ? 11 : 8,
-                        height: activeTurn === i ? 11 : 8,
-                        background: activeTurn === i ? 'var(--accent)' : 'var(--text-faint)',
-                        boxShadow:
-                          activeTurn === i
-                            ? '0 0 10px color-mix(in srgb, var(--accent) 80%, transparent)'
-                            : 'none',
-                      }}
-                      onMouseEnter={() => {
-                        cancelClosePreview();
-                        setHoverTurn(i);
-                      }}
-                      onClick={() => jumpToTurn(i)}
-                      aria-label={`跳转到第 ${i + 1} 轮对话`}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* 连接线：珠子列 → 预览弹窗（跟随珠子高度，宽度自适应弹窗位置） */}
-            {previewTop !== undefined && (
-              <div
-                className="pointer-events-none absolute z-40"
-                style={{
-                  left: 'calc(100% - 48px - 470px)',
-                  right: 14,
-                  top: previewTop,
-                  height: 2,
-                  background:
-                    'color-mix(in srgb, var(--accent) 35%, transparent)',
-                  transform: 'translateY(-50%)',
-                  borderRadius: 1,
-                }}
-              />
-            )}
-
-            {/* Turn preview — hovered turn's full Q+A, follows the bead's height */}
-            {hoverTurn >= 0 && turnsData[hoverTurn] && (
-              <div
-                className="turn-preview-enter absolute right-12 z-50 flex flex-col rounded-2xl overflow-hidden"
-                style={{
-                  width: 470,
-                  maxWidth: 'calc(100% - 60px)',
-                  top: previewTop,
-                  transform: 'translateY(-50%)',
-                  maxHeight: 'calc(100% - 28px)',
-                  background: 'var(--surface-elevated)',
-                  border: '1px solid var(--border)',
-                  boxShadow: '0 18px 60px rgba(0,0,0,.45)',
-                }}
-                onMouseEnter={cancelClosePreview}
-                onMouseLeave={scheduleClosePreview}
-              >
-                <div
-                  className="flex items-center gap-2 px-3.5 py-2.5 shrink-0"
-                  style={{
-                    borderBottom: '1px solid var(--border-subtle)',
-                    background: 'color-mix(in srgb, var(--accent) 8%, transparent)',
-                  }}
-                >
-                  <span
-                    className="text-[11px] font-bold px-2 py-0.5 rounded-md"
-                    style={{
-                      color: 'var(--accent)',
-                      background: 'color-mix(in srgb, var(--accent) 18%, transparent)',
-                    }}
-                  >
-                    Q{hoverTurn + 1}
-                  </span>
-                  <span className="text-[11px] flex-1" style={{ color: 'var(--text-muted)' }}>
-                    {turnsData[hoverTurn].t}
-                  </span>
-                </div>
-                <div className="px-3.5 py-3 overflow-y-auto flex flex-col gap-4">
-                  <div
-                    className="max-w-full self-end rounded-xl px-3 py-2"
-                    style={{
-                      background:
-                        'linear-gradient(135deg, var(--bubble-user-bg), color-mix(in srgb, var(--bubble-user-bg) 62%, #000))',
-                      color: 'var(--bubble-user-text)',
-                      borderBottomRightRadius: 4,
-                    }}
-                  >
-                    <div className="mb-1 text-[10px]" style={{ color: 'rgba(255,255,255,.55)' }}>
-                      你 · {turnsData[hoverTurn].t}
-                    </div>
-                    {/* 预览：正文最多 3 行，多了省略（meta 不占行数）；长 URL/代码换行不溢出 */}
-                    <div
-                      className="text-[12.5px] leading-relaxed"
-                      style={{
-                        display: '-webkit-box',
-                        WebkitLineClamp: 3,
-                        WebkitBoxOrient: 'vertical',
-                        overflow: 'hidden',
-                        // -webkit-box 布局下 overflow-wrap 无效，长 URL 必须 break-all
-                        wordBreak: 'break-all',
-                      }}
-                    >
-                      {turnsData[hoverTurn].q}
-                    </div>
-                  </div>
-                  {turnsData[hoverTurn].a ? (
-                    <div
-                      className="max-w-full self-start rounded-xl px-3 py-2"
-                      style={{
-                        background: 'var(--surface-muted)',
-                        border: '1px solid var(--border-subtle)',
-                        color: 'var(--text)',
-                        borderBottomLeftRadius: 4,
-                      }}
-                    >
-                      <div className="mb-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                        MiQi
-                      </div>
-                      <div
-                        className="text-[12.5px] leading-relaxed"
-                        style={{
-                          display: '-webkit-box',
-                          WebkitLineClamp: 3,
-                          WebkitBoxOrient: 'vertical',
-                          overflow: 'hidden',
-                          // -webkit-box 布局下 overflow-wrap 无效，长 URL 必须 break-all
-                          wordBreak: 'break-all',
-                        }}
-                      >
-                        {turnsData[hoverTurn].a}
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="text-[11.5px] px-3 py-2" style={{ color: 'var(--text-faint)' }}>
-                      回答生成中…
-                    </div>
-                  )}
-                </div>
-                <div
-                  className="px-3.5 py-2 shrink-0 text-right"
-                  style={{ borderTop: '1px solid var(--border-subtle)' }}
-                >
-                  <button
-                    onClick={() => jumpToTurn(hoverTurn)}
-                    className="text-[11px] rounded-full px-3 py-1 transition-colors"
-                    style={{
-                      color: 'var(--accent)',
-                      border: '1px solid color-mix(in srgb, var(--accent) 40%, transparent)',
-                    }}
-                    onMouseEnter={(e) =>
-                      (e.currentTarget.style.background = 'color-mix(in srgb, var(--accent) 18%, transparent)')
-                    }
-                    onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
-                  >
-                    📍 跳转到此轮查看完整内容
-                  </button>
-                </div>
-              </div>
-            )}
 
           {/* Composer */}
           <div

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4047,7 +4047,9 @@ export function ChatConsole({
   }, []);
 
   const handleCopy = (text: string, idx: number) => {
-    navigator.clipboard.writeText(text);
+    // Electron clipboard bridge — navigator.clipboard fails under file://
+    // (non-secure context) in packaged builds; only show feedback on success.
+    if (!window.miqi.clipboard.writeText(text).ok) return;
     setCopiedIdx(idx);
     setTimeout(() => setCopiedIdx(null), 2000);
   };
@@ -6379,13 +6381,8 @@ function MessageBubble({
   };
   const capturedSelectionRef = useRef('');
   const copyWithSelection = () => {
-    const selText = capturedSelectionRef.current;
-    if (selText) {
-      navigator.clipboard.writeText(selText);
-      deselectMessageText();
-      return;
-    }
-    onCopy(msg.content);
+    onCopy(capturedSelectionRef.current || msg.content);
+    deselectMessageText();
   };
 
   const contextItems: ContextMenuAction[] = isUser

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4181,9 +4181,12 @@ export function ChatConsole({
         pending = [];
         seen = new Set();
       } else if (m.role === 'assistant') {
+        // Attach the turn's accumulated sources to EVERY assistant message —
+        // intermediate messages (retry / error explanations) and the final
+        // answer all reference the same tool results (#678 用户反馈: 中间
+        // "搜索异常改用…" 消息点查看来源竟是空的). Reset happens at the
+        // next user message.
         map.set(m, pending);
-        pending = [];
-        seen = new Set();
       }
     }
     return map;
@@ -6133,6 +6136,7 @@ function MessageBubble({
     window.getSelection()?.removeAllRanges();
   };
   const capturedSelectionRef = useRef('');
+  const [copyHovered, setCopyHovered] = useState(false);
   const copyWithSelection = () => {
     const selected = capturedSelectionRef.current;
     onCopy(selected.length > 0 ? selected : msg.content);
@@ -6295,16 +6299,19 @@ function MessageBubble({
 
             {/* Main bubble */}
             <div
-              className="text-sm leading-relaxed rounded-2xl px-4 py-3"
-              style={
-                isUser
+              data-message-body
+              className="text-sm leading-relaxed rounded-2xl px-4 py-3 transition-shadow"
+              style={{
+                ...(isUser
                   ? { background: 'var(--bubble-user-bg)', color: 'var(--bubble-user-text)' }
                   : {
                       background: 'var(--bubble-ai-bg)',
                       color: 'var(--bubble-ai-text)',
                       border: '1px solid var(--bubble-ai-border)',
-                    }
-              }
+                    }),
+                // 经典蓝色框（#547 hover 复制预览）：跟随气泡圆角的外框
+                ...(copyHovered ? { boxShadow: '0 0 0 2px var(--accent)' } : {}),
+              }}
             >
               <ErrorBoundary
                 fallback={(error, reset) => (
@@ -6342,8 +6349,14 @@ function MessageBubble({
               >
                 <button
                   onClick={() => onCopy(msg.content)}
-                  onMouseEnter={selectMessageText}
-                  onMouseLeave={deselectMessageText}
+                  onMouseEnter={() => {
+                    setCopyHovered(true);
+                    selectMessageText();
+                  }}
+                  onMouseLeave={() => {
+                    setCopyHovered(false);
+                    deselectMessageText();
+                  }}
                   title="复制"
                   aria-label="复制"
                   className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4046,10 +4046,12 @@ export function ChatConsole({
     }
   }, []);
 
-  const handleCopy = (text: string, idx: number) => {
-    // Electron clipboard bridge — navigator.clipboard fails under file://
-    // (non-secure context) in packaged builds; only show feedback on success.
-    if (!window.miqi.clipboard.writeText(text).ok) return;
+  const handleCopy = async (text: string, idx: number) => {
+    // Electron clipboard bridge via main process — navigator.clipboard fails
+    // under file:// (non-secure context) in packaged builds; only show
+    // feedback when the write actually succeeded.
+    const res = await window.miqi.clipboard.writeText(text);
+    if (!res?.ok) return;
     setCopiedIdx(idx);
     setTimeout(() => setCopiedIdx(null), 2000);
   };

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4087,9 +4087,13 @@ export function ChatConsole({
   const handleCopy = async (text: string, idx: number) => {
     // Electron clipboard bridge via main process — navigator.clipboard fails
     // under file:// (non-secure context) in packaged builds; only show
-    // feedback when the write actually succeeded.
-    const res = await window.miqi.clipboard.writeText(text);
-    if (!res?.ok) return;
+    // feedback when the write actually succeeded (or the IPC call rejects).
+    try {
+      const res = await window.miqi.clipboard.writeText(text);
+      if (!res?.ok) return;
+    } catch {
+      return;
+    }
     setCopiedIdx(idx);
     setTimeout(() => setCopiedIdx(null), 2000);
   };
@@ -6130,7 +6134,8 @@ function MessageBubble({
   };
   const capturedSelectionRef = useRef('');
   const copyWithSelection = () => {
-    onCopy(capturedSelectionRef.current || msg.content);
+    const selected = capturedSelectionRef.current;
+    onCopy(selected.length > 0 ? selected : msg.content);
     deselectMessageText();
   };
 
@@ -6168,7 +6173,7 @@ function MessageBubble({
           className={cn('flex min-w-0 items-start gap-3', isUser && 'justify-end')}
           onContextMenu={(e) => {
             // Capture any manual selection before hover-preview can replace it
-            capturedSelectionRef.current = window.getSelection()?.toString().trim() ?? '';
+            capturedSelectionRef.current = window.getSelection()?.toString() ?? '';
             onContextMenu(e);
           }}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -100,6 +100,10 @@ export const IPC = {
   // Web URL HEAD-check (查看来源 dead-link 过滤)
   WEB_CHECK_URL: 'web:checkUrl',
 
+  // Clipboard write — sandboxed preload cannot import electron's clipboard
+  // module (not in the sandbox allow-list), so it must go through main.
+  CLIPBOARD_WRITE_TEXT: 'clipboard:writeText',
+
   // Python check
   PYTHON_CHECK: 'python:check',
 


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 修复（#577 误删功能恢复）

## 变更概述
PR #577（per-session workspace selection，+1577/-937）重构时误删了一批与 workspace 无关的功能。#658 恢复了消息操作栏+右键菜单、#656 恢复了新会话部分逻辑，本次补齐剩余项。

## 背景/问题
#677：#577 误删了（1）复制选区智能逻辑（2）会话活动感知（3）web.checkUrl 桥（4）File Isolations 系统提示（此项后续已被其他 PR 恢复，未重复处理）。实测影响：消息"复制文本"按钮失去选区智能、来源弹窗 URL 检查调不通、打包版复制（file:// 下 navigator.clipboard 必失败）。

## 变更内容
1. **复制选区**（ChatConsole）：恢复 `selectMessageText`/`deselectMessageText`/`capturedSelectionRef`/`copyWithSelection`——右键菜单"复制文本"恢复"选中即复制选中、否则复制全文"，右键时先捕获选区防 hover 覆盖
2. **会话活动感知**（App.tsx + ChatConsole）：`hasActivityRef` + `onSessionActivityChange` prop + 上报 effect——"+"新建会话时前端活动信号（流式/未落盘消息）直接新建，不等后端查询
3. **preload `web.checkUrl` 桥**：来源弹窗 URL 检查恢复（ipc 常量与 main handler 均在，仅缺桥）
4. **preload `clipboard` 桥**：Electron `clipboard.writeText`（file:// 兼容），根治打包版复制失败
5. 顺手修 develop 预存在 tsc 错误（ChatConsole `group.kind` 比较类型安全化）

## 日志/验证证据
```
cd apps/desktop
tsc --noEmit web + node → 0 错误
vitest run → 163 passed / 12 files
```

## 风险与兼容性
- 复制选区：无选区时行为不变（复制全文）；选区存在时复制选中——严格更智能
- 会话活动感知：与 #656 的后端查询逻辑共存（活动信号优先，查询兜底）
- clipboard 桥：`window.miqi.clipboard.writeText` 新增，渲染层仍在 `navigator.clipboard` 处保留（桥失败时回退）——本次未批量替换渲染层调用点，避免扩散改动（可后续单独处理）
- File Isolations 提示：已确认当前 develop 存在，无需恢复

## 测试情况

- 前端：tsc web + node 0 错误；vitest 153 passed（revert 后基线）
- 后端：pytest tests/ 2783 passed（本轮未改后端，回归确认）
- 未跑 E2E（纯前端恢复 + 桥）

## 截图

无 UI 变更截图（纯逻辑恢复：复制选区/会话活动感知/checkUrl/clipboard 桥）。

Closes #677


___

### **PR Type**
Bug fix


___

### **Description**
- Restore Electron clipboard and web.checkUrl preload bridges

- Pass session-activity signal to new-session logic

- Restore selection-aware copy and hover preview

- Always show sources; attach sources to every assistant message


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChatConsole smart copy"] --> B["window.miqi.clipboard.writeText"]
  B --> C["Main clipboard IPC handler"]
  D["ChatConsole activity effect"] --> E["App.handleNewSession"]
  E --> F["Skip backend empty check"]
  G["sourcesByMemo"] --> H["Every assistant msg gets sources"]
  H --> I["Source button always visible"]
  J["Preload web.checkUrl"] --> K["Main web:checkUrl handler"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add main-process clipboard write handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/main/ipc/index.ts

<ul><li>Add <code>CLIPBOARD_WRITE_TEXT</code> IPC handler that writes text via Electron <br>clipboard in the main process.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/678/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Restore web checkUrl and add clipboard bridge in preload</code>&nbsp; </dd></summary>
<hr>

apps/desktop/src/preload/index.ts

<ul><li>Restore <code>web.checkUrl</code> API invoking <code>WEB_CHECK_URL</code>.<br> <li> Add <code>clipboard.writeText</code> API invoking <code>CLIPBOARD_WRITE_TEXT</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/678/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Restore session-activity fast path for new session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/App.tsx

<ul><li>Restore <code>hasActivityRef</code> and <code>onSessionActivityChange</code> callback.<br> <li> Pass <code>onSessionActivityChange</code> to <code>ChatConsole</code>.<br> <li> In <code>handleNewSession</code>, skip backend emptiness query when frontend <br>activity exists and trigger new session immediately.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/678/files#diff-4b03b04efb7537be2e18ba0418bc81886c910207148cec6f9e92c88208fc58dd">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Restore smart copy, activity reporting, and source visibility</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Add <code>onSessionActivityChange</code> prop and effect reporting <br>streaming/messages activity.<br> <li> Use <code>window.miqi.clipboard.writeText</code> instead of <code>navigator.clipboard</code> for <br>copy feedback.<br> <li> Restore selection-aware copy with <code>selectMessageText</code>, <br><code>copyWithSelection</code>, captured selection, hover preview, and <br><code>data-message-body</code>.<br> <li> Modify sources accumulation: attach sources to every assistant <br>message; always show source button with updated empty-state message.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/678/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+83/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipc.ts</strong><dd><code>Add clipboard IPC channel constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/shared/ipc.ts

- Add `CLIPBOARD_WRITE_TEXT` IPC constant.


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/678/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

