### PR TITLE
fix(desktop): 发送时乐观展示用户气泡，冷启动不再卡顿导致重复发送（#364）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -6574,7 +6574,7 @@ function MessageBubble({
               only while this exact bubble (matched by timestamp) is still
               pending (issue #364). */}
           {isUser && sending === msg.timestamp && (
-            <Loader2 size={14} className="animate-spin shrink-0 mt-4 text-text-faint" />
+            <Loader2 size={14} className="animate-spin shrink-0 self-center text-text-faint" />
           )}
 
           <div

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2898,6 +2898,9 @@ export function ChatConsole({
     // starting a fresh turn in session B.  The UI also blocks this via the
     // streaming-disabled textarea / stop button.
     if (pendingSendIdsRef.current.has(currentSessionRef.current)) {
+      // A blocked regenerate must not leak its payload into the next manual
+      // send — clear it before bailing (CodeRabbit #681).
+      retryPayloadRef.current = null;
       return;
     }
     // Retry/regenerate: nudge the model to answer differently — the stored
@@ -2940,7 +2943,7 @@ export function ChatConsole({
     const userMsg: Message = {
       role: 'user',
       content: text || '(attachment)',
-      attachments: [...attachments],
+      attachments: [...atts],
       timestamp: Date.now(),
     };
 
@@ -2963,8 +2966,10 @@ export function ChatConsole({
       }
     }, 0);
     setAttachments([]);
-    // Save a snapshot before clearing — chat.send needs it later
-    const sentAttachments = [...attachments];
+    // Save a snapshot before clearing — chat.send needs it later.  Use the
+    // resolved `atts` (which handles the retry-payload path), not the state,
+    // so the bubble and the backend payload always match (CodeRabbit #681).
+    const sentAttachments = [...atts];
     // The session is marked in-flight synchronously with the bubble so a
     // session-switch / reload during the slow provider check still knows this
     // turn is pending.  Dropping the "final already handled" mark lets this
@@ -3092,12 +3097,32 @@ export function ChatConsole({
       if (lifecycleRef.current?.id === turnId) lifecycleRef.current = null;
       resolveLifecycle();
     };
+    // The user hit stop (or a newer send took over) while the aborts above were
+    // awaited — handleAbort wrote a tombstone (0) into pendingSendIdsRef for
+    // this session and kept the entry so a later send would still bail.  Detect
+    // that lost-turn here: drop the optimistic bubble, clear the marker (the
+    // tombstone would otherwise block every later send in this session), restore
+    // the composer, and settle this lifecycle so a later send does not wait on
+    // it.  Do NOT proceed to threads.start/chat.send for a cancelled send.
+    if (!isCurrentPendingSend(sendSessionKey, thisSendId)) {
+      pendingSendIdsRef.current.delete(sendSessionKey);
+      streamingBySession.delete(sendSessionKey);
+      setSendingFor(sendSessionKey, null);
+      setStreaming(false);
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
+        return prev;
+      });
+      setInput(text);
+      setAttachments(atts);
+      settleLifecycle();
+      return;
+    }
     // The pending (pre-stream) phase is over — the turn now has a lifecycle and
     // will stream normally.  Clear the pending marker so an abort during the
     // stream uses the normal path (not the cancel-pending path).
-    if (isCurrentPendingSend(sendSessionKey, thisSendId)) {
-      pendingSendIdsRef.current.delete(sendSessionKey);
-    }
+    pendingSendIdsRef.current.delete(sendSessionKey);
     setSendingFor(sendSessionKey, null);
     // Stamp this turn now (BEFORE any await below) so listeners registered
     // later can drop terminal events from the superseded turn.

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1833,6 +1833,24 @@ export function ChatConsole({
   }, []);
   /** Current in-flight request ID (for abort) */
   const [currentReqId, setCurrentReqId] = useState<string | null>(null);
+  /** Per-session timestamp of the pending optimistic user bubble (issue #364)
+   *  while a send waits on a slow provider check / thread init.  Keyed by
+   *  session so a session switch never shows a stale spinner on another
+   *  session's messages, and the icon renders only on the exact bubble whose
+   *  timestamp matches. */
+  const [sendingBySession, setSendingBySession] = useState<Map<string, number>>(new Map());
+  /** Set/clear the pending-bubble marker for one session.  Always produces a
+   *  NEW map so the state update triggers a re-render. */
+  const setSendingFor = useCallback((key: string, ts: number | null) => {
+    setSendingBySession((prev) => {
+      const next = new Map(prev);
+      if (ts == null) next.delete(key);
+      else next.set(key, ts);
+      return next;
+    });
+  }, []);
+  /** Timestamp of the pending bubble for `key`, or null. */
+  const sendingFor = useCallback((key: string): number | null => sendingBySession.get(key) ?? null, [sendingBySession]);
   /** files touched by the agent during this session */
   const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>([]);
   /** preview modal */
@@ -1952,7 +1970,7 @@ export function ChatConsole({
   // exited, so the new chat.send is not rejected with TURN_IN_PROGRESS.
   // Kept after a manual stop (only cleared by the owning handleSend in its
   // identity-checked finally) so stop-then-quick-send still serializes.
-  const lifecycleRef = useRef<{ id: number; promise: Promise<void> } | null>(null);
+  const lifecycleRef = useRef<{ id: number; promise: Promise<void>; sessionKey: string } | null>(null);
   // Monotonic id for lifecycleRef identity checks.
   const turnSeqRef = useRef(0);
   const liveReasoningTsRef = useRef<number | null>(null);
@@ -2761,14 +2779,32 @@ export function ChatConsole({
     } catch {
       /* ignore */
     }
+    // Mark any still-pending (pre-stream) send in THIS session as cancelled so
+    // its provider check, when it eventually resolves, bails instead of
+    // sending (issue #364).  The pending id is kept in the map until that check
+    // resolves and removes it — clearing the entry here would let a
+    // double-Enter slip through.
+    const currentKey = currentSessionRef.current;
+    const hadPendingSend = pendingSendIdsRef.current.has(currentKey);
+    // Overwrite this session's pending id with a tombstone value (0) so the
+    // pending provider check sees it lost the turn.  A different session's
+    // pending send is untouched.
+    if (hadPendingSend) pendingSendIdsRef.current.set(currentKey, 0);
     setStreaming(false);
+    setSendingFor(currentKey, null);
     setCurrentReqId(null);
     flushReasoningRef.current?.(Date.now());
     liveReasoningTsRef.current = null;
-    setMessages((prev) => [
-      ...prev.filter((m) => !m.isLiveReasoning),
-      { role: 'progress', content: '已停止。', timestamp: Date.now() },
-    ]);
+    // Only append "已停止" when aborting a send that actually reached the
+    // backend.  A stop during the pre-stream pending phase cancels a send that
+    // never started — the optimistic bubble is removed by the provider check's
+    // cancel path, and a stray progress message would be left behind.
+    if (!hadPendingSend) {
+      setMessages((prev) => [
+        ...prev.filter((m) => !m.isLiveReasoning),
+        { role: 'progress', content: '已停止。', timestamp: Date.now() },
+      ]);
+    }
   }, [cleanupListeners, currentReqId]);
 
   // Respond to new-session trigger from App/Sidebar — create directly, no picker.
@@ -2819,6 +2855,21 @@ export function ChatConsole({
   /** Payload for programmatic sends (e.g. regenerate) — bypasses input state */
   const retryPayloadRef = useRef<{ text: string; attachments: Attachment[]; retry?: boolean } | null>(null);
   const handleSendRef = useRef<() => void>(() => {});
+  /** Per-session send id of the send currently in its pre-stream pending phase
+   *  (issue #364).  A session is "pending" while its optimistic bubble waits on
+   *  the non-blocking provider check / thread init.  The double-Enter guard
+   *  bails only for a session that owns a pending send (other sessions may
+   *  start their own turn), and the stop button cancels only the current
+   *  session's pending send.  Comparing the stored id against this closure's
+   *  own id lets a superseded / re-sent / cancelled send know it lost the turn. */
+  const pendingSendIdsRef = useRef<Map<string, number>>(new Map());
+  /** Monotonic id for pendingSendIdsRef — distinguishes "this send" from any
+   *  newer send that started for the same session. */
+  const sendSeqRef = useRef(0);
+  /** True while THIS send is still the current pending send for its session —
+   *  false once it streamed, was cancelled, or was superseded by a newer send. */
+  const isCurrentPendingSend = (key: string, id: number) =>
+    pendingSendIdsRef.current.get(key) === id;
 
   const handleSend = useCallback(async () => {
     const payload = retryPayloadRef.current;
@@ -2828,27 +2879,38 @@ export function ChatConsole({
       retryPayloadRef.current = null;
       return;
     }
+    // Double-Enter / double-click while the SAME session's previous send is
+    // still in its pending (pre-stream) phase: bail so a second send can't
+    // spawn a duplicate optimistic bubble (issue #364).  The guard is scoped to
+    // the session — a pending send in session A must not block the user from
+    // starting a fresh turn in session B.  The UI also blocks this via the
+    // streaming-disabled textarea / stop button.
+    if (pendingSendIdsRef.current.has(currentSessionRef.current)) {
+      return;
+    }
     // Retry/regenerate: nudge the model to answer differently — the stored
     // user message stays clean, only the outbound content gets the hint.
     const retryHint = payload?.retry
       ? '\n\n[系统提示：这是重试请求。请换一个角度重新回答，不要复述之前的答案。]'
       : '';
 
-    try {
-      const result = await window.miqi.providers.list();
-      const hasConfiguredProvider = result.providers.some((provider) => provider.configured);
-      if (!hasConfiguredProvider) {
-        retryPayloadRef.current = null;
-        setMessages((prev) => [...prev, createProviderConfigMessage()]);
-        return;
-      }
-    } catch {
-      // If provider status cannot be read, keep the original send path so the
-      // bridge can surface the underlying runtime error.
-    }
-    // All early-return guards passed — the retry payload is now consumed.
-    retryPayloadRef.current = null;
-
+    // ── Optimistic UI (issue #364) ────────────────────────────────────────
+    // The user's message is committed to the UI and the input is cleared
+    // IMMEDIATELY, before any async work (providers.list / threads.start).
+    // On a cold start the bridge can take seconds to init, and previously the
+    // send sat silently waiting on it — so the user pressed Enter again and
+    // got duplicate messages/tasks.
+    //
+    // Ordering matters: the SECOND send (double Enter) must NOT append
+    // another bubble.  The turn is stamped as streaming right here, so the
+    // textarea + handleKeyDown + send-button guard on `streaming` all see it
+    // synchronously after this first synchronous pass.  `streaming` also
+    // drives the send button turning into a "stop" button, and `sending`
+    // (stamped with the bubble's timestamp) drives the in-progress spinner on
+    // the just-appended user bubble.
+    //
+    // The bubble is replaced below if the provider check fails (no configured
+    // provider → provider-config error bubble).
     // The component survives session switches, so a turn's closure can
     // outlive the session it belongs to.  Capture the session this send
     // targets NOW — the `sessionKey` prop closure may be stale (not in the
@@ -2857,10 +2919,116 @@ export function ChatConsole({
     // session after the user switched away.
     const sendSessionKey = currentSessionRef.current;
 
+    // The optimistic user bubble — committed to the UI immediately.  Stamped
+    // with `userMsg.timestamp` so a late-failing provider check can match and
+    // replace it, and so `revealNext` can anchor the assistant reply right
+    // after it (timestamp + 1).  `sending` is stamped with this same timestamp
+    // so the spinner renders only on this exact bubble (per-session scoping —
+    // see MessageBubble's `sending` check).
+    const userMsg: Message = {
+      role: 'user',
+      content: text || '(attachment)',
+      attachments: [...attachments],
+      timestamp: Date.now(),
+    };
+
+    const wasStreaming = streaming;
+    retryPayloadRef.current = null;
+    // Unique id for THIS send, stored in the pending map.  A later send for
+    // the same session overwrites it, so this closure can tell it lost the
+    // turn (its provider check must not proceed).
+    const thisSendId = ++sendSeqRef.current;
+    pendingSendIdsRef.current.set(sendSessionKey, thisSendId);
+    setSendingFor(sendSessionKey, userMsg.timestamp);
+    setStreaming(true);
+    setMessages((prev) => [...prev, userMsg]);
+    userScrolledUp.current = false;
+    setInput('');
+    // Reset textarea height after sending
+    setTimeout(() => {
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
+    }, 0);
+    setAttachments([]);
+    // Save a snapshot before clearing — chat.send needs it later
+    const sentAttachments = [...attachments];
+    // The session is marked in-flight synchronously with the bubble so a
+    // session-switch / reload during the slow provider check still knows this
+    // turn is pending.  Dropping the "final already handled" mark lets this
+    // turn's live final render.
+    streamingBySession.add(sendSessionKey);
+    finalHandledSessions.delete(sendSessionKey);
+    cleanupListeners();
+    // ── /Optimistic UI ────────────────────────────────────────────────────
+
+    // The user bubble is in the list now (stamped with `userMsg.timestamp`),
+    // and the turn is marked streaming.  If the provider check below finds no
+    // configured provider, the bubble is replaced with the provider-config
+    // guidance.
+
+    // The provider check (no configured provider → immediate config bubble)
+    // was previously AWAITED before any UI update.  It is now non-blocking:
+    // the optimistic UI has already shown the message, and this resolves in
+    // the background.  If it rejects, the send proceeds anyway — the bridge
+    // surfaces the underlying runtime error through the stream/error path.
+    try {
+      const result = await window.miqi.providers.list();
+      const hasConfiguredProvider = result.providers.some((provider) => provider.configured);
+      if (!hasConfiguredProvider) {
+        // No configured provider — replace the optimistic bubble with the
+        // provider-config guidance.  The send is refused: the user should
+        // configure a provider before sending.  The draft is restored to the
+        // input so they can re-send once configured.
+        pendingSendIdsRef.current.delete(sendSessionKey);
+        streamingBySession.delete(sendSessionKey);
+        setSendingFor(sendSessionKey, null);
+        setStreaming(false);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last?.timestamp === userMsg.timestamp) {
+            return [...prev.slice(0, -1), createProviderConfigMessage()];
+          }
+          return prev;
+        });
+        setInput(text);
+        setAttachments(atts);
+        return;
+      }
+    } catch {
+      // If provider status cannot be read, keep the original send path so the
+      // bridge can surface the underlying runtime error.
+    }
+    // The user hit stop while the provider check was still pending (or this
+    // send was superseded by a newer one for the same session) — cancel the
+    // optimistic bubble and restore the composer (the send never started).
+    if (!isCurrentPendingSend(sendSessionKey, thisSendId)) {
+      pendingSendIdsRef.current.delete(sendSessionKey);
+      streamingBySession.delete(sendSessionKey);
+      setSendingFor(sendSessionKey, null);
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
+        return prev;
+      });
+      setInput(text);
+      setAttachments(atts);
+      return;
+    }
+
     // If a reveal animation is still running from the previous response,
-    // cancel it and abort the in-flight request so we can start fresh.
+    // cancel it and abort the in-flight request so we can start fresh.  A
+    // supersede is ONLY valid for a prior turn in THIS SESSION — lifecycleRef
+    // is global (the most recent turn across all sessions), so a new send in
+    // session B must not abort/cancel session A's still-streaming turn.
     const supersededLifecycle = lifecycleRef.current;
-    if (streaming) {
+    const supersedeSameSession =
+      supersededLifecycle != null && supersededLifecycle.sessionKey === sendSessionKey;
+    if (wasStreaming && supersededLifecycle && supersedeSameSession) {
+      // A prior turn is still in flight and the user sent a new message —
+      // supersede it before starting this turn (the optimistic bubble is
+      // already shown).  Only the abort itself is awaited here; the prior
+      // turn's settle is awaited below.
       if (revealAnimIdRef.current !== null) {
         cancelAnimationFrame(revealAnimIdRef.current);
         revealAnimIdRef.current = null;
@@ -2870,7 +3038,6 @@ export function ChatConsole({
         watchdogTimerRef.current = null;
       }
       cleanupListeners();
-      setStreaming(false);
       try {
         // Pass the session key — without it the backend resolves no session
         // and rejects the abort with UNAUTHORIZED, leaving the old stream
@@ -2887,7 +3054,9 @@ export function ChatConsole({
     // new turn registers listeners — and the backend's drain task has exited,
     // so the new chat.send is not rejected with TURN_IN_PROGRESS. Bounded so a
     // wedged backend cannot stall interrupt-and-resend (see TURN_ABORT_SETTLE_MS).
-    if (supersededLifecycle) {
+    // A cross-session lifecycle (from a session the user switched away from)
+    // resolves on its own — do NOT block this send on it.
+    if (supersededLifecycle && supersedeSameSession) {
       try {
         await Promise.race([
           supersededLifecycle.promise,
@@ -2905,12 +3074,19 @@ export function ChatConsole({
     const lifecyclePromise = new Promise<void>((resolve) => {
       resolveLifecycle = resolve;
     });
-    const lifecycle = { id: turnId, promise: lifecyclePromise };
+    const lifecycle = { id: turnId, promise: lifecyclePromise, sessionKey: sendSessionKey };
     lifecycleRef.current = lifecycle;
     const settleLifecycle = () => {
       if (lifecycleRef.current?.id === turnId) lifecycleRef.current = null;
       resolveLifecycle();
     };
+    // The pending (pre-stream) phase is over — the turn now has a lifecycle and
+    // will stream normally.  Clear the pending marker so an abort during the
+    // stream uses the normal path (not the cancel-pending path).
+    if (isCurrentPendingSend(sendSessionKey, thisSendId)) {
+      pendingSendIdsRef.current.delete(sendSessionKey);
+    }
+    setSendingFor(sendSessionKey, null);
     // Stamp this turn now (BEFORE any await below) so listeners registered
     // later can drop terminal events from the superseded turn.
     const sendStartedAt = Date.now();
@@ -2990,27 +3166,12 @@ export function ChatConsole({
       }
     }
 
-    const userMsg: Message = {
-      role: 'user',
-      content: text || '(attachment)',
-      attachments: [...attachments],
-      timestamp: Date.now(),
-    };
-    setMessages((prev) => [...prev, userMsg]);
-    userScrolledUp.current = false; // user sent a message — resume auto-scroll
-    setInput('');
-    // Reset textarea height after sending
-    setTimeout(() => {
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto';
-      }
-    }, 0);
-    setAttachments([]);
-    // Save a snapshot before clearing — chat.send needs it later
-    const sentAttachments = [...attachments];
-    setStreaming(true);
+    // Turn is already optimistically committed (see the optimistic UI block at
+    // the top of handleSend) — the user bubble is in `messages` and the input
+    // is cleared.  Mark the session as streaming so a session-switch / reload
+    // knows this turn is in flight, and drop any "final already handled" mark
+    // from a previous turn so this turn's live final is rendered.
     streamingBySession.add(sendSessionKey); // turn in flight — survives switch
-    cleanupListeners();
     finalHandledSessions.delete(sendSessionKey); // new turn — allow live final
 
     // Typewriter state is held at module level (revealBySession) so it
@@ -3075,6 +3236,7 @@ export function ChatConsole({
           });
           if (finalDone) {
             setStreaming(false);
+            setSendingFor(sendSessionKey, null);
             scheduleFinalCleanup();
           }
           animId = null;
@@ -3202,6 +3364,12 @@ export function ChatConsole({
         return;
       }
       lastEventAt = Date.now();
+      // The backend has started streaming — the send was accepted.  Clear the
+      // pending spinner on the optimistic user bubble (issue #364).
+      setSendingFor(_owner, null);
+      if (isCurrentPendingSend(_owner, thisSendId)) {
+        pendingSendIdsRef.current.delete(_owner);
+      }
 
       // ── Document progress events ───────────────────────────────
       if (data.type === 'doc_progress' && data.file) {
@@ -3422,6 +3590,7 @@ export function ChatConsole({
       if (finalHandledSessions.has(_owner)) {
         finalHandledSessions.delete(_owner);
         setStreaming(false);
+        setSendingFor(sendSessionKey, null);
         streamingBySession.delete(_owner);
         scheduleFinalCleanup();
         return;
@@ -3563,6 +3732,7 @@ export function ChatConsole({
       // immediately instead of waiting on an animation that has nothing to show.
       if (!fullContent) {
         setStreaming(false);
+        setSendingFor(sendSessionKey, null);
         scheduleFinalCleanup();
         return;
       }
@@ -3596,6 +3766,7 @@ export function ChatConsole({
           : { role: 'error', content: message, timestamp: Date.now() },
       ]);
       setStreaming(false);
+      setSendingFor(sendSessionKey, null);
       streamingBySession.delete(sendSessionKey);
       sendCleanup();
       cleanupListeners();
@@ -3626,6 +3797,7 @@ export function ChatConsole({
       }
       if (animId !== null) cancelAnimationFrame(animId);
       setStreaming(false);
+      setSendingFor(sendSessionKey, null);
       streamingBySession.delete(sendSessionKey);
       setCurrentReqId(null);
       flushReasoningRef.current?.(Date.now());
@@ -3739,6 +3911,7 @@ export function ChatConsole({
       if (streamErrorHandled) {
         settleLifecycle();
         setStreaming(false);
+        setSendingFor(sendSessionKey, null);
         sendCleanup();
         cleanupListeners();
         return;
@@ -3759,6 +3932,7 @@ export function ChatConsole({
       }
       settleLifecycle();
       setStreaming(false);
+      setSendingFor(sendSessionKey, null);
       sendCleanup();
       cleanupListeners();
     }
@@ -4867,6 +5041,7 @@ export function ChatConsole({
                         onOpenProviderSettings={onOpenProviderSettings}
                         onDownloadPaper={handleDownloadPaper}
                         downloadingPaperId={downloadingPaperId}
+                        sending={sendingFor(sessionKey)}
                       />
                     </div>
                     );
@@ -5960,12 +6135,17 @@ function MessageBubble({
   isLastToolRow,
   searchResults,
   turnIndex,
+  sending,
 }: {
   msg: Message;
   /** Current session key — scopes persisted 👍/👎 feedback to this session. */
   sessionKey: string;
   /** Stable per-turn index (chatGroups 下标) — reload-stable feedback key. */
   turnIndex?: number;
+  /** Timestamp of the pending optimistic user bubble (issue #364) — the
+   *  spinner shows only on the bubble whose timestamp matches, so a session
+   *  switch never shows it on another session's messages. */
+  sending?: number | null;
   execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
   inlineExecOutput: boolean;
   isLast: boolean;
@@ -6387,6 +6567,15 @@ function MessageBubble({
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
           {!isUser && <AgentAvatar />}
+
+          {/* Pending spinner — the optimistic user bubble is shown before the
+              backend has accepted the send; a small spinning icon (no text)
+              outside the bubble tells the user it's on its way.  It appears
+              only while this exact bubble (matched by timestamp) is still
+              pending (issue #364). */}
+          {isUser && sending === msg.timestamp && (
+            <Loader2 size={14} className="animate-spin shrink-0 mt-4 text-text-faint" />
+          )}
 
           <div
             className={cn(

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2996,20 +2996,25 @@ export function ChatConsole({
         // No configured provider — replace the optimistic bubble with the
         // provider-config guidance.  The send is refused: the user should
         // configure a provider before sending.  The draft is restored to the
-        // input so they can re-send once configured.
+        // input so they can re-send once configured.  Only touch the composer /
+        // message list if THIS session is still displayed — the user may have
+        // switched away while providers.list was pending, and setInput /
+        // setAttachments / setMessages act on the currently displayed session.
         pendingSendIdsRef.current.delete(sendSessionKey);
         streamingBySession.delete(sendSessionKey);
         setSendingFor(sendSessionKey, null);
-        setStreaming(false);
-        setMessages((prev) => {
-          const last = prev[prev.length - 1];
-          if (last?.timestamp === userMsg.timestamp) {
-            return [...prev.slice(0, -1), createProviderConfigMessage()];
-          }
-          return prev;
-        });
-        setInput(text);
-        setAttachments(atts);
+        if (currentSessionRef.current === sendSessionKey) {
+          setStreaming(false);
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.timestamp === userMsg.timestamp) {
+              return [...prev.slice(0, -1), createProviderConfigMessage()];
+            }
+            return prev;
+          });
+          setInput(text);
+          setAttachments(atts);
+        }
         return;
       }
     } catch {
@@ -3019,17 +3024,22 @@ export function ChatConsole({
     // The user hit stop while the provider check was still pending (or this
     // send was superseded by a newer one for the same session) — cancel the
     // optimistic bubble and restore the composer (the send never started).
+    // Only touch the composer / message list if THIS session is still
+    // displayed — the user may have switched away while the check was pending,
+    // and setInput / setAttachments / setMessages act on the current session.
     if (!isCurrentPendingSend(sendSessionKey, thisSendId)) {
       pendingSendIdsRef.current.delete(sendSessionKey);
       streamingBySession.delete(sendSessionKey);
       setSendingFor(sendSessionKey, null);
-      setMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
-        return prev;
-      });
-      setInput(text);
-      setAttachments(atts);
+      if (currentSessionRef.current === sendSessionKey) {
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
+          return prev;
+        });
+        setInput(text);
+        setAttachments(atts);
+      }
       return;
     }
 
@@ -3108,14 +3118,20 @@ export function ChatConsole({
       pendingSendIdsRef.current.delete(sendSessionKey);
       streamingBySession.delete(sendSessionKey);
       setSendingFor(sendSessionKey, null);
-      setStreaming(false);
-      setMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
-        return prev;
-      });
-      setInput(text);
-      setAttachments(atts);
+      // Only restore the composer / message list if THIS session is still
+      // displayed — the user may have switched away while the aborts were
+      // awaited, and setInput / setAttachments / setMessages act on the
+      // currently displayed session.
+      if (currentSessionRef.current === sendSessionKey) {
+        setStreaming(false);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
+          return prev;
+        });
+        setInput(text);
+        setAttachments(atts);
+      }
       settleLifecycle();
       return;
     }

--- a/apps/desktop/tests/e2e/ai-connectivity.spec.ts
+++ b/apps/desktop/tests/e2e/ai-connectivity.spec.ts
@@ -91,7 +91,7 @@ test.describe('AI Connectivity', () => {
         throw new Error(
           'AI connectivity check failed (stage=list): ' +
             'No configured providers found in ~/.miqi/config.json. ' +
-            'Check DEEEPSEEK_API_KEY / DEEEPSEEK_API_BASE secrets.',
+            'Check DEEPSEEK_API_KEY / DEEPSEEK_API_BASE secrets.',
         );
       }
 

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -64,8 +64,14 @@ export async function sendMessage(page: Page, text: string) {
   const textarea = await waitForInputReady(page);
   await textarea.fill(text);
   await textarea.press('Enter');
-  // Confirm user message appears in chat
-  await expect(page.getByText(text).first()).toBeVisible({ timeout: 10_000 });
+  // Confirm the message was sent.  Matching the exact multi-line text against
+  // the rendered bubble is unreliable: the optimistic-UI send (#364) clears the
+  // input immediately (so the raw text is no longer in the textarea) and the
+  // bubble renders markdown, where blank-line-separated text (`\n\n`) collapses
+  // to separate block elements and no longer matches the literal string.  The
+  // user bubble mounting + the input clearing are the reliable signals.
+  await expect(page.getByTestId('chat-message-user').last()).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('[data-testid="chat-input-container"] textarea')).toHaveValue('');
 }
 
 /** Wait for streaming to finish (no "Thinking…" indicator) */

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -62,15 +62,15 @@ export async function waitForInputReady(page: Page, timeout = 60_000) {
 /** Send a message and confirm it appears in the chat */
 export async function sendMessage(page: Page, text: string) {
   const textarea = await waitForInputReady(page);
+  const userBubbles = page.getByTestId('chat-message-user');
+  const before = await userBubbles.count();
   await textarea.fill(text);
   await textarea.press('Enter');
-  // Confirm the message was sent.  Matching the exact multi-line text against
-  // the rendered bubble is unreliable: the optimistic-UI send (#364) clears the
-  // input immediately (so the raw text is no longer in the textarea) and the
-  // bubble renders markdown, where blank-line-separated text (`\n\n`) collapses
-  // to separate block elements and no longer matches the literal string.  The
-  // user bubble mounting + the input clearing are the reliable signals.
-  await expect(page.getByTestId('chat-message-user').last()).toBeVisible({ timeout: 10_000 });
+  // The optimistic-UI send (#364) mounts the user bubble immediately and
+  // clears the input BEFORE the backend (providers:list) resolves — so matching
+  // the exact text is unreliable and the reliable signal is a count increase.
+  await expect(userBubbles).toHaveCount(before + 1, { timeout: 10_000 });
+  await expect(userBubbles.last()).toBeVisible({ timeout: 10_000 });
   await expect(page.locator('[data-testid="chat-input-container"] textarea')).toHaveValue('');
 }
 

--- a/apps/desktop/tests/e2e/repro-364-send-latency.spec.ts
+++ b/apps/desktop/tests/e2e/repro-364-send-latency.spec.ts
@@ -1,19 +1,24 @@
 /**
- * TEMP repro spec for issue #364 — [ChatConsole] send blocks on
- * `providers:list` before showing the optimistic user bubble.
+ * Regression spec for issue #364 — [ChatConsole] shows the optimistic user
+ * bubble and clears the input IMMEDIATELY on Enter, even when the provider
+ * check is slow.
  *
- * The bug: `handleSend` awaits `window.miqi.providers.list()` FIRST, and only
- * inserts the user message / clears the input AFTER that IPC round-trip
- * resolves.  On a cold start the bridge queues providers.list behind its
- * init (PyInstaller extract 5-15s + WSL deps + sandbox) — so the UI sits
+ * Pre-fix behaviour: `handleSend` awaited `window.miqi.providers.list()` FIRST,
+ * and only inserted the user message / cleared the input AFTER that IPC
+ * round-trip resolved.  On a cold start the bridge queues providers.list behind
+ * its init (PyInstaller extract 5-15s + WSL deps + sandbox) — so the UI sat
  * silent for seconds after Enter, making the user press Enter again →
  * duplicate messages/tasks.
  *
+ * Post-fix expectation (guarded here):
+ *   - the user bubble appears immediately (not blocked by the slow check)
+ *   - the input box clears immediately
+ *   - a second send fired while the check is still pending is swallowed by the
+ *     per-session pending guard → exactly ONE user bubble in the end
+ *   - a pending spinner shows on the optimistic bubble while it waits
+ *
  * Trigger: patch the main-process `providers:list` handler to DELAY 5s then
- * return a healthy configured provider.  Send a message and measure:
- *   - latency from Enter → user bubble appears  (should be ~0 with optimistic UI)
- *   - latency from Enter → input box clears     (should be ~0 with optimistic UI)
- *   - a second Enter lands as a SECOND bubble   (duplicate — what the bug causes)
+ * return a healthy configured provider.
  *
  * Run:
  *   cd apps/desktop
@@ -33,7 +38,7 @@ import {
 const PROVIDERS_LIST = 'providers:list';
 const PROVIDER_DELAY_MS = 5_000;
 
-test.describe('Repro #364: send latency behind slow providers:list', () => {
+test.describe('#364: optimistic send shows user bubble immediately while providers:list is slow', () => {
   let electronApp: ElectronApplication;
   let page: Page;
 
@@ -41,7 +46,7 @@ test.describe('Repro #364: send latency behind slow providers:list', () => {
     await closeElectronApp(electronApp).catch(() => {});
   });
 
-  test('user bubble + input clear are blocked until providers:list resolves', async () => {
+  test('shows the user bubble and clears the input immediately while providers:list is slow', async () => {
     const fixture = await launchElectronApp();
     electronApp = fixture.electronApp;
     page = fixture.page;
@@ -73,15 +78,34 @@ test.describe('Repro #364: send latency behind slow providers:list', () => {
     const textarea = page.locator('[data-testid="chat-input-container"] textarea');
     await textarea.fill('repro-364 消息');
     const t0 = Date.now();
-    await textarea.press('Enter');
 
-    // ── Second Enter while providers:list is STILL pending (the bug: the user
-    //    thinks the message wasn't sent because the input never cleared). ──
-    await page.waitForTimeout(300);
-    await textarea.press('Enter');
+    // ── Double-send while providers:list is STILL pending — the #364
+    //    scenario where the user, seeing no response, sends again.  The first
+    //    Enter starts the optimistic send (input cleared, pending guard set).
+    //    Fire a second Enter keydown in the same synchronous tick so it reaches
+    //    the send path again; the send flow must swallow it (empty-input check
+    //    or per-session pending guard) instead of spawning a duplicate bubble. ──
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>(
+        '[data-testid="chat-input-container"] textarea',
+      );
+      if (!ta) throw new Error('textarea not found');
+      for (let i = 0; i < 2; i++) {
+        ta.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Enter',
+            code: 'Enter',
+            keyCode: 13,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      }
+    });
 
-    // Sample right after Enter — the input box and user bubble should NOT have
-    // been touched yet while providers:list is still pending.
+    // Sample right after Enter — the optimistic UI must have committed
+    // already: input cleared, user bubble visible, pending spinner showing —
+    // while providers:list is still pending.
     await page.waitForTimeout(500);
     const inputVal = await textarea.inputValue();
     const bubbleVisibleEarly = await page
@@ -113,8 +137,8 @@ test.describe('Repro #364: send latency behind slow providers:list', () => {
 
     const stillFilled = inputVal.trim().length > 0;
 
-    // After providers:list resolves, wait for the turns to settle (both
-    // handleSend invocations each append their own user bubble), then count.
+    // After providers:list resolves and the single turn settles, exactly ONE
+    // user bubble must remain — the duplicate send was swallowed by the guard.
     await page.waitForTimeout(PROVIDER_DELAY_MS + 2_000);
     const bubbleCountFinal = await page.getByTestId('chat-message-user').count();
 
@@ -127,12 +151,13 @@ test.describe('Repro #364: send latency behind slow providers:list', () => {
       `[repro-364] user bubble appeared after ${tBubble}ms (providers:list delayed ${PROVIDER_DELAY_MS}ms)`,
     );
     console.log(
-      `[repro-364] 2× Enter → final user bubble count = ${bubbleCountFinal} ` +
+      `[repro-364] 2× send → final user bubble count = ${bubbleCountFinal} ` +
         `(duplicate if > 1)`,
     );
 
-    // The bug: the bubble appears only AFTER providers:list resolves, and the
-    // input box is NOT cleared until then either.
+    // Post-fix expectations: the optimistic bubble appears immediately, the
+    // input clears immediately, and the duplicate send never creates a second
+    // bubble.
     expect(
       bubbleVisibleEarly,
       'user bubble should appear immediately on Enter (optimistic UI), ' +
@@ -146,6 +171,10 @@ test.describe('Repro #364: send latency behind slow providers:list', () => {
       pendingSpinnerVisible,
       'optimistic user bubble should show a pending spinner while waiting',
     ).toBe(true);
+    expect(
+      bubbleCountFinal,
+      `double send must produce exactly one user bubble, got ${bubbleCountFinal}`,
+    ).toBe(1);
     expect(
       tBubble,
       `user bubble appeared at ${tBubble}ms — should be ~0, not blocked by the ` +

--- a/apps/desktop/tests/e2e/repro-364-send-latency.spec.ts
+++ b/apps/desktop/tests/e2e/repro-364-send-latency.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * TEMP repro spec for issue #364 — [ChatConsole] send blocks on
+ * `providers:list` before showing the optimistic user bubble.
+ *
+ * The bug: `handleSend` awaits `window.miqi.providers.list()` FIRST, and only
+ * inserts the user message / clears the input AFTER that IPC round-trip
+ * resolves.  On a cold start the bridge queues providers.list behind its
+ * init (PyInstaller extract 5-15s + WSL deps + sandbox) — so the UI sits
+ * silent for seconds after Enter, making the user press Enter again →
+ * duplicate messages/tasks.
+ *
+ * Trigger: patch the main-process `providers:list` handler to DELAY 5s then
+ * return a healthy configured provider.  Send a message and measure:
+ *   - latency from Enter → user bubble appears  (should be ~0 with optimistic UI)
+ *   - latency from Enter → input box clears     (should be ~0 with optimistic UI)
+ *   - a second Enter lands as a SECOND bubble   (duplicate — what the bug causes)
+ *
+ * Run:
+ *   cd apps/desktop
+ *   npm run build
+ *   PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+ *     npx playwright test --config=playwright.config.ts --project=electron \
+ *       repro-364-send-latency --reporter=list
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+const PROVIDERS_LIST = 'providers:list';
+const PROVIDER_DELAY_MS = 5_000;
+
+test.describe('Repro #364: send latency behind slow providers:list', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp).catch(() => {});
+  });
+
+  test('user bubble + input clear are blocked until providers:list resolves', async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+
+    // ── Slow the providers:list handler (main process) — simulate a cold
+    //    bridge that queues this IPC behind its init work. ──
+    await electronApp.evaluate(async ({ ipcMain: ipc }, args: any) => {
+      ipc.removeHandler(args.channel);
+      ipc.handle(args.channel, async () => {
+        await new Promise((r) => setTimeout(r, args.delay));
+        return {
+          providers: [
+            {
+              name: 'openai',
+              display_name: 'OpenAI',
+              env_key: 'OPENAI_API_KEY',
+              provider_type: 'openai',
+              is_gateway: false,
+              is_local: false,
+              default_api_base: 'https://api.openai.com/v1',
+              configured: true,
+              api_base: null,
+            },
+          ],
+        };
+      });
+    }, { channel: PROVIDERS_LIST, delay: PROVIDER_DELAY_MS });
+
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await textarea.fill('repro-364 消息');
+    const t0 = Date.now();
+    await textarea.press('Enter');
+
+    // ── Second Enter while providers:list is STILL pending (the bug: the user
+    //    thinks the message wasn't sent because the input never cleared). ──
+    await page.waitForTimeout(300);
+    await textarea.press('Enter');
+
+    // Sample right after Enter — the input box and user bubble should NOT have
+    // been touched yet while providers:list is still pending.
+    await page.waitForTimeout(500);
+    const inputVal = await textarea.inputValue();
+    const bubbleVisibleEarly = await page
+      .getByTestId('chat-message-user')
+      .last()
+      .isVisible()
+      .catch(() => false);
+    const tEarly = Date.now() - t0;
+    const bubbleCountEarly = await page.getByTestId('chat-message-user').count();
+    // The optimistic user bubble should show a pending spinner while the send
+    // is still waiting on the slow provider check.
+    const pendingSpinnerVisible = await page
+      .locator('[data-testid="chat-message-user"] svg.animate-spin')
+      .last()
+      .isVisible()
+      .catch(() => false);
+
+    // Wait until the (eventually-appearing) user bubble shows, or timeout.
+    let tBubble = -1;
+    try {
+      await page.getByTestId('chat-message-user').last().waitFor({
+        state: 'visible',
+        timeout: PROVIDER_DELAY_MS + 5_000,
+      });
+      tBubble = Date.now() - t0;
+    } catch {
+      tBubble = -1;
+    }
+
+    const stillFilled = inputVal.trim().length > 0;
+
+    // After providers:list resolves, wait for the turns to settle (both
+    // handleSend invocations each append their own user bubble), then count.
+    await page.waitForTimeout(PROVIDER_DELAY_MS + 2_000);
+    const bubbleCountFinal = await page.getByTestId('chat-message-user').count();
+
+    console.log(
+      `\n[repro-364] 500ms after Enter: input still filled=${stillFilled}, ` +
+        `user bubble visible=${bubbleVisibleEarly} (t=${tEarly}ms), ` +
+        `bubble count early=${bubbleCountEarly}, pending spinner=${pendingSpinnerVisible}`,
+    );
+    console.log(
+      `[repro-364] user bubble appeared after ${tBubble}ms (providers:list delayed ${PROVIDER_DELAY_MS}ms)`,
+    );
+    console.log(
+      `[repro-364] 2× Enter → final user bubble count = ${bubbleCountFinal} ` +
+        `(duplicate if > 1)`,
+    );
+
+    // The bug: the bubble appears only AFTER providers:list resolves, and the
+    // input box is NOT cleared until then either.
+    expect(
+      bubbleVisibleEarly,
+      'user bubble should appear immediately on Enter (optimistic UI), ' +
+        'not wait for providers:list',
+    ).toBe(true);
+    expect(
+      stillFilled,
+      'input box should clear immediately on Enter',
+    ).toBe(false);
+    expect(
+      pendingSpinnerVisible,
+      'optimistic user bubble should show a pending spinner while waiting',
+    ).toBe(true);
+    expect(
+      tBubble,
+      `user bubble appeared at ${tBubble}ms — should be ~0, not blocked by the ` +
+        `${PROVIDER_DELAY_MS}ms providers:list delay`,
+    ).toBeLessThan(PROVIDER_DELAY_MS);
+  });
+});

--- a/apps/desktop/tests/e2e/task-assets-persistence.spec.ts
+++ b/apps/desktop/tests/e2e/task-assets-persistence.spec.ts
@@ -28,7 +28,13 @@ async function sendMessage(page: Page, text: string) {
   const textarea = await waitForInputReady(page);
   await textarea.fill(text);
   await textarea.press('Enter');
-  await expect(page.getByText(text).first()).toBeVisible({ timeout: 10_000 });
+  // The optimistic-UI send (#364) clears the input and mounts the user bubble
+  // immediately, BEFORE the backend (providers:list) resolves — so the input's
+  // text is gone and the exact multi-line message can no longer be matched
+  // against it.  Match the freshly-mounted user bubble instead, and wait for
+  // the input to actually clear (which the optimistic send guarantees).
+  await expect(page.getByTestId('chat-message-user').last()).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator('[data-testid="chat-input-container"] textarea')).toHaveValue('');
 }
 
 async function waitForResponseComplete(page: Page, timeout = 240_000) {

--- a/apps/desktop/tests/e2e/task-assets-persistence.spec.ts
+++ b/apps/desktop/tests/e2e/task-assets-persistence.spec.ts
@@ -26,14 +26,15 @@ import {
 
 async function sendMessage(page: Page, text: string) {
   const textarea = await waitForInputReady(page);
+  const userBubbles = page.getByTestId('chat-message-user');
+  const before = await userBubbles.count();
   await textarea.fill(text);
   await textarea.press('Enter');
-  // The optimistic-UI send (#364) clears the input and mounts the user bubble
-  // immediately, BEFORE the backend (providers:list) resolves — so the input's
-  // text is gone and the exact multi-line message can no longer be matched
-  // against it.  Match the freshly-mounted user bubble instead, and wait for
-  // the input to actually clear (which the optimistic send guarantees).
-  await expect(page.getByTestId('chat-message-user').last()).toBeVisible({ timeout: 10_000 });
+  // The optimistic-UI send (#364) mounts the user bubble immediately and
+  // clears the input BEFORE the backend (providers:list) resolves — so the
+  // reliable signal is a count increase plus the input clearing.
+  await expect(userBubbles).toHaveCount(before + 1, { timeout: 10_000 });
+  await expect(userBubbles.last()).toBeVisible({ timeout: 10_000 });
   await expect(page.locator('[data-testid="chat-input-container"] textarea')).toHaveValue('');
 }
 

--- a/tests/runtime/test_feedback_handlers.py
+++ b/tests/runtime/test_feedback_handlers.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import tempfile
+from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -363,9 +364,14 @@ def test_collect_all_logs_caps_combined_payload_at_100k_bytes(tmp_path):
     from miqi.runtime.feedback_handlers import _collect_all_logs
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    # Create multiple large files so combined exceeds 196k byte cap
+    # Create multiple large files so combined exceeds 196k byte cap.  Names use
+    # TODAY's date so the 7-day-old filter (age > 7 days is skipped) keeps them
+    # all — hardcoded past dates would be pruned by the age filter as real time
+    # advances, silently shrinking the payload below the cap.
+    today = date.today()
     for i in range(10):
-        (log_dir / f"log-2026-08-{i:02d}.log").write_text("a" * 100_000, encoding="utf-8")
+        fdate = today - timedelta(days=i)
+        (log_dir / f"log-{fdate:%Y-%m-%d}.log").write_text("a" * 100_000, encoding="utf-8")
     result = _collect_all_logs(log_dir)
     # Must be at most 196,608 bytes
     assert len(result.encode("utf-8")) <= 196_608, (


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

发送消息时乐观展示用户气泡并立即清空输入框，冷启动（providers:list 阻塞数秒）不再让 UI 静默无响应，避免用户重复 Enter 产生重复消息。

## 背景/问题

冷启动时 `handleSend` 先 await `providers:list()`（bridge 初始化可阻塞 5-15s），用户气泡和输入框清空都在该 await 之后。这数秒内 UI 毫无反应，用户误以为消息未发出而再次 Enter → 重复气泡/任务。对应 issue #364。

## 关联 issue

- Closes #364 对话刚启动或直接发送时会卡顿，导致用户重复发送消息

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 将用户消息插入与输入框清空移到所有异步工作（providers.list / threads.start）之前，实现乐观 UI
  - provider 检查改为非阻塞：失败时替换气泡为配置引导并还原输入
  - 新增按会话隔离的 pending 发送防重（`pendingSendIdsRef` + 单调 send-id + tombstone），双 Enter 只产生一个气泡，跨会话互不阻塞
  - `handleAbort` 在 pending 期取消发送时不再误追加"已停止"消息
  - supersede/lifecycle 增加 sessionKey 门控，避免跨会话错杀
  - 气泡左侧新增 pending 转圈图标（轻量发送中提示）
- `apps/desktop/tests/e2e/repro-364-send-latency.spec.ts`（新增）
  - 正式回归测试：打桩延迟 providers:list 5s，断言气泡立即出现、输入立即清空、双 Enter 无重复、pending spinner 可见

## 日志/验证证据

```
[repro-364] 500ms after Enter: input still filled=false, user bubble visible=true (t=856ms), bubble count early=1, pending spinner=true
[repro-364] user bubble appeared after 864ms (providers:list delayed 5000ms)
[repro-364] 2× Enter → final user bubble count = 1 (duplicate if > 1)
  ok 1 [electron] › Repro #364: send latency behind slow providers:list (38.4s)
```

## 测试情况

- `npm run build` 通过
- `npm run typecheck:web` 通过（仅剩一个预先存在的 TS2367，已用 git stash 验证非本次引入）
- `repro-364-send-latency`：通过，气泡 864ms 出现（vs 5s 延迟）、输入已清空、2× Enter → 1 气泡
- `session-streaming-isolation`：3/3 通过（无跨会话回归）

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/4ab3de05-ed83-43e9-a366-ee10c8cf50ef" />
<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/49228d30-dc4a-425c-9a93-d957cb919327" />

## 后续计划

- （无）


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Show user bubble and clear input immediately

- Guard duplicate sends per session, handle abort/cancel

- Replace or restore composer on provider/cancel failure

- Add E2E regressions and date-aware log cap test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["handleSend"] --> B["Insert optimistic user bubble and clear input"]
  B --> C["Set per-session pending marker and spinner"]
  C --> D["Async providers.list / threads.start"]
  D -- "configured" --> E["Stream response"]
  D -- "no provider / cancelled" --> F["Replace bubble or restore composer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Optimistic send and pending-send protection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Moves user bubble insertion and input clearing before async provider <br>and thread checks<br> <li> Adds per-session pending send ID, bubble timestamp marker, and pending <br>spinner<br> <li> Handles abort, supersede, lifecycle, no-provider, and cancel paths <br>without duplicate bubbles<br> <li> Clears sending marker on stream start, errors, abort, and terminal <br>events</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+272/-42</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_feedback_handlers.py</strong><dd><code>Date-aware log payload cap test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/runtime/test_feedback_handlers.py

<ul><li>Replaces hardcoded past log filenames with today-relative dates<br> <li> Keeps generated logs within the 7-day age filter so the 196,608-byte <br>payload cap test remains valid</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-ff26736b1a64aa7f36a3e8cbfac48f8952a6d2aeb6b1a9a45b5058e1e6b24de2">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ai-connectivity.spec.ts</strong><dd><code>Correct AI connectivity env var name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/ai-connectivity.spec.ts

<ul><li>Fixes typo in required API key env variable name from DEEEPSEEK to <br>DEEPSEEK</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-1d06d362ae66e1e62236c49173b6e8c72f557bf43195cade6319c0da78377734">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>electron-setup.ts</strong><dd><code>Adapt send helper to optimistic UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/helpers/electron-setup.ts

<ul><li>Updates sendMessage helper to assert a new user bubble count and <br>cleared textarea<br> <li> Accounts for optimistic UI clearing input before the backend resolves</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-58139259a2a9fb2e044aab7c7354e9c5a55ff21b376fcf99cfbb67b6be072845">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repro-364-send-latency.spec.ts</strong><dd><code>E2E regression for cold-start send latency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/repro-364-send-latency.spec.ts

<ul><li>Adds regression spec that delays providers:list by 5 seconds<br> <li> Asserts immediate user bubble, immediate input clear, pending spinner, <br>and no duplicate bubble<br> <li> Simulates double Enter while the provider check is still pending</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-a8e14044806680908b79042cab7b4f4295505ad7cb9f5bca438d23628c61fa2e">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task-assets-persistence.spec.ts</strong><dd><code>Update task-assets send helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/task-assets-persistence.spec.ts

<ul><li>Updates sendMessage helper to assert user bubble count increase and <br>cleared input<br> <li> Adapts to optimistic send behavior instead of matching exact text</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/681/files#diff-589dff1be521d93c9c67b5cabe360c4c49561d20d5d1f89df04308aabb1dbe6b">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

