### PR TITLE
fix(build): PyInstaller 打包 rapidocr onnx 模型 — exe 版图片 OCR 恢复（#704）

### DIFF
--- a/miqi.spec
+++ b/miqi.spec
@@ -1,4 +1,12 @@
 
+import os
+import rapidocr_onnxruntime as _roc
+
+# rapidocr ONNX models live under site-packages/rapidocr_onnxruntime/models
+# (ch_PP-OCRv4_det/rec + cls, ~15MB). PyInstaller does NOT auto-collect them —
+# without this the packaged miqi-bridge.exe silently loses image OCR (#704).
+_roc_models = os.path.join(os.path.dirname(_roc.__file__), "models")
+
 a = Analysis(
     ['miqi/bridge/server.py'],
     pathex=['.'],
@@ -6,6 +14,7 @@ a = Analysis(
     datas=[
         ('miqi/templates', 'miqi/templates'),
         ('miqi/skills', 'miqi/skills'),
+        (_roc_models, 'rapidocr_onnxruntime/models'),
     ],
     hiddenimports=[
         # MiQi internal modules
@@ -27,6 +36,11 @@ a = Analysis(
         'httpx',
         'httpcore',
         'loguru',
+        # OCR: rapidocr imports onnxruntime dynamically (#704)
+        'rapidocr_onnxruntime',
+        'rapidocr_onnxruntime.onnxruntime_engine',
+        'onnxruntime',
+        'onnxruntime.capi._pybind_state',
     ],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 exe 打包版图片 OCR 不可用（#704）：PyInstaller 打包时收集 rapidocr-onnxruntime 的 ONNX 模型文件 + 动态导入模块，使 miqi-bridge.exe 内的 RapidOCR 引擎可用。

## 背景/问题

#704（mentor 提交）：图片上传 OCR 在开发版正常、exe 打包版静默降级为"无文字"。根因：

- `_image_ocr()` 使用 RapidOCR（纯 Python + ONNX runtime，无系统二进制依赖）
- rapidocr 的 ONNX 模型（`ch_PP-OCRv4_det/rec_infer.onnx` + `ch_ppocr_mobile_v2.0_cls_infer.onnx`，约 15MB）位于 `site-packages/rapidocr_onnxruntime/models/`，**PyInstaller 不会自动收集**
- 打包版中 `RapidOCR()` 初始化抛异常 → 静默降级到 tesseract（打包版也没有）→ 返回空 → 预览"无文字"

## 变更内容

`miqi.spec`：
- `datas` 新增 rapidocr models 目录（构建时动态定位，打包为 `rapidocr_onnxruntime/models` 相对路径）
- `hiddenimports` 新增 `rapidocr_onnxruntime`、`onnxruntime` 及其动态导入的子模块（PyInstaller 静态分析检测不到）

## 日志/验证证据

```
修复前（#704）：打包版 RapidOCR() 抛异常 → 静默降级 → 无文字
修复后（本分支）：
$ python -c "import rapidocr_onnxruntime as r; print(r.__file__)"
.../rapidocr_onnxruntime/__init__.py
models dir 含 3 个 onnx 文件（det/rec/cls）→ 打包后 exe 内同样可加载
$ pytest tests/documents → 39 passed
```

## 测试情况

- spec 语法校验通过（ast.parse）；模型路径动态解析验证通过
- `tests/documents` 39 passed（OCR 路径回归）
- 打包产物验证需构建环境跑 PyInstaller（CI macos-build/electron 流程覆盖）

## 截图

无需截图。

## 已知限制（后续）

扫描版 PDF 的 OCR 仍依赖 `pdftoppm + tesseract`（外部二进制，打包版无）——完整修复需引入 PyMuPDF 渲染 + rapidocr 识别，建议独立 PR。


___

### **PR Type**
Bug fix


___

### **Description**
- Add RapidOCR ONNX models to PyInstaller `datas` for bundled exe.

- Register RapidOCR/ONNX Runtime dynamic imports as `hiddenimports`.

- Restore image OCR in packaged `miqi-bridge.exe` (#704).


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["miqi.spec"] --> B["Locate rapidocr_onnxruntime/models"]
  A --> C["Add models to datas"]
  A --> D["Add OCR dynamic imports to hiddenimports"]
  C --> E["Packaged exe includes ONNX models"]
  D --> E
  E --> F["Image OCR restored in miqi-bridge.exe"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miqi.spec</strong><dd><code>Bundle RapidOCR models and hidden imports in PyInstaller spec</code></dd></summary>
<hr>

miqi.spec

<ul><li>Import <code>os</code> and <code>rapidocr_onnxruntime</code> to compute the installed models <br>directory.<br> <li> Add <code>rapidocr_onnxruntime/models</code> to PyInstaller <code>datas</code> so ONNX <br>det/rec/cls models are packaged.<br> <li> Add <code>rapidocr_onnxruntime</code>, <code>rapidocr_onnxruntime.onnxruntime_engine</code>, <br><code>onnxruntime</code>, and <code>onnxruntime.capi._pybind_state</code> to <code>hiddenimports</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/708/files#diff-5613b8a2114ee1d20c4ffa540e59da22c27e08b8dc99b864b31abdb2e24701e3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

