### PR TITLE
ci: 评论通知保留正文，PR/issue 只带标题

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -22,8 +22,12 @@ jobs:
           SENDER="${{ github.actor }}"
           TITLE=$(jq -r '(.issue.title // .pull_request.title // "")' "$GITHUB_EVENT_PATH")
           URL=$(jq -r '(.comment.html_url // .issue.html_url // .pull_request.html_url // "")' "$GITHUB_EVENT_PATH")
-          # 评论事件取评论正文，其余取 issue/PR 正文
-          BODY_RAW=$(jq -r '(.comment.body // .issue.body // .pull_request.body // "")' "$GITHUB_EVENT_PATH")
+          # PR 通知只带标题（正文太长刷屏）；评论/issue 保留正文
+          if [ "$EVENT" = "pull_request" ]; then
+            BODY_RAW=""
+          else
+            BODY_RAW=$(jq -r '(.comment.body // .issue.body // "")' "$GITHUB_EVENT_PATH")
+          fi
           # 企微 markdown 上限 4096 字节：正文最多保留 2500 字节
           BODY=$(printf '%s' "$BODY_RAW" | head -c 2500 | iconv -c -f UTF-8 -t UTF-8)
           if [ "$(printf '%s' "$BODY_RAW" | wc -c)" -gt "$(printf '%s' "$BODY" | wc -c)" ]; then
@@ -39,6 +43,7 @@ jobs:
             --arg url "$URL" \
             --arg body "$BODY" \
             --arg hint "$HINT" \
-            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: [点此查看](" + $url + ")\n\n" + $body + $hint)}}' > msg.json
+            --arg sep "$(if [ -n "$BODY" ]; then printf '\n\n'; else printf ''; fi)" \
+            '{msgtype:"markdown", markdown:{content:("**GitHub 通知**\n> 事件: " + $ev + "\n> 仓库: " + $repo + "\n> 发起人: " + $sender + "\n> 标题: " + $title + "\n> 链接: [点此查看](" + $url + ")" + $sep + $body + $hint)}}' > msg.json
           curl -s "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${WECOM_KEY}" \
             -H "Content-Type: application/json" -d @msg.json


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

调整企微通知策略：只有评论通知保留正文，PR/issue 通知均只带标题+链接。

## 背景/问题

PR 描述和 issue 正文通常较长，推送全文会导致企微群刷屏。改为只推标题+可点击链接，成员按需点开详情。评论是协作中的即时互动，正文较短且需要直接看到内容，继续保留。

## 变更内容

- `.github/workflows/wecom-notify.yml`
  - `pull_request` 事件：仅标题+链接
  - `issues` 事件：仅标题+链接
  - `issue_comment` 事件：保留评论正文（2500 字节截断保护不变）
  - 正文为空时不输出多余空行

## 日志/验证证据

```
# PR 事件模拟（仅标题）
{"errcode":0,"errmsg":"ok"}

# 评论事件模拟（保留内容）
{"errcode":0,"errmsg":"ok"}

# CI 真实触发（PR #694 opened）
notify job: {"errcode":0,"errmsg":"ok"}
```

## 测试情况

- PR 事件和评论事件均向企微群发送实测消息验证（errcode=0）
- PR 事件消息不含正文；评论事件正文正常显示
- issue 事件与 PR 事件走同一空正文代码路径

## 截图

无需截图