### PR TITLE
test(e2e): waitForResponseComplete 尊重调用方超时 — 慢 LLM provider 下不再 90s 截断误报

### DIFF
--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -102,7 +102,11 @@ export async function waitForResponseComplete(page: Page, timeout = 120_000) {
     }
     s.stable++;
     return s.stable >= 2;
-  }, { timeout: Math.min(timeout, 90_000), polling: 200 });
+    // Respect the caller's timeout: CI LLM providers have been slow enough
+    // that PR-Agent's ai_timeout was raised to 600s (#707).  The old
+    // Math.min(timeout, 90_000) cap made 240s callers time out at 90s and
+    // deterministically fail LLM-dependent tests like regression-480.
+  }, { timeout, polling: 200 });
 }
 
 /** Poll for approval dialogs and click "永久允许" until the AI stops

--- a/miqi.spec
+++ b/miqi.spec
@@ -1,4 +1,12 @@
 
+import os
+import rapidocr_onnxruntime as _roc
+
+# rapidocr ONNX models live under site-packages/rapidocr_onnxruntime/models
+# (ch_PP-OCRv4_det/rec + cls, ~15MB). PyInstaller does NOT auto-collect them —
+# without this the packaged miqi-bridge.exe silently loses image OCR (#704).
+_roc_models = os.path.join(os.path.dirname(_roc.__file__), "models")
+
 a = Analysis(
     ['miqi/bridge/server.py'],
     pathex=['.'],
@@ -6,6 +14,7 @@ a = Analysis(
     datas=[
         ('miqi/templates', 'miqi/templates'),
         ('miqi/skills', 'miqi/skills'),
+        (_roc_models, 'rapidocr_onnxruntime/models'),
     ],
     hiddenimports=[
         # MiQi internal modules
@@ -27,6 +36,11 @@ a = Analysis(
         'httpx',
         'httpcore',
         'loguru',
+        # OCR: rapidocr imports onnxruntime dynamically (#704)
+        'rapidocr_onnxruntime',
+        'rapidocr_onnxruntime.onnxruntime_engine',
+        'onnxruntime',
+        'onnxruntime.capi._pybind_state',
     ],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🧪 测试

## 变更概述

`waitForResponseComplete` 不再把等待上限截断到 90s，而是尊重调用方传入的 `timeout`——修复慢 LLM provider 下 LLM 依赖 e2e 测试的确定性误报。

## 背景/问题

- CI 上的 LLM provider 近期明显变慢：PR-Agent 的 `ai_timeout` 已被提到 600s（#707）
- `waitForResponseComplete` 内部 `Math.min(timeout, 90_000)` 把 240s 的调用硬截断为 90s
- 后果：`regression-480`（240s 等待 AI 回复）在 provider 回复 >90s 时**确定性失败**（连续多轮 electron-e2e/macos-e2e 误报），且 develop 自身的 macos-e2e 同样红——全仓性 flaky

## 变更内容

- `apps/desktop/tests/e2e/helpers/electron-setup.ts`：`waitForResponseComplete` 的 `waitForFunction` 超时从 `Math.min(timeout, 90_000)` 改为直接使用 `timeout`（默认 120s 行为不变；显式传 240s 的调用方真正等到 240s）

## 日志/验证证据

```
修复前：#708/#703 等 PR 的 electron-e2e 连续 2 轮挂 regression-480
        （Session B 的 AI 回复 >90s，被 90s 截断误判为超时）
修复后（本分支）：
$ npm run typecheck → 0 错误
$ npx vitest run → 164 passed
$ npx playwright test --list regression-480 → 2 tests 收集正常
```

## 测试情况

- typecheck 0 错；vitest 164 passed 无回归
- 行为验证由 CI e2e 执行（LLM 真实等待）

## 截图

无需截图。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Bundle RapidOCR ONNX models and hidden imports.

- Remove 90-second cap from `waitForResponseComplete`.

- Restore packaged exe OCR; avoid slow-LLM e2e failures.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>electron-setup.ts</strong><dd><code>Respect caller timeout in waitForResponseComplete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/helpers/electron-setup.ts

<ul><li>Remove <code>Math.min(timeout, 90_000)</code> cap in <code>waitForResponseComplete</code>.<br> <li> Pass the caller-provided <code>timeout</code> directly to <code>waitForFunction</code>.<br> <li> Add explanatory comment referencing slow CI LLM providers and PR-Agent <br><code>ai_timeout</code> 600s.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/709/files#diff-58139259a2a9fb2e044aab7c7354e9c5a55ff21b376fcf99cfbb67b6be072845">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>miqi.spec</strong><dd><code>Bundle RapidOCR ONNX models and hidden imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi.spec

<ul><li>Import <code>os</code> and <code>rapidocr_onnxruntime</code> to locate installed <code>models</code> <br>directory.<br> <li> Add <code>rapidocr_onnxruntime/models</code> to PyInstaller <code>datas</code>.<br> <li> Add RapidOCR/ONNX Runtime dynamic imports to <code>hiddenimports</code>.<br> <li> Restore image OCR in packaged <code>miqi-bridge.exe</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/709/files#diff-5613b8a2114ee1d20c4ffa540e59da22c27e08b8dc99b864b31abdb2e24701e3">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

