### PR TITLE
ci: add GitHub → WeCom notification workflow

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -1,0 +1,28 @@
+name: WeCom Notify
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, review_requested]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.sender.type != 'Bot' && !contains(fromJson('["coderabbitai[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) }}
+    steps:
+      - name: Send to WeCom
+        env:
+          WECOM_KEY: ${{ secrets.WECOM_WEBHOOK_KEY }}
+        run: |
+          MSG=$(jq -n \
+            --arg ev "${{ github.event_name }}" \
+            --arg repo "${{ github.repository }}" \
+            --arg sender "${{ github.actor }}" \
+            --arg title "${{ github.event.issue.title || github.event.pull_request.title }}" \
+            --arg url "${{ github.event.issue.html_url || github.event.pull_request.html_url }}" \
+            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: " + $url)}}')
+          curl -s "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${WECOM_KEY}" \
+            -H "Content-Type: application/json" -d "$MSG"


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

新增 GitHub Actions workflow：将 issue/PR/评论事件（含正文内容）实时推送到企业微信内部群。

## 背景/问题

团队成员不看 GitHub 邮件通知，导致 issue/PR 评论和 review 请求被忽略。通过企业微信「消息推送」（原群机器人）Webhook，把 GitHub 事件实时推到企微群，提高协作响应速度。

## 变更内容

- `.github/workflows/wecom-notify.yml`：新增 workflow
  - 触发事件：`issues opened`、`issue_comment created`、`pull_request opened/review_requested`
  - **推送正文内容**：评论事件取评论正文，其余取 issue/PR 正文；超过 2500 字节截断并加提示（企微 markdown 上限 4096 字节）
  - 链接做成 markdown 可点击格式（[点此查看](url)）
  - 过滤机器人：`sender.type != 'Bot'` + 用户名黑名单（coderabbitai/dependabot/github-actions）
  - Webhook key 从 `WECOM_WEBHOOK_KEY` secret 读取（已配置到仓库 Secrets）

## 日志/验证证据

```
# 1. Webhook 直连测试
$ curl -X POST "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<KEY>" \
  -H "Content-Type: application/json" \
  -d '{"msgtype":"text","text":{"content":"【接入测试】收到请回复"}}'
{"errcode":0,"errmsg":"ok"}

# 2. 模拟 issue 事件，带正文的 markdown 消息实测
{"errcode":0,"errmsg":"ok"}

# 3. CI 中真实触发（PR opened 事件）
notify job 日志: {"errcode":0,"errmsg":"ok"}
```

## 测试情况

- Webhook 实测可用：测试消息已成功送达企微群（errcode=0）
- 带正文的 markdown 消息实测：正文正常显示，链接可点击
- CI 中真实触发：PR opened 事件自动推送成功
- 机器人过滤逻辑：job 级 `if` 条件，被过滤的触发不会执行 curl

## 截图

无需截图