### PR TITLE
ci: include issue/PR/comment body in WeCom notification

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -1,0 +1,28 @@
+name: WeCom Notify
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, review_requested]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.sender.type != 'Bot' && !contains(fromJson('["coderabbitai[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) }}
+    steps:
+      - name: Send to WeCom
+        env:
+          WECOM_KEY: ${{ secrets.WECOM_WEBHOOK_KEY }}
+        run: |
+          MSG=$(jq -n \
+            --arg ev "${{ github.event_name }}" \
+            --arg repo "${{ github.repository }}" \
+            --arg sender "${{ github.actor }}" \
+            --arg title "${{ github.event.issue.title || github.event.pull_request.title }}" \
+            --arg url "${{ github.event.issue.html_url || github.event.pull_request.html_url }}" \
+            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: " + $url)}}')
+          curl -s "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${WECOM_KEY}" \
+            -H "Content-Type: application/json" -d "$MSG"

--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -17,12 +17,28 @@ jobs:
         env:
           WECOM_KEY: ${{ secrets.WECOM_WEBHOOK_KEY }}
         run: |
-          MSG=$(jq -n \
-            --arg ev "${{ github.event_name }}" \
-            --arg repo "${{ github.repository }}" \
-            --arg sender "${{ github.actor }}" \
-            --arg title "${{ github.event.issue.title || github.event.pull_request.title }}" \
-            --arg url "${{ github.event.issue.html_url || github.event.pull_request.html_url }}" \
-            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: " + $url)}}')
+          EVENT="${{ github.event_name }}"
+          REPO="${{ github.repository }}"
+          SENDER="${{ github.actor }}"
+          TITLE=$(jq -r '(.issue.title // .pull_request.title // "")' "$GITHUB_EVENT_PATH")
+          URL=$(jq -r '(.comment.html_url // .issue.html_url // .pull_request.html_url // "")' "$GITHUB_EVENT_PATH")
+          # 评论事件取评论正文，其余取 issue/PR 正文
+          BODY_RAW=$(jq -r '(.comment.body // .issue.body // .pull_request.body // "")' "$GITHUB_EVENT_PATH")
+          # 企微 markdown 上限 4096 字节：正文最多保留 2500 字节
+          BODY=$(printf '%s' "$BODY_RAW" | head -c 2500 | iconv -c -f UTF-8 -t UTF-8)
+          if [ "$(printf '%s' "$BODY_RAW" | wc -c)" -gt "$(printf '%s' "$BODY" | wc -c)" ]; then
+            HINT="$(printf '\n…（内容过长，已截断，全文见链接）')"
+          else
+            HINT=""
+          fi
+          jq -n \
+            --arg ev "$EVENT" \
+            --arg repo "$REPO" \
+            --arg sender "$SENDER" \
+            --arg title "$TITLE" \
+            --arg url "$URL" \
+            --arg body "$BODY" \
+            --arg hint "$HINT" \
+            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: [点此查看](" + $url + ")\n\n" + $body + $hint)}}' > msg.json
           curl -s "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${WECOM_KEY}" \
-            -H "Content-Type: application/json" -d "$MSG"
+            -H "Content-Type: application/json" -d @msg.json


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🔧 其他

## 变更概述

新增 GitHub Actions workflow：将 issue/PR/评论事件（含正文内容）实时推送到企业微信内部群。

## 背景/问题

团队成员不看 GitHub 邮件通知，导致 issue/PR 评论和 review 请求被忽略。通过企业微信「消息推送」（原群机器人）Webhook，把 GitHub 事件实时推到企微群，提高协作响应速度。

## 变更内容

- `.github/workflows/wecom-notify.yml`：新增 workflow
  - 触发事件：`issues opened`、`issue_comment created`、`pull_request opened/review_requested`
  - **推送正文内容**：评论事件取评论正文，其余取 issue/PR 正文；超过 2500 字节截断并加提示（企微 markdown 上限 4096 字节）
  - 链接做成 markdown 可点击格式（[点此查看](url)）
  - 过滤机器人：`sender.type != 'Bot'` + 用户名黑名单（coderabbitai/dependabot/github-actions）
  - Webhook key 从 `WECOM_WEBHOOK_KEY` secret 读取（已配置到仓库 Secrets）

## 日志/验证证据

```
# 1. Webhook 直连测试
$ curl -X POST "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<KEY>" \
  -H "Content-Type: application/json" \
  -d '{"msgtype":"text","text":{"content":"【接入测试】收到请回复"}}'
{"errcode":0,"errmsg":"ok"}

# 2. 模拟 issue 事件，带正文的 markdown 消息实测
{"errcode":0,"errmsg":"ok"}

# 3. CI 中真实触发（PR opened 事件）
notify job 日志: {"errcode":0,"errmsg":"ok"}
```

## 测试情况

- Webhook 实测可用：测试消息已成功送达企微群（errcode=0）
- 带正文的 markdown 消息实测：正文正常显示，链接可点击
- CI 中真实触发：PR opened 事件自动推送成功
- 机器人过滤逻辑：job 级 `if` 条件，被过滤的触发不会执行 curl

## 截图

无需截图


___

### **PR Type**
Enhancement


___

### **Description**
- Extract issue, PR, or comment body from GitHub event payload.

- Truncate body to 2500 bytes with truncation hint.

- Format notification URL as clickable Markdown link.

- Send JSON via file payload to WeCom webhook.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub event payload"] --> B["Extract title, URL, body via jq"]
  B --> C["Truncate body to 2500 bytes / add hint"]
  C --> D["Build msg.json markdown notification"]
  D --> E["POST to WeCom webhook"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wecom-notify.yml</strong><dd><code>Enhance WeCom notification with event body content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/wecom-notify.yml

<ul><li>Read event fields from <code>$GITHUB_EVENT_PATH</code> with separate <code>jq -r</code> calls.<br> <li> Select body from comment, issue, or pull request payload.<br> <li> Cap body at 2500 bytes and add truncation hint if shortened.<br> <li> Make notification URL a clickable Markdown link.<br> <li> Write generated JSON to <code>msg.json</code> and curl with <code>-d @msg.json</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/688/files#diff-64485b0408b275154738b779ded187100e0c7add8ebe28d0e031e1876e49e9d4">+24/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

