### PR TITLE
fix(tools): add actionable guidance to cross-session isolation error

### DIFF
--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -372,7 +372,10 @@ def _canonicalize_wsl_mnt_path(
                     # another session's identifier and file layout.
                     raise PermissionError(
                         "Path is inside another session's files dir — "
-                        "per-session isolation forbids cross-session access."
+                        "per-session isolation forbids cross-session access. "
+                        "Do not retry or enumerate sessions/; use the current "
+                        "session's workspace instead, or ask the user to share "
+                        "the file via the file panel."
                     )
 
     resolved_str = str(resolved).replace("\\", "/")


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #690：跨 session 隔离的 PermissionError 增加可操作的引导信息，让 agent 停止无意义重试和枚举 sessions/ 目录。

## 背景/问题

agent 访问其他会话文件区时收到：

```
PermissionError: Path is inside another session's files dir — per-session isolation forbids cross-session access.
```

错误只说明了"被禁止"，没有告诉 agent 该怎么做，导致 agent 反复重试、枚举 `sessions/` 目录、甚至全盘 `find`，浪费大量工具调用和时间。

## 变更内容

- `miqi/agent/tools/filesystem.py`: 隔离检查的 PermissionError 追加引导语——不要重试或枚举 sessions/、使用当前会话 workspace、或让用户通过文件面板分享文件（+4/-1 行）

保持原有防泄露设计：错误仍不包含目标路径（防止泄露其他会话的标识和布局）。

1 文件，+4 / -1 行。

## 日志/验证证据

```
修复前：
PermissionError: Path is inside another session's files dir — per-session isolation forbids cross-session access.

修复后：
PermissionError: Path is inside another session's files dir — per-session isolation forbids cross-session access. Do not retry or enumerate sessions/; use the current session's workspace instead, or ask the user to share the file via the file panel.

pytest tests/agent/tools/test_apply_patch.py tests/runtime/test_tool_registry_factory.py → 32 passed, 1 skipped
```

## 测试情况

- [x] `tests/agent/tools/test_apply_patch.py` + `tests/runtime/test_tool_registry_factory.py`: 32 passed, 1 skipped
- [ ] 手动验证：agent 访问跨 session 路径后不再反复重试

## 截图

无需截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Improve cross-session isolation error with actionable guidance

- Add no-retry, current workspace, file panel instructions

- Preserve path omission to avoid leakage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cross-session path access"] --> B["PermissionError raised"]
  B --> C["Message includes actionable guidance"]
  C --> D["Agent avoids retry and enumeration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filesystem.py</strong><dd><code>Add actionable guidance to cross-session isolation error</code>&nbsp; </dd></summary>
<hr>

miqi/agent/tools/filesystem.py

<ul><li>Extend <code>PermissionError</code> message for cross-session path access with <br>actionable guidance.<br> <li> Add instructions to avoid retrying or enumerating <code>sessions/</code>.<br> <li> Suggest using current session workspace or asking user via file panel.<br> <li> Preserve omission of resolved path to avoid leaking another session's <br>identifier.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/693/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

