### PR TITLE
ci: 通知只保留评论正文，PR/issue 均只带标题

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -22,11 +22,11 @@ jobs:
           SENDER="${{ github.actor }}"
           TITLE=$(jq -r '(.issue.title // .pull_request.title // "")' "$GITHUB_EVENT_PATH")
           URL=$(jq -r '(.comment.html_url // .issue.html_url // .pull_request.html_url // "")' "$GITHUB_EVENT_PATH")
-          # PR 通知只带标题（正文太长刷屏）；评论/issue 保留正文
-          if [ "$EVENT" = "pull_request" ]; then
-            BODY_RAW=""
+          # 只有评论通知带正文；PR/issue 只带标题，避免刷屏
+          if [ "$EVENT" = "issue_comment" ]; then
+            BODY_RAW=$(jq -r '(.comment.body // "")' "$GITHUB_EVENT_PATH")
           else
-            BODY_RAW=$(jq -r '(.comment.body // .issue.body // "")' "$GITHUB_EVENT_PATH")
+            BODY_RAW=""
           fi
           # 企微 markdown 上限 4096 字节：正文最多保留 2500 字节
           BODY=$(printf '%s' "$BODY_RAW" | head -c 2500 | iconv -c -f UTF-8 -t UTF-8)


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

调整企微通知策略：只有评论通知保留正文，PR/issue 通知均只带标题+链接；修复评论正文与链接挤在一起的问题。

## 背景/问题

PR 描述和 issue 正文通常较长，推送全文会导致企微群刷屏。改为只推标题+可点击链接，成员按需点开详情。评论是协作中的即时互动，正文较短且需要直接看到内容，继续保留。

上一版评论正文紧贴链接行没有换行分隔，阅读体验差。根因：bash 命令替换 `$(printf '\n\n')` 会剥掉尾部换行符，导致分隔变量永远是空字符串。改为在 jq 表达式内用条件判断生成换行。

## 变更内容

- `.github/workflows/wecom-notify.yml`
  - `pull_request` 事件：仅标题+链接
  - `issues` 事件：仅标题+链接
  - `issue_comment` 事件：保留评论正文（2500 字节截断保护不变）
  - 换行分隔移入 jq 内部：`(if $body != "" then "\n\n" else "" end)`，避免 bash 命令替换剥换行

## 日志/验证证据

```
# 评论事件模拟（链接与正文有 \n\n 分隔）
消息内容 repr：
'...> 链接: [点此查看](...)\n\n评论第一行\n评论第二行'
{"errcode":0,"errmsg":"ok"}

# CI 真实触发
notify job: {"errcode":0,"errmsg":"ok"}
```

## 测试情况

- 评论事件消息已实测：链接与正文之间有空行分隔，正文多行正常显示
- PR/issue 事件走空正文分支，消息以链接行结尾
- 截断逻辑未改动，仍受 2500 字节保护

## 截图

无需截图