### PR TITLE
fix(#696): CodeRabbit 4 条意见补发（will-download 生命周期 / 会话隔离 / ToolChainGroup 透传 / 失败重试）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1944,7 +1944,7 @@ for m in ("pydantic", "httpx", "loguru"):
           finish(state === 'completed', state === 'completed' ? undefined : `download ${state}`);
         });
       };
-      session.once('will-download', onWillDownload);
+      session.on('will-download', onWillDownload);
       win.webContents.downloadURL(url);
       // Guard: if will-download never fires (e.g. the URL navigates instead
       // of downloading), don't leave the renderer hanging forever.

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3804,7 +3804,7 @@ export function ChatConsole({
               // #668 补：成功反馈——按钮变「✓ 已下载」+ 打开文件夹
               setPaperDownloadStates((prev) => ({
                 ...prev,
-                [paper.id || '']: { status: 'done', savePath: res.savePath },
+                [`${sessionKey}:${paper.id || ''}`]: { status: 'done', savePath: res.savePath },
               }));
               // #696 补：下载完成 toast（居中，1.5s 后淡出，2s 移除）
               if (res.savePath) {
@@ -3820,13 +3820,13 @@ export function ChatConsole({
               if (res.error === 'cancelled') {
                 setPaperDownloadStates((prev) => {
                   const next = { ...prev };
-                  delete next[paper.id || ''];
+                  delete next[`${sessionKey}:${paper.id || ''}`];
                   return next;
                 });
               } else {
                 setPaperDownloadStates((prev) => ({
                   ...prev,
-                  [paper.id || '']: { status: 'failed', error: res.error ?? '直链下载失败' },
+                  [`${sessionKey}:${paper.id || ''}`]: { status: 'failed', error: res.error ?? '直链下载失败' },
                 }));
               }
             }
@@ -3835,7 +3835,7 @@ export function ChatConsole({
             setDownloadingPaperId(null);
             setPaperDownloadStates((prev) => ({
               ...prev,
-              [paper.id || '']: {
+              [`${sessionKey}:${paper.id || ''}`]: {
                 status: 'failed',
                 error: e instanceof Error ? e.message : '直链下载异常',
               },
@@ -4728,6 +4728,7 @@ export function ChatConsole({
                       onOpenProviderSettings={onOpenProviderSettings}
                       onDownloadPaper={handleDownloadPaper}
                       downloadingPaperId={downloadingPaperId}
+                      paperDownloadStates={paperDownloadStates}
                     />
                   ) : (
                     <div key={`${group.msg.timestamp}-${i}`}>
@@ -5824,6 +5825,7 @@ function MessageBubble({
           onDownloadPaper={onDownloadPaper || (() => {})}
           downloadingId={downloadingPaperId || null}
           paperDownloadStates={paperDownloadStates}
+          downloadStateKeyPrefix={sessionKey}
         />
       );
     }

--- a/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
+++ b/apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   FolderOpen,
   AlertCircle,
+  RotateCw,
   ChevronDown,
   ChevronRight,
 } from 'lucide-react';
@@ -234,12 +235,21 @@ function PaperCard({
           </div>
         )}
         {hasPdf && downloadState?.status === 'failed' && (
-          <span
-            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium"
-            style={{ background: 'var(--danger-bg, #f8e8e8)', color: 'var(--danger, #c04040)' }}
-            title={downloadState.error}
-          >
-            <AlertCircle size={12} /> 下载失败{downloadState.error ? `：${downloadState.error}` : ''}
+          <span className="inline-flex items-center gap-1.5">
+            <span
+              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium"
+              style={{ background: 'var(--danger-bg, #f8e8e8)', color: 'var(--danger, #c04040)' }}
+              title={downloadState.error}
+            >
+              <AlertCircle size={12} /> 下载失败{downloadState.error ? `：${downloadState.error}` : ''}
+            </span>
+            <button
+              onClick={() => onDownload(paper)}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium cursor-pointer hover:underline"
+              style={{ background: 'none', border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+            >
+              <RotateCw size={11} /> 重试
+            </button>
           </span>
         )}
         {hasPdf && (!downloadState || downloadState.status === undefined) && (
@@ -273,12 +283,15 @@ export default function PaperSearchResult({
   onDownloadPaper,
   downloadingId,
   paperDownloadStates,
+  downloadStateKeyPrefix,
 }: {
   data: PaperSearchPayload;
   onDownloadPaper: (paper: PaperItem) => void;
   downloadingId: string | null;
   /** #668 补：下载结果反馈（paperId → done/failed + savePath/error） */
   paperDownloadStates?: Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>;
+  /** #696 补：session 前缀键（防跨会话串状态，CodeRabbit） */
+  downloadStateKeyPrefix?: string;
 }) {
   const items = data.items ?? [];
 
@@ -337,7 +350,7 @@ export default function PaperSearchResult({
           paper={paper}
           onDownload={onDownloadPaper}
           isDownloading={downloadingId === paper.id}
-          downloadState={paperDownloadStates?.[paper.id || '']}
+          downloadState={paperDownloadStates?.[`${downloadStateKeyPrefix ?? ''}:${paper.id || ''}`]}
         />
       ))}
     </div>


### PR DESCRIPTION
### **User description**
## 类型
- [x] 🐛 修复

## 变更概述
**#696 的 CodeRabbit 4 条意见补发**——#696 已于 07:29 被合并（合并 SHA 2400f443），但 CodeRabbit 4 条修复（本分支）在合并后几分钟才推送，未进入 develop。本 PR 补上。

## 背景/问题
#696 合并后，CodeRabbit 评审提出的 4 条意见未合入：
1. **will-download listener 生命周期**（Major/Stability）：`session.once` 在别的窗口先触发下载时消费掉 handler → 本请求 60s 超时误报
2. **下载状态跨会话泄漏**（Major/Correctness）：paperDownloadStates 只按 paperId 键控，会话切换后旧结果写入新会话
3. **ToolChainGroup 未透传**（Major/Correctness）：工具链内的论文卡片收不到下载状态（显示不了已完成/失败）
4. **失败无重试**（Minor/UX）：直链失败后卡片只有静态错误文案，无法重试

## 变更内容
- `main/ipc/index.ts`：`session.once` → `session.on`（finish 里已有 removeListener 清理）
- `ChatConsole.tsx`：状态键加 `${sessionKey}:` 前缀（3 处写入 + 1 处删除）；ToolChainGroup 调用补 `paperDownloadStates` 透传
- `PaperSearchResult.tsx`：`downloadStateKeyPrefix` prop（session 前缀键）；失败态加「重试」按钮（RotateCw → onDownload(paper)）

## 日志/验证证据
```
tsc web + node → 0 错误
vitest → 153 passed / 12 files
```

## 测试情况
- 前端编译 + 单测全绿
- 4 条修复逐条对应 CodeRabbit 意见

## 截图
无（逻辑修复）

## 风险与兼容性
- 下载状态键格式变化（加 session 前缀）——历史会话的下载状态不复现（可接受，状态是瞬时的）
- 其余行为不变


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace `session.once` with `session.on` for will-download.

- Scope `paperDownloadStates` with `sessionKey` to prevent leakage.

- Pass `paperDownloadStates` through `ToolChainGroup` to nested cards.

- Add retry button on failed paper download.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Replace session.once with session.on"] --> B["Stable will-download listener"]
  C["Prefix paperDownloadStates with sessionKey"] --> D["Prevent cross-session state leakage"]
  E["Pass paperDownloadStates to ToolChainGroup"] --> F["Nested paper cards receive status"]
  G["Failed download state UI"] --> H["Add retry button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Use session.on for stable will-download handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/main/ipc/index.ts

<ul><li>Replace <code>session.once</code> with <code>session.on</code> for the <code>will-download</code> listener.<br> <li> Prevent listener consumption by other windows, avoiding false 60s <br>timeout.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/703/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Scope paper download states per session and propagate</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Add <code>sessionKey</code> prefix to all <code>paperDownloadStates</code> read/write/delete.<br> <li> Pass <code>paperDownloadStates</code> to <code>ToolChainGroup</code> and <code>MessageBubble</code>.<br> <li> Pass <code>downloadStateKeyPrefix={sessionKey}</code> to <code>PaperSearchResult</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/703/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PaperSearchResult.tsx</strong><dd><code>Add retry button and session key prefix for paper cards</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/PaperSearchResult.tsx

<ul><li>Add <code>RotateCw</code> import and retry button in failed download state.<br> <li> Add <code>downloadStateKeyPrefix</code> prop; use session-prefixed key lookup.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/703/files#diff-52e59847eb62dd0bb9d1ee24db1fd1c43b6e0208ed08b4c942a5bb5d417afa9b">+20/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

