### PR TITLE
fix(#668): 论文下载结果反馈——成功路径 + 打开文件夹 + 失败原因

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1908,15 +1908,16 @@ for m in ("pydantic", "httpx", "loguru"):
       ? p.filename.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120)
       : undefined;
     const session = win.webContents.session;
-    return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    return await new Promise<{ ok: boolean; error?: string; savePath?: string }>((resolve) => {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
+      let savePath: string | undefined;
       const finish = (ok: boolean, error?: string) => {
         if (settled) return;
         settled = true;
         if (timer) clearTimeout(timer);
         session.removeListener('will-download', onWillDownload);
-        resolve({ ok, error });
+        resolve(ok ? { ok, savePath } : { ok, error });
       };
       const onWillDownload = (
         _e: Electron.Event,
@@ -1930,6 +1931,7 @@ for m in ("pydantic", "httpx", "loguru"):
         } catch {
           // fall back to default download path
         }
+        savePath = item.getSavePath();
         item.once('done', (_ev, state) => {
           finish(state === 'completed', state === 'completed' ? undefined : `download ${state}`);
         });

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util';
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { isAbsolute, join } from 'path';
+import type { BrowserWindow } from 'electron';
 import type { BridgeManager } from '../bridge';
 import {
   IPC,
@@ -1907,17 +1908,25 @@ for m in ("pydantic", "httpx", "loguru"):
     const safe = p.filename
       ? p.filename.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120)
       : undefined;
+    // #696: 保存位置由用户选择（保存对话框），不再固定 Downloads 目录
+    const picked = await electron.dialog.showSaveDialog(win, {
+      title: '保存文件',
+      defaultPath: join(electron.app.getPath('downloads'), safe || 'download.pdf'),
+      filters: [{ name: 'PDF', extensions: ['pdf'] }],
+    });
+    if (picked.canceled || !picked.filePath) {
+      return { ok: false, error: 'cancelled' };
+    }
     const session = win.webContents.session;
     return await new Promise<{ ok: boolean; error?: string; savePath?: string }>((resolve) => {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
-      let savePath: string | undefined;
       const finish = (ok: boolean, error?: string) => {
         if (settled) return;
         settled = true;
         if (timer) clearTimeout(timer);
         session.removeListener('will-download', onWillDownload);
-        resolve(ok ? { ok, savePath } : { ok, error });
+        resolve(ok ? { ok, savePath: picked.filePath } : { ok, error });
       };
       const onWillDownload = (
         _e: Electron.Event,
@@ -1927,11 +1936,10 @@ for m in ("pydantic", "httpx", "loguru"):
         // Only the initiating webContents's downloads get our filename.
         if (wc !== win.webContents) return;
         try {
-          if (safe) item.setSavePath(join(electron.app.getPath('downloads'), safe));
+          item.setSavePath(picked.filePath);
         } catch {
           // fall back to default download path
         }
-        savePath = item.getSavePath();
         item.once('done', (_ev, state) => {
           finish(state === 'completed', state === 'completed' ? undefined : `download ${state}`);
         });

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -355,7 +355,10 @@ const api = {
 
   // -- Direct downloads (issue #667: paper PDF etc.) -----------------------
   downloads: {
-    download: (url: string, filename?: string): Promise<{ ok: boolean; error?: string }> =>
+    download: (
+      url: string,
+      filename?: string,
+    ): Promise<{ ok: boolean; error?: string; savePath?: string }> =>
       ipcRenderer.invoke(IPC.DOWNLOADS_DOWNLOAD, { url, filename }),
   },
 

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1704,6 +1704,8 @@ export function ChatConsole({
   const [paperDownloadStates, setPaperDownloadStates] = useState<
     Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>
   >({});
+  /** #696 补：下载完成 toast（成功提示 + 打开文件夹） */
+  const [downloadToast, setDownloadToast] = useState<{ filename: string; savePath: string } | null>(null);
 
   // Lazily re-read image attachments after session load: the sender embeds
   // only "[Image: name]" in the persisted content; the actual bytes live in
@@ -3803,6 +3805,11 @@ export function ChatConsole({
                 ...prev,
                 [paper.id || '']: { status: 'done', savePath: res.savePath },
               }));
+              // #696 补：下载完成 toast（3.5s 自动消失）
+              if (res.savePath) {
+                setDownloadToast({ filename, savePath: res.savePath });
+                setTimeout(() => setDownloadToast(null), 3500);
+              }
             } else {
               // 失败不再静默 fallback：显示失败原因（用户可决定是否让 AI 下载）；
               // 用户主动取消保存对话框 → 回默认状态（不算失败）
@@ -5537,6 +5544,42 @@ export function ChatConsole({
           </div>
         </div>
       </Modal>
+      {/* #696 补：下载完成 toast（右下角浮层，3.5s 自动消失） */}
+      {downloadToast && (
+        <div
+          className="fixed bottom-6 right-6 z-[100] flex items-center gap-3 rounded-xl px-4 py-3 shadow-lg"
+          style={{
+            background: 'var(--surface)',
+            border: '1px solid var(--success)',
+            boxShadow: '0 8px 30px rgba(0,0,0,.12)',
+            animation: 'msgIn .3s cubic-bezier(.22,.8,.32,1)',
+          }}
+        >
+          <span
+            className="w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0"
+            style={{ background: 'var(--success-bg)', color: 'var(--success-text)' }}
+          >
+            ✓
+          </span>
+          <div className="min-w-0">
+            <div className="text-[13px] font-semibold" style={{ color: 'var(--text)' }}>
+              下载成功
+            </div>
+            <div className="text-[11.5px] truncate max-w-[220px]" style={{ color: 'var(--text-muted)' }}>
+              {downloadToast.filename}
+            </div>
+          </div>
+          <button
+            onClick={() => window.miqi.files?.openContainingFolder(downloadToast.savePath)}
+            className="text-[12px] font-medium px-2.5 py-1 rounded-lg cursor-pointer shrink-0 transition-all"
+            style={{ background: 'var(--success-bg)', color: 'var(--success-text)', border: 'none' }}
+            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.8')}
+            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+          >
+            打开文件夹
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1704,8 +1704,9 @@ export function ChatConsole({
   const [paperDownloadStates, setPaperDownloadStates] = useState<
     Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>
   >({});
-  /** #696 补：下载完成 toast（成功提示 + 打开文件夹） */
+  /** #696 补：下载完成 toast（成功提示 + 打开文件夹，居中 + 淡入淡出 + 2s） */
   const [downloadToast, setDownloadToast] = useState<{ filename: string; savePath: string } | null>(null);
+  const [toastVisible, setToastVisible] = useState(false);
 
   // Lazily re-read image attachments after session load: the sender embeds
   // only "[Image: name]" in the persisted content; the actual bytes live in
@@ -3805,10 +3806,12 @@ export function ChatConsole({
                 ...prev,
                 [paper.id || '']: { status: 'done', savePath: res.savePath },
               }));
-              // #696 补：下载完成 toast（3.5s 自动消失）
+              // #696 补：下载完成 toast（居中，1.5s 后淡出，2s 移除）
               if (res.savePath) {
                 setDownloadToast({ filename, savePath: res.savePath });
-                setTimeout(() => setDownloadToast(null), 3500);
+                setToastVisible(true);
+                setTimeout(() => setToastVisible(false), 1500);
+                setTimeout(() => setDownloadToast(null), 2000);
               }
             } else {
               // 失败不再静默 fallback：显示失败原因（用户可决定是否让 AI 下载）；
@@ -5544,40 +5547,46 @@ export function ChatConsole({
           </div>
         </div>
       </Modal>
-      {/* #696 补：下载完成 toast（右下角浮层，3.5s 自动消失） */}
+      {/* #696 补：下载完成 toast（屏幕居中 + 淡入淡出 + 2s 停留） */}
       {downloadToast && (
         <div
-          className="fixed bottom-6 right-6 z-[100] flex items-center gap-3 rounded-xl px-4 py-3 shadow-lg"
-          style={{
-            background: 'var(--surface)',
-            border: '1px solid var(--success)',
-            boxShadow: '0 8px 30px rgba(0,0,0,.12)',
-            animation: 'msgIn .3s cubic-bezier(.22,.8,.32,1)',
-          }}
+          className="fixed inset-0 z-[100] flex items-center justify-center pointer-events-none"
+          style={{ animation: 'msgIn .25s cubic-bezier(.22,.8,.32,1)' }}
         >
-          <span
-            className="w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0"
-            style={{ background: 'var(--success-bg)', color: 'var(--success-text)' }}
+          <div
+            className="flex items-center gap-3 rounded-xl px-5 py-3.5 shadow-lg pointer-events-auto"
+            style={{
+              background: 'var(--surface)',
+              border: '1px solid var(--success)',
+              boxShadow: '0 12px 40px rgba(0,0,0,.15)',
+              opacity: toastVisible ? 1 : 0,
+              transition: 'opacity .4s ease',
+            }}
           >
-            ✓
-          </span>
-          <div className="min-w-0">
-            <div className="text-[13px] font-semibold" style={{ color: 'var(--text)' }}>
-              下载成功
+            <span
+              className="w-7 h-7 rounded-full flex items-center justify-center text-sm shrink-0"
+              style={{ background: 'var(--success-bg)', color: 'var(--success-text)' }}
+            >
+              ✓
+            </span>
+            <div className="min-w-0">
+              <div className="text-[14px] font-semibold" style={{ color: 'var(--text)' }}>
+                下载成功
+              </div>
+              <div className="text-[12px] truncate max-w-[260px]" style={{ color: 'var(--text-muted)' }}>
+                {downloadToast.filename}
+              </div>
             </div>
-            <div className="text-[11.5px] truncate max-w-[220px]" style={{ color: 'var(--text-muted)' }}>
-              {downloadToast.filename}
-            </div>
+            <button
+              onClick={() => window.miqi.files?.openContainingFolder(downloadToast.savePath)}
+              className="text-[12.5px] font-medium px-3 py-1.5 rounded-lg cursor-pointer shrink-0 transition-all"
+              style={{ background: 'var(--success-bg)', color: 'var(--success-text)', border: 'none' }}
+              onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.8')}
+              onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
+            >
+              打开文件夹
+            </button>
           </div>
-          <button
-            onClick={() => window.miqi.files?.openContainingFolder(downloadToast.savePath)}
-            className="text-[12px] font-medium px-2.5 py-1 rounded-lg cursor-pointer shrink-0 transition-all"
-            style={{ background: 'var(--success-bg)', color: 'var(--success-text)', border: 'none' }}
-            onMouseEnter={(e) => (e.currentTarget.style.opacity = '0.8')}
-            onMouseLeave={(e) => (e.currentTarget.style.opacity = '1')}
-          >
-            打开文件夹
-          </button>
         </div>
       )}
     </div>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1700,6 +1700,10 @@ export function ChatConsole({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [downloadingPaperId, setDownloadingPaperId] = useState<string | null>(null);
+  /** #668 补：论文下载结果反馈（paperId → done+savePath / failed+error） */
+  const [paperDownloadStates, setPaperDownloadStates] = useState<
+    Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>
+  >({});
 
   // Lazily re-read image attachments after session load: the sender embeds
   // only "[Image: name]" in the persisted content; the actual bytes live in
@@ -3789,20 +3793,35 @@ export function ChatConsole({
       if (directUrl) {
         setDownloadingPaperId(paper.id || null);
         const filename = `${filenameBase}.pdf`;
-        const fallback = () => {
-          setDownloadingPaperId(null);
-          aiDownload(paper, title);
-        };
         window.miqi.downloads
           .download(directUrl, filename)
           .then((res) => {
             if (res?.ok) {
               setDownloadingPaperId(null);
+              // #668 补：成功反馈——按钮变「✓ 已下载」+ 打开文件夹
+              setPaperDownloadStates((prev) => ({
+                ...prev,
+                [paper.id || '']: { status: 'done', savePath: res.savePath },
+              }));
             } else {
-              fallback();
+              // 失败不再静默 fallback：显示失败原因（用户可决定是否让 AI 下载）
+              setDownloadingPaperId(null);
+              setPaperDownloadStates((prev) => ({
+                ...prev,
+                [paper.id || '']: { status: 'failed', error: res.error ?? '直链下载失败' },
+              }));
             }
           })
-          .catch(() => fallback());
+          .catch((e: unknown) => {
+            setDownloadingPaperId(null);
+            setPaperDownloadStates((prev) => ({
+              ...prev,
+              [paper.id || '']: {
+                status: 'failed',
+                error: e instanceof Error ? e.message : '直链下载异常',
+              },
+            }));
+          });
         return;
       }
       // 无直链：fallback 让 AI 下载
@@ -4715,6 +4734,7 @@ export function ChatConsole({
                         onOpenProviderSettings={onOpenProviderSettings}
                         onDownloadPaper={handleDownloadPaper}
                         downloadingPaperId={downloadingPaperId}
+                        paperDownloadStates={paperDownloadStates}
                       />
                     </div>
                   )
@@ -5616,6 +5636,7 @@ function MessageBubble({
   onOpenProviderSettings,
   onDownloadPaper,
   downloadingPaperId,
+  paperDownloadStates,
   sources,
   toolStepIndex,
   isLastToolRow,
@@ -5639,6 +5660,8 @@ function MessageBubble({
   onOpenProviderSettings?: () => void;
   onDownloadPaper?: (paper: PaperItem) => void;
   downloadingPaperId?: string | null;
+  /** #668 补：论文下载结果反馈（paperId → done/failed） */
+  paperDownloadStates?: Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>;
   /** Reference URLs collected from the tool calls preceding this answer */
   sources?: MessageSource[];
   /** Workflow step number when this progress row is a tool call. */
@@ -5739,6 +5762,7 @@ function MessageBubble({
           data={msg.toolData as PaperSearchPayload}
           onDownloadPaper={onDownloadPaper || (() => {})}
           downloadingId={downloadingPaperId || null}
+          paperDownloadStates={paperDownloadStates}
         />
       );
     }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3804,12 +3804,21 @@ export function ChatConsole({
                 [paper.id || '']: { status: 'done', savePath: res.savePath },
               }));
             } else {
-              // 失败不再静默 fallback：显示失败原因（用户可决定是否让 AI 下载）
+              // 失败不再静默 fallback：显示失败原因（用户可决定是否让 AI 下载）；
+              // 用户主动取消保存对话框 → 回默认状态（不算失败）
               setDownloadingPaperId(null);
-              setPaperDownloadStates((prev) => ({
-                ...prev,
-                [paper.id || '']: { status: 'failed', error: res.error ?? '直链下载失败' },
-              }));
+              if (res.error === 'cancelled') {
+                setPaperDownloadStates((prev) => {
+                  const next = { ...prev };
+                  delete next[paper.id || ''];
+                  return next;
+                });
+              } else {
+                setPaperDownloadStates((prev) => ({
+                  ...prev,
+                  [paper.id || '']: { status: 'failed', error: res.error ?? '直链下载失败' },
+                }));
+              }
             }
           })
           .catch((e: unknown) => {

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -15,6 +15,9 @@ import {
   ExternalLink,
   Loader2,
   CheckCircle,
+  Check,
+  FolderOpen,
+  AlertCircle,
   ChevronDown,
   ChevronRight,
 } from 'lucide-react';
@@ -89,10 +92,13 @@ function PaperCard({
   paper,
   onDownload,
   isDownloading,
+  downloadState,
 }: {
   paper: PaperItem;
   onDownload: (paper: PaperItem) => void;
   isDownloading: boolean;
+  /** #668 补：下载结果反馈（成功路径 + 打开文件夹 / 失败原因） */
+  downloadState?: { status: 'done' | 'failed'; savePath?: string; error?: string };
 }) {
   const [showAbstract, setShowAbstract] = useState(false);
   const hasAbstract = paper.abstract?.trim().length > 10;
@@ -207,8 +213,36 @@ function PaperCard({
 
         <div className="flex-1" />
 
-        {/* Download PDF button */}
-        {hasPdf && (
+        {/* Download PDF button + 结果反馈（#668 补：成功/失败不再静默） */}
+        {hasPdf && downloadState?.status === 'done' && (
+          <div className="inline-flex items-center gap-2">
+            <span
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'var(--success-bg, #d4f5e0)', color: 'var(--success-text, #1d7e3a)' }}
+            >
+              <Check size={12} /> 已下载
+            </span>
+            {downloadState.savePath && (
+              <button
+                onClick={() => window.miqi.files?.openContainingFolder(downloadState.savePath!)}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium cursor-pointer hover:underline"
+                style={{ background: 'none', border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+              >
+                <FolderOpen size={12} /> 打开文件夹
+              </button>
+            )}
+          </div>
+        )}
+        {hasPdf && downloadState?.status === 'failed' && (
+          <span
+            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium"
+            style={{ background: 'var(--danger-bg, #f8e8e8)', color: 'var(--danger, #c04040)' }}
+            title={downloadState.error}
+          >
+            <AlertCircle size={12} /> 下载失败{downloadState.error ? `：${downloadState.error}` : ''}
+          </span>
+        )}
+        {hasPdf && (!downloadState || downloadState.status === undefined) && (
           <button
             onClick={() => onDownload(paper)}
             disabled={isDownloading}
@@ -238,10 +272,13 @@ export default function PaperSearchResult({
   data,
   onDownloadPaper,
   downloadingId,
+  paperDownloadStates,
 }: {
   data: PaperSearchPayload;
   onDownloadPaper: (paper: PaperItem) => void;
   downloadingId: string | null;
+  /** #668 补：下载结果反馈（paperId → done/failed + savePath/error） */
+  paperDownloadStates?: Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>;
 }) {
   const items = data.items ?? [];
 
@@ -300,6 +337,7 @@ export default function PaperSearchResult({
           paper={paper}
           onDownload={onDownloadPaper}
           isDownloading={downloadingId === paper.id}
+          downloadState={paperDownloadStates?.[paper.id || '']}
         />
       ))}
     </div>

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -981,6 +981,7 @@ class BridgeRuntimeLoop:
                 ExecCommandOutputDeltaEvent,
                 ToolCallBeginEvent,
                 ToolCallEndEvent,
+                ToolCallOutputDeltaEvent,
                 TurnAbortedEvent,
                 TurnCompleteEvent,
                 TurnStartedEvent,
@@ -1057,6 +1058,17 @@ class BridgeRuntimeLoop:
                         "stream": event.stream,
                         "delta": event.delta,
                         "tool_call_id": event.tool_call_id,
+                    })
+                    continue
+
+                # Tool output deltas (paper_search_result cards etc.):
+                # same top-level delta shape — ChatConsole parses
+                # data.delta for structured payloads (issue #668 regression).
+                if isinstance(event, ToolCallOutputDeltaEvent):
+                    await _emit("progress", {
+                        "delta": event.delta,
+                        "tool_call_id": event.tool_call_id,
+                        "tool_hint": True,
                     })
                     continue
 


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 修复

## 变更概述
**#668 论文下载的结果反馈补全**——用户实测：点「下载 PDF」后无任何反馈（不知道成功没、下到哪、失败原因）。本 PR 补上完整反馈链路。

## 背景/问题
#668（已合并）只实现了"触发下载"（webContents.downloadURL），但：
1. 成功 → 按钮回到「下载 PDF」，无"已下载/文件位置"提示
2. 失败 → 静默 fallback 到 AI 下载（用户困惑"怎么又发消息了"）
3. 无下载位置、无失败原因

## 变更内容
- `main/ipc/index.ts`：`downloads:download` 成功时返回 **savePath**（will-download 记录真实保存路径）
- `preload/index.ts`：download 返回类型补 `savePath`
- `ChatConsole.tsx`：`paperDownloadStates` state——成功 → `{status:'done', savePath}`；失败 → `{status:'failed', error}`（**不再静默 fallback**，失败原因明确展示）；两处 MessageBubble 透传
- `PaperSearchResult.tsx`：按钮区三态
  - `✓ 已下载` + **打开文件夹**（`files.openContainingFolder`）
  - `⚠ 下载失败：原因`（title 悬浮详情）
  - `下载 PDF`（下载中 spin）

## 日志/验证证据
```
tsc web + node → 0 错误
vitest → 160 passed / 12 files
```

## 测试情况
- 前端编译 + 单测全绿
- UI 三态渲染（done/failed/默认）逻辑自检
- 真机下载链路待用户验证（需真实论文卡片）

## 截图
<img width="1264" height="821" alt="a8480b897bb79fef90333babe2757d76" src="https://github.com/user-attachments/assets/68af21d5-8111-498f-a87f-9ed9bbc1c08a" />

## 风险与兼容性
- 失败不再自动 fallback AI 下载——用户看到失败原因后可自行决定（无直链论文仍走 AI 下载，行为不变）
- savePath 为可选字段，旧调用不受影响


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add save dialog for user-selected PDF path

- Return real `savePath` after successful Electron download

- Show success/failure states in paper cards and toast

- Fix `ToolCallOutputDeltaEvent` forwarding so paper cards render


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["bridge/loop.py forwards ToolCallOutputDeltaEvent"] --> B["paper_search_result cards render"]
  B --> C["User clicks Download PDF"]
  C --> D["showSaveDialog selects save path"]
  D --> E["Electron downloads URL"]
  E --> F["Success returns savePath"]
  F --> G["Card shows ✓ 已下载 + 打开文件夹"]
  F --> H["Toast opens containing folder"]
  E --> I["Failure/cancel shows error or resets"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loop.py</strong><dd><code>Forward tool output deltas in expected shape</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/bridge/loop.py

<ul><li>Adds <code>ToolCallOutputDeltaEvent</code> to recognized terminal event types<br> <li> Emits <code>progress</code> with top-level <code>delta</code>, <code>tool_call_id</code>, and <code>tool_hint: true</code><br> <li> Fixes paper_search_result card rendering regression from tool output <br>delta format</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/696/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Use save dialog and return real savePath</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/main/ipc/index.ts

<ul><li>Adds <code>showSaveDialog</code> so user chooses download path instead of fixed <br>Downloads directory<br> <li> Returns <code>{ ok: false, error: 'cancelled' }</code> when dialog is canceled<br> <li> Resolves success with <code>savePath</code> from picked file path after Electron <br>download completes<br> <li> Sets save path on <code>will-download</code> item to selected path</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/696/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Expose savePath in preload download type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/preload/index.ts

- Extends `downloads.download` return type with optional `savePath`


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/696/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Add download result state, toast, and no silent fallback</code>&nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Adds <code>paperDownloadStates</code> for per-paper success/failure feedback<br> <li> On download success sets <code>done</code> with savePath and triggers centered <br>toast<br> <li> On failure sets <code>failed</code> with error; canceled resets state instead of <br>failing<br> <li> Removes silent fallback to AI download on direct-download failure or <br>catch<br> <li> Passes <code>paperDownloadStates</code> to <code>MessageBubble</code> and renders download toast</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/696/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+91/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PaperSearchResult.tsx</strong><dd><code>Show paper download success/failure UI states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx

<ul><li>Adds <code>downloadState</code> prop to <code>PaperCard</code> for done/failed status<br> <li> Renders <code>✓ 已下载</code> and <code>打开文件夹</code> button on success<br> <li> Renders <code>⚠ 下载失败：原因</code> with error tooltip on failure<br> <li> Passes <code>paperDownloadStates</code> from result list to each card</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/696/files#diff-52e59847eb62dd0bb9d1ee24db1fd1c43b6e0208ed08b4c942a5bb5d417afa9b">+40/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

