### PR TITLE
ci: 按内容过滤 semantic-release 发布通知评论

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -28,6 +28,12 @@ jobs:
           else
             BODY_RAW=""
           fi
+          # semantic-release 发布通知评论由 RELEASE_TOKEN（本人 PAT）发出，
+          # 用户名过滤无效，按内容特征跳过
+          if printf '%s' "$BODY_RAW" | grep -qE ':tada:.*(resolved in version|included in version)'; then
+            echo "release notification comment, skip"
+            exit 0
+          fi
           # 企微 markdown 上限 4096 字节：正文最多保留 2500 字节
           BODY=$(printf '%s' "$BODY_RAW" | head -c 2500 | iconv -c -f UTF-8 -t UTF-8)
           if [ "$(printf '%s' "$BODY_RAW" | wc -c)" -gt "$(printf '%s' "$BODY" | wc -c)" ]; then


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🔧 其他

## 变更概述

企微通知按内容过滤 semantic-release 的发布通知评论，发版自动评论不再推送。

## 背景/问题

semantic-release 发版后会在 issue/PR 上自动评论（如 ":tada: This issue has been resolved in version 0.16.0 :tada:"）。这些评论通过 RELEASE_TOKEN 发出，sender 是账号持有人本人（14790897），不是 Bot，因此按用户名过滤无效（前一个方案 #705 已关闭）。

## 变更内容

- `.github/workflows/wecom-notify.yml`
  - 新增内容特征过滤：评论正文匹配 `:tada: ... (resolved in version|included in version)` 时跳过推送
  - 覆盖 semantic-release 两类通知：issue 已解决、PR 已包含在版本中
  - 过滤发生在 curl 之前（exit 0），不产生任何网络请求

## 日志/验证证据

```
# semantic-release 实际评论内容（sender = 14790897，本人 PAT）
:tada: This issue has been resolved in version 0.16.0 :tada:
The release is available on [GitHub release](https://githu...

# 过滤逻辑（本地 grep 模拟）
$ echo ':tada: This issue has been resolved in version 0.16.0 :tada:' | grep -qE ':tada:.*(resolved in version|included in version)'
→ 匹配，exit 0 跳过
$ echo '普通评论内容' | grep -qE ':tada:.*(resolved in version|included in version)'
→ 不匹配，正常推送
```

## 测试情况

- 两条语义路径均验证：发布通知匹配被跳过、普通评论不匹配正常发送
- 过滤位于 curl 之前，被过滤的评论不会产生企微消息
- 不影响 PR/issue 事件（BODY_RAW 为空，grep 不匹配）

## 截图

无需截图


___

### **PR Type**
Other


___

### **Description**
- Add content-based filter for semantic-release release comments.

- Uses `grep -qE ':tada:.*(resolved in version|included in version)'`.

- Skips WeCom notification and exits before `curl`.

- Applies only to `issue_comment` bodies; PR/issue events unaffected.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["issue_comment event"] --> B["Extract BODY_RAW"]
  B --> C{"Matches release notification pattern?"}
  C -- "Yes" --> D["exit 0 / skip notification"]
  C -- "No" --> E["Send WeCom notification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wecom-notify.yml</strong><dd><code>Add semantic-release release comment content filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/wecom-notify.yml

<ul><li>Add content-based filter before WeCom <code>curl</code>.<br> <li> Match semantic-release release comments via <code>:tada:.*(resolved in </code><br><code>version|included in version)</code>.<br> <li> On match, print skip message and <code>exit 0</code> to avoid notification.<br> <li> Preserve existing behavior for PR/issue events with empty <code>BODY_RAW</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/706/files#diff-64485b0408b275154738b779ded187100e0c7add8ebe28d0e031e1876e49e9d4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

