### PR TITLE
fix(ci): raise ai_timeout to 600s for PR-Agent code suggestions

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -41,4 +41,5 @@ jobs:
           config.custom_model_max_tokens: "128000"
           config.max_model_tokens: "128000"
           config.reasoning_effort: "xhigh"
+          config.ai_timeout: "600"
           OPENAI.API_BASE: "https://new.sixiangjia.de/v1"


### PR DESCRIPTION
### **User description**
xhigh reasoning takes 360s+ per request but ai_timeout defaults to 120s, killing the LLM call before it completes. This caused repeated "Failed to generate code suggestions for PR" on PR #681.


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Add `config.ai_timeout: "600"` to PR-Agent workflow.

- Prevent default 120s timeout from killing xhigh reasoning requests.

- Allow long code-suggestion LLM calls to complete up to 600s.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR-Agent workflow"] --> B["Set config.ai_timeout = 600"]
  B --> C["Allow xhigh reasoning requests up to 600s"]
  C --> D["Prevent failed code suggestions from 120s default timeout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Raise PR-Agent ai_timeout to 600 seconds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Add <code>config.ai_timeout: "600"</code> to the PR-Agent GitHub Action <br>configuration.<br> <li> Extend the LLM request timeout from the default 120s to 600s.<br> <li> Prevent long xhigh reasoning calls from being terminated before <br>completion.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/707/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

