### PR TITLE
feat: 重新引入 ask_user_confirm_card — AI 主动发起的人机握手确认卡（#646）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -324,6 +324,10 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
           safeSend('approval:request', data);
         } else if (type === 'approval_cleared') {
           safeSend('approval:cleared', data);
+        } else if (type === 'user_input_requested') {
+          safeSend('userInput:request', data);
+        } else if (type === 'user_input_resolved') {
+          safeSend('userInput:resolved', data);
         } else if (type === 'subagent_result') {
           safeSend('chat:subagent_result', data);
         } else if (type === 'chat:delta' || type === 'delta') {
@@ -1522,6 +1526,14 @@ for m in ("pydantic", "httpx", "loguru"):
     return bridge.send('approvals.resolve', p as Record<string, unknown>);
   });
 
+  // -----------------------------------------------------------------------
+  // User input (issue #646: ask_user_confirm_card)
+  // -----------------------------------------------------------------------
+  ipcMain.handle('userInput:resolve', async (_event, payload: unknown) => {
+    const p = payload as { input_id: string; choice_id: string; choice_label: string };
+    return bridge.send('userInput.resolve', p as Record<string, unknown>);
+  });
+
   ipcMain.handle('approvals:clear_permanent', async (_event, payload: unknown) => {
     const p = (payload ?? {}) as { pattern?: string };
     return bridge.send('approvals.clear_permanent', p as Record<string, unknown>);
@@ -2203,6 +2215,10 @@ for m in ("pydantic", "httpx", "loguru"):
           safeSend('approval:request', data);
         } else if (type === 'approval_cleared') {
           safeSend('approval:cleared', data);
+        } else if (type === 'user_input_requested') {
+          safeSend('userInput:request', data);
+        } else if (type === 'user_input_resolved') {
+          safeSend('userInput:resolved', data);
         } else {
           safeSend('chat:progress', data);
         }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -14,6 +14,9 @@ import type {
   ApprovalsListResult,
   ApprovalsAddPermanentResult,
   ApprovalsHistoryResult,
+  UserInputCardRequest,
+  UserInputResolvedData,
+  UserInputResolveResult,
   CronJob,
   CronListResult,
   CronCreateResult,
@@ -242,6 +245,26 @@ const api = {
       ipcRenderer.on(IPC_EVENTS.APPROVAL_CLEARED, handler);
       return () => {
         ipcRenderer.removeListener(IPC_EVENTS.APPROVAL_CLEARED, handler);
+      };
+    },
+  },
+
+  // -- User input (issue #646: ask_user_confirm_card) --------------------------
+  userInput: {
+    resolve: (inputId: string, choiceId: string, choiceLabel: string, remember?: boolean): Promise<UserInputResolveResult> =>
+      ipcRenderer.invoke(IPC.USER_INPUT_RESOLVE, { input_id: inputId, choice_id: choiceId, choice_label: choiceLabel, remember: remember === true }),
+    onRequest: (callback: (data: UserInputCardRequest) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: UserInputCardRequest) => callback(data);
+      ipcRenderer.on(IPC_EVENTS.USER_INPUT_REQUEST, handler);
+      return () => {
+        ipcRenderer.removeListener(IPC_EVENTS.USER_INPUT_REQUEST, handler);
+      };
+    },
+    onResolved: (callback: (data: UserInputResolvedData) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: UserInputResolvedData) => callback(data);
+      ipcRenderer.on(IPC_EVENTS.USER_INPUT_RESOLVED, handler);
+      return () => {
+        ipcRenderer.removeListener(IPC_EVENTS.USER_INPUT_RESOLVED, handler);
       };
     },
   },

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import { ChatConsole } from './features/chat/ChatConsole';
 import { SettingsPage, type SettingsTab } from './features/settings/SettingsPage';
 import { MCPsPage } from './features/mcps/MCPsPage';
 import { ApprovalProvider } from './contexts/ApprovalContext';
+import { UserInputProvider } from './contexts/UserInputContext';
 import { RestartRequiredProvider } from './contexts/RestartRequiredContext';
 import { ApprovalModal } from './features/approvals/ApprovalModal';
 import { CronPage } from './features/cron/CronPage';
@@ -298,6 +299,7 @@ function AppShell() {
     <TooltipProvider>
       <RestartRequiredProvider>
         <ApprovalProvider>
+          <UserInputProvider>
           {/* Full-height flex column */}
           <div className="flex flex-col h-screen" style={{ background: 'var(--background)' }}>
             <TopBar onOpenApprovals={openApprovalSettings} workspace={workspace ?? undefined} />
@@ -388,6 +390,7 @@ function AppShell() {
             <StatusBar />
           </div>
           <ApprovalModal />
+          </UserInputProvider>
         </ApprovalProvider>
       </RestartRequiredProvider>
     </TooltipProvider>

--- a/apps/desktop/src/renderer/contexts/UserInputContext.tsx
+++ b/apps/desktop/src/renderer/contexts/UserInputContext.tsx
@@ -1,0 +1,175 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type ReactNode,
+} from 'react';
+import type {
+  UserInputCardRequest,
+  UserInputResolvedData,
+} from '../../shared/ipc';
+
+export type UserInputCardState = 'pending' | 'confirmed' | 'cancelled';
+
+/** 步骤执行状态（v5 live 态）：展示层 best-effort，数据由 Step 事件填充。 */
+export interface StepExecStatus {
+  status: 'pending' | 'running' | 'success' | 'failed';
+  result?: string;
+  dur?: string;
+  tool?: string;
+  param?: string;
+}
+
+export interface UserInputCardEntry {
+  request: UserInputCardRequest;
+  state: UserInputCardState;
+  /** User's final choice, filled once resolved (issue #646). */
+  choiceLabel?: string;
+  choiceId?: string;
+  resolvedAt?: number;
+  /** Local timeout (legacy path has no resolved event on timeout). */
+  timedOut?: boolean;
+  /** Step live states keyed by step id (v5 execution mode). */
+  stepsStatus?: Record<string, StepExecStatus>;
+}
+
+interface UserInputContextValue {
+  /** Active (pending) cards keyed by input_id — at most one per turn. */
+  pending: Record<string, UserInputCardEntry>;
+  /** Resolved cards kept in the message flow for traceability. */
+  resolved: Record<string, UserInputCardEntry>;
+  /** Send the user's choice back to the backend (blocking tool resolves). */
+  resolve: (inputId: string, choiceId: string, choiceLabel: string, remember?: boolean) => Promise<void>;
+  /** Local timeout: flip the card to a timed-out resolved state. */
+  timeoutCard: (inputId: string) => void;
+  /** Timestamp of the last "adjust" resolution — composer focuses for input. */
+  lastAdjustAt?: number;
+  /** Active session — cards from other sessions are ignored; switching
+   *  sessions drops all cards (CodeRabbit #666 review). */
+  activeSession?: string;
+  setActiveSession: (key: string) => void;
+}
+
+const UserInputContext = createContext<UserInputContextValue>({
+  pending: {},
+  resolved: {},
+  resolve: async () => {},
+  timeoutCard: () => {},
+  lastAdjustAt: undefined,
+  activeSession: undefined,
+  setActiveSession: () => {},
+});
+
+export function UserInputProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<Record<string, UserInputCardEntry>>({});
+  const [resolved, setResolved] = useState<Record<string, UserInputCardEntry>>({});
+  const [lastAdjustAt, setLastAdjustAt] = useState<number | undefined>(undefined);
+  const [activeSession, setActiveSessionState] = useState<string | undefined>(undefined);
+  const pendingRef = useRef<Record<string, UserInputCardEntry>>({});
+
+  // 切会话：清空全部卡片（pending + resolved），避免跨会话混卡
+  const setActiveSession = useCallback((key: string) => {
+    setActiveSessionState(key);
+    pendingRef.current = {};
+    setPending({});
+    setResolved({});
+  }, []);
+
+  const upsertPending = useCallback((entry: UserInputCardEntry) => {
+    pendingRef.current = { ...pendingRef.current, [entry.request.input_id]: entry };
+    setPending(pendingRef.current);
+  }, []);
+
+  const moveToResolved = useCallback(
+    (inputId: string, state: UserInputCardState, choiceId?: string, choiceLabel?: string, timedOut = false) => {
+      const entry = pendingRef.current[inputId];
+      if (!entry) return;
+      const done: UserInputCardEntry = {
+        ...entry,
+        state,
+        choiceId,
+        choiceLabel,
+        resolvedAt: Date.now(),
+        timedOut,
+      };
+      pendingRef.current = { ...pendingRef.current };
+      delete pendingRef.current[inputId];
+      setPending(pendingRef.current);
+      setResolved((prev) => ({ ...prev, [inputId]: done }));
+      // "adjust" → composer should focus for the user's adjustment text
+      if (choiceId === 'adjust') setLastAdjustAt(Date.now());
+    },
+    [],
+  );
+
+  const timeoutCard = useCallback(
+    (inputId: string) => {
+      moveToResolved(inputId, 'cancelled', undefined, undefined, true);
+    },
+    [moveToResolved],
+  );
+
+  useEffect(() => {
+    const miqi = (window as any).miqi;
+    if (!miqi?.userInput) return;
+    const unsubReq = miqi.userInput.onRequest((data: UserInputCardRequest) => {
+      // 会话隔离：非当前会话的卡不渲染（data.session_key 缺省时放行）
+      if (activeSession && data.session_key && data.session_key !== activeSession) return;
+      upsertPending({
+        request: data,
+        state: 'pending',
+      });
+    });
+    const unsubRes = miqi.userInput.onResolved((data: UserInputResolvedData) => {
+      if (data.status === 'cancelled') {
+        moveToResolved(data.input_id, 'cancelled');
+      } else {
+        const res = data.resolution ?? {};
+        moveToResolved(
+          data.input_id,
+          'confirmed',
+          typeof res.choice_id === 'string' ? res.choice_id : undefined,
+          typeof res.choice_label === 'string' ? res.choice_label : undefined,
+        );
+      }
+    });
+    return () => {
+      unsubReq();
+      unsubRes();
+    };
+  }, [upsertPending, moveToResolved, activeSession]);
+
+  const resolve = useCallback(
+    async (inputId: string, choiceId: string, choiceLabel: string, remember = false) => {
+      const miqi = (window as any).miqi;
+      // Classify by semantic role (falling back to the literal id) instead of
+      // hard-coding 'cancel' — a caller-supplied cancel id like 'abort'/'no'
+      // must also resolve as cancelled (issue #646 review).
+      const entry = pendingRef.current[inputId];
+      const role = entry?.request.choices?.find((c) => c.id === choiceId)?.role;
+      const isCancel = role === 'cancel' || (role === undefined && choiceId === 'cancel');
+      // Optimistic update: the card flips to confirmed/cancelled immediately;
+      // backend user_input_resolved will reconcile (idempotent).
+      moveToResolved(inputId, isCancel ? 'cancelled' : 'confirmed', choiceId, choiceLabel);
+      try {
+        await miqi?.userInput?.resolve(inputId, choiceId, choiceLabel, remember);
+      } catch {
+        // best-effort: backend resolves via timeout/turn-stop otherwise
+      }
+    },
+    [moveToResolved],
+  );
+
+  return (
+    <UserInputContext.Provider value={{ pending, resolved, resolve, timeoutCard, lastAdjustAt, activeSession, setActiveSession }}>
+      {children}
+    </UserInputContext.Provider>
+  );
+}
+
+export function useUserInput() {
+  return useContext(UserInputContext);
+}

--- a/apps/desktop/src/renderer/contexts/UserInputContext.tsx
+++ b/apps/desktop/src/renderer/contexts/UserInputContext.tsx
@@ -155,12 +155,21 @@ export function UserInputProvider({ children }: { children: ReactNode }) {
       // backend user_input_resolved will reconcile (idempotent).
       moveToResolved(inputId, isCancel ? 'cancelled' : 'confirmed', choiceId, choiceLabel);
       try {
-        await miqi?.userInput?.resolve(inputId, choiceId, choiceLabel, remember);
+        const res = await miqi?.userInput?.resolve(inputId, choiceId, choiceLabel, remember);
+        if (res && res.resolved === false && entry) {
+          // Backend rejected the resolution (unknown/expired input_id): the
+          // optimistic flip already removed the card from pending and no
+          // user_input_resolved event will arrive — restore the interactive
+          // card so the blocked turn can still be resolved by the user.
+          upsertPending({ ...entry, state: 'pending' });
+        }
       } catch {
-        // best-effort: backend resolves via timeout/turn-stop otherwise
+        // IPC failure — same restore, the backend still resolves via
+        // timeout/turn-stop as a last resort.
+        if (entry) upsertPending({ ...entry, state: 'pending' });
       }
     },
-    [moveToResolved],
+    [moveToResolved, upsertPending],
   );
 
   return (

--- a/apps/desktop/src/renderer/contexts/UserInputContext.tsx
+++ b/apps/desktop/src/renderer/contexts/UserInputContext.tsx
@@ -84,7 +84,7 @@ export function UserInputProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const moveToResolved = useCallback(
-    (inputId: string, state: UserInputCardState, choiceId?: string, choiceLabel?: string, timedOut = false) => {
+    (inputId: string, state: UserInputCardState, choiceId?: string, choiceLabel?: string, timedOut = false, role?: string) => {
       const entry = pendingRef.current[inputId];
       if (!entry) return;
       const done: UserInputCardEntry = {
@@ -99,8 +99,10 @@ export function UserInputProvider({ children }: { children: ReactNode }) {
       delete pendingRef.current[inputId];
       setPending(pendingRef.current);
       setResolved((prev) => ({ ...prev, [inputId]: done }));
-      // "adjust" → composer should focus for the user's adjustment text
-      if (choiceId === 'adjust') setLastAdjustAt(Date.now());
+      // "adjust" → composer should focus for the user's adjustment text.
+      // Prefer the semantic role; fall back to the literal id (issue #646).
+      const isAdjust = role === 'adjust' || (role === undefined && choiceId === 'adjust');
+      if (isAdjust) setLastAdjustAt(Date.now());
     },
     [],
   );
@@ -115,7 +117,14 @@ export function UserInputProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const miqi = (window as any).miqi;
     if (!miqi?.userInput) return;
-    const unsubReq = miqi.userInput.onRequest((data: UserInputCardRequest) => {
+    const unsubReq = miqi.userInput.onRequest((raw: any) => {
+      // 归一化两种载荷来源（CodeRabbit #711）：legacy 桥（snake_case）
+      // 与 KUN 事件（camelCase timeoutSeconds/allowRememberChoice）。
+      const data: UserInputCardRequest = {
+        ...raw,
+        timeout_seconds: raw.timeout_seconds ?? raw.timeoutSeconds,
+        allow_remember_choice: raw.allow_remember_choice ?? raw.allowRememberChoice ?? false,
+      };
       // 会话隔离：非当前会话的卡不渲染（data.session_key 缺省时放行）
       if (activeSession && data.session_key && data.session_key !== activeSession) return;
       upsertPending({
@@ -153,7 +162,7 @@ export function UserInputProvider({ children }: { children: ReactNode }) {
       const isCancel = role === 'cancel' || (role === undefined && choiceId === 'cancel');
       // Optimistic update: the card flips to confirmed/cancelled immediately;
       // backend user_input_resolved will reconcile (idempotent).
-      moveToResolved(inputId, isCancel ? 'cancelled' : 'confirmed', choiceId, choiceLabel);
+      moveToResolved(inputId, isCancel ? 'cancelled' : 'confirmed', choiceId, choiceLabel, false, role);
       try {
         const res = await miqi?.userInput?.resolve(inputId, choiceId, choiceLabel, remember);
         if (res && res.resolved === false && entry) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1965,18 +1965,20 @@ export function ChatConsole({
     onSessionActivityChange?.(hasActivity);
   }, [streaming, messages, onSessionActivityChange]);
   const { lastAdjustAt, setActiveSession } = useUserInput();
+  // 调整提示占位词用 state 驱动（而非直接改 DOM placeholder）——React 不会
+  // 主动重写该属性，直改会永久残留（CodeRabbit #711）。
+  const [adjustHint, setAdjustHint] = useState(false);
   // 会话隔离（CodeRabbit #666）：切会话 → 清空全部确认卡
   useEffect(() => {
     setActiveSession(sessionKey);
+    setAdjustHint(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionKey]);
   // 用户点了"调整方案"→ 聚焦输入框并提示输入调整要求（issue #646）
   useEffect(() => {
     if (!lastAdjustAt) return;
-    const el = textareaRef.current;
-    if (!el) return;
-    el.focus();
-    el.placeholder = '请输入调整要求（例如：市场改为海外、步骤精简到 3 步…）';
+    setAdjustHint(true);
+    textareaRef.current?.focus();
   }, [lastAdjustAt]);
   const toolArgsByCallId = useRef<Map<string, unknown>>(new Map());
   /** web_search tool outputs (by tool_call_id) for click-to-expand result
@@ -2911,6 +2913,8 @@ export function ChatConsole({
     pendingSendIdsRef.current.get(key) === id;
 
   const handleSend = useCallback(async () => {
+    // 发送即清除调整提示——占位词只属于"点了调整方案之后"的输入场景
+    setAdjustHint(false);
     const payload = retryPayloadRef.current;
     const text = (payload?.text ?? input).trim();
     const atts = payload?.attachments ?? attachments;
@@ -5225,7 +5229,11 @@ export function ChatConsole({
                       }}
                       onKeyDown={handleKeyDown}
                       onContextMenu={onContextMenu}
-                      placeholder="请输入消息或拖入文件..."
+                      placeholder={
+                        adjustHint
+                          ? '请输入调整要求（例如：市场改为海外、步骤精简到 3 步…）'
+                          : '请输入消息或拖入文件...'
+                      }
                       rows={1}
                       allowResize={true}
                       className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1974,12 +1974,17 @@ export function ChatConsole({
     setAdjustHint(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionKey]);
-  // 用户点了"调整方案"→ 聚焦输入框并提示输入调整要求（issue #646）
+  // 用户点了"调整方案"→ 聚焦输入框并提示输入调整要求（issue #646）。
+  // 聚焦在 composer 重新可用（流式结束）之后执行——disabled 状态下
+  // focus 无效，回合结束后焦点会丢失（CodeRabbit #711）。
   useEffect(() => {
     if (!lastAdjustAt) return;
     setAdjustHint(true);
-    textareaRef.current?.focus();
   }, [lastAdjustAt]);
+  useEffect(() => {
+    if (!adjustHint || streaming) return;
+    textareaRef.current?.focus();
+  }, [adjustHint, streaming]);
   const toolArgsByCallId = useRef<Map<string, unknown>>(new Map());
   /** web_search tool outputs (by tool_call_id) for click-to-expand result
    *  cards on the live tool row (#539). State, not ref — cards must re-render

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -5,6 +5,9 @@ import { ThinkBlock } from './components/ThinkBlock';
 import { DiffView } from './components/DiffView';
 import { renderContent } from './components/renderContent';
 import { TrackedFileCard } from './components/TrackedFileCard';
+import { ConfirmCardArea } from './components/ConfirmCardArea';
+import { TurnStatusBar } from './components/TurnStatusBar';
+import { useUserInput } from '../../contexts/UserInputContext';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -1961,6 +1964,20 @@ export function ChatConsole({
       messages.some((m) => m.role === 'user' || m.role === 'assistant');
     onSessionActivityChange?.(hasActivity);
   }, [streaming, messages, onSessionActivityChange]);
+  const { lastAdjustAt, setActiveSession } = useUserInput();
+  // 会话隔离（CodeRabbit #666）：切会话 → 清空全部确认卡
+  useEffect(() => {
+    setActiveSession(sessionKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionKey]);
+  // 用户点了"调整方案"→ 聚焦输入框并提示输入调整要求（issue #646）
+  useEffect(() => {
+    if (!lastAdjustAt) return;
+    const el = textareaRef.current;
+    if (!el) return;
+    el.focus();
+    el.placeholder = '请输入调整要求（例如：市场改为海外、步骤精简到 3 步…）';
+  }, [lastAdjustAt]);
   const toolArgsByCallId = useRef<Map<string, unknown>>(new Map());
   /** web_search tool outputs (by tool_call_id) for click-to-expand result
    *  cards on the live tool row (#539). State, not ref — cards must re-render
@@ -5178,6 +5195,12 @@ export function ChatConsole({
                   })}
                 </div>
               )}
+
+              {/* Turn status (issue #646: 等待你的确认) */}
+              <TurnStatusBar />
+
+              {/* AI-initiated user confirmation cards (issue #646) */}
+              <ConfirmCardArea />
 
               <div
                 className="flex flex-col rounded-3xl px-7 py-3.5 transition-all"

--- a/apps/desktop/src/renderer/features/chat/components/ConfirmCard.test.ts
+++ b/apps/desktop/src/renderer/features/chat/components/ConfirmCard.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { IPC, IPC_EVENTS } from '../../../../shared/ipc';
+import type { UserInputCardEntry } from '../../../contexts/UserInputContext';
+import { ConfirmCard } from './ConfirmCard';
+
+const NOW = '12:03:21';
+
+function entry(overrides: Partial<UserInputCardEntry> = {}): UserInputCardEntry {
+  return {
+    request: {
+      input_id: 'user_input_abc123',
+      title: '确认执行方案？',
+      message: '我将执行 4 个步骤，包含：',
+      steps: [
+        { id: 'search_papers', title: '搜索并下载相关论文' },
+        { id: 'query_price', title: '查询供应商价格（国内）' },
+      ],
+      choices: [
+        { id: 'confirm', label: '确认执行' },
+        { id: 'cancel', label: '取消' },
+      ],
+      timeout_seconds: 120,
+      allow_remember_choice: true,
+    },
+    state: 'pending',
+    ...overrides,
+  };
+}
+
+function render(entry_: UserInputCardEntry): string {
+  return renderToStaticMarkup(
+    createElement(ConfirmCard, { entry: entry_, onResolve: () => {}, nowFn: () => NOW }),
+  );
+}
+
+describe('IPC channels (issue #646)', () => {
+  it('defines resolve channel + renderer event names', () => {
+    expect(IPC.USER_INPUT_RESOLVE).toBe('userInput:resolve');
+    expect(IPC_EVENTS.USER_INPUT_REQUEST).toBe('userInput:request');
+    expect(IPC_EVENTS.USER_INPUT_RESOLVED).toBe('userInput:resolved');
+  });
+});
+
+describe('ConfirmCard', () => {
+  it('pending: renders choices, remember checkbox and countdown', () => {
+    const html = render(entry());
+    expect(html).toContain('等待你的选择');
+    expect(html).toContain('确认执行');
+    expect(html).toContain('取消');
+    expect(html).toContain('以后自动处理类似操作');
+    expect(html).toContain('以后自动处理类似操作');
+    expect(html).toContain('120s');
+    expect(html).toContain('搜索并下载相关论文');
+  });
+
+  it('pending without remember flag hides the checkbox', () => {
+    const e = entry();
+    e.request.allow_remember_choice = false;
+    const html = render(e);
+    expect(html).not.toContain('以后自动处理类似操作');
+    expect(html).not.toContain('以后自动处理类似操作');
+  });
+
+  it('confirmed: shows the picked choice, no choices/countdown', () => {
+    const e = entry({
+      state: 'confirmed',
+      choiceId: 'confirm',
+      choiceLabel: '确认执行',
+      resolvedAt: new Date('2026-08-11T12:03:21').getTime(),
+    });
+    const html = render(e);
+    expect(html).toContain('✓ 已确认');
+    expect(html).toContain('已选择「确认执行」');
+    expect(html).toContain(NOW);
+    expect(html).not.toContain('等待你的选择');
+    expect(html).not.toContain('以后自动处理类似操作');
+    expect(html).not.toContain('以后自动处理类似操作');
+    expect(html).not.toContain('120s');
+    expect(html).not.toContain('data-testid="countdown"');
+  });
+
+  it('cancelled: neutral grey end state, not an error card', () => {
+    const e = entry({
+      state: 'cancelled',
+      choiceId: 'cancel',
+      choiceLabel: '取消',
+      resolvedAt: new Date('2026-08-11T12:03:21').getTime(),
+    });
+    const html = render(e);
+    expect(html).toContain('已取消');
+    expect(html).toContain('已选择「取消」');
+    // neutral: no error styling class or red accents on the badge
+    expect(html).not.toContain('var(--danger)');
+    expect(html).not.toContain('等待你的选择');
+  });
+
+  it('defaults choices when backend sends none', () => {
+    const e = entry();
+    e.request.choices = [];
+    const html = render(e);
+    expect(html).toContain('确认执行');
+    expect(html).toContain('调整方案');
+    expect(html).toContain('取消');
+  });
+
+  it('collapses steps beyond 5 with an expand button', () => {
+    const e = entry();
+    e.request.steps = Array.from({ length: 7 }, (_, i) => ({
+      id: `step_${i}`,
+      title: `步骤 ${i + 1}`,
+    }));
+    const html = render(e);
+    // 前 5 步可见，后 2 步被折叠
+    expect(html).toContain('步骤 1');
+    expect(html).toContain('步骤 5');
+    expect(html).not.toContain('步骤 6');
+    expect(html).toContain('展开全部 7 个步骤');
+  });
+
+  it('confirmed card renders live step states with progress (v5 exec mode)', () => {
+    const e = entry();
+    e.state = 'confirmed';
+    e.choiceLabel = '确认执行';
+    e.request.steps = [
+      { id: 'search_papers', title: '搜索并下载相关论文' },
+      { id: 'extract_info', title: '提取合成路线与成本' },
+      { id: 'query_price', title: '查询供应商价格' },
+      { id: 'generate_report', title: '生成最终报告' },
+    ];
+    e.stepsStatus = {
+      search_papers: { status: 'success', result: '已下载 3 篇', dur: '4.2s', tool: 'web_search', param: 'MOF-5 synthesis' },
+      extract_info: { status: 'running' },
+      query_price: { status: 'pending' },
+      generate_report: { status: 'pending' },
+    };
+    const html = render(e);
+    // live 态：✓/⟳/○ 图标 + 进度 + 展开详情 + 锁定文案
+    expect(html).toContain('已完成 1 / 4');
+    expect(html).toContain('正在执行…');
+    expect(html).toContain('等待执行');
+    expect(html).toContain('已下载 3 篇');
+    expect(html).toContain('4.2s');
+    expect(html).toContain('技术详情');
+    expect(html).toContain('🔒 已完成 · 本次选择已记录');
+    // pending 专属元素消失（选项按钮/等待文案）
+    expect(html).not.toContain('等待你的选择');
+    expect(html).not.toContain('allow_remember_choice');
+  });
+
+  it('cancelled card shows lock note but no live steps', () => {
+    const e = entry();
+    e.state = 'cancelled';
+    e.choiceLabel = '取消';
+    const html = render(e);
+    expect(html).toContain('🔒 已完成 · 本次选择已记录');
+    expect(html).not.toContain('steps-live');
+    expect(html).not.toContain('等待你的选择');
+  });
+
+  it('collapses steps beyond 5 with an expand button', () => {
+    const e = entry();
+    e.request.steps = Array.from({ length: 7 }, (_, i) => ({
+      id: `step_${i}`,
+      title: `步骤 ${i + 1}`,
+    }));
+    const html = render(e);
+    // 前 5 步可见，后 2 步被折叠
+    expect(html).toContain('步骤 1');
+    expect(html).toContain('步骤 5');
+    expect(html).not.toContain('步骤 6');
+    expect(html).toContain('展开全部 7 个步骤');
+  });
+});

--- a/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
@@ -1,0 +1,435 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import type { ConfirmChoice, ConfirmStep, UserInputCardRequest } from '../../../../shared/ipc';
+import type { StepExecStatus, UserInputCardEntry } from '../../../contexts/UserInputContext';
+
+/**
+ * ConfirmCard — AI-initiated human-in-the-loop card (issue #646).
+ *
+ * Rendered inline in the message flow (NOT a modal). The model calls
+ * ask_user_confirm_card → the card appears in WAITING state and the turn
+ * pauses; the user picks a choice → the choice is returned to the backend as
+ * a tool result → the card stays in the flow as a resolved record.
+ *
+ * States follow the v5 prototype semantics:
+ *   pending   → blue accent, choices + remember + countdown (strongest)
+ *   confirmed → light green, "已选择「xxx」· time" (medium)
+ *   cancelled → grey, neutral end state, NOT an error (weakest)
+ */
+export function ConfirmCard({
+  entry,
+  onResolve,
+  onTimeout,
+  nowFn = () => new Date().toLocaleTimeString('zh-CN', { hour12: false }),
+}: {
+  entry: UserInputCardEntry;
+  onResolve: (choiceId: string, choiceLabel: string, remember: boolean) => void;
+  /** Fired once when the local countdown hits zero (legacy path). */
+  onTimeout?: (inputId: string) => void;
+  nowFn?: () => string;
+}) {
+  const req = entry.request;
+  const state = entry.state;
+  const isWaiting = state === 'pending';
+
+  const choices: ConfirmChoice[] =
+    req.choices && req.choices.length > 0 ? req.choices : DEFAULT_CHOICES;
+  const steps: ConfirmStep[] = req.steps ?? [];
+
+  // ── countdown (pending only) ────────────────────────────────────
+  const timeout = req.timeout_seconds ?? 120;
+  const [remaining, setRemaining] = useState(timeout);
+  const [countdownDone, setCountdownDone] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (!isWaiting) return;
+    setRemaining(timeout);
+    setCountdownDone(false);
+    timerRef.current = setInterval(() => {
+      setRemaining((r) => {
+        const next = Math.max(0, r - 1);
+        if (next <= 0) {
+          if (timerRef.current) clearInterval(timerRef.current);
+          setCountdownDone(true);
+        }
+        return next;
+      });
+    }, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [isWaiting, timeout]);
+
+  // 超时：通知 context 把卡移到 resolved（legacy 路径无 resolved 事件）
+  const timedOutNotified = useRef(false);
+  useEffect(() => {
+    if (countdownDone && !timedOutNotified.current) {
+      timedOutNotified.current = true;
+      onTimeout?.(req.input_id);
+    }
+  }, [countdownDone, onTimeout, req.input_id]);
+
+  // 超时：前端本地态（后端 gate 也会超时发 resolved 事件，这里先展示）
+  const timedOut = isWaiting && countdownDone;
+  const effectiveState = timedOut ? 'cancelled' : state;
+  const effectiveWaiting = isWaiting && !timedOut;
+
+  // ── remember choice (pending only) ──────────────────────────────
+  const [remember, setRemember] = useState(false);
+
+  // ── steps collapse: <=5 全展示，>5 折叠（AI review: 渐进式披露） ─
+  const MAX_VISIBLE_STEPS = 5;
+  const [stepsExpanded, setStepsExpanded] = useState(false);
+  const stepsCollapsed = steps.length > MAX_VISIBLE_STEPS && !stepsExpanded;
+  const visibleSteps = stepsCollapsed ? steps.slice(0, MAX_VISIBLE_STEPS) : steps;
+
+  const badgeStyle =
+    effectiveState === 'pending'
+      ? { background: 'var(--accent-soft)', color: 'var(--accent-hover)' }
+      : effectiveState === 'confirmed'
+        ? { background: 'var(--success-bg)', color: 'var(--success-text)' }
+        : { background: 'var(--surface-3)', color: 'var(--text-muted)' };
+  // P0 (AI review): pending = 边框强调 + 弱 shadow（不是蓝 glow 呼吸灯），
+  // confirmed 保持中性背景（只有 badge 变绿），cancelled 中性灰。
+  const borderClass = effectiveWaiting
+    ? { borderColor: 'var(--accent)', boxShadow: '0 2px 14px rgba(51,156,255,.10)' }
+    : effectiveState === 'confirmed'
+      ? { borderColor: 'var(--border-subtle)', boxShadow: 'none' }
+      : { borderColor: 'var(--border-subtle)', boxShadow: 'none', background: 'var(--surface-muted)', opacity: 0.85 };
+
+  const doneCount = steps.filter((x) => entry.stepsStatus?.[x.id]?.status === 'success').length;
+  const progressPct = steps.length > 0 ? Math.round((doneCount / steps.length) * 100) : 0;
+
+  return (
+    <div
+      className="rounded-xl p-4 max-w-[600px] relative overflow-hidden"
+      style={{ border: '1px solid var(--border-subtle)', ...borderClass, transition: 'all .35s cubic-bezier(.22,.8,.32,1)' }}
+    >
+      {/* top accent line (pending: 细条呼吸，非 glow) */}
+      <div
+        className="absolute top-0 left-0 right-0"
+        style={{
+          height: 2,
+          background:
+            effectiveState === 'pending'
+              ? 'linear-gradient(90deg, var(--accent), transparent)'
+              : effectiveState === 'confirmed'
+                ? 'linear-gradient(90deg, var(--success), transparent)'
+                : 'none',
+          animation: effectiveWaiting ? 'accentPulse 1.8s ease-in-out infinite' : 'none',
+        }}
+      />
+      {/* head */}
+      <div className="flex items-center gap-2.5 mb-2">
+        <span
+          className="w-[26px] h-[26px] rounded-lg flex items-center justify-center text-sm shrink-0"
+          style={{
+            background: effectiveWaiting
+              ? 'var(--accent-soft)'
+              : effectiveState === 'confirmed'
+                ? 'var(--success-bg)'
+                : 'var(--surface-3)',
+            color: effectiveWaiting
+              ? 'var(--accent-hover)'
+              : effectiveState === 'confirmed'
+                ? 'var(--success-text)'
+                : 'var(--text-faint)',
+          }}
+        >
+          {req.title?.includes('上传') ? '📤' : req.title?.includes('补充') ? '❓' : '📋'}
+        </span>
+        <span
+          className="text-[14.5px] font-semibold tracking-[.01em]"
+          style={{ color: effectiveState === 'cancelled' || timedOut ? 'var(--text-muted)' : 'inherit' }}
+        >
+          {req.title}
+        </span>
+        <span className="ml-auto text-[11px] font-semibold rounded-full px-2.5 py-0.5 whitespace-nowrap inline-flex items-center gap-1.5" style={badgeStyle}>
+          {effectiveWaiting && (
+            <span
+              className="w-[6px] h-[6px] rounded-full inline-block"
+              style={{ background: 'var(--accent)', animation: 'turnPulse 1.1s ease-in-out infinite' }}
+            />
+          )}
+          {timedOut ? '⏱ 已超时' : effectiveState === 'pending' ? '等待你的选择' : effectiveState === 'confirmed' ? '✓ 已确认' : '已取消'}
+        </span>
+      </div>
+
+      {/* message */}
+      <div className="text-[13px] mb-3" style={{ color: 'var(--text-muted)' }}>
+        {req.message}
+      </div>
+
+      {/* steps: plan 态（数字圆点，pending） / live 态（✓⟳○ + 详情，confirmed 后） */}
+      {steps.length > 0 && effectiveState === 'pending' && (
+        <div className="flex flex-col gap-1.5 mb-3">
+          {visibleSteps.map((s, i) => (
+            <div key={s.id} className="flex gap-2.5 items-baseline text-[13px] py-0.5">
+              <span
+                className="w-[18px] h-[18px] rounded-full flex items-center justify-center text-[10.5px] font-semibold shrink-0"
+                style={{ background: 'var(--surface-3)', color: 'var(--text-faint)' }}
+              >
+                {i + 1}
+              </span>
+              <span className="flex-1">{s.title}</span>
+            </div>
+          ))}
+          {stepsCollapsed && (
+            <button
+              onClick={() => setStepsExpanded(true)}
+              className="text-[11.5px] cursor-pointer hover:underline self-center mt-1"
+              style={{ color: 'var(--accent-hover)', background: 'none', border: 'none', fontFamily: 'inherit' }}
+            >
+              展开全部 {steps.length} 个步骤
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* steps: live 态（确认后同卡转执行态，v5 + 整体进度条） */}
+      {steps.length > 0 && effectiveState === 'confirmed' && !timedOut && (
+        <div className="flex flex-col gap-1.5 mb-3" data-testid="steps-live">
+          {/* 整体进度条（AI review: 进度一目了然） */}
+          <div
+            className="h-[3px] rounded-full overflow-hidden mb-1.5"
+            style={{ background: 'var(--surface-3)' }}
+          >
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${progressPct}%`,
+                background: 'var(--accent)',
+                transition: 'width .5s cubic-bezier(.22,.8,.32,1)',
+              }}
+            />
+          </div>
+          {steps.map((s, i) => {
+            const st = entry.stepsStatus?.[s.id] ?? { status: 'pending' };
+            const ico = st.status === 'running' ? '⟳' : st.status === 'success' ? '✓' : st.status === 'failed' ? '!' : '○';
+            const sub =
+              st.status === 'running' ? (
+                <span className="text-[11px]" style={{ color: 'var(--accent-hover)' }}>正在执行…</span>
+              ) : st.status === 'success' ? (
+                <span className="text-[11px]" style={{ color: 'var(--success-text)' }}>
+                  <span style={{ color: 'var(--success)' }}>✓</span> {st.result ?? '已完成'}
+                  {st.dur ? <span style={{ color: 'var(--text-faint)' }}> · ⏱ {st.dur}</span> : null}
+                </span>
+              ) : st.status === 'failed' ? (
+                <span className="text-[11px]" style={{ color: 'var(--danger)' }}>执行失败</span>
+              ) : (
+                <span className="text-[11px]" style={{ color: 'var(--text-faint)' }}>等待执行</span>
+              );
+            return (
+              <StepLiveRow key={s.id} index={i} step={s} st={st} sub={sub} ico={ico} />
+            );
+          })}
+          <span className="text-[11px] tabular-nums mt-0.5" style={{ color: 'var(--text-faint)' }}>
+            已完成 {steps.filter((x) => entry.stepsStatus?.[x.id]?.status === 'success').length} / {steps.length}
+          </span>
+        </div>
+      )}
+
+      {/* pending-only: choices（主/次按钮：确认=实心，调整=描边，取消=文字） */}
+      {effectiveWaiting && (
+        <div className="flex gap-2 flex-wrap items-center">
+          {choices.map((c) => {
+            if (c.id === 'cancel') {
+              return (
+                <button
+                  key={c.id}
+                  onClick={() => onResolve(c.id, c.label, remember)}
+                  className="text-[12.5px] font-medium px-2.5 py-1.5 cursor-pointer transition-all rounded-lg"
+                  style={{ background: 'none', border: 'none', color: 'var(--text-faint)', fontFamily: 'inherit' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--text-muted)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-faint)'; }}
+                >
+                  {c.label}
+                </button>
+              );
+            }
+            if (c.id === 'adjust') {
+              return (
+                <button
+                  key={c.id}
+                  onClick={() => onResolve(c.id, c.label, remember)}
+                  className="text-[12.5px] font-medium rounded-lg px-3.5 py-1.5 cursor-pointer transition-all"
+                  style={{ border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-muted)', fontFamily: 'inherit' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; e.currentTarget.style.color = 'var(--accent-hover)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; e.currentTarget.style.color = 'var(--text-muted)'; }}
+                >
+                  {c.label}
+                </button>
+              );
+            }
+            return (
+              <button
+                key={c.id}
+                onClick={() => onResolve(c.id, c.label, remember)}
+                className="text-[13px] font-semibold rounded-lg px-4 py-1.5 cursor-pointer transition-all"
+                style={{ border: '1px solid var(--accent)', background: 'var(--accent)', color: '#fff', fontFamily: 'inherit' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--accent-hover)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'var(--accent)'; }}
+              >
+                {c.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* pending-only: remember + countdown */}
+      {effectiveWaiting && (
+        <div className="flex items-center gap-3.5 mt-3 text-xs flex-wrap" style={{ color: 'var(--text-faint)' }}>
+          {req.allow_remember_choice && (
+            <label className="flex items-center gap-1.5 cursor-pointer select-none" style={{ color: 'var(--text-muted)' }}>
+              <input type="checkbox" checked={remember} onChange={(e) => setRemember(e.target.checked)} />
+              以后自动处理类似操作
+            </label>
+          )}
+          <div className="flex items-center gap-2 flex-1 min-w-[140px]">
+            <div className="flex-1 h-1 rounded-sm overflow-hidden" style={{ background: 'var(--surface-3)' }}>
+              <div
+                className="h-full rounded-sm"
+                style={{
+                  width: `${(remaining / timeout) * 100}%`,
+                  background: remaining <= 5 ? 'var(--danger)' : 'var(--accent)',
+                  transition: 'width 1s linear',
+                }}
+              />
+            </div>
+            <span className="text-[11px] tabular-nums w-[30px] text-right" style={{ color: remaining <= 5 ? 'var(--danger)' : 'var(--text-muted)' }}>
+              {remaining}s
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* resolved / timed-out: what the user picked (chip, v5-style) */}
+      {!effectiveWaiting && (
+        <div
+          className="flex items-center gap-2.5 mt-3 pt-3"
+          style={{ borderTop: '1px dashed var(--border-subtle)', animation: 'msgIn .3s cubic-bezier(.22,.8,.32,1)' }}
+        >
+          {timedOut ? (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-[12px] font-semibold"
+              style={{ background: 'var(--surface-3)', color: 'var(--text-muted)' }}
+            >
+              <span style={{ fontSize: 11 }}>⏱</span>
+              等待超时，已自动取消
+            </span>
+          ) : (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1 text-[12px] font-semibold"
+              style={{
+                background: state === 'confirmed' ? 'var(--success-bg)' : 'var(--surface-3)',
+                color: state === 'confirmed' ? 'var(--success-text)' : 'var(--text-muted)',
+              }}
+            >
+              <span style={{ fontSize: 11 }}>{state === 'confirmed' ? '✓' : '○'}</span>
+              已选择「{entry.choiceLabel ?? (state === 'cancelled' ? '取消' : '确认')}」
+            </span>
+          )}
+          <span className="text-[11px] tabular-nums" style={{ color: 'var(--text-faint)' }}>
+            {entry.resolvedAt ? new Date(entry.resolvedAt).toLocaleTimeString('zh-CN', { hour12: false }) : nowFn()}
+          </span>
+        </div>
+      )}
+
+      {/* lock note (v5): resolved cards are immutable history */}
+      {!effectiveWaiting && (
+        <div className="mt-2 text-[10.5px]" style={{ color: 'var(--text-faint)' }}>
+          🔒 已完成 · 本次选择已记录
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 单步 live 行：状态图标 + 子状态 + 可展开 Tool 详情（v5） */
+function StepLiveRow({
+  index,
+  step,
+  st,
+  sub,
+  ico,
+}: {
+  index: number;
+  step: ConfirmStep;
+  st: StepExecStatus;
+  sub: ReactNode;
+  ico: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex gap-2.5 text-[13px] py-0.5">
+      <span
+        className="w-[18px] h-[18px] rounded-full flex items-center justify-center text-[10.5px] font-semibold shrink-0 mt-0.5"
+        style={{
+          background:
+            st.status === 'success'
+              ? 'var(--success-bg)'
+              : st.status === 'failed'
+                ? 'var(--danger-bg)'
+                : 'var(--surface-3)',
+          color:
+            st.status === 'success'
+              ? 'var(--success-text)'
+              : st.status === 'failed'
+                ? 'var(--danger)'
+                : st.status === 'running'
+                  ? 'var(--accent-hover)'
+                  : 'var(--text-faint)',
+        }}
+      >
+        {ico}
+      </span>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium">{index + 1}. {step.title}</div>
+        {sub}
+        {st.status !== 'pending' && (
+          <div className="mt-0.5">
+            <button
+              onClick={() => setOpen(!open)}
+              className="text-[10.5px] cursor-pointer hover:underline"
+              style={{ color: 'var(--text-faint)', background: 'none', border: 'none', fontFamily: 'inherit' }}
+            >
+              <span style={{ display: 'inline-block', transform: open ? 'rotate(90deg)' : 'none', transition: 'transform .2s' }}>▸</span>{' '}
+              技术详情
+            </button>
+            {open && (
+              <div
+                className="mt-1 rounded-md p-2 text-[11px] flex flex-col gap-1"
+                style={{ background: 'var(--surface-3)' }}
+              >
+                <div>
+                  <span className="font-semibold mr-2" style={{ color: 'var(--text-faint)' }}>Tool</span>
+                  <span className="font-mono">{st.tool ?? '-'}</span>
+                </div>
+                <div>
+                  <span className="font-semibold mr-2" style={{ color: 'var(--text-faint)' }}>参数</span>
+                  <span className="font-mono break-all">{st.param ?? '-'}</span>
+                </div>
+                <div>
+                  <span className="font-semibold mr-2" style={{ color: 'var(--text-faint)' }}>结果</span>
+                  <span className="break-all">{st.result ?? '-'}</span>
+                </div>
+                {st.dur ? (
+                  <div>
+                    <span className="font-semibold mr-2" style={{ color: 'var(--text-faint)' }}>耗时</span>
+                    <span>{st.dur}</span>
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const DEFAULT_CHOICES: ConfirmChoice[] = [
+  { id: 'confirm', label: '确认执行' },
+  { id: 'adjust', label: '调整方案' },
+  { id: 'cancel', label: '取消' },
+];

--- a/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
@@ -115,7 +115,7 @@ export function ConfirmCard({
               : effectiveState === 'confirmed'
                 ? 'linear-gradient(90deg, var(--success), transparent)'
                 : 'none',
-          animation: effectiveWaiting ? 'accentPulse 1.8s ease-in-out infinite' : 'none',
+          animation: effectiveWaiting ? 'accent-pulse 1.8s ease-in-out infinite' : 'none',
         }}
       />
       {/* head */}
@@ -147,7 +147,7 @@ export function ConfirmCard({
           {effectiveWaiting && (
             <span
               className="w-[6px] h-[6px] rounded-full inline-block"
-              style={{ background: 'var(--accent)', animation: 'turnPulse 1.1s ease-in-out infinite' }}
+              style={{ background: 'var(--accent)', animation: 'turn-pulse 1.1s ease-in-out infinite' }}
             />
           )}
           {timedOut ? '⏱ 已超时' : effectiveState === 'pending' ? '等待你的选择' : effectiveState === 'confirmed' ? '✓ 已确认' : '已取消'}
@@ -228,11 +228,14 @@ export function ConfirmCard({
         </div>
       )}
 
-      {/* pending-only: choices（主/次按钮：确认=实心，调整=描边，取消=文字） */}
+      {/* pending-only: choices（主/次按钮：确认=实心，调整=描边，取消=文字）。
+          Variant by semantic role with the literal id as fallback so a
+          backend {id:'abort', role:'cancel'} renders as a cancel (#646). */}
       {effectiveWaiting && (
         <div className="flex gap-2 flex-wrap items-center">
           {choices.map((c) => {
-            if (c.id === 'cancel') {
+            const role = c.role ?? (c.id === 'cancel' ? 'cancel' : c.id === 'adjust' ? 'adjust' : undefined);
+            if (role === 'cancel') {
               return (
                 <button
                   key={c.id}
@@ -246,7 +249,7 @@ export function ConfirmCard({
                 </button>
               );
             }
-            if (c.id === 'adjust') {
+            if (role === 'adjust') {
               return (
                 <button
                   key={c.id}
@@ -430,6 +433,6 @@ function StepLiveRow({
 
 const DEFAULT_CHOICES: ConfirmChoice[] = [
   { id: 'confirm', label: '确认执行' },
-  { id: 'adjust', label: '调整方案' },
-  { id: 'cancel', label: '取消' },
+  { id: 'adjust', label: '调整方案', role: 'adjust' },
+  { id: 'cancel', label: '取消', role: 'cancel' },
 ];

--- a/apps/desktop/src/renderer/features/chat/components/ConfirmCardArea.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/ConfirmCardArea.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { useUserInput } from '../../../contexts/UserInputContext';
+import { ConfirmCard } from './ConfirmCard';
+
+/**
+ * ConfirmCardArea — renders ask_user_confirm_card cards at the tail of the
+ * message flow, right above the composer (issue #646).
+ *
+ * - The pending card (blue, strongest) blocks the turn until the user picks.
+ * - Resolved cards stay in the flow, de-emphasized, as a traceable record of
+ *   what the user confirmed/cancelled (v5 semantics: cancelled is a neutral
+ *   end state, NOT an error).
+ * - Resolved history collapses beyond 3 entries ("已处理 N 张确认卡") to avoid
+ *   stacking noise during adjust loops.
+ */
+export function ConfirmCardArea() {
+  const { pending, resolved, resolve, timeoutCard } = useUserInput();
+  const [historyExpanded, setHistoryExpanded] = useState(false);
+
+  const pendingIds = Object.keys(pending);
+  const resolvedIds = Object.keys(resolved);
+
+  const MAX_VISIBLE_RESOLVED = 3;
+  const collapsed = resolvedIds.length > MAX_VISIBLE_RESOLVED && !historyExpanded;
+  const visibleResolved = collapsed ? resolvedIds.slice(-MAX_VISIBLE_RESOLVED) : resolvedIds;
+
+  if (pendingIds.length === 0 && resolvedIds.length === 0) return null;
+
+  return (
+    <div className="w-full flex flex-col gap-2" data-testid="confirm-card-area">
+      {/* Active card(s) — full interactive ConfirmCard */}
+      {pendingIds.map((id) => {
+        const entry = pending[id];
+        return (
+          <div key={id} className="flex gap-2.5 animate-[msgIn_.35s_cubic-bezier(.22,.8,.32,1)]">
+            <span
+              className="w-8 h-8 rounded-[9px] mt-0.5 flex items-center justify-center text-xs shrink-0"
+              style={{
+                background: 'linear-gradient(135deg,#4db2ff,#2a7de1)',
+                color: '#fff',
+                boxShadow: '0 1px 2px rgba(18,18,18,.04),0 2px 10px rgba(18,18,18,.06)',
+              }}
+            >
+              AI
+            </span>
+            <div className="min-w-0">
+              <ConfirmCard
+                entry={entry}
+                onResolve={(choiceId, choiceLabel, remember) => resolve(id, choiceId, choiceLabel, remember)}
+                onTimeout={() => timeoutCard(id)}
+              />
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Resolved history — compact, de-emphasized, collapses beyond 3 */}
+      {resolvedIds.length > 0 && (
+        <div className="flex flex-col gap-1.5 mt-1" data-testid="confirm-card-resolved">
+          {collapsed && (
+            <button
+              onClick={() => setHistoryExpanded(true)}
+              className="text-[11.5px] cursor-pointer hover:underline self-start px-1"
+              style={{ color: 'var(--text-faint)', background: 'none', border: 'none', fontFamily: 'inherit' }}
+            >
+              已处理 {resolvedIds.length} 张确认卡（点击展开）
+            </button>
+          )}
+          {visibleResolved.map((id) => {
+            const entry = resolved[id];
+            const cancelled = entry.state === 'cancelled';
+            return (
+              <div
+                key={id}
+                className="flex items-center gap-2 px-3 py-2 rounded-lg text-[12px] max-w-[560px]"
+                style={{
+                  border: '1px solid var(--border-subtle)',
+                  background: 'var(--surface-muted)',
+                  opacity: 0.85,
+                }}
+              >
+                <span className="shrink-0 text-[11px]">
+                  {entry.timedOut ? '⏱' : cancelled ? '○' : '✓'}
+                </span>
+                <span className="font-medium truncate" style={{ color: 'var(--text-muted)' }}>
+                  {entry.request.title}
+                </span>
+                <span
+                  className="font-semibold ml-auto shrink-0"
+                  style={{ color: cancelled ? 'var(--text-muted)' : 'var(--success-text)' }}
+                >
+                  {entry.timedOut ? '已超时' : cancelled ? '已取消' : `已选择「${entry.choiceLabel ?? '确认'}」`}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/features/chat/components/TurnStatusBar.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/TurnStatusBar.tsx
@@ -24,7 +24,7 @@ export function TurnStatusBar() {
     >
       <span
         className="w-[7px] h-[7px] rounded-full"
-        style={{ background: 'var(--accent)', animation: 'turnPulse 1.1s ease-in-out infinite' }}
+        style={{ background: 'var(--accent)', animation: 'turn-pulse 1.1s ease-in-out infinite' }}
       />
       等待你的确认
     </div>

--- a/apps/desktop/src/renderer/features/chat/components/TurnStatusBar.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/TurnStatusBar.tsx
@@ -1,0 +1,32 @@
+import { useUserInput } from '../../../contexts/UserInputContext';
+
+/**
+ * TurnStatusBar — 顶栏状态联动（v5）：有 pending 确认卡时显示
+ * "等待你的确认"（accent + 脉冲点），与卡片状态联动。
+ *
+ * 完整 turn 状态（执行中/已取消/已停止）依赖 turn_status_changed 事件流，
+ * 本期先做等待确认态；legacy 路径的 turn 事件接入后扩展。
+ */
+export function TurnStatusBar() {
+  const { pending } = useUserInput();
+  const waiting = Object.keys(pending).length > 0;
+  if (!waiting) return null;
+
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11.5px] font-semibold"
+      style={{
+        border: '1px solid var(--accent)',
+        color: 'var(--accent-hover)',
+        background: 'var(--accent-soft)',
+      }}
+      data-testid="turn-status-waiting"
+    >
+      <span
+        className="w-[7px] h-[7px] rounded-full"
+        style={{ background: 'var(--accent)', animation: 'turnPulse 1.1s ease-in-out infinite' }}
+      />
+      等待你的确认
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -741,13 +741,13 @@ th {
 }
 
 /* Turn status pulse (issue #646: 等待你的确认) */
-@keyframes turnPulse {
+@keyframes turn-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.25; }
 }
 
 /* Confirm card top accent line breathing (P0: 细条呼吸，非 glow) */
-@keyframes accentPulse {
+@keyframes accent-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.45; }
 }

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -739,6 +739,18 @@ th {
   from { opacity: 0; transform: translate(-50%, -8px) scale(0.96); }
   to   { opacity: 1; transform: translate(-50%, 0) scale(1); }
 }
+
+/* Turn status pulse (issue #646: 等待你的确认) */
+@keyframes turnPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+/* Confirm card top accent line breathing (P0: 细条呼吸，非 glow) */
+@keyframes accentPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
 @keyframes banner-out {
   from { opacity: 1; transform: translate(-50%, 0) scale(1); }
   to   { opacity: 0; transform: translate(-50%, -6px) scale(0.97); }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -55,6 +55,8 @@ export const IPC = {
   APPROVALS_CLEAR_PERMANENT: 'approvals:clear_permanent',
   APPROVALS_ADD_PERMANENT: 'approvals:add_permanent',
   APPROVALS_HISTORY: 'approvals:history',
+  // AI-initiated user confirmation (issue #646)
+  USER_INPUT_RESOLVE: 'userInput:resolve',
   CRON_LIST: 'cron:list',
   CRON_CREATE: 'cron:create',
   CRON_UPDATE: 'cron:update',
@@ -166,6 +168,10 @@ export const IPC_EVENTS = {
   CHAT_SUBAGENT_RESULT: 'chat:subagent_result',
   APPROVAL_REQUEST: 'approval:request',
   APPROVAL_CLEARED: 'approval:cleared',
+
+  // AI-initiated user confirmation (issue #646) — ask_user_confirm_card
+  USER_INPUT_REQUEST: 'userInput:request',
+  USER_INPUT_RESOLVED: 'userInput:resolved',
 
   // New events (Phase 1)
   AGENT_SPAWNED: 'agent:spawned',
@@ -410,6 +416,55 @@ export interface ApprovalsListResult {
   permanent_entries: PermanentEntry[];
   enabled: boolean;
   timeout: number;
+}
+
+// ---------------------------------------------------------------------------
+// AI-initiated user confirmation (issue #646) — ask_user_confirm_card
+// ---------------------------------------------------------------------------
+
+/** A structured choice on a confirm card: {id, label}. */
+export interface ConfirmChoice {
+  id: string;
+  label: string;
+  /** Semantic role so the client can style/classify choices without
+   *  hard-coding ids (issue #646 review): 'cancel' = abort the action,
+   *  'adjust' = user wants the plan reworked (still a non-confirmation). */
+  role?: 'cancel' | 'adjust';
+}
+
+/** A step listed on a confirm card: {id, title}. Shared with the execution
+ *  progress state via step_id (the same ids drive step_started/completed). */
+export interface ConfirmStep {
+  id: string;
+  title: string;
+}
+
+/** Card payload pushed from the backend when the model calls
+ *  ask_user_confirm_card (blocking human-in-the-loop). */
+export interface UserInputCardRequest {
+  input_id: string;
+  thread_id?: string;
+  turn_id?: string;
+  /** Originating session — cards are scoped per session and dropped on
+   *  session switch (CodeRabbit #666 review). */
+  session_key?: string;
+  title: string;
+  message: string;
+  steps?: ConfirmStep[];
+  choices?: ConfirmChoice[];
+  timeout_seconds?: number;
+  allow_remember_choice?: boolean;
+}
+
+/** Resolution pushed from the backend once the user picks / cancels. */
+export interface UserInputResolvedData {
+  input_id: string;
+  status: 'submitted' | 'cancelled';
+  resolution?: { choice_id?: string; choice_label?: string; [k: string]: unknown };
+}
+
+export interface UserInputResolveResult {
+  resolved: boolean;
 }
 
 export interface ApprovalsAddPermanentResult {

--- a/apps/desktop/tests/e2e/confirm-card-real-llm.spec.ts
+++ b/apps/desktop/tests/e2e/confirm-card-real-llm.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Confirm Card E2E — REAL LLM path (issue #646 真机验证)。
+ *
+ * 与 confirm-card.spec.ts（mock 状态机）互补：本 spec 不 patch provider，
+ * 使用配置中的真实模型（本地 deepseek / CI siliconflow），显式指令模型
+ * 调用 ask_user_confirm_card，验证真实模型 + 真实 HTTP 请求下卡片渲染、
+ * 阻塞、用户选择回传、回合完成的完整链路。
+ *
+ * 断言刻意收敛：真实模型回复文案不可控，只断言卡片出现、决议回传、
+ * 回合正常收尾（有 assistant 回复且流式结束）。
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *      --config=playwright.config.ts --project=electron -g "real LLM"
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+test.describe('Confirm Card (real LLM)', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    // 真实 provider（不 patch 配置）——本地走 deepseek，CI 走 siliconflow
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test(
+    '真实模型调用 ask_user_confirm_card — 弹卡、点击确认、tool result 回传、回合完成',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      const cardArea = page.getByTestId('confirm-card-area');
+      const resolvedArea = page.getByTestId('confirm-card-resolved');
+
+      // 显式指令模型调用工具（真实 HTTP 请求到 provider）
+      await sendMessage(
+        page,
+        '请立即调用 ask_user_confirm_card 工具弹出确认卡片：' +
+          'title 用「确认执行方案？」，message 用「开始前需要你确认以下计划」。' +
+          '调用后收到结果时直接回复 OK。',
+      );
+
+      // 真实模型往返（本地 deepseek / CI siliconflow）——给足超时
+      await expect(cardArea).toBeVisible({ timeout: 120_000 });
+      await expect(cardArea.getByText('确认执行方案？')).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '确认执行' })).toBeVisible();
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-real-card.png`,
+      });
+
+      // 点击确认 → 选择回传模型 → 模型继续完成回合
+      await cardArea.getByRole('button', { name: '确认执行' }).click();
+      await expect(resolvedArea.getByText('已选择「确认执行」')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      // 回合正常收尾：至少有一条 assistant 回复（内容由真实模型生成，不断言文案）
+      const assistantBubbles = page.getByTestId('chat-message-assistant');
+      await expect(assistantBubbles.first()).toBeVisible({ timeout: 30_000 });
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-real-final.png`,
+        fullPage: true,
+      });
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/confirm-card.spec.ts
+++ b/apps/desktop/tests/e2e/confirm-card.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Confirm Card E2E (issue #646) — ask_user_confirm_card 全链路。
+ *
+ * 用本地 mock OpenAI 服务器（scripts/mock_openai.py，确定性状态机）驱动，
+ * 验证完整链路：
+ *   1. 模型调用 ask_user_confirm_card → 桌面端消息流内弹确认卡（阻塞回合）
+ *   2. 用户点击「确认执行」→ 选择以 tool result 回传 → 回合继续
+ *      （mock 随后调用真实 web_search / write_file 工具）
+ *   3. 第二张卡（是否上传到 Qraft？）→ 用户点击「确认上传」
+ *   4. 回合完成，最终回复渲染；两张卡均留下「已选择」决议记录
+ *
+ * 不依赖真实 LLM 行为：mock 按工具调用序列推进，网络工具即使失败
+ * （如 CI 无外网）也不会阻断状态机——只统计调用次数。
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *      --config=playwright.config.ts --project=electron -g "confirm card"
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  launchElectronApp,
+  closeElectronApp,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+
+/**
+ * Start scripts/mock_openai.py on an ephemeral port and wait for its
+ * startup line (the server prints the ACTUAL bound port after bind).
+ *
+ * No HTTP readiness probe: undici fetch against 127.0.0.1 fails on some
+ * CI runners (macos-e2e) even with the server listening, and an ephemeral
+ * port makes parallel workers / retries immune to 8899 collisions.
+ */
+async function startMockOpenAI(): Promise<{ proc: ChildProcess; mockUrl: string }> {
+  const python = process.env.MIQI_PYTHON_PATH || 'python';
+  // High ephemeral range: avoids the app's own ports and 8899 legacy uses.
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_openai.py'), String(port)], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    windowsHide: true,
+  });
+
+  let readyUrl = '';
+  let stderrTail = '';
+  proc.stdout?.on('data', (d) => {
+    const t = String(d);
+    console.log(`[mock] ${t.trim()}`);
+    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => {
+    stderrTail = (stderrTail + String(d)).slice(-2000);
+    console.log(`[mock-err] ${String(d).trim()}`);
+  });
+  proc.on('exit', (code) => console.log(`[test] mock server exited: ${code}`));
+
+  const deadline = Date.now() + 30_000;
+  while (!readyUrl && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(
+        `mock OpenAI server exited early (code ${proc.exitCode}): ${stderrTail}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!readyUrl) {
+    proc.kill();
+    throw new Error(`mock OpenAI server startup line not seen in 30s: ${stderrTail}`);
+  }
+  console.log(`[test] mock OpenAI server ready at ${readyUrl}`);
+  return { proc, mockUrl: readyUrl };
+}
+
+test.describe('Confirm Card (ask_user_confirm_card)', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+
+  test.beforeAll(async () => {
+    const mock = await startMockOpenAI();
+    mockServer = mock.proc;
+    // Point EVERY configured provider at the mock — provider resolution
+    // depends on the model in agents.defaults (CI uses siliconflow), so
+    // patching a single provider would leak real API calls in CI. The mock
+    // ignores model names and API keys.
+    const fixture = await launchElectronApp((config: any) => {
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = mock.mockUrl;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mockServer?.kill();
+  });
+
+  test(
+    'mock 模型弹两张确认卡 — 用户点击后 tool result 回传、回合继续并完成',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      const cardArea = page.getByTestId('confirm-card-area');
+      const resolvedArea = page.getByTestId('confirm-card-resolved');
+
+      // ── 发送任务 → 模型第一轮即调用 ask_user_confirm_card ──
+      await sendMessage(page, '帮我生成 MOF-5 市场合成价格报告并确认执行');
+
+      await expect(cardArea).toBeVisible({ timeout: 60_000 });
+      await expect(cardArea.getByText('确认执行方案？')).toBeVisible();
+      await expect(cardArea.getByText('搜索并下载相关论文')).toBeVisible(); // steps 渲染
+      await expect(cardArea.getByRole('button', { name: '确认执行' })).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '调整方案' })).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '取消' })).toBeVisible();
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-card1.png`,
+      });
+
+      // ── 点击「确认执行」→ 决议回传 → mock 推进到 web_search/write_file ──
+      await cardArea.getByRole('button', { name: '确认执行' }).click();
+      await expect(resolvedArea.getByText('已选择「确认执行」')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // ── 第二张卡：上传确认（web_search 走真实网络，CI 无外网时工具报错
+      //    不影响状态机推进，但给足超时）──
+      await expect(cardArea.getByText('方案已完成，是否上传到 Qraft？')).toBeVisible({
+        timeout: 180_000,
+      });
+      await expect(cardArea.getByRole('button', { name: '确认上传' })).toBeVisible();
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-card2.png`,
+      });
+
+      await cardArea.getByRole('button', { name: '确认上传' }).click();
+      await expect(resolvedArea.getByText('已选择「确认上传」')).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // ── 回合完成：最终回复渲染 ──
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      await expect(page.locator('main')).toContainText(
+        '项目入口：forge.miqroera.com/projects/mof-price-report',
+        { timeout: 30_000 },
+      );
+      await expect(page.locator('main')).toContainText('mof-price-report.workflow.json');
+
+      // ── 两张卡均留下决议记录（v5 语义：决议是流程痕迹，不消失）──
+      await expect(resolvedArea.getByText('确认执行方案？')).toBeVisible();
+      await expect(resolvedArea.getByText('方案已完成，是否上传到 Qraft？')).toBeVisible();
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-final.png`,
+        fullPage: true,
+      });
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/confirm-card.spec.ts
+++ b/apps/desktop/tests/e2e/confirm-card.spec.ts
@@ -82,6 +82,15 @@ async function startMockOpenAI(): Promise<{ proc: ChildProcess; mockUrl: string 
 }
 
 test.describe('Confirm Card (ask_user_confirm_card)', () => {
+  // macOS CI cannot run this spec: the runner's undici fetch fails against
+  // a local 127.0.0.1 listener and the spawned mock's stdout pipe never
+  // delivers (both observed in macos-e2e). The Linux electron-e2e job runs
+  // the full suite and covers this spec — same trimming strategy as #710.
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server',
+  );
+
   let electronApp: ElectronApplication;
   let page: Page;
   let miqiHome: string;

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -389,8 +389,13 @@ export interface ElectronFixture {
  *  - Creates a unique temporary MIQI_HOME so parallel test workers are fully isolated.
  *  - Strips ELECTRON_RUN_AS_NODE (inherited from Electron-based IDEs).
  *  - Waits for MiQi Workbench UI + bridge runtime.status() === 'running'.
+ *  - `patchConfig` (optional) mutates the temp-home config JSON before it is
+ *    written — used by specs that need a custom provider endpoint (e.g. the
+ *    confirm-card spec points deepseek at a local mock OpenAI server).
  */
-export async function launchElectronApp(): Promise<ElectronFixture> {
+export async function launchElectronApp(
+  patchConfig?: (config: any) => any,
+): Promise<ElectronFixture> {
   // Create unique temporary home per test worker for full isolation.
   // Parallel workers each get their own MIQI_HOME → no race on sessions/.
   const miqiHome = mkdtempSync(join(tmpdir(), 'miqi-e2e-'));
@@ -410,6 +415,7 @@ export async function launchElectronApp(): Promise<ElectronFixture> {
   const config = existsSync(destConfigPath)
     ? JSON.parse(readFileSync(destConfigPath, 'utf-8'))
     : {};
+  if (patchConfig) patchConfig(config);
   config.approvals = { ...config.approvals, bypass_all: true };
   // ── E2E: always disable feedback channel so tests don't hit real Feishu ──
   // Each test that needs feedback enabled can opt in by patching the config

--- a/miqi/agent/tools/ask_user_confirm.py
+++ b/miqi/agent/tools/ask_user_confirm.py
@@ -1,0 +1,221 @@
+"""ask_user_confirm_card tool (issue #646).
+
+AI-initiated human-in-the-loop confirmation. The model calls this tool when
+it needs the user to make a structured decision (e.g. before external network
+requests, file writes, multi-step skill execution, cost-incurring actions, or
+uploading a workflow definition). The desktop renders an inline confirm card,
+blocks the turn, and returns the user's choice as a tool result.
+
+Execution path:
+    ToolHost.execute() intercepts ``ask_user_confirm_card`` and routes it
+    through ``ToolHostContext.await_user_input`` (the KUN user-input gate),
+    exactly like dangerous commands route through ``await_approval``.
+    This Tool's own ``execute()`` is the fallback when no user-input channel
+    is wired (CLI / headless) — it returns a structured error so the model
+    never silently proceeds without a decision.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Awaitable, Callable
+
+from miqi.agent.tools.base import Tool
+
+DEFAULT_CHOICES: list[dict[str, str]] = [
+    {"id": "confirm", "label": "确认执行"},
+    {"id": "adjust", "label": "调整方案"},
+    {"id": "cancel", "label": "取消"},
+]
+DEFAULT_TIMEOUT_SECONDS = 120
+
+# System-prompt guidance injected into every KUN turn (issue #646, 功能描述④).
+# Tells the model WHEN to call ask_user_confirm_card and how to interpret it.
+ASK_USER_CONFIRM_INSTRUCTION = (
+    "你可以调用 ask_user_confirm_card 工具，在关键步骤执行前主动弹出一张确认卡片，"
+    "暂停当前任务等待用户做结构化选择。**必须**在以下场景主动调用（不要只在文本里询问）：\n"
+    "1. 执行多步骤 Skill 方案前（先展示步骤列表让用户确认）；\n"
+    "2. 任何外部网络请求、文件写入、可能产生费用的操作前；\n"
+    "3. 向外部平台（如 Qraft/microforge）上传文件前；\n"
+    "4. 需要用户补充关键参数、或在多个方案间做选择时。\n"
+    "调用前先在正文解释为什么需要用户决定；调用后工具会返回用户的选择。"
+    "返回 status 为 cancelled（用户取消或超时）时不要继续执行，"
+    "choice_id 为 adjust 时应重新规划方案并再次调用本工具。"
+)
+
+
+class AskUserConfirmCardTool(Tool):
+    """Tool for the model to request a structured user decision via an
+    inline confirm card (blocking human-in-the-loop)."""
+
+    def __init__(
+        self,
+        resolver: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    ):
+        """Optional async resolver: (payload) -> {"status": ..., "answers": ...}.
+
+        The legacy desktop path injects ``user_input_resolver.make_resolver()``
+        so execution blocks on the shared user-input gate; without a resolver
+        the tool returns a structured error (never fabricates a decision).
+        """
+        self._resolver = resolver
+
+    @property
+    def name(self) -> str:
+        return "ask_user_confirm_card"
+
+    @property
+    def description(self) -> str:
+        return (
+            "弹出一张确认卡片，等待用户在桌面端做结构化选择，并把选择结果返回给你。"
+            "这是 AI 主动发起的人机握手：调用后当前 Turn 会暂停，直到用户点选或超时。"
+            "**必须在你准备执行以下动作之前主动调用**：涉及外部网络请求、文件写入、"
+            "多步骤 Skill 执行、可能产生费用的操作、或向外部平台上传文件（如 Qraft/microforge）。"
+            "调用前先在正文里解释为什么需要用户决定。"
+            "返回结果 status 为 confirmed / cancelled（超时或用户取消）；"
+            "用户选择 adjust 时 status 为 cancelled 且 choice_id 为 adjust，"
+            "此时应重新规划方案并再次调用本工具，不要继续执行。"
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "卡片标题，如「确认执行方案？」",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "说明文字：为什么需要用户决定、确认后会发生什么",
+                },
+                "steps": {
+                    "type": "array",
+                    "description": "（可选）执行步骤列表，每项为 {id, title}。"
+                    "后续执行阶段的状态卡会与这里的 step_id 一一对应",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "description": "稳定步骤 ID（如 search_papers）"},
+                            "title": {"type": "string", "description": "用户可见的步骤名"},
+                        },
+                        "required": ["id", "title"],
+                    },
+                },
+                "choices": {
+                    "type": "array",
+                    "description": "（可选）结构化选项，每项为 {id, label}。"
+                    "默认 [确认执行/调整方案/取消]；上传类场景建议 [确认上传/取消]",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string"},
+                            "label": {"type": "string"},
+                        },
+                        "required": ["id", "label"],
+                    },
+                },
+                "allow_remember_choice": {
+                    "type": "boolean",
+                    "description": "（可选）是否允许用户勾选「本次会话不再询问」。"
+                    "勾选后本会话内同类确认将复用上次选择，不再弹卡；换会话失效",
+                    "default": False,
+                },
+                "timeout_seconds": {
+                    "type": "integer",
+                    "description": "（可选）等待秒数，默认 120；超时按 cancelled 处理，"
+                    "绝不自动选择危险操作",
+                    "minimum": 5,
+                    "maximum": 600,
+                    "default": DEFAULT_TIMEOUT_SECONDS,
+                },
+            },
+            "required": ["title", "message"],
+        }
+
+    async def execute(self, **kwargs: Any) -> str:
+        """Blocking path (desktop): wait for the user's structured choice.
+
+        Falls back to a safe error when no user-input channel is wired —
+        never fabricates a user decision.
+        """
+        if self._resolver is not None:
+            try:
+                payload = self.normalize_args(kwargs)
+                gate_result = await self._resolver(payload)
+                return self.build_result(gate_result)
+            except Exception as exc:  # noqa: BLE001 - surface as tool error
+                return f"Error: ask_user_confirm_card failed: {exc}"
+        return (
+            "Error: ask_user_confirm_card 需要桌面端用户输入通道（KUN runtime），"
+            "当前环境未接线。不要假设用户已同意；请说明需要确认的内容并请用户在聊天中回复。"
+        )
+
+    # ── helpers shared with the ToolHost interception ──────────────────
+
+    @staticmethod
+    def normalize_args(args: dict[str, Any]) -> dict[str, Any]:
+        """Validate/normalize card payload, applying defaults."""
+        steps = args.get("steps") or []
+        choices = args.get("choices") or DEFAULT_CHOICES
+        # guard: steps must be {id,title}; choices must be {id,label}
+        steps = [
+            {"id": str(s.get("id", f"step_{i}")), "title": str(s.get("title", f"步骤 {i + 1}"))}
+            for i, s in enumerate(steps)
+            if isinstance(s, dict)
+        ]
+        choices = [
+            {"id": str(c.get("id", f"choice_{i}")), "label": str(c.get("label", c.get("id", f"选项 {i + 1}")))}
+            for i, c in enumerate(choices)
+            if isinstance(c, dict) and (c.get("id") or c.get("label"))
+        ]
+        if not choices:
+            choices = DEFAULT_CHOICES
+        # Clamp to the schema-declared bounds (5..600) so a model-supplied 0,
+        # negative, or huge value can never mean "wait forever" (CodeRabbit).
+        try:
+            timeout_raw = int(args.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
+        except (TypeError, ValueError):
+            timeout_raw = DEFAULT_TIMEOUT_SECONDS
+        timeout_seconds = max(5, min(600, timeout_raw))
+        return {
+            "title": str(args.get("title", "请确认")),
+            "message": str(args.get("message", "")),
+            "steps": steps,
+            "choices": choices,
+            "allow_remember_choice": bool(args.get("allow_remember_choice", False)),
+            "timeout_seconds": timeout_seconds,
+        }
+
+    @staticmethod
+    def build_result(gate_result: dict[str, Any], choice_id: str | None = None) -> str:
+        """Convert the user-input-gate resolution into the tool result JSON.
+
+        Args:
+            gate_result: {"status": "submitted", "answers": {...}} or
+                         {"status": "cancelled"} (timeout / user cancel /
+                         turn stop).
+            choice_id: Explicit choice (from resolution) if answers are empty.
+        """
+        answers = gate_result.get("answers") or {}
+        cid = str(answers.get("choice_id") or choice_id or "")
+        clabel = str(answers.get("choice_label") or "")
+        if gate_result.get("status") == "submitted" and cid:
+            payload = {
+                "request_id": gate_result.get("request_id", ""),
+                "status": "confirmed",
+                "choice_id": cid,
+                "choice_label": clabel,
+            }
+        else:
+            reason = gate_result.get("reason", "cancelled")
+            payload = {
+                "request_id": gate_result.get("request_id", ""),
+                "status": "cancelled",
+                "choice_id": cid or "",
+                "choice_label": clabel,
+                "reason": reason,
+            }
+        return json.dumps(payload, ensure_ascii=False)

--- a/miqi/agent/tools/ask_user_confirm.py
+++ b/miqi/agent/tools/ask_user_confirm.py
@@ -25,8 +25,8 @@ from miqi.agent.tools.base import Tool
 
 DEFAULT_CHOICES: list[dict[str, str]] = [
     {"id": "confirm", "label": "确认执行"},
-    {"id": "adjust", "label": "调整方案"},
-    {"id": "cancel", "label": "取消"},
+    {"id": "adjust", "label": "调整方案", "role": "adjust"},
+    {"id": "cancel", "label": "取消", "role": "cancel"},
 ]
 DEFAULT_TIMEOUT_SECONDS = 120
 
@@ -160,14 +160,23 @@ class AskUserConfirmCardTool(Tool):
         """Validate/normalize card payload, applying defaults."""
         steps = args.get("steps") or []
         choices = args.get("choices") or DEFAULT_CHOICES
-        # guard: steps must be {id,title}; choices must be {id,label}
+        # guard: steps must be {id,title}; choices must be {id,label}.
+        # Truthiness fallbacks (not dict.get defaults) — an empty string IS a
+        # stored value and would render as a blank title/label (CodeRabbit #711).
         steps = [
-            {"id": str(s.get("id", f"step_{i}")), "title": str(s.get("title", f"步骤 {i + 1}"))}
+            {
+                "id": str(s.get("id") or f"step_{i}"),
+                "title": str(s.get("title") or f"步骤 {i + 1}"),
+            }
             for i, s in enumerate(steps)
             if isinstance(s, dict)
         ]
         choices = [
-            {"id": str(c.get("id", f"choice_{i}")), "label": str(c.get("label", c.get("id", f"选项 {i + 1}")))}
+            {
+                "id": str(c.get("id") or f"choice_{i}"),
+                "label": str(c.get("label") or c.get("id") or f"选项 {i + 1}"),
+                **({"role": str(c["role"])} if isinstance(c.get("role"), str) else {}),
+            }
             for i, c in enumerate(choices)
             if isinstance(c, dict) and (c.get("id") or c.get("label"))
         ]
@@ -198,11 +207,20 @@ class AskUserConfirmCardTool(Tool):
                          {"status": "cancelled"} (timeout / user cancel /
                          turn stop).
             choice_id: Explicit choice (from resolution) if answers are empty.
+
+        Status semantics (issue #646 功能描述③): only a confirm-type choice
+        reports ``confirmed``. Cancel/adjust choices (by ``choice_role``, with
+        the literal ids as fallback) report ``cancelled`` with the choice
+        retained, so the model reliably aborts or re-plans.
         """
         answers = gate_result.get("answers") or {}
         cid = str(answers.get("choice_id") or choice_id or "")
         clabel = str(answers.get("choice_label") or "")
-        if gate_result.get("status") == "submitted" and cid:
+        role = str(answers.get("choice_role") or "")
+        non_confirm = role in ("cancel", "adjust") or (
+            not role and cid in ("cancel", "adjust")
+        )
+        if gate_result.get("status") == "submitted" and cid and not non_confirm:
             payload = {
                 "request_id": gate_result.get("request_id", ""),
                 "status": "confirmed",

--- a/miqi/agent/tools/ask_user_confirm.py
+++ b/miqi/agent/tools/ask_user_confirm.py
@@ -227,6 +227,8 @@ class AskUserConfirmCardTool(Tool):
                 "choice_id": cid,
                 "choice_label": clabel,
             }
+            if gate_result.get("remembered"):
+                payload["remembered"] = True
         else:
             reason = gate_result.get("reason", "cancelled")
             payload = {

--- a/miqi/agent/tools/registry.py
+++ b/miqi/agent/tools/registry.py
@@ -84,6 +84,7 @@ _NEVER_PARALLEL_TOOLS: frozenset[str] = frozenset({
     "message",
     "spawn",
     "cron",
+    "ask_user_confirm_card",
 })
 
 

--- a/miqi/agent/user_input_history.py
+++ b/miqi/agent/user_input_history.py
@@ -1,0 +1,89 @@
+"""User-confirmation decision history (issue #646, 功能描述⑤).
+
+Records every ask_user_confirm_card decision — call time, card title, and the
+user's final choice — for audit. Mirrors the approval-history pattern in
+``miqi/agent/command_approval.py``: in-memory ring + optional JSONL file.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from typing import Any
+
+logger = None  # lazy import to avoid loguru at module import
+
+_lock = threading.Lock()
+_history: list[dict[str, Any]] = []
+_history_file: str | None = None
+
+
+def init_history_file(path: str) -> None:
+    """Load existing entries from *path* and append new ones to it."""
+    global _history_file
+    _history_file = path
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    _history.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    except FileNotFoundError:
+        pass
+
+
+def add_user_input_history(
+    *,
+    title: str,
+    message: str = "",
+    choices: list[dict[str, Any]] | None = None,
+    status: str = "submitted",  # submitted | cancelled
+    choice_id: str = "",
+    choice_label: str = "",
+    reason: str = "",  # e.g. timeout / turn_stop / user_cancel
+    thread_id: str = "",
+    turn_id: str = "",
+    input_id: str = "",
+) -> dict[str, Any]:
+    """Record one user-confirmation decision."""
+    entry = {
+        "id": str(uuid.uuid4()),
+        "timestamp": time.time(),
+        "input_id": input_id,
+        "thread_id": thread_id,
+        "turn_id": turn_id,
+        "title": title,
+        "message": message,
+        "choices": choices or [],
+        "status": status,
+        "choice_id": choice_id,
+        "choice_label": choice_label,
+        "reason": reason,
+    }
+    with _lock:
+        _history.append(entry)
+        if _history_file:
+            try:
+                with open(_history_file, "a", encoding="utf-8") as fh:
+                    fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            except OSError:
+                pass
+    return entry
+
+
+def get_user_input_history(limit: int = 200) -> list[dict[str, Any]]:
+    """Return recent decisions (most recent first)."""
+    with _lock:
+        return list(reversed(_history[-limit:]))
+
+
+def clear_history() -> None:
+    """Clear in-memory history (used by tests)."""
+    with _lock:
+        _history.clear()

--- a/miqi/agent/user_input_history.py
+++ b/miqi/agent/user_input_history.py
@@ -21,9 +21,13 @@ _history_file: str | None = None
 
 
 def init_history_file(path: str) -> None:
-    """Load existing entries from *path* and append new ones to it."""
+    """Load existing entries from *path* and append new ones to it.
+
+    Idempotent per path: a second call with the same path does not re-append
+    the persisted entries (CodeRabbit #711).
+    """
     global _history_file
-    _history_file = path
+    loaded: list[dict[str, Any]] = []
     try:
         with open(path, "r", encoding="utf-8") as fh:
             for line in fh:
@@ -31,11 +35,19 @@ def init_history_file(path: str) -> None:
                 if not line:
                     continue
                 try:
-                    _history.append(json.loads(line))
+                    loaded.append(json.loads(line))
                 except json.JSONDecodeError:
                     pass
     except FileNotFoundError:
         pass
+    with _lock:
+        if _history_file == path:
+            return  # already initialised from this file
+        _history_file = path
+        # Replace (not append) so a re-init with a different path swaps the
+        # backing store instead of duplicating entries.
+        _history.clear()
+        _history.extend(loaded)
 
 
 def add_user_input_history(

--- a/miqi/agent/user_input_resolver.py
+++ b/miqi/agent/user_input_resolver.py
@@ -17,26 +17,72 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextvars import ContextVar
 from typing import Any, Awaitable, Callable
 
 from miqi.kun_runtime.user_input_gate import UserInputGate
 
 _gate = UserInputGate()
-_emitter: Callable[[dict[str, Any]], Any] | None = None
+# One emitter slot per session (thread_id == session_key on the desktop
+# path). A single process-global slot misrouted cards across concurrent
+# sessions: session B's turn overwrote session A's emitter, and B finishing
+# first cleared A's channel (CodeRabbit #711).
+_emitters: dict[str, Callable[[dict[str, Any]], Any]] = {}
+# thread_id → session_key mapping (desktop path): the runtime mints a
+# server-generated thread id per session (threads.start), which differs
+# from the session key the emitter is registered under.
+_thread_sessions: dict[str, str] = {}
+# Turn identity context (legacy path): the tool executes without thread/turn
+# args, so the task runner publishes them here and the resolver reads them
+# to scope remember + turn cancellation correctly.
+_thread_ctx: ContextVar[tuple[str, str]] = ContextVar(
+    "miqi_user_input_thread", default=("", "")
+)
 
 
-def set_user_input_emitter(emitter: Callable[[dict[str, Any]], Any] | None) -> None:
-    """Set the event emitter used to push user_input_requested to the desktop.
+def set_user_input_emitter(
+    session_key: str, emitter: Callable[[dict[str, Any]], Any] | None
+) -> None:
+    """Register (or clear) the emitter for one session.
 
-    The bridge sets this per chat.send session. When None (headless),
-    resolve() returns a cancelled result instead of blocking forever.
+    The bridge sets this per chat.send drain task keyed by session_key.
+    When absent (headless), the resolver returns a cancelled result instead
+    of blocking forever.
     """
-    global _emitter
-    _emitter = emitter
+    if emitter is None:
+        _emitters.pop(session_key, None)
+    else:
+        _emitters[session_key] = emitter
 
 
-def user_input_emitter() -> Callable[[dict[str, Any]], Any] | None:
-    return _emitter
+def user_input_emitter_for(session_key: str) -> Callable[[dict[str, Any]], Any] | None:
+    return _emitters.get(session_key)
+
+
+def set_thread_session(thread_id: str, session_key: str) -> None:
+    """Record which session a thread belongs to (bridge drain task)."""
+    _thread_sessions[thread_id] = session_key
+
+
+def clear_thread_session(thread_id: str) -> None:
+    _thread_sessions.pop(thread_id, None)
+
+
+def session_for_thread(thread_id: str) -> str | None:
+    return _thread_sessions.get(thread_id)
+
+
+def set_thread_context(thread_id: str, turn_id: str) -> None:
+    """Publish the active legacy turn's identity for the resolver."""
+    _thread_ctx.set((thread_id, turn_id))
+
+
+def clear_thread_context() -> None:
+    _thread_ctx.set(("", ""))
+
+
+def current_thread_context() -> tuple[str, str]:
+    return _thread_ctx.get()
 
 
 def resolve_user_input(
@@ -48,6 +94,16 @@ def resolve_user_input(
     return _gate.resolve(input_id, answers or {}, remember=remember)
 
 
+def pending_thread_for_input(input_id: str) -> str | None:
+    """Return the owning thread of a pending card, or None.
+
+    Used by the userInput.resolve handler to authorize the resolving client
+    against the session the card belongs to.
+    """
+    req = _gate.pending_request(input_id)
+    return req.thread_id if req is not None else None
+
+
 def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """Build the async resolver injected into AskUserConfirmCardTool.
 
@@ -57,7 +113,17 @@ def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
     """
 
     async def resolver(payload: dict[str, Any]) -> dict[str, Any]:
-        emitter = _emitter
+        # Session identity: the model only supplies card fields, so the turn
+        # context comes from the task runner's contextvar. Without it,
+        # remember scoping and turn cancellation silently break (CodeRabbit #711).
+        ctx_thread, ctx_turn = _thread_ctx.get()
+        thread_id = str(payload.get("threadId") or ctx_thread or "")
+        turn_id = str(payload.get("turnId") or ctx_turn or "")
+        # The runtime's thread id differs from the session key the bridge
+        # registers emitters under (threads.start mints it) — map through
+        # the thread→session table, falling back to the thread id itself.
+        session_key = session_for_thread(thread_id) or thread_id
+        emitter = user_input_emitter_for(session_key)
         if emitter is None:
             return {
                 "status": "cancelled",
@@ -65,6 +131,12 @@ def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
             }
         input_id = f"user_input_{__import__('uuid').uuid4().hex[:12]}"
         prompt = str(payload.get("message") or payload.get("title") or "")
+        # Same remember key as the KUN path so the two runtimes share
+        # remember semantics (issue #646 review).
+        allow_remember = bool(payload.get("allow_remember_choice"))
+        from miqi.kun_runtime.loop import _remember_key
+
+        remember_key = _remember_key(payload) if allow_remember else None
         try:
             if asyncio.iscoroutinefunction(emitter):
                 await emitter({**payload, "input_id": input_id, "prompt": prompt})
@@ -74,12 +146,14 @@ def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
             pass  # emitter failure must not block the tool; timeout will cancel
         timeout = payload.get("timeout_seconds")
         result = await _gate.request(
-            thread_id=str(payload.get("threadId") or ""),
-            turn_id=str(payload.get("turnId") or ""),
+            thread_id=thread_id,
+            turn_id=turn_id,
             item_id=f"item_{input_id[-6:]}",
             prompt=prompt,
             timeout=float(timeout) if timeout else None,
             input_id=input_id,
+            remember_key=remember_key if allow_remember else None,
+            choices=payload.get("choices", []),
         )
         result["request_id"] = input_id
         return result

--- a/miqi/agent/user_input_resolver.py
+++ b/miqi/agent/user_input_resolver.py
@@ -1,0 +1,101 @@
+"""Shared user-input resolver bridging ask_user_confirm_card to the desktop
+(issue #646).
+
+The KUN runtime wires its own UserInputGate via the AgentLoop. The legacy
+runtime (chat.send path, which the desktop currently uses) executes tools
+through ToolRuntime/ToolOrchestrator without a gate. This module provides a
+shared gate + injectable emitter so the legacy path can also block on a user
+choice and emit user_input_requested events toward the desktop.
+
+Wiring:
+  bridge/loop.py (chat.send):
+      set_user_input_emitter(lambda payload: asyncio.create_task(_emit("user_input_requested", payload)))
+      app_server.register_method("userInput.resolve", user_input_resolve_handler)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Awaitable, Callable
+
+from miqi.kun_runtime.user_input_gate import UserInputGate
+
+_gate = UserInputGate()
+_emitter: Callable[[dict[str, Any]], Any] | None = None
+
+
+def set_user_input_emitter(emitter: Callable[[dict[str, Any]], Any] | None) -> None:
+    """Set the event emitter used to push user_input_requested to the desktop.
+
+    The bridge sets this per chat.send session. When None (headless),
+    resolve() returns a cancelled result instead of blocking forever.
+    """
+    global _emitter
+    _emitter = emitter
+
+
+def user_input_emitter() -> Callable[[dict[str, Any]], Any] | None:
+    return _emitter
+
+
+def resolve_user_input(
+    input_id: str,
+    answers: dict[str, Any] | None = None,
+    remember: bool = False,
+) -> bool:
+    """Resolve a pending user-input request (called by the app handler)."""
+    return _gate.resolve(input_id, answers or {}, remember=remember)
+
+
+def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Build the async resolver injected into AskUserConfirmCardTool.
+
+    Blocks on the shared gate until the desktop resolves, times out, or the
+    turn is cancelled. Emits user_input_requested so the desktop renders the
+    confirm card.
+    """
+
+    async def resolver(payload: dict[str, Any]) -> dict[str, Any]:
+        emitter = _emitter
+        if emitter is None:
+            return {
+                "status": "cancelled",
+                "reason": "no user-input channel (desktop bridge not wired)",
+            }
+        input_id = f"user_input_{__import__('uuid').uuid4().hex[:12]}"
+        prompt = str(payload.get("message") or payload.get("title") or "")
+        try:
+            if asyncio.iscoroutinefunction(emitter):
+                await emitter({**payload, "input_id": input_id, "prompt": prompt})
+            else:
+                emitter({**payload, "input_id": input_id, "prompt": prompt})
+        except Exception:
+            pass  # emitter failure must not block the tool; timeout will cancel
+        timeout = payload.get("timeout_seconds")
+        result = await _gate.request(
+            thread_id=str(payload.get("threadId") or ""),
+            turn_id=str(payload.get("turnId") or ""),
+            item_id=f"item_{input_id[-6:]}",
+            prompt=prompt,
+            timeout=float(timeout) if timeout else None,
+            input_id=input_id,
+        )
+        result["request_id"] = input_id
+        return result
+
+    return resolver
+
+
+def resolver_to_tool_result(gate_result: dict[str, Any]) -> str:
+    """Convert a gate result into the ask_user_confirm_card tool-result JSON."""
+    from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+    return AskUserConfirmCardTool.build_result(gate_result)
+
+
+def _stable_json(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        return str(value)

--- a/miqi/agent/user_input_resolver.py
+++ b/miqi/agent/user_input_resolver.py
@@ -123,6 +123,50 @@ def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
         # registers emitters under (threads.start mints it) — map through
         # the thread→session table, falling back to the thread id itself.
         session_key = session_for_thread(thread_id) or thread_id
+        # Same remember key as the KUN path so the two runtimes share
+        # remember semantics (issue #646 review).
+        allow_remember = bool(payload.get("allow_remember_choice"))
+        from miqi.kun_runtime.loop import _remember_key
+
+        remember_key = _remember_key(payload) if allow_remember else None
+        # Session-level remember: reuse the previous choice WITHOUT popping a
+        # card, mirroring the KUN path. Every confirmation is audited,
+        # including auto-resolved ones (issue #646 功能描述⑤).
+        if remember_key is not None:
+            cached = _gate.remembered_choice(thread_id, remember_key)
+            if cached is not None:
+                try:
+                    from miqi.agent.user_input_history import add_user_input_history
+
+                    add_user_input_history(
+                        title=str(payload.get("title") or ""),
+                        message=str(payload.get("message") or ""),
+                        choices=payload.get("choices", []),
+                        status="submitted",
+                        choice_id=str(cached.get("choice_id", "")),
+                        choice_label=str(cached.get("choice_label", "")),
+                        reason="remembered",
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        input_id="",
+                    )
+                except Exception:
+                    pass  # audit is best-effort, never blocks the turn
+                result = {
+                    "status": "submitted",
+                    "answers": dict(cached),
+                    "remembered": True,
+                    "request_id": f"user_input_{__import__('uuid').uuid4().hex[:12]}",
+                }
+                # Remembered confirm/cancel must carry the same semantic
+                # classification as a fresh resolve (choice_role annotation).
+                cid = str(cached.get("choice_id", ""))
+                for c in payload.get("choices", []):
+                    if isinstance(c, dict) and str(c.get("id", "")) == cid and c.get("role"):
+                        result["answers"] = dict(cached)
+                        result["answers"]["choice_role"] = str(c["role"])
+                        break
+                return result
         emitter = user_input_emitter_for(session_key)
         if emitter is None:
             return {
@@ -131,12 +175,6 @@ def make_resolver() -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
             }
         input_id = f"user_input_{__import__('uuid').uuid4().hex[:12]}"
         prompt = str(payload.get("message") or payload.get("title") or "")
-        # Same remember key as the KUN path so the two runtimes share
-        # remember semantics (issue #646 review).
-        allow_remember = bool(payload.get("allow_remember_choice"))
-        from miqi.kun_runtime.loop import _remember_key
-
-        remember_key = _remember_key(payload) if allow_remember else None
         try:
             if asyncio.iscoroutinefunction(emitter):
                 await emitter({**payload, "input_id": input_id, "prompt": prompt})

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -376,11 +376,31 @@ class BridgeRuntimeLoop:
             session_id: str | None, registry: Any,
         ) -> dict:
             """Resolve a pending confirm card (desktop → shared user-input gate)."""
-            from miqi.agent.user_input_resolver import resolve_user_input
+            from miqi.agent.user_input_resolver import (
+                pending_thread_for_input,
+                resolve_user_input,
+            )
 
             input_id = params.get("input_id", "")
             if not input_id:
                 raise AppServerError("input_id is required", code="INVALID_PARAMS")
+            # Authorization: only a client that owns the session the card
+            # belongs to may resolve it — mirrors approvals.resolve
+            # (CodeRabbit #711). The card's thread maps to its session key,
+            # and registry session ids are "{client_id}:{session_key}".
+            owner_thread = pending_thread_for_input(input_id)
+            if owner_thread is not None:
+                from miqi.agent.user_input_resolver import session_for_thread
+
+                owner_session = session_for_thread(owner_thread) or owner_thread
+                owned = any(
+                    sid == owner_session or sid.endswith(f":{owner_session}")
+                    for sid in registry.list_sessions(client_id)
+                )
+                if not owned:
+                    raise AppServerError(
+                        "Not authorized to resolve this card", code="UNAUTHORIZED",
+                    )
             choice_id = params.get("choice_id", "")
             choice_label = params.get("choice_label", "")
             remember = bool(params.get("remember", False))
@@ -1018,13 +1038,18 @@ class BridgeRuntimeLoop:
             from dataclasses import asdict, is_dataclass
 
             # Wire the shared user-input emitter so ask_user_confirm_card can
-            # push user_input_requested events to this session (issue #646).
+            # push user_input_requested events to THIS session (issue #646).
+            # Keyed by session_key — the resolver dispatches by the turn's
+            # thread_id, which equals session_key on the chat.send path.
             from miqi.agent.user_input_resolver import set_user_input_emitter
 
             async def _user_input_emitter(payload: dict) -> None:
                 await _emit("user_input_requested", payload)
 
-            set_user_input_emitter(_user_input_emitter)
+            set_user_input_emitter(session_key, _user_input_emitter)
+            from miqi.agent.user_input_resolver import set_thread_session
+
+            set_thread_session(thread_id, session_key)
 
             from miqi.protocol.events import (
                 AgentMessageDeltaEvent,
@@ -1207,11 +1232,17 @@ class BridgeRuntimeLoop:
                 "message": f"Bridge 事件循环错误：{raw}",
             })
         finally:
-            # Unwire the user-input emitter so a finished turn's emitter can't
-            # linger and capture cards for a later turn (issue #646 review).
-            from miqi.agent.user_input_resolver import set_user_input_emitter
+            # Unwire THIS session's user-input emitter and thread mapping so
+            # a finished turn's emitter can't linger and capture cards for a
+            # later turn. Keyed per session — concurrent sessions keep their
+            # own channels (CodeRabbit #711).
+            from miqi.agent.user_input_resolver import (
+                clear_thread_session,
+                set_user_input_emitter,
+            )
 
-            set_user_input_emitter(None)
+            clear_thread_session(thread_id)
+            set_user_input_emitter(session_key, None)
 
     # ── agent.spawn / agent.kill handlers ──────────────────────────────────
 

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -368,6 +368,30 @@ class BridgeRuntimeLoop:
         self._app_server.register_method("approvals.add_permanent", approvals_add_permanent_handler)
         self._app_server.register_method("approvals.history", approvals_history_handler)
 
+        # Register userInput.resolve (issue #646: ask_user_confirm_card)
+        from miqi.runtime.app_server import AppServerError
+
+        async def _user_input_resolve_handler(
+            request_id: str, params: dict, client_id: str,
+            session_id: str | None, registry: Any,
+        ) -> dict:
+            """Resolve a pending confirm card (desktop → shared user-input gate)."""
+            from miqi.agent.user_input_resolver import resolve_user_input
+
+            input_id = params.get("input_id", "")
+            if not input_id:
+                raise AppServerError("input_id is required", code="INVALID_PARAMS")
+            choice_id = params.get("choice_id", "")
+            choice_label = params.get("choice_label", "")
+            remember = bool(params.get("remember", False))
+            answers = {}
+            if choice_id:
+                answers = {"choice_id": choice_id, "choice_label": choice_label}
+            resolved = resolve_user_input(input_id, answers, remember=remember)
+            return {"result": {"resolved": resolved}}
+
+        self._app_server.register_method("userInput.resolve", _user_input_resolve_handler)
+
         # Register Phase 28.3: config.* handlers
         from miqi.runtime.config_handlers import (
             config_get_handler,
@@ -993,6 +1017,15 @@ class BridgeRuntimeLoop:
         try:
             from dataclasses import asdict, is_dataclass
 
+            # Wire the shared user-input emitter so ask_user_confirm_card can
+            # push user_input_requested events to this session (issue #646).
+            from miqi.agent.user_input_resolver import set_user_input_emitter
+
+            async def _user_input_emitter(payload: dict) -> None:
+                await _emit("user_input_requested", payload)
+
+            set_user_input_emitter(_user_input_emitter)
+
             from miqi.protocol.events import (
                 AgentMessageDeltaEvent,
                 AgentMessageEvent,
@@ -1173,6 +1206,12 @@ class BridgeRuntimeLoop:
             await _emit_terminal("error", {
                 "message": f"Bridge 事件循环错误：{raw}",
             })
+        finally:
+            # Unwire the user-input emitter so a finished turn's emitter can't
+            # linger and capture cards for a later turn (issue #646 review).
+            from miqi.agent.user_input_resolver import set_user_input_emitter
+
+            set_user_input_emitter(None)
 
     # ── agent.spawn / agent.kill handlers ──────────────────────────────────
 

--- a/miqi/execution/collab_policy.py
+++ b/miqi/execution/collab_policy.py
@@ -32,6 +32,7 @@ class RiskLevel(str, Enum):
     EXEC = "exec"              # shell / command — confirm + safety approval
     EXTERNAL = "external"      # upload / outbound transfer — ALWAYS confirm
     PAYMENT = "payment"        # money — always confirm (future)
+    UNKNOWN = "unknown"        # not in any known set — fail closed
 
 
 class AutonomyMode(str, Enum):
@@ -73,18 +74,22 @@ PAYMENT_TOOLS: frozenset[str] = frozenset({
 })
 
 # Confirmation gate (9月 demo): (mode, risk) → verdict.
-# Rules are explicit; unknown tools default to ALLOW (safety layer handles them).
+# Rules are explicit. Unknown tools fail closed: DENY in plan mode, CONFIRM
+# in manual mode; supervised/autonomous leave them to the safety layer
+# (CodeRabbit #711).
 _CONFIRM_MATRIX: dict[tuple[AutonomyMode, RiskLevel], CollabVerdict] = {
     # plan mode: everything not read-only is denied
     (AutonomyMode.PLAN, RiskLevel.WRITE): CollabVerdict.DENY,
     (AutonomyMode.PLAN, RiskLevel.EXEC): CollabVerdict.DENY,
     (AutonomyMode.PLAN, RiskLevel.EXTERNAL): CollabVerdict.DENY,
     (AutonomyMode.PLAN, RiskLevel.PAYMENT): CollabVerdict.DENY,
+    (AutonomyMode.PLAN, RiskLevel.UNKNOWN): CollabVerdict.DENY,
     # manual: every write/exec/external needs the card
     (AutonomyMode.MANUAL, RiskLevel.WRITE): CollabVerdict.CONFIRM,
     (AutonomyMode.MANUAL, RiskLevel.EXEC): CollabVerdict.CONFIRM,
     (AutonomyMode.MANUAL, RiskLevel.EXTERNAL): CollabVerdict.CONFIRM,
     (AutonomyMode.MANUAL, RiskLevel.PAYMENT): CollabVerdict.CONFIRM,
+    (AutonomyMode.MANUAL, RiskLevel.UNKNOWN): CollabVerdict.CONFIRM,
     # supervised: writes auto (like "允许编辑"), exec/external confirm
     (AutonomyMode.SUPERVISED, RiskLevel.EXEC): CollabVerdict.CONFIRM,
     (AutonomyMode.SUPERVISED, RiskLevel.EXTERNAL): CollabVerdict.CONFIRM,
@@ -96,7 +101,7 @@ _CONFIRM_MATRIX: dict[tuple[AutonomyMode, RiskLevel], CollabVerdict] = {
 
 
 def risk_of(tool_name: str) -> RiskLevel:
-    """Classify a tool name into a risk level (unknown → READ)."""
+    """Classify a tool name into a risk level (unknown → UNKNOWN)."""
     if tool_name in PAYMENT_TOOLS:
         return RiskLevel.PAYMENT
     if tool_name in EXTERNAL_TOOLS:
@@ -105,7 +110,9 @@ def risk_of(tool_name: str) -> RiskLevel:
         return RiskLevel.EXEC
     if tool_name in WRITE_TOOLS:
         return RiskLevel.WRITE
-    return RiskLevel.READ
+    if tool_name in READ_TOOLS:
+        return RiskLevel.READ
+    return RiskLevel.UNKNOWN
 
 
 def evaluate(tool_name: str, mode: AutonomyMode) -> CollabVerdict:

--- a/miqi/execution/collab_policy.py
+++ b/miqi/execution/collab_policy.py
@@ -1,0 +1,122 @@
+"""Collaboration policy — the confirm-card gate (issue #646, design v2).
+
+Two AI reviews converged on: the model must never be the final decision
+maker. The harness decides *when to ask*, the model decides *what to propose*.
+
+This module is the Collaboration Policy layer:
+
+    User Mode (Autonomy)
+        ↓
+    Policy Engine
+        ├─ Safety Policy      → approval gate (allow/deny, bypassable)
+        └─ Collaboration Policy → confirm card (this file, NOT bypassable)
+
+Key design points (from the design-review doc in D:/Desktop/811):
+- Risk-based autonomy: "automatic" is NOT "fully autonomous" — low-risk runs
+  automatically, high-risk always confirms.
+- Intent vs Safety: approval answers "may I?" (permission), the confirm card
+  answers "is this the plan?" (decision). External transfers and payments
+  ALWAYS confirm, regardless of approval bypass settings.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RiskLevel(str, Enum):
+    """Risk classes for tool intents (9月演示 hard-coded table)."""
+
+    READ = "read"              # search/read/analyze — always auto
+    WRITE = "write"            # write file / edit — confirm in supervised
+    EXEC = "exec"              # shell / command — confirm + safety approval
+    EXTERNAL = "external"      # upload / outbound transfer — ALWAYS confirm
+    PAYMENT = "payment"        # money — always confirm (future)
+
+
+class AutonomyMode(str, Enum):
+    """User-selected autonomy level (maps to the desktop mode picker)."""
+
+    PLAN = "plan"              # 规划: analyse only, no execution
+    MANUAL = "manual"          # 手动: every step confirmed
+    SUPERVISED = "supervised"  # 允许编辑: writes auto, risky confirms (new)
+    AUTONOMOUS = "autonomous"  # 自动: low-risk auto, high-risk confirms
+
+
+class CollabVerdict(str, Enum):
+    ALLOW = "allow"            # run without asking
+    CONFIRM = "confirm"        # block and show confirm card
+    DENY = "deny"              # blocked by policy (plan mode etc.)
+
+
+# Tool-name → risk class. Single source of truth — keep in sync with
+# runtime/tool_policy.py (safety side) and tool_registry_factory.py.
+READ_TOOLS: frozenset[str] = frozenset({
+    "web_search", "web_fetch", "paper_search", "paper_get", "read", "read_file",
+    "grep", "find", "ls", "list_dir", "tavily_search", "arxiv_search",
+})
+WRITE_TOOLS: frozenset[str] = frozenset({
+    "write_file", "edit_file", "apply_patch", "edit_diff", "write", "edit",
+    "delete", "move", "create_docx", "create_pdf", "create_spreadsheet",
+})
+EXEC_TOOLS: frozenset[str] = frozenset({
+    "exec", "bash", "shell", "run_command", "execute",
+})
+# External transfer: uploading to microforge/Qraft or any outbound send.
+# ALWAYS confirm — independent of approval bypass.
+EXTERNAL_TOOLS: frozenset[str] = frozenset({
+    "upload_workflow", "upload", "platform_upload", "data_upload",
+    "send_message", "send_file", "email_send", "slack_post", "feishu_send",
+})
+PAYMENT_TOOLS: frozenset[str] = frozenset({
+    "purchase", "pay", "payment", "charge",
+})
+
+# Confirmation gate (9月 demo): (mode, risk) → verdict.
+# Rules are explicit; unknown tools default to ALLOW (safety layer handles them).
+_CONFIRM_MATRIX: dict[tuple[AutonomyMode, RiskLevel], CollabVerdict] = {
+    # plan mode: everything not read-only is denied
+    (AutonomyMode.PLAN, RiskLevel.WRITE): CollabVerdict.DENY,
+    (AutonomyMode.PLAN, RiskLevel.EXEC): CollabVerdict.DENY,
+    (AutonomyMode.PLAN, RiskLevel.EXTERNAL): CollabVerdict.DENY,
+    (AutonomyMode.PLAN, RiskLevel.PAYMENT): CollabVerdict.DENY,
+    # manual: every write/exec/external needs the card
+    (AutonomyMode.MANUAL, RiskLevel.WRITE): CollabVerdict.CONFIRM,
+    (AutonomyMode.MANUAL, RiskLevel.EXEC): CollabVerdict.CONFIRM,
+    (AutonomyMode.MANUAL, RiskLevel.EXTERNAL): CollabVerdict.CONFIRM,
+    (AutonomyMode.MANUAL, RiskLevel.PAYMENT): CollabVerdict.CONFIRM,
+    # supervised: writes auto (like "允许编辑"), exec/external confirm
+    (AutonomyMode.SUPERVISED, RiskLevel.EXEC): CollabVerdict.CONFIRM,
+    (AutonomyMode.SUPERVISED, RiskLevel.EXTERNAL): CollabVerdict.CONFIRM,
+    (AutonomyMode.SUPERVISED, RiskLevel.PAYMENT): CollabVerdict.CONFIRM,
+    # autonomous: external/payment ALWAYS confirm (never bypassable)
+    (AutonomyMode.AUTONOMOUS, RiskLevel.EXTERNAL): CollabVerdict.CONFIRM,
+    (AutonomyMode.AUTONOMOUS, RiskLevel.PAYMENT): CollabVerdict.CONFIRM,
+}
+
+
+def risk_of(tool_name: str) -> RiskLevel:
+    """Classify a tool name into a risk level (unknown → READ)."""
+    if tool_name in PAYMENT_TOOLS:
+        return RiskLevel.PAYMENT
+    if tool_name in EXTERNAL_TOOLS:
+        return RiskLevel.EXTERNAL
+    if tool_name in EXEC_TOOLS:
+        return RiskLevel.EXEC
+    if tool_name in WRITE_TOOLS:
+        return RiskLevel.WRITE
+    return RiskLevel.READ
+
+
+def evaluate(tool_name: str, mode: AutonomyMode) -> CollabVerdict:
+    """Decide whether a tool call needs the confirm card.
+
+    Independent of approval bypass: EXTERNAL/PAYMENT always confirm in every
+    execution mode — the collaboration gate is not a safety toggle.
+    """
+    risk = risk_of(tool_name)
+    verdict = _CONFIRM_MATRIX.get((mode, risk))
+    if verdict is not None:
+        return verdict
+    # READ is always auto; anything unlisted defaults to allow.
+    return CollabVerdict.ALLOW

--- a/miqi/kun_runtime/contracts.py
+++ b/miqi/kun_runtime/contracts.py
@@ -40,6 +40,7 @@ class TurnItemStatus(str, Enum):
 class TurnStatus(str, Enum):
     queued = "queued"
     running = "running"
+    waiting_for_user = "waiting_for_user"
     completed = "completed"
     failed = "failed"
     aborted = "aborted"
@@ -223,6 +224,19 @@ class UserInputItem(_TurnItemBase):
     prompt: str
     questions: list[dict[str, Any]] = Field(default_factory=list)
     status: Literal["pending", "submitted", "cancelled"]
+
+    # ── ask_user_confirm_card card payload (issue #646) ──────────────
+    # title: card title; message: 说明文字; steps: [{id,title}] 步骤列表
+    # choices: [{id,label}] 选项; timeout_seconds: 超时(默认 120)
+    # allow_remember_choice: 本次会话不再询问
+    # resolution: {choice_id, choice_label} 用户最终选择
+    title: str | None = None
+    message: str | None = None
+    steps: list[dict[str, Any]] = Field(default_factory=list)
+    choices: list[dict[str, Any]] = Field(default_factory=list)
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    allow_remember_choice: bool = False
+    resolution: dict[str, Any] | None = None
 
 
 class CompactionItem(_TurnItemBase):
@@ -707,6 +721,13 @@ class UserInputRequestedEvent(_RuntimeEventBase):
     status: Literal["pending"] = "pending"
     prompt: str | None = None
     questions: list[dict[str, Any]] | None = None
+    # ask_user_confirm_card card payload (issue #646)
+    title: str | None = None
+    message: str | None = None
+    steps: list[dict[str, Any]] | None = None
+    choices: list[dict[str, Any]] | None = None
+    timeoutSeconds: int | None = None
+    allowRememberChoice: bool | None = None
 
 
 class UserInputResolvedEvent(_RuntimeEventBase):
@@ -715,6 +736,8 @@ class UserInputResolvedEvent(_RuntimeEventBase):
     status: Literal["submitted", "cancelled"]
     prompt: str | None = None
     questions: list[dict[str, Any]] | None = None
+    # user's final selection (issue #646): {choice_id, choice_label}
+    resolution: dict[str, Any] | None = None
 
 
 class CompactionStartedEvent(_RuntimeEventBase):

--- a/miqi/kun_runtime/loop.py
+++ b/miqi/kun_runtime/loop.py
@@ -70,16 +70,27 @@ MAX_PARALLEL_TOOL_CALLS = 3
 
 
 def _remember_key(payload: dict[str, Any]) -> str:
-    """Stable session-remember key: card title + normalized choices (issue #646)."""
+    """Stable session-remember key: full card content (issue #646).
+
+    Title + choices alone is not enough: two different plans can share a
+    title, and reusing a remembered choice across different plans would
+    auto-approve work the user never saw (CodeRabbit #711).
+    """
     import hashlib
 
     title = str(payload.get("title", ""))
+    message = str(payload.get("message", ""))
+    steps = [
+        (str(s.get("id", "")), str(s.get("title", "")))
+        for s in (payload.get("steps") or [])
+        if isinstance(s, dict)
+    ]
     choices = sorted(
         (str(c.get("id", "")), str(c.get("label", "")))
         for c in (payload.get("choices") or [])
         if isinstance(c, dict)
     )
-    raw = f"{title}|{choices}"
+    raw = f"{title}|{message}|{steps}|{choices}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
@@ -275,7 +286,12 @@ class AgentLoop:
                     item_id,
                     prompt,
                     timeout=float(timeout) if timeout else None,
+                    # The announced input_id MUST be passed through — a fresh
+                    # gate-generated id would make desktop resolve() calls
+                    # miss and every card block until timeout (CodeRabbit #711).
+                    input_id=input_id,
                     remember_key=_remember_key(payload) if allow_remember else None,
+                    choices=payload.get("choices", []),
                 )
             finally:
                 # Resolve the pending item (submitted/cancelled) and restore
@@ -310,21 +326,27 @@ class AgentLoop:
                 if remember_key is not None and submitted:
                     user_input_gate.remember(thread_id, remember_key, answers)
 
-                # Observability (issue #646, 功能描述⑤): audit trail
-                from miqi.agent.user_input_history import add_user_input_history
+                # Observability (issue #646, 功能描述⑤): audit trail.
+                # Best-effort and guarded — an audit failure inside finally
+                # must never replace the in-flight gate exception
+                # (CodeRabbit #711).
+                try:
+                    from miqi.agent.user_input_history import add_user_input_history
 
-                add_user_input_history(
-                    title=str(payload.get("title") or prompt),
-                    message=str(payload.get("message") or ""),
-                    choices=payload.get("choices", []),
-                    status="submitted" if submitted else "cancelled",
-                    choice_id=str(answers.get("choice_id", "")),
-                    choice_label=str(answers.get("choice_label", "")),
-                    reason="" if submitted else str((result or {}).get("reason", "cancelled")),
-                    thread_id=thread_id,
-                    turn_id=turn_id,
-                    input_id=input_id,
-                )
+                    add_user_input_history(
+                        title=str(payload.get("title") or prompt),
+                        message=str(payload.get("message") or ""),
+                        choices=payload.get("choices", []),
+                        status="submitted" if submitted else "cancelled",
+                        choice_id=str(answers.get("choice_id", "")),
+                        choice_label=str(answers.get("choice_label", "")),
+                        reason="" if submitted else str((result or {}).get("reason", "cancelled")),
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        input_id=input_id,
+                    )
+                except Exception:
+                    pass  # audit is best-effort, never blocks the turn
 
             if result is None:
                 # gate.request raised and the exception is propagating — a

--- a/miqi/kun_runtime/loop.py
+++ b/miqi/kun_runtime/loop.py
@@ -9,6 +9,7 @@ All dependencies are constructor-injected for testability.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import uuid
 from typing import Any, Literal
 
 from loguru import logger
@@ -22,6 +23,7 @@ from miqi.kun_runtime.model_client import (
 )
 from miqi.kun_runtime.stores import FileSessionStore, FileThreadStore
 from miqi.kun_runtime.tool_host import (
+    ASK_USER_CONFIRM_TOOL,
     ToolCallLike,
     ToolHostContext,
     ToolHostResult,
@@ -65,6 +67,20 @@ class AgentLoopOptions:
 
 PARALLEL_READ_ONLY_TOOL_NAMES = frozenset({"read", "grep", "find", "ls", "read_file", "list_dir", "web_search", "web_fetch", "paper_search", "paper_get"})
 MAX_PARALLEL_TOOL_CALLS = 3
+
+
+def _remember_key(payload: dict[str, Any]) -> str:
+    """Stable session-remember key: card title + normalized choices (issue #646)."""
+    import hashlib
+
+    title = str(payload.get("title", ""))
+    choices = sorted(
+        (str(c.get("id", "")), str(c.get("label", "")))
+        for c in (payload.get("choices") or [])
+        if isinstance(c, dict)
+    )
+    raw = f"{title}|{choices}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -159,6 +175,7 @@ class AgentLoop:
         await self._record_pipeline(thread_id, turn_id, "input_routed", {"model": model})
 
         approval_gate = self._opts.approval_gate
+        user_input_gate = self._opts.user_input_gate
 
         async def await_approval(payload: dict[str, Any]) -> Literal["allow", "deny"]:
             if approval_gate is None:
@@ -171,6 +188,153 @@ class AgentLoop:
                 payload,
             )
 
+        async def await_user_input(payload: dict[str, Any]) -> dict[str, Any]:
+            """Blocking human-in-the-loop confirmation (issue #646).
+
+            Emits user_input_requested, marks the turn waiting_for_user, and
+            waits on the user-input gate. Resolution (submitted/cancelled)
+            comes from the desktop via UserInputGate.resolve(); timeout or
+            turn cancellation resolves as cancelled.
+            """
+            if user_input_gate is None:
+                return {"status": "cancelled", "reason": "user_input_gate unavailable"}
+
+            # Session-level remember (issue #646): same thread + same card
+            # (title+choices) reuses the previous choice without popping a card.
+            allow_remember = bool(payload.get("allow_remember_choice"))
+            remember_key = _remember_key(payload) if allow_remember else None
+            if remember_key is not None:
+                cached = user_input_gate.remembered_choice(thread_id, remember_key)
+                if cached is not None:
+                    # Audit the reuse too — issue #646 requires a record of
+                    # every confirmation, including auto-resolved ones.
+                    try:
+                        from miqi.agent.user_input_history import add_user_input_history
+
+                        add_user_input_history(
+                            title=str(payload.get("title") or ""),
+                            message=str(payload.get("message") or ""),
+                            choices=payload.get("choices", []),
+                            status="submitted",
+                            choice_id=str(cached.get("choice_id", "")),
+                            choice_label=str(cached.get("choice_label", "")),
+                            reason="remembered",
+                            thread_id=thread_id,
+                            turn_id=turn_id,
+                            input_id="",
+                        )
+                    except Exception:
+                        pass  # audit is best-effort, never blocks the turn
+                    return {"status": "submitted", "answers": cached, "remembered": True}
+
+            input_id = f"user_input_{uuid.uuid4().hex[:12]}"
+            item_id = f"item_{turn_id}_{input_id[-6:]}"
+            prompt = str(payload.get("message") or payload.get("title") or "")
+
+            # Pending item + event so the desktop renders the confirm card
+            await self._opts.turns.apply_item(thread_id, {
+                "kind": "user_input",
+                "id": item_id,
+                "turnId": turn_id,
+                "threadId": thread_id,
+                "role": "system",
+                "inputId": input_id,
+                "prompt": prompt,
+                "status": "pending",
+                "title": payload.get("title"),
+                "message": payload.get("message"),
+                "steps": payload.get("steps", []),
+                "choices": payload.get("choices", []),
+                "timeout_seconds": payload.get("timeout_seconds"),
+                "allow_remember_choice": payload.get("allow_remember_choice", False),
+                "createdAt": self._opts.now_iso(),
+            })
+            await self._opts.events.record({
+                "kind": "user_input_requested",
+                "threadId": thread_id,
+                "turnId": turn_id,
+                "inputId": input_id,
+                "itemId": item_id,
+                "status": "pending",
+                "title": payload.get("title"),
+                "message": payload.get("message"),
+                "steps": payload.get("steps", []),
+                "choices": payload.get("choices", []),
+                "timeoutSeconds": payload.get("timeout_seconds"),
+                "allowRememberChoice": payload.get("allow_remember_choice", False),
+                "createdAt": self._opts.now_iso(),
+            })
+            await self._opts.turns.update_turn_status(thread_id, turn_id, "waiting_for_user")
+
+            result: dict[str, Any] | None = None
+            try:
+                timeout = payload.get("timeout_seconds")
+                result = await user_input_gate.request(
+                    thread_id,
+                    turn_id,
+                    item_id,
+                    prompt,
+                    timeout=float(timeout) if timeout else None,
+                    remember_key=_remember_key(payload) if allow_remember else None,
+                )
+            finally:
+                # Resolve the pending item (submitted/cancelled) and restore
+                # the turn to running. result may be None when request raised
+                # (e.g. turn cancellation) — every downstream read must go
+                # through the submitted/answers locals, never result.get()
+                # directly, or the cleanup itself raises AttributeError and
+                # masks the original exception (CodeRabbit #666).
+                submitted = result is not None and result.get("status") == "submitted"
+                answers = (result or {}).get("answers") or {}
+                item_patch = {
+                    "status": "submitted" if submitted else "cancelled",
+                    "resolution": answers or (None if submitted else {"status": "cancelled"}),
+                    "finishedAt": self._opts.now_iso(),
+                }
+                if item_patch.get("resolution") is None:
+                    item_patch["resolution"] = {}
+                await self._opts.turns.update_item(thread_id, item_id, item_patch)
+                await self._opts.events.record({
+                    "kind": "user_input_resolved",
+                    "threadId": thread_id,
+                    "turnId": turn_id,
+                    "inputId": input_id,
+                    "itemId": item_id,
+                    "status": "submitted" if submitted else "cancelled",
+                    "resolution": item_patch["resolution"],
+                    "createdAt": self._opts.now_iso(),
+                })
+                await self._opts.turns.update_turn_status(thread_id, turn_id, "running")
+
+                # Remember choice for this session (issue #646)
+                if remember_key is not None and submitted:
+                    user_input_gate.remember(thread_id, remember_key, answers)
+
+                # Observability (issue #646, 功能描述⑤): audit trail
+                from miqi.agent.user_input_history import add_user_input_history
+
+                add_user_input_history(
+                    title=str(payload.get("title") or prompt),
+                    message=str(payload.get("message") or ""),
+                    choices=payload.get("choices", []),
+                    status="submitted" if submitted else "cancelled",
+                    choice_id=str(answers.get("choice_id", "")),
+                    choice_label=str(answers.get("choice_label", "")),
+                    reason="" if submitted else str((result or {}).get("reason", "cancelled")),
+                    thread_id=thread_id,
+                    turn_id=turn_id,
+                    input_id=input_id,
+                )
+
+            if result is None:
+                # gate.request raised and the exception is propagating — a
+                # None result would crash the caller's build_result(); hand
+                # back a structured cancelled result instead (never reached
+                # when the exception propagates, but safe for gate impls
+                # that return None without raising).
+                return {"status": "cancelled", "reason": "user-input request failed", "answers": {"status": "cancelled"}}
+            return result
+
         # List tools
         tool_context = ToolHostContext(
             thread_id=thread_id,
@@ -178,9 +342,11 @@ class AgentLoop:
             workspace=thread.get("workspace", ""),
             thread_mode=thread.get("mode"),
             approval_policy=thread.get("approvalPolicy", "auto"),
+            autonomy_mode=thread.get("autonomyMode", "supervised"),
             abort_signal=token,
             active_skill_ids=turn.get("activeSkillIds", []),
             await_approval=await_approval if approval_gate is not None else None,
+            await_user_input=await_user_input if user_input_gate is not None else None,
         )
         tools = await self._opts.tool_host.list_tools(tool_context)
         tool_specs = [ModelToolSpec(
@@ -214,6 +380,12 @@ class AgentLoop:
             from miqi.kun_runtime.token_economy import TOKEN_ECONOMY_INSTRUCTION
             request.context_instructions = request.context_instructions or []
             request.context_instructions.append(TOKEN_ECONOMY_INSTRUCTION)
+
+        # ask_user_confirm_card usage guidance (issue #646, 功能描述④)
+        if any(t.name == ASK_USER_CONFIRM_TOOL for t in tool_specs):
+            from miqi.agent.tools.ask_user_confirm import ASK_USER_CONFIRM_INSTRUCTION
+            request.context_instructions = request.context_instructions or []
+            request.context_instructions.append(ASK_USER_CONFIRM_INSTRUCTION)
 
         await self._record_pipeline(thread_id, turn_id, "pre_send", {
             "model": model, "historyItems": len(history), "toolCount": len(tools),

--- a/miqi/kun_runtime/runtime.py
+++ b/miqi/kun_runtime/runtime.py
@@ -21,6 +21,7 @@ from miqi.kun_runtime.thread_service import ThreadService
 from miqi.kun_runtime.tool_host import MiQiToolHost
 from miqi.kun_runtime.turn_service import TurnService
 from miqi.kun_runtime.usage import UsageService
+from miqi.kun_runtime.user_input_gate import UserInputGate
 
 
 @dataclass
@@ -84,7 +85,7 @@ class KunRuntime:
 
         # Gates
         self.approval_gate: Any = None  # set later
-        self.user_input_gate: Any = None  # set later
+        self.user_input_gate = UserInputGate()  # issue #646: ask_user_confirm_card
 
         # Loop (created lazily)
         self._loop: AgentLoop | None = None

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -44,6 +44,7 @@ class ToolHostContext:
     workspace: str
     thread_mode: str | None = None
     approval_policy: str = "auto"
+    autonomy_mode: str = "supervised"  # collab gate: plan/manual/supervised/autonomous
     abort_signal: Any = None  # CancellationToken
     active_skill_ids: list[str] = field(default_factory=list)
     allowed_tool_names: list[str] | None = None
@@ -69,6 +70,9 @@ class ToolHostResult:
 _PARALLEL_SAFE_NAMES = frozenset({"read", "grep", "find", "ls", "list_dir", "read_file", "web_search", "web_fetch", "paper_search", "paper_get"})
 _NEVER_PARALLEL_NAMES = frozenset({"exec", "bash", "message", "spawn", "cron", "write", "edit", "delete", "move", "apply_patch", "edit_diff"})
 _MAX_PARALLEL_TOOL_CALLS = 3
+
+# AI-initiated user confirmation (issue #646): blocking human-in-the-loop tool
+ASK_USER_CONFIRM_TOOL = "ask_user_confirm_card"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -192,6 +196,78 @@ class MiQiToolHost:
                     "isError": True,
                 })
 
+        # Collaboration gate (issue #646, design v2): the harness — not the
+        # model — decides when a card is required. ask_user_confirm_card itself
+        # is exempt (it IS the card). External transfers / payments confirm in
+        # every autonomy mode; writes/exec confirm per the mode matrix.
+        from miqi.execution.collab_policy import (
+            AutonomyMode,
+            CollabVerdict,
+            evaluate as collab_evaluate,
+        )
+
+        if tool_name != ASK_USER_CONFIRM_TOOL and context.await_user_input is not None:
+            try:
+                collab_verdict = collab_evaluate(tool_name, AutonomyMode(context.autonomy_mode))
+            except (ValueError, KeyError):
+                collab_verdict = CollabVerdict.ALLOW
+            if collab_verdict == CollabVerdict.CONFIRM:
+                gate_result = await context.await_user_input({
+                    "threadId": context.thread_id,
+                    "turnId": context.turn_id,
+                    "toolName": tool_name,
+                    "title": f"确认执行：{tool_name}",
+                    "message": f"该操作需要你确认后才会执行（当前模式：{context.autonomy_mode}）。",
+                    "choices": [
+                        {"id": "confirm", "label": "确认执行"},
+                        {"id": "cancel", "label": "取消"},
+                    ],
+                    "timeout_seconds": 120,
+                })
+                answers = gate_result.get("answers") or {}
+                if gate_result.get("status") != "submitted" or answers.get("choice_id") != "confirm":
+                    return ToolHostResult(item={
+                        "kind": "tool_result",
+                        "id": f"item_{context.turn_id}_{call.call_id}",
+                        "turnId": context.turn_id,
+                        "threadId": context.thread_id,
+                        "role": "tool",
+                        "status": "cancelled",
+                        "createdAt": _now_iso(),
+                        "finishedAt": _now_iso(),
+                        "toolName": tool_name,
+                        "callId": call.call_id,
+                        "toolKind": _classify_tool_kind(tool_name),
+                        "output": "User cancelled the operation (policy confirmation).",
+                        "isError": True,
+                    })
+            elif collab_verdict == CollabVerdict.DENY:
+                return ToolHostResult(item={
+                    "kind": "tool_result",
+                    "id": f"item_{context.turn_id}_{call.call_id}",
+                    "turnId": context.turn_id,
+                    "threadId": context.thread_id,
+                    "role": "tool",
+                    "status": "failed",
+                    "createdAt": _now_iso(),
+                    "finishedAt": _now_iso(),
+                    "toolName": tool_name,
+                    "callId": call.call_id,
+                    "toolKind": _classify_tool_kind(tool_name),
+                    "output": f"Tool '{tool_name}' is blocked in {context.autonomy_mode} mode",
+                    "isError": True,
+                })
+
+        # AI-initiated user confirmation (issue #646): ask_user_confirm_card
+        # is a blocking human-in-the-loop tool. When the user-input channel is
+        # wired (KUN runtime), route through await_user_input so the desktop
+        # renders an inline confirm card and the turn pauses for the choice.
+        if (
+            tool_name == ASK_USER_CONFIRM_TOOL
+            and context.await_user_input is not None
+        ):
+            return await self._execute_user_confirm(call, context, args)
+
         # Execute
         try:
             result = await self._registry.execute(tool_name, args)
@@ -216,6 +292,53 @@ class MiQiToolHost:
             "toolName": tool_name,
             "callId": call.call_id,
             "toolKind": _classify_tool_kind(tool_name),
+            "output": result,
+            "isError": is_error,
+        })
+
+    async def _execute_user_confirm(
+        self,
+        call: ToolCallLike,
+        context: ToolHostContext,
+        args: dict[str, Any],
+    ) -> ToolHostResult:
+        """Execute the blocking ask_user_confirm_card tool via the user-input gate.
+
+        The turn pauses until the user picks a choice, times out, or the turn
+        is cancelled. Returns the structured decision as a tool result so the
+        model can continue / abort / re-plan.
+        """
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        try:
+            payload = AskUserConfirmCardTool.normalize_args(args)
+            gate_result = await context.await_user_input({
+                "threadId": context.thread_id,
+                "turnId": context.turn_id,
+                "toolName": call.tool_name,
+                **payload,
+            })
+            result = AskUserConfirmCardTool.build_result(gate_result)
+            is_error = False
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("ask_user_confirm_card failed")
+            result = f"Error: user confirmation failed: {exc}"
+            is_error = True
+
+        return ToolHostResult(item={
+            "kind": "tool_result",
+            "id": f"item_{context.turn_id}_{call.call_id}",
+            "turnId": context.turn_id,
+            "threadId": context.thread_id,
+            "role": "tool",
+            "status": "failed" if is_error else "completed",
+            "createdAt": _now_iso(),
+            "finishedAt": _now_iso(),
+            "toolName": call.tool_name,
+            "callId": call.call_id,
+            "toolKind": _classify_tool_kind(call.tool_name),
             "output": result,
             "isError": is_error,
         })

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -206,12 +206,32 @@ class MiQiToolHost:
             evaluate as collab_evaluate,
         )
 
-        if tool_name != ASK_USER_CONFIRM_TOOL and context.await_user_input is not None:
+        if tool_name != ASK_USER_CONFIRM_TOOL:
             try:
                 collab_verdict = collab_evaluate(tool_name, AutonomyMode(context.autonomy_mode))
             except (ValueError, KeyError):
-                collab_verdict = CollabVerdict.ALLOW
-            if collab_verdict == CollabVerdict.CONFIRM:
+                # Unparsable mode → evaluate under the most conservative mode
+                # instead of defaulting to ALLOW (CodeRabbit #711).
+                collab_verdict = collab_evaluate(tool_name, AutonomyMode.MANUAL)
+            if collab_verdict == CollabVerdict.DENY:
+                # DENY blocks in every context — including headless runs with
+                # no user-input channel (CodeRabbit #711).
+                return ToolHostResult(item={
+                    "kind": "tool_result",
+                    "id": f"item_{context.turn_id}_{call.call_id}",
+                    "turnId": context.turn_id,
+                    "threadId": context.thread_id,
+                    "role": "tool",
+                    "status": "failed",
+                    "createdAt": _now_iso(),
+                    "finishedAt": _now_iso(),
+                    "toolName": tool_name,
+                    "callId": call.call_id,
+                    "toolKind": _classify_tool_kind(tool_name),
+                    "output": f"Tool '{tool_name}' is blocked in {context.autonomy_mode} mode",
+                    "isError": True,
+                })
+            if collab_verdict == CollabVerdict.CONFIRM and context.await_user_input is not None:
                 gate_result = await context.await_user_input({
                     "threadId": context.thread_id,
                     "turnId": context.turn_id,
@@ -241,22 +261,9 @@ class MiQiToolHost:
                         "output": "User cancelled the operation (policy confirmation).",
                         "isError": True,
                     })
-            elif collab_verdict == CollabVerdict.DENY:
-                return ToolHostResult(item={
-                    "kind": "tool_result",
-                    "id": f"item_{context.turn_id}_{call.call_id}",
-                    "turnId": context.turn_id,
-                    "threadId": context.thread_id,
-                    "role": "tool",
-                    "status": "failed",
-                    "createdAt": _now_iso(),
-                    "finishedAt": _now_iso(),
-                    "toolName": tool_name,
-                    "callId": call.call_id,
-                    "toolKind": _classify_tool_kind(tool_name),
-                    "output": f"Tool '{tool_name}' is blocked in {context.autonomy_mode} mode",
-                    "isError": True,
-                })
+            # CONFIRM without a wired channel (headless/CLI): fall through to
+            # normal execution — the safety approval layer still backstops
+            # dangerous commands.
 
         # AI-initiated user confirmation (issue #646): ask_user_confirm_card
         # is a blocking human-in-the-loop tool. When the user-input channel is

--- a/miqi/kun_runtime/tool_storm_breaker.py
+++ b/miqi/kun_runtime/tool_storm_breaker.py
@@ -10,7 +10,9 @@ from typing import Any
 
 DEFAULT_WINDOW_SIZE = 8
 DEFAULT_THRESHOLD = 3
-STORM_EXEMPT_TOOLS = frozenset({"request_user_input", "user_input", "ask_user"})
+STORM_EXEMPT_TOOLS = frozenset({
+    "request_user_input", "user_input", "ask_user", "ask_user_confirm_card",
+})
 
 
 class ToolStormBreaker:

--- a/miqi/kun_runtime/turn_service.py
+++ b/miqi/kun_runtime/turn_service.py
@@ -255,7 +255,12 @@ class TurnService:
         })
         return updated
 
-    async def update_turn_status(self, thread_id: str, turn_id: str, status: str) -> bool:
+    async def update_turn_status(
+        self,
+        thread_id: str,
+        turn_id: str,
+        status: Literal["queued", "running", "waiting_for_user", "completed", "failed", "aborted"],
+    ) -> bool:
         """Set a turn's status (e.g. running → waiting_for_user → running).
 
         Returns True if the turn was found and updated. Used by the loop for

--- a/miqi/kun_runtime/turn_service.py
+++ b/miqi/kun_runtime/turn_service.py
@@ -255,6 +255,31 @@ class TurnService:
         })
         return updated
 
+    async def update_turn_status(self, thread_id: str, turn_id: str, status: str) -> bool:
+        """Set a turn's status (e.g. running → waiting_for_user → running).
+
+        Returns True if the turn was found and updated. Used by the loop for
+        the human-in-the-loop pause (issue #646).
+        """
+        thread = await self._thread_store.get(thread_id)
+        if thread is None:
+            return False
+        for turn in thread.get("turns", []):
+            if turn.get("id") == turn_id:
+                turn["status"] = status
+                # Refresh updatedAt before upsert so consumers that sort or
+                # invalidate by it observe the transition (issue #646 review).
+                thread["updatedAt"] = self._now_iso()
+                await self._thread_store.upsert(thread)
+                await self._events.record({
+                    "kind": "turn_status_changed",
+                    "threadId": thread_id,
+                    "turnId": turn_id,
+                    "status": status,
+                })
+                return True
+        return False
+
     async def get_turn(self, thread_id: str, turn_id: str) -> dict[str, Any] | None:
         """Return a turn record or None."""
         thread = await self._thread_store.get(thread_id)

--- a/miqi/kun_runtime/user_input_gate.py
+++ b/miqi/kun_runtime/user_input_gate.py
@@ -21,6 +21,7 @@ class UserInputRequest:
         item_id: str,
         prompt: str,
         questions: list[dict[str, Any]] | None = None,
+        remember_key: str | None = None,
     ):
         self.id = input_id
         self.thread_id = thread_id
@@ -28,6 +29,9 @@ class UserInputRequest:
         self.item_id = item_id
         self.prompt = prompt
         self.questions = questions or []
+        # Session-level remember key (issue #646): when the user checks
+        # "本次会话不再询问" the resolved choice is stored under this key.
+        self.remember_key = remember_key
         self._event = asyncio.Event()
         self._resolution: dict[str, Any] | None = None
 
@@ -67,6 +71,16 @@ class UserInputGate:
 
     def __init__(self) -> None:
         self._pending: dict[str, UserInputRequest] = {}
+        # Session-level remember (issue #646): thread_id → remember_key → choice
+        self._remembered: dict[str, dict[str, dict[str, Any]]] = {}
+
+    def remembered_choice(self, thread_id: str, key: str) -> dict[str, Any] | None:
+        """Return a remembered choice for this thread+key, or None."""
+        return self._remembered.get(thread_id, {}).get(key)
+
+    def remember(self, thread_id: str, key: str, answers: dict[str, Any]) -> None:
+        """Persist a choice for this thread+key (session-scoped, not permanent)."""
+        self._remembered.setdefault(thread_id, {})[key] = dict(answers)
 
     async def request(
         self,
@@ -75,9 +89,20 @@ class UserInputGate:
         item_id: str,
         prompt: str,
         questions: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        input_id: str | None = None,
+        remember_key: str | None = None,
     ) -> dict[str, Any]:
-        """Submit a user input request and wait for resolution."""
-        input_id = f"user_input_{uuid.uuid4().hex[:12]}"
+        """Submit a user input request and wait for resolution.
+
+        Args:
+            timeout: Optional seconds to wait before auto-cancelling.
+                None means wait indefinitely (e.g. CLI interactive).
+            input_id: Optional explicit request id (must match the id already
+                announced to the caller/desktop). Defaults to a fresh one.
+        """
+        if input_id is None:
+            input_id = f"user_input_{uuid.uuid4().hex[:12]}"
         req = UserInputRequest(
             input_id=input_id,
             thread_id=thread_id,
@@ -85,19 +110,27 @@ class UserInputGate:
             item_id=item_id,
             prompt=prompt,
             questions=questions,
+            remember_key=remember_key,
         )
         self._pending[input_id] = req
         try:
-            return await req.wait()
+            return await req.wait(timeout=timeout)
         finally:
             self._pending.pop(input_id, None)
 
-    def resolve(self, input_id: str, answers: dict[str, str] | None = None) -> bool:
-        """Resolve a pending user input request. Returns True if it existed."""
+    def resolve(self, input_id: str, answers: dict[str, str] | None = None, remember: bool = False) -> bool:
+        """Resolve a pending user input request. Returns True if it existed.
+
+        When *remember* is True and the request carries a remember key, the
+        submitted choice is stored for this thread so the same card is
+        auto-resolved on later calls (issue #646).
+        """
         req = self._pending.get(input_id)
         if req is None:
             return False
         req.resolve(answers)
+        if remember and req.remember_key and answers:
+            self.remember(req.thread_id, req.remember_key, dict(answers))
         return True
 
     def cancel_all(self, turn_id: str) -> None:

--- a/miqi/kun_runtime/user_input_gate.py
+++ b/miqi/kun_runtime/user_input_gate.py
@@ -22,6 +22,7 @@ class UserInputRequest:
         prompt: str,
         questions: list[dict[str, Any]] | None = None,
         remember_key: str | None = None,
+        choices: list[dict[str, Any]] | None = None,
     ):
         self.id = input_id
         self.thread_id = thread_id
@@ -29,6 +30,9 @@ class UserInputRequest:
         self.item_id = item_id
         self.prompt = prompt
         self.questions = questions or []
+        # Card choices ({id,label,role?}) so resolve() can annotate the
+        # answer with the semantic choice_role (issue #646 review).
+        self.choices = choices or []
         # Session-level remember key (issue #646): when the user checks
         # "本次会话不再询问" the resolved choice is stored under this key.
         self.remember_key = remember_key
@@ -62,7 +66,11 @@ class UserInputRequest:
         try:
             await asyncio.wait_for(self._event.wait(), timeout=timeout)
         except asyncio.TimeoutError:
-            self._resolution = {"status": "cancelled"}
+            # A resolve() that landed just before the timer expired already
+            # set _resolution — overwriting it would discard the user's
+            # submitted choice and report cancelled (CodeRabbit #711).
+            if self._resolution is None:
+                self._resolution = {"status": "cancelled"}
         return self._resolution or {"status": "cancelled"}
 
 
@@ -92,6 +100,7 @@ class UserInputGate:
         timeout: float | None = None,
         input_id: str | None = None,
         remember_key: str | None = None,
+        choices: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Submit a user input request and wait for resolution.
 
@@ -100,6 +109,8 @@ class UserInputGate:
                 None means wait indefinitely (e.g. CLI interactive).
             input_id: Optional explicit request id (must match the id already
                 announced to the caller/desktop). Defaults to a fresh one.
+            choices: Card choices so resolve() can annotate the answer with
+                the semantic choice_role.
         """
         if input_id is None:
             input_id = f"user_input_{uuid.uuid4().hex[:12]}"
@@ -111,6 +122,7 @@ class UserInputGate:
             prompt=prompt,
             questions=questions,
             remember_key=remember_key,
+            choices=choices,
         )
         self._pending[input_id] = req
         try:
@@ -128,6 +140,18 @@ class UserInputGate:
         req = self._pending.get(input_id)
         if req is None:
             return False
+        if answers and req.choices:
+            # Annotate the answer with the semantic choice_role so tool
+            # results can classify cancel/adjust without hard-coding ids
+            # (issue #646 review).
+            cid = str(answers.get("choice_id", ""))
+            for c in req.choices:
+                if isinstance(c, dict) and str(c.get("id", "")) == cid:
+                    role = c.get("role")
+                    if role:
+                        answers = dict(answers)
+                        answers["choice_role"] = str(role)
+                    break
         req.resolve(answers)
         if remember and req.remember_key and answers:
             self.remember(req.thread_id, req.remember_key, dict(answers))
@@ -145,6 +169,10 @@ class UserInputGate:
         if turn_id is None:
             return list(self._pending.values())
         return [r for r in self._pending.values() if r.turn_id == turn_id]
+
+    def pending_request(self, input_id: str) -> UserInputRequest | None:
+        """Return the pending request for *input_id*, or None."""
+        return self._pending.get(input_id)
 
     @property
     def pending_count(self) -> int:

--- a/miqi/runtime/agent_registry.py
+++ b/miqi/runtime/agent_registry.py
@@ -162,6 +162,7 @@ class AgentRegistry:
                 "session_search", "task_begin", "task_end",
                 "skill_manage", "message", "spawn",
                 "paper_search", "paper_get", "paper_download",
+                "ask_user_confirm_card",
             ],
         ))
 

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -571,6 +571,19 @@ class TaskRunner:
             "具体文章页面，不要批量抓取 RSS 聚合源或新闻站点首页。"
         )
 
+        # ask_user_confirm_card usage guidance (issue #646, 功能描述④) —
+        # mirrors the KUN loop injection: when the tool is exposed to the
+        # model, the prompt must tell it WHEN to call it.
+        if any(
+            (t.get("function", {}) or {}).get("name") == "ask_user_confirm_card"
+            or t.get("name") == "ask_user_confirm_card"
+            for t in tools
+            if isinstance(t, dict)
+        ):
+            from miqi.agent.tools.ask_user_confirm import ASK_USER_CONFIRM_INSTRUCTION
+
+            effective_system_prompt += "\n\n" + ASK_USER_CONFIRM_INSTRUCTION
+
         # ── Inject session workspace into the prompt ─────────────────────
         # The AI must know its working directory without needing `pwd`.
         # Inside a bwrap/WSL sandbox `pwd` returns the fixed sandbox path

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -761,15 +761,28 @@ class TaskRunner:
                 ))
                 return
 
-            result = await self.services.turn_runner.run(
-                turn=turn,
-                user_content=msg.content,
-                system_prompt=effective_system_prompt,
-                tools=tools,
-                history=history,
-                cancel_event=cancel_evt,
-                steer_queue=steer_queue,
+            # Publish the turn identity for the user-input resolver: the
+            # model's tool args carry no thread/turn ids, and without them
+            # remember scoping + turn cancellation silently break
+            # (issue #646 / CodeRabbit #711).
+            from miqi.agent.user_input_resolver import (
+                clear_thread_context,
+                set_thread_context,
             )
+
+            set_thread_context(thread_id, turn_id)
+            try:
+                result = await self.services.turn_runner.run(
+                    turn=turn,
+                    user_content=msg.content,
+                    system_prompt=effective_system_prompt,
+                    tools=tools,
+                    history=history,
+                    cancel_event=cancel_evt,
+                    steer_queue=steer_queue,
+                )
+            finally:
+                clear_thread_context()
 
             # Persist assistant messages to all stores in a single pass.
             # Build the extra-fields mapping once per message so every

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -203,6 +203,14 @@ def create_runtime_tool_registry(
 
     registry = ToolRegistry()
 
+    # 0. AI-initiated user confirmation (issue #646): registered for schema
+    #    exposure; execution blocks on the shared user-input gate so the
+    #    desktop can render the confirm card (legacy bridge path).
+    from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+    from miqi.agent.user_input_resolver import make_resolver
+
+    registry.register(AskUserConfirmCardTool(resolver=make_resolver()))
+
     # 1. Filesystem tools
     for cls in (ReadFileTool, ListDirTool):
         registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm, shared_roots=_read_shared_roots))

--- a/scripts/e2e_ask_user_confirm.py
+++ b/scripts/e2e_ask_user_confirm.py
@@ -94,7 +94,7 @@ def _preview(msg) -> str:
     return text if text else "(工具结果，见上)"
 
 
-async def main() -> None:
+async def main() -> int:
     print("=" * 64)
     print("E2E: ask_user_confirm_card — 模型调用 → 卡片 → 用户选择 → 回传")
     print("=" * 64)
@@ -179,4 +179,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main()) or 1)
+    sys.exit(asyncio.run(main()))

--- a/scripts/e2e_ask_user_confirm.py
+++ b/scripts/e2e_ask_user_confirm.py
@@ -1,0 +1,182 @@
+"""E2E: ask_user_confirm_card 全链路（issue #646）.
+
+模拟真实桌面场景：
+  模型(第1轮) 调用 ask_user_confirm_card
+    → KUN loop 发 user_input_requested 事件 + turn 转 waiting_for_user
+    → 脚本扮演"用户"点击卡片（gate.resolve）
+    → 工具结果 {"status":"confirmed","choice_id":...} 回传给模型
+  模型(第2轮) 收到确认，输出最终文本
+    → turn 完成
+
+运行：
+  cd D:\\Desktop\\811\\MiQi
+  PYTHONPATH=. .venv/Scripts/python.exe scripts/e2e_ask_user_confirm.py
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from miqi.agent.tools.registry import ToolRegistry
+from miqi.kun_runtime.model_client import FakeModelClient
+from miqi.kun_runtime.runtime import KunRuntime, RuntimeOptions
+
+
+class RoundRobinModel(FakeModelClient):
+    """Per-round responses: round 0 → confirm-card tool call, round 1 → final text."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = "fake-model"
+        self.provider_name = "RoundRobinModel"
+
+    async def stream(self, request):
+        self._requests.append(request)
+        round_no = len(self._requests) - 1
+        print(f"\n  ── [模型] 第 {round_no + 1} 轮请求 ──")
+        if round_no == 0:
+            print("  [模型] 决定调用 ask_user_confirm_card（上传前确认）")
+            yield await _chunk("tool_call_complete", {
+                "id": "call_confirm_1",
+                "name": "ask_user_confirm_card",
+                "arguments": {
+                    "title": "方案已完成，是否上传到 Qraft？",
+                    "message": "工作流方案已生成并通过校验，上传后将作为 WorkflowDefinition 发布到 Qraft 平台。",
+                    "steps": [
+                        {"id": "search_papers", "title": "搜索并下载相关论文"},
+                        {"id": "extract_info", "title": "提取 MOF-5 合成路线与成本信息"},
+                        {"id": "query_price", "title": "查询供应商价格（国内）"},
+                        {"id": "generate_report", "title": "生成最终报告"},
+                    ],
+                    "choices": [
+                        {"id": "confirm", "label": "确认上传"},
+                        {"id": "cancel", "label": "取消"},
+                    ],
+                    "timeout_seconds": 30,
+                    "allow_remember_choice": True,
+                },
+            })
+            yield await _chunk("completed", {"stopReason": "tool_calls"})
+            return
+
+        # Round 1: 工具结果已回传，模型确认并继续
+        last_user = request.history[-1] if request.history else None
+        print(f"  [模型] 收到工具结果: {_preview(last_user)}")
+        for text in ["好的，已确认上传。WorkflowDefinition 已发布到 Qraft，项目入口：forge.miqroera.com/projects/mof-price-report。"]:
+            yield await _chunk("assistant_text_delta", {"text": text})
+        yield await _chunk("completed", {"stopReason": "stop"})
+
+
+def _chunk(kind: str, data: dict):
+    from miqi.kun_runtime.model_client import ModelStreamChunk
+
+    if kind == "tool_call_complete":
+        return _a(ModelStreamChunk(
+            kind=kind,
+            callId=data.get("id", "call_1"),
+            toolName=data.get("name", "unknown"),
+            arguments=data.get("arguments", {}),
+        ))
+    return _a(ModelStreamChunk(kind=kind, **data))
+
+
+async def _a(value):
+    return value
+
+
+def _preview(msg) -> str:
+    if not msg:
+        return "(无)"
+    text = str(msg.get("content", ""))[:160]
+    return text if text else "(工具结果，见上)"
+
+
+async def main() -> None:
+    print("=" * 64)
+    print("E2E: ask_user_confirm_card — 模型调用 → 卡片 → 用户选择 → 回传")
+    print("=" * 64)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "data"
+        ws = Path(tmp) / "ws"
+        ws.mkdir(parents=True, exist_ok=True)
+
+        runtime = KunRuntime(RuntimeOptions(
+            data_dir=data_dir,
+            workspace=str(ws),
+            model="fake-model",
+        ))
+
+        # 注册真实工具集（含 ask_user_confirm_card）
+        from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+        from miqi.config.loader import load_config
+
+        config = load_config() if hasattr(load_config, "__call__") else None
+        # 轻量 registry：只挂确认卡工具
+        registry = ToolRegistry()
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        registry.register(AskUserConfirmCardTool())
+        runtime.set_tool_registry(registry)
+
+        model = RoundRobinModel()
+        runtime.model = model  # 直接注入假模型（不走 set_provider）
+
+        # 建线程 + 起 turn
+        thread = await runtime.threads.create(workspace=str(ws), model="fake-model")
+        thread_id = thread["id"]
+        turn = await runtime.turns.start_turn(thread_id, "帮我查 MOF-5 市场合成价格并上传方案")
+        turn_id = turn["turnId"]
+        print(f"\n线程 {thread_id} / Turn {turn_id} 启动\n")
+
+        # ── 模拟用户：等卡片出现后点击「确认上传」 ──
+        async def fake_user():
+            deadline = time.time() + 15
+            while time.time() < deadline:
+                pend = runtime.user_input_gate.get_pending()
+                if pend:
+                    req = pend[0]
+                    print(f"\n  👤 [用户] 看到确认卡: 「{req.prompt[:40]}…」")
+                    print(f"  👤 [用户] 点击「确认上传」→ gate.resolve({req.id})")
+                    runtime.user_input_gate.resolve(
+                        req.id, {"choice_id": "confirm", "choice_label": "确认上传"}
+                    )
+                    return
+                await asyncio.sleep(0.1)
+            print("  ⚠ [用户] 15s 内未等到卡片")
+
+        # ── 事件监听：打印 user_input 事件流 ──
+        async def watcher():
+            async for event in runtime.event_bus.subscribe(thread_id):
+                kind = event.get("kind", "")
+                if kind in ("user_input_requested", "user_input_resolved", "turn_status_changed", "turn_completed"):
+                    brief = {k: v for k, v in event.items() if k in ("kind", "inputId", "status", "choice_id", "resolution")}
+                    print(f"  📡 [事件] {kind}: {brief}")
+
+        asyncio.get_event_loop().create_task(watcher())
+        asyncio.get_event_loop().create_task(fake_user())
+
+        # ── 跑 turn ──
+        result = await runtime.loop.run_turn(thread_id, turn_id)
+        print(f"\n{'=' * 64}\nTurn 结果: {result}\n{'=' * 64}")
+
+        # ── 验证最终消息 ──
+        items = await runtime.session_store.load_items(thread_id)
+        texts = [i.get("content", "") for i in items if i.get("role") == "assistant" and i.get("content")]
+        print("\n✅ 最终消息:")
+        for t in texts:
+            print(f"   {t[:100]}")
+
+        has_confirm_tool = any(i.get("kind") == "tool_call" and i.get("toolName") == "ask_user_confirm_card" for i in items)
+        has_result = any("confirmed" in str(i.get("output", "")) for i in items if i.get("kind") == "tool_result")
+        ok = has_confirm_tool and has_result and result == "completed"
+        print(f"\n验证: 确认卡工具调用记录={'✓' if has_confirm_tool else '✗'} | 确认结果回传={'✓' if has_result else '✗'}")
+        print("E2E 完成 ✅" if ok else "E2E 异常 ❌")
+        return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()) or 1)

--- a/scripts/mock_openai.py
+++ b/scripts/mock_openai.py
@@ -1,0 +1,335 @@
+"""Mock OpenAI-compatible server for desktop E2E (issue #646) — full flow.
+
+State machine driven by tool results already in the request history:
+
+  Round 1: tool_call → ask_user_confirm_card #1 (确认执行方案?, 4 steps)
+  Round 2: confirmed → tool_call → web_search (real tool, actually runs)
+  Round 3: web_search done → tool_call → write_file (WorkflowDefinition JSON)
+  Round 4: file written → tool_call → ask_user_confirm_card #2 (是否上传到 Qraft?)
+  Round 5: confirmed → final text (uploaded + project link)
+
+Run:  PYTHONPATH=. .venv/Scripts/python.exe scripts/mock_openai.py
+"""
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+EXEC_TITLE = "确认执行方案？"
+EXEC_MESSAGE = "我将执行 4 个步骤（涉及外网论文下载与价格查询），开始前需要你确认。"
+EXEC_STEPS = [
+    {"id": "search_papers", "title": "搜索并下载相关论文"},
+    {"id": "extract_info", "title": "提取 MOF-5 合成路线与成本信息"},
+    {"id": "query_price", "title": "查询供应商价格（国内）"},
+    {"id": "generate_report", "title": "生成最终报告"},
+]
+EXEC_CHOICES = [
+    {"id": "confirm", "label": "确认执行"},
+    {"id": "adjust", "label": "调整方案"},
+    {"id": "cancel", "label": "取消"},
+]
+
+UPLOAD_TITLE = "方案已完成，是否上传到 Qraft？"
+UPLOAD_MESSAGE = "工作流方案已生成并通过校验，上传后将作为 WorkflowDefinition 发布到 Qraft 平台。"
+UPLOAD_CHOICES = [
+    {"id": "confirm", "label": "确认上传"},
+    {"id": "cancel", "label": "取消"},
+]
+
+def _build_steps(text: str) -> list[dict]:
+    """动态生成步骤：解析用户调整要求（步数/市场/复杂度），模拟 LLM 理解。"""
+    import re
+
+    n = 3
+    # Bounded digit run — avoids CodeQL py/polynomial-redos on long inputs.
+    m = re.search(r"(\d{1,4})\s*步", text[:200])
+    if m:
+        n = max(3, min(int(m.group(1)), 10))
+    market = "海外" if ("海外" in text or "国外" in text or "全球" in text) else ("国内" if "国内" in text else "市场")
+    complex_ = any(k in text for k in ("复杂", "足够", "完整", "详细", "全面"))
+    if complex_ and n < 5:
+        n = 5  # 要求"复杂/完整"时至少 5 步
+
+    steps = [
+        {"id": "search_lit", "title": f"搜索{market}文献（MOF-5 合成）"},
+        {"id": "extract", "title": f"提取{market}合成路线与成本"},
+    ]
+    if n >= 4:
+        steps.append({"id": "benchmark", "title": f"对比{market}主流合成工艺（溶剂/温度/产率）"})
+    if n >= 5:
+        steps.append({"id": "sensitivity", "title": "成本敏感性分析（原料价格波动影响）"})
+    if complex_ and n >= 6:
+        steps.append({"id": "validate", "title": "交叉验证数据来源与精度"})
+    steps.append({"id": "report", "title": "生成最终报告"})
+    extras = ["供应商报价", "纯度与等级", "供应链风险", "政策与环保影响"]
+    while len(steps) < n:
+        steps.append({"id": f"step_extra_{len(steps)}", "title": f"补充分析：{extras[len(steps) % len(extras)]}"})
+    return steps[:max(n, 3)]
+
+
+WORKFLOW_JSON = {
+    "spec_version": "1.0.0",
+    "document_kind": "workflow_definition",
+    "metadata": {
+        "id": "com.acme.mof-price-report",
+        "name": "mof-price-report",
+        "title": "MOF-5 市场合成价格报告",
+        "version": "1.0.0",
+        "description": "查询 MOF-5 合成成本与市场价格并生成报告",
+    },
+    "interface": {},
+    "activation": {"policy": "explicit"},
+    "inputs": [],
+    "parameters": [],
+    "execution": {
+        "default_mode": "full",
+        "entrypoints": [{"id": "run", "mode": "full", "executor": {"type": "shell"}}],
+        "backend_policy": {"strategy": "fixed", "backends": [{"id": "local", "kind": "local"}]},
+    },
+    "graph": {
+        "nodes": [
+            {"id": "step1", "title": "步骤一", "kind": "task", "executor": {"type": "shell"},
+             "presentation": {"data_view": {}, "action_view": {}}},
+            {"id": "step2", "title": "步骤二", "kind": "task", "executor": {"type": "shell"},
+             "presentation": {"data_view": {}, "action_view": {}}},
+            {"id": "step3", "title": "步骤三", "kind": "task", "executor": {"type": "shell"},
+             "presentation": {"data_view": {}, "action_view": {}}},
+            {"id": "step4", "title": "步骤四", "kind": "task", "executor": {"type": "shell"},
+             "presentation": {"data_view": {}, "action_view": {}}},
+        ],
+        "edges": [],
+    },
+    "completion": [{"id": "done", "description": "完成", "severity": "success"}],
+}
+
+
+def _tool_result(messages):
+    """Collect (tool_name, output) of the LAST ask_user_confirm_card result."""
+    results = []
+    for m in messages:
+        if m.get("role") == "tool":
+            try:
+                parsed = json.loads(m.get("content", "{}"))
+                # Keep only dict-shaped results — web_search/write_file may
+                # return JSON arrays or strings (issue #646 review).
+                if isinstance(parsed, dict):
+                    results.append(parsed)
+            except Exception:
+                results.append({})
+    return results
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_sse(self, obj, streamed=True):
+        """Streaming (stream:true) response in OpenAI SSE format.
+
+        The OpenAI SDK only parses `text/event-stream` bodies: a plain JSON
+        body served to a stream:true request yields zero chunks and the
+        provider completes with an empty response (desktop turns then end
+        with no content). Emit one full message chunk + a finish chunk +
+        [DONE], matching real OpenAI-compatible providers.
+        """
+        msg = obj["choices"][0]["message"]
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            delta = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "index": i,
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": tc["function"],
+                    }
+                    for i, tc in enumerate(tool_calls)
+                ],
+            }
+            finish = obj["choices"][0].get("finish_reason") or "tool_calls"
+        else:
+            delta = {"role": "assistant", "content": msg.get("content") or ""}
+            finish = obj["choices"][0].get("finish_reason") or "stop"
+        chunk1 = {
+            "id": obj.get("id", "mock"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-model"),
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+        chunk2 = {
+            "id": obj.get("id", "mock"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-model"),
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+        }
+        body = (
+            "data: " + json.dumps(chunk1, ensure_ascii=False) + "\n\n"
+            "data: " + json.dumps(chunk2, ensure_ascii=False) + "\n\n"
+            "data: [DONE]\n\n"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _respond(self, obj):
+        """Respond to a chat.completions call in the requested format."""
+        if self._stream_requested:
+            self._send_sse(obj)
+        else:
+            self._send(200, obj)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._send(200, {"object": "list", "data": [{"id": "mock-model", "object": "model"}]})
+        else:
+            self._send(404, {"error": {"message": "not found"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            req = json.loads(raw)
+        except Exception:
+            self._send(400, {"error": {"message": "bad json"}})
+            return
+        if not self.path.startswith("/v1/chat/completions"):
+            self._send(404, {"error": {"message": "not found"}})
+            return
+
+        # stream:true responses must be SSE — plain JSON yields 0 chunks.
+        self._stream_requested = bool(req.get("stream"))
+        messages = req.get("messages", [])
+        results = _tool_result(messages)
+
+        # 用 assistant 消息里的 tool_call 序列判断流程进度（可靠，不看结果内容）
+        calls_seen: list[str] = []
+        for m in messages:
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                for tc in m["tool_calls"]:
+                    name = (tc.get("function") or {}).get("name", "")
+                    if name:
+                        calls_seen.append(name)
+        n_search = calls_seen.count("web_search")
+        n_write = calls_seen.count("write_file")
+        n_confirm_cards = sum(1 for r in results if r.get("status") == "confirmed")
+
+        def tc(name, args, cid="call_x"):
+            return {
+                "id": cid,
+                "object": "chat.completion",
+                "created": 0,
+                "model": "mock-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": None, "tool_calls": [{
+                        "id": cid, "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args, ensure_ascii=False)},
+                    }]},
+                    "finish_reason": "tool_calls",
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+            }
+
+        def text(content):
+            return {
+                "id": "mock-final", "object": "chat.completion", "created": 0, "model": "mock-model",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+            }
+
+        # ── state machine（按工具调用序列推进） ──
+        if not results:
+            print("  [mock] R1 → 确认执行方案卡（4 步骤）")
+            self._respond(tc("ask_user_confirm_card", {
+                "title": EXEC_TITLE, "message": EXEC_MESSAGE,
+                "steps": EXEC_STEPS, "choices": EXEC_CHOICES,
+                "timeout_seconds": 60, "allow_remember_choice": True,
+            }, "call_exec_confirm"))
+            return
+
+        last = results[-1] if results else {}
+        last_role = messages[-1].get("role") if messages else ""
+        had_adjust = any(r.get("choice_id") == "adjust" for r in results)
+
+        # 调整闭环：用户已点"调整方案"并输入了调整内容 → 弹调整后方案卡
+        if had_adjust and last_role == "user":
+            user_text = str(messages[-1].get("content", "")).strip()
+            print(f"  [mock] 收到调整输入「{user_text[:30]}」→ 动态生成方案", flush=True)
+            steps = _build_steps(user_text)
+            self._respond(tc("ask_user_confirm_card", {
+                "title": EXEC_TITLE,
+                "message": f"已按你的要求调整（{user_text[:60]}），请再次确认。",
+                "steps": steps, "choices": EXEC_CHOICES,
+                "timeout_seconds": 60,
+            }, "call_exec_confirm_2"))
+            return
+
+        # 刚点了"调整方案" → 引导用户输入调整内容（卡片不承担 controller）
+        if last.get("choice_id") == "adjust":
+            print("  [mock] 用户选择调整 → 引导输入", flush=True)
+            self._respond(text(
+                "好的，请告诉我如何调整方案。\n"
+                "例如：市场改为海外、文献限定 2 篇、只保留前 3 步……"
+            ))
+            return
+
+        if last.get("status") == "cancelled":
+            print(f"  [mock] 用户取消（{last.get('reason','')}）→ 结束", flush=True)
+            self._respond(text("好的，已取消。需要调整方案随时告诉我。"))
+            return
+
+        # confirmed 流程推进（按已发生的工具调用）
+        if n_confirm_cards == 1 and n_search == 0:
+            print("  [mock] R2 → 真实执行 web_search（MOF-5 合成价格）", flush=True)
+            self._respond(tc("web_search", {"query": "MOF-5 metal-organic framework synthesis cost price", "max_results": 3}, "call_search"))
+            return
+        if n_confirm_cards == 1 and n_write == 0:
+            print("  [mock] R3 → 真实执行 write_file（生成 WorkflowDefinition JSON）", flush=True)
+            self._respond(tc("write_file", {
+                "path": "mof-price-report.workflow.json",
+                "content": json.dumps(WORKFLOW_JSON, ensure_ascii=False, indent=2),
+            }, "call_write"))
+            return
+        if n_confirm_cards == 1:
+            print("  [mock] R4 → 上传确认卡", flush=True)
+            self._respond(tc("ask_user_confirm_card", {
+                "title": UPLOAD_TITLE, "message": UPLOAD_MESSAGE,
+                "choices": UPLOAD_CHOICES, "timeout_seconds": 60,
+            }, "call_upload_confirm"))
+            return
+
+        print("  [mock] R5 → 上传确认收到 confirmed，输出最终结果", flush=True)
+        self._respond(text(
+            "✅ 已完成并上传：\n"
+            "- 工作流：MOF-5 市场合成价格报告（4 节点）\n"
+            "- 文件：mof-price-report.workflow.json（已生成在工作区）\n"
+            "- 校验：WorkflowSpec v1.0.0 通过\n"
+            "- 项目入口：forge.miqroera.com/projects/mof-price-report"
+        ))
+
+
+if __name__ == "__main__":
+    # Optional port argument: E2E passes an ephemeral port so parallel
+    # workers / CI retries never collide on 8899. Port 0 lets the OS pick.
+    import sys
+
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8899
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    # Print the ACTUAL bound port — with port 0 it differs from argv.
+    actual_port = server.server_address[1]
+    print(f"Mock OpenAI server on http://127.0.0.1:{actual_port}/v1", flush=True)
+    server.serve_forever()

--- a/tests/bridge/test_phase69_core_contract_audit.py
+++ b/tests/bridge/test_phase69_core_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan69_reduces_legacy_method_count():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 160  # +1 for sessions.rename, +1 for sessions.listRecentWorkspaces
+        assert len(catalog["methods"]) == 161  # +1 sessions.rename, +1 listRecentWorkspaces, +1 userInput.resolve (issue #646)
         assert len(typed) >= 44
         assert len(legacy) <= 110
     finally:

--- a/tests/bridge/test_phase70_plugin_skill_contract_audit.py
+++ b/tests/bridge/test_phase70_plugin_skill_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan70_plugin_skill_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 160  # +1 for sessions.rename, +1 for sessions.listRecentWorkspaces
+        assert len(catalog["methods"]) == 161  # +1 sessions.rename, +1 listRecentWorkspaces, +1 userInput.resolve (issue #646)
         assert len(typed) >= 56
         assert len(legacy) <= 98
     finally:

--- a/tests/bridge/test_phase71_session_contract_audit.py
+++ b/tests/bridge/test_phase71_session_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan71_session_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 160  # +1 for sessions.rename, +1 for sessions.listRecentWorkspaces
+        assert len(catalog["methods"]) == 161  # +1 sessions.rename, +1 listRecentWorkspaces, +1 userInput.resolve (issue #646)
         assert len(typed) >= 65
         assert len(legacy) <= 89
     finally:

--- a/tests/bridge/test_phase72_thread_contract_audit.py
+++ b/tests/bridge/test_phase72_thread_contract_audit.py
@@ -54,7 +54,7 @@ async def test_plan72_primary_thread_contract_counts():
         typed = [item for item in catalog["methods"] if item["stability"] != "legacy"]
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
-        assert len(catalog["methods"]) == 160  # +1 for sessions.rename, +1 for sessions.listRecentWorkspaces
+        assert len(catalog["methods"]) == 161  # +1 sessions.rename, +1 listRecentWorkspaces, +1 userInput.resolve (issue #646)
         assert len(typed) >= 83
         assert len(legacy) <= 77  # +1 legacy: sessions.rename, +1 legacy: sessions.list_recent_workspaces
     finally:

--- a/tests/fixtures/protocol/app_protocol_snapshot.v1.json
+++ b/tests/fixtures/protocol/app_protocol_snapshot.v1.json
@@ -5487,6 +5487,21 @@
         "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
         "emits": [],
         "eventSchemas": {},
+        "method": "userInput.resolve",
+        "paramsSchema": {
+          "type": "object"
+        },
+        "resultSchema": {
+          "type": "object"
+        },
+        "scope": "session",
+        "stability": "legacy"
+      },
+      {
+        "deprecatedBy": null,
+        "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
+        "emits": [],
+        "eventSchemas": {},
         "method": "workbench/process/history",
         "paramsSchema": {
           "type": "object"
@@ -5537,8 +5552,8 @@
     "source": "miqi.runtime.export_app_protocol_ts.render_typescript_contract"
   },
   "methodCounts": {
-    "legacy": 76,
-    "total": 160,
+    "legacy": 77,
+    "total": 161,
     "typed": 84
   },
   "schemaVersion": 1

--- a/tests/kun_runtime/test_ask_user_confirm_card.py
+++ b/tests/kun_runtime/test_ask_user_confirm_card.py
@@ -364,6 +364,61 @@ class TestLegacyResolverPath:
         assert result.startswith("Error")
         assert "不要假设用户已同意" in result
 
+    def test_remembered_choice_skips_card_on_legacy_path(self):
+        """Legacy resolver reuses the remembered choice without re-emitting."""
+        import json as _json
+
+        from miqi.agent.user_input_resolver import (
+            resolve_user_input,
+            set_user_input_emitter,
+        )
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        emissions = []
+
+        async def emitter(payload):
+            emissions.append(payload)
+
+        set_user_input_emitter("", emitter)
+        try:
+            tool = AskUserConfirmCardTool(resolver=make_resolver())
+            args = {
+                "title": "确认执行方案？",
+                "message": "4 个步骤",
+                "timeout_seconds": 5,
+                "allow_remember_choice": True,
+            }
+
+            async def scenario():
+                first = asyncio.create_task(tool.execute(**args))
+                for _ in range(50):
+                    if emissions:
+                        break
+                    await asyncio.sleep(0.02)
+                assert len(emissions) == 1, "首次应弹卡"
+                ok = resolve_user_input(
+                    emissions[0]["input_id"],
+                    {"choice_id": "confirm", "choice_label": "确认执行"},
+                    remember=True,
+                )
+                assert ok
+                first_result = await first
+                # 第二次：同卡片应命中 remember，不再发射事件
+                second = await tool.execute(**args)
+                return first_result, second, len(emissions)
+
+            first_result, second, n_emissions = asyncio.run(scenario())
+        finally:
+            set_user_input_emitter("", None)
+
+        first = _json.loads(first_result)
+        assert first["status"] == "confirmed"
+        second = _json.loads(second)
+        assert second["status"] == "confirmed"
+        assert second.get("remembered") is True
+        assert second["choice_id"] == "confirm"
+        assert n_emissions == 1, "remember 命中后不应再次弹卡"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Regression: gate.request() raising must not mask the original error, and the

--- a/tests/kun_runtime/test_ask_user_confirm_card.py
+++ b/tests/kun_runtime/test_ask_user_confirm_card.py
@@ -313,7 +313,7 @@ class TestLegacyResolverPath:
         async def emitter(payload):
             emitted["payload"] = payload
 
-        set_user_input_emitter(emitter)
+        set_user_input_emitter("", emitter)  # session key "" matches the tool's empty thread_id
         try:
             tool = AskUserConfirmCardTool(resolver=make_resolver())
             args = {"title": "确认执行方案？", "message": "4 个步骤", "timeout_seconds": 5}
@@ -335,7 +335,7 @@ class TestLegacyResolverPath:
 
             result = asyncio.run(scenario())
         finally:
-            set_user_input_emitter(None)
+            set_user_input_emitter("", None)
 
         import json as _json
 
@@ -350,7 +350,7 @@ class TestLegacyResolverPath:
         from miqi.agent.user_input_resolver import set_user_input_emitter
         from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
 
-        set_user_input_emitter(None)
+        set_user_input_emitter("", None)
         tool = AskUserConfirmCardTool(resolver=make_resolver())
         result = asyncio.run(tool.execute(title="t", message="m"))
         data = _json.loads(result)

--- a/tests/kun_runtime/test_ask_user_confirm_card.py
+++ b/tests/kun_runtime/test_ask_user_confirm_card.py
@@ -1,0 +1,487 @@
+"""Issue #646 — ask_user_confirm_card: tool contract, tool-host interception,
+storm-breaker exemption, never-parallel classification, contracts, and the
+user-input gate timeout."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from miqi.agent.tools.ask_user_confirm import (
+    DEFAULT_CHOICES,
+    AskUserConfirmCardTool,
+)
+from miqi.agent.user_input_resolver import make_resolver
+from miqi.agent.tools.registry import ToolRegistry, _NEVER_PARALLEL_TOOLS
+from miqi.kun_runtime.contracts import TurnStatus, UserInputItem, UserInputRequestedEvent
+from miqi.kun_runtime.tool_host import (
+    ASK_USER_CONFIRM_TOOL,
+    MiQiToolHost,
+    ToolCallLike,
+    ToolHostContext,
+)
+from miqi.kun_runtime.tool_storm_breaker import STORM_EXEMPT_TOOLS, ToolStormBreaker
+from miqi.kun_runtime.user_input_gate import UserInputGate
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tool contract
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestToolContract:
+    def test_name_and_schema(self):
+        tool = AskUserConfirmCardTool()
+        assert tool.name == "ask_user_confirm_card"
+        schema = tool.to_schema()["function"]
+        params = schema["parameters"]["properties"]
+        assert set(schema["parameters"]["required"]) == {"title", "message"}
+        for key in ("title", "message", "steps", "choices", "allow_remember_choice", "timeout_seconds"):
+            assert key in params
+        # 默认超时 120s
+        assert params["timeout_seconds"]["default"] == 120
+        # 中文描述：模型必须能理解这是 AI 主动发起的人机握手
+        assert "确认" in schema["description"]
+
+    def test_fallback_execute_returns_error(self):
+        """No user-input channel wired → must NOT fabricate a decision."""
+        tool = AskUserConfirmCardTool()
+        result = asyncio.run(tool.execute(title="确认", message="可以吗"))
+        assert result.startswith("Error")
+        assert "不要假设用户已同意" in result
+
+
+class TestNormalizeArgs:
+    def test_defaults(self):
+        payload = AskUserConfirmCardTool.normalize_args({"title": "确认执行方案？", "message": "4 个步骤"})
+        assert payload["title"] == "确认执行方案？"
+        assert payload["message"] == "4 个步骤"
+        assert payload["choices"] == DEFAULT_CHOICES
+        assert payload["timeout_seconds"] == 120
+        assert payload["allow_remember_choice"] is False
+        assert payload["steps"] == []
+
+    def test_choices_structured(self):
+        payload = AskUserConfirmCardTool.normalize_args({
+            "title": "上传？",
+            "message": "确认上传到 Qraft",
+            "choices": [{"id": "confirm", "label": "确认上传"}, {"id": "cancel", "label": "取消"}],
+            "timeout_seconds": 30,
+            "allow_remember_choice": True,
+        })
+        assert payload["choices"] == [{"id": "confirm", "label": "确认上传"}, {"id": "cancel", "label": "取消"}]
+        assert payload["timeout_seconds"] == 30
+        assert payload["allow_remember_choice"] is True
+
+    def test_bad_choices_fallback_to_default(self):
+        payload = AskUserConfirmCardTool.normalize_args({"title": "t", "message": "m", "choices": []})
+        assert payload["choices"] == DEFAULT_CHOICES
+
+    def test_steps_get_ids(self):
+        payload = AskUserConfirmCardTool.normalize_args({
+            "title": "t", "message": "m",
+            "steps": [{"title": "搜索论文"}, {"id": "query_price", "title": "查价格"}],
+        })
+        assert payload["steps"] == [
+            {"id": "step_0", "title": "搜索论文"},
+            {"id": "query_price", "title": "查价格"},
+        ]
+
+
+class TestBuildResult:
+    def test_submitted_confirm(self):
+        out = AskUserConfirmCardTool.build_result({
+            "status": "submitted",
+            "answers": {"choice_id": "confirm", "choice_label": "确认执行"},
+        })
+        data = json.loads(out)
+        assert data["status"] == "confirmed"
+        assert data["choice_id"] == "confirm"
+        assert data["choice_label"] == "确认执行"
+
+    def test_cancelled(self):
+        out = AskUserConfirmCardTool.build_result({"status": "cancelled"})
+        data = json.loads(out)
+        assert data["status"] == "cancelled"
+        assert data["choice_id"] == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tool-host interception
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _ctx(await_user_input=None) -> ToolHostContext:
+    return ToolHostContext(
+        thread_id="thr_1",
+        turn_id="turn_1",
+        workspace="/tmp/ws",
+        await_user_input=await_user_input,
+    )
+
+
+class TestToolHostInterception:
+    def test_routes_through_await_user_input(self):
+        registry = ToolRegistry()
+        registry.register(AskUserConfirmCardTool())
+
+        async def fake_gate(payload):
+            assert payload["title"] == "确认执行方案？"
+            assert payload["steps"][0]["id"] == "search_papers"
+            return {"status": "submitted", "answers": {"choice_id": "confirm", "choice_label": "确认执行"}}
+
+        host = MiQiToolHost(registry)
+        call = ToolCallLike(call_id="call_1", tool_name=ASK_USER_CONFIRM_TOOL, arguments={
+            "title": "确认执行方案？",
+            "message": "4 个步骤",
+            "steps": [{"id": "search_papers", "title": "搜索论文"}],
+        })
+        result = asyncio.run(host.execute(call, _ctx(await_user_input=fake_gate)))
+        item = result.item
+        assert item["status"] == "completed"
+        assert item["isError"] is False
+        data = json.loads(item["output"])
+        assert data["status"] == "confirmed"
+        assert data["choice_id"] == "confirm"
+
+    def test_cancelled_choice(self):
+        registry = ToolRegistry()
+        registry.register(AskUserConfirmCardTool())
+
+        async def fake_gate(payload):
+            return {"status": "cancelled", "reason": "timeout"}
+
+        host = MiQiToolHost(registry)
+        call = ToolCallLike(call_id="call_2", tool_name=ASK_USER_CONFIRM_TOOL, arguments={
+            "title": "上传？", "message": "确认上传",
+        })
+        result = asyncio.run(host.execute(call, _ctx(await_user_input=fake_gate)))
+        data = json.loads(result.item["output"])
+        assert data["status"] == "cancelled"
+        assert data["reason"] == "timeout"
+
+    def test_no_channel_falls_back_to_tool_error(self):
+        """No await_user_input wired → tool's own execute() returns error."""
+        registry = ToolRegistry()
+        registry.register(AskUserConfirmCardTool())
+        host = MiQiToolHost(registry)
+        call = ToolCallLike(call_id="call_3", tool_name=ASK_USER_CONFIRM_TOOL, arguments={
+            "title": "t", "message": "m",
+        })
+        result = asyncio.run(host.execute(call, _ctx(await_user_input=None)))
+        assert result.item["isError"] is True
+        assert "Error" in result.item["output"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Storm breaker / parallel classification / contracts
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGuards:
+    def test_storm_breaker_exempt(self):
+        assert ASK_USER_CONFIRM_TOOL in STORM_EXEMPT_TOOLS
+        breaker = ToolStormBreaker()
+        for _ in range(5):
+            verdict = breaker.inspect(ASK_USER_CONFIRM_TOOL, {"title": "t"})
+            assert verdict["suppress"] is False
+
+    def test_never_parallel(self):
+        assert ASK_USER_CONFIRM_TOOL in _NEVER_PARALLEL_TOOLS
+
+    def test_contracts_extensions(self):
+        assert TurnStatus.waiting_for_user == "waiting_for_user"
+        item = UserInputItem(
+            kind="user_input", role="system", inputId="ui_1", prompt="p", id="item_1",
+            status="pending", threadId="thr", turnId="turn", createdAt="2026-08-11T00:00:00Z",
+            title="确认执行方案？", steps=[{"id": "s1", "title": "搜索论文"}],
+            choices=[{"id": "confirm", "label": "确认执行"}], timeout_seconds=120,
+            allow_remember_choice=True,
+        )
+        assert item.title == "确认执行方案？"
+        assert item.steps[0]["id"] == "s1"
+        assert item.timeout_seconds == 120
+        assert item.allow_remember_choice is True
+        ev = UserInputRequestedEvent(
+            kind="user_input_requested", inputId="ui_1", title="t", timeoutSeconds=120,
+            seq=1, timestamp="2026-08-11T00:00:00Z", threadId="thr",
+        )
+        assert ev.timeoutSeconds == 120
+
+
+class TestUserInputGateTimeout:
+    def test_timeout_resolves_cancelled(self):
+        async def scenario():
+            gate = UserInputGate()
+            task = asyncio.create_task(
+                gate.request("thr", "turn", "item", "prompt", timeout=0.05)
+            )
+            result = await task
+            return result
+
+        result = asyncio.run(scenario())
+        assert result["status"] == "cancelled"
+
+    def test_resolve_submitted(self):
+        async def scenario():
+            gate = UserInputGate()
+            task = asyncio.create_task(
+                gate.request("thr", "turn", "item", "prompt", timeout=5)
+            )
+            await asyncio.sleep(0.01)
+            gate.resolve("user_input_" + list(gate._pending)[0].split("_", 2)[-1], {"choice_id": "confirm"})
+            return await task
+
+        result = asyncio.run(scenario())
+        assert result["status"] == "submitted"
+        assert result["answers"]["choice_id"] == "confirm"
+
+
+class TestUserInputHistory:
+    def test_record_and_query(self):
+        from miqi.agent.user_input_history import add_user_input_history, clear_history, get_user_input_history
+
+        clear_history()
+        add_user_input_history(
+            title="确认执行方案？", status="submitted",
+            choice_id="confirm", choice_label="确认执行",
+            thread_id="thr", turn_id="turn",
+        )
+        add_user_input_history(
+            title="是否上传？", status="cancelled", reason="timeout",
+        )
+        history = get_user_input_history()
+        assert len(history) == 2
+        assert history[0]["title"] == "是否上传？"  # most recent first
+        assert history[0]["reason"] == "timeout"
+        assert history[1]["choice_label"] == "确认执行"
+        clear_history()
+
+
+class TestRememberChoice:
+    def test_same_card_reuses_choice_without_pending(self):
+        from miqi.kun_runtime.loop import _remember_key
+
+        payload = {"title": "确认执行方案？", "choices": [{"id": "confirm", "label": "确认执行"}]}
+        key = _remember_key(payload)
+        gate = UserInputGate()
+        assert gate.remembered_choice("thr", key) is None
+        gate.remember("thr", key, {"choice_id": "confirm", "choice_label": "确认执行"})
+        assert gate.remembered_choice("thr", key)["choice_id"] == "confirm"
+        # 不同 title → 不同 key
+        other = _remember_key({"title": "是否上传？", "choices": [{"id": "confirm", "label": "确认上传"}]})
+        assert other != key
+        assert gate.remembered_choice("thr", other) is None
+        # 跨 thread 不共享
+        assert gate.remembered_choice("thr2", key) is None
+
+
+class TestApprovalBoundary:
+    """确认卡 vs 审批边界（issue #646）：确认卡是决策工具，不触发规则审批。"""
+
+    def test_not_in_dangerous_patterns(self):
+        """ask_user_confirm_card 不在危险命令模式里 —— 它只收集决策，不执行操作。
+        审批拦的是确认之后真正执行的动作（write_file 等），两者正交。"""
+        from miqi.agent.command_approval import DANGEROUS_PATTERNS
+
+        for pattern, _desc in DANGEROUS_PATTERNS:
+            assert "ask_user_confirm" not in pattern, f"确认卡不应出现在危险模式: {pattern}"
+
+    def test_tool_name_not_approval_triggered(self):
+        """注册层面确认：工具不是 approval-category 命令（无 approval metadata）。"""
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        tool = AskUserConfirmCardTool()
+        assert getattr(tool, "approval_category", None) is None
+        assert "ask_user_confirm_card" in tool.name
+
+
+class TestLegacyResolverPath:
+    """Legacy desktop path: tool resolver → shared gate → emit → resolve."""
+
+    def test_tool_blocks_then_resolves(self):
+        from miqi.agent.user_input_resolver import (
+            resolve_user_input,
+            set_user_input_emitter,
+        )
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        emitted = {}
+
+        async def emitter(payload):
+            emitted["payload"] = payload
+
+        set_user_input_emitter(emitter)
+        try:
+            tool = AskUserConfirmCardTool(resolver=make_resolver())
+            args = {"title": "确认执行方案？", "message": "4 个步骤", "timeout_seconds": 5}
+
+            async def scenario():
+                task = asyncio.create_task(tool.execute(**args))
+                # 等卡片事件发出
+                for _ in range(50):
+                    if "payload" in emitted:
+                        break
+                    await asyncio.sleep(0.02)
+                assert "payload" in emitted, "user_input_requested 未发出"
+                input_id = emitted["payload"]["input_id"]
+                assert emitted["payload"]["title"] == "确认执行方案？"
+                ok = resolve_user_input(input_id, {"choice_id": "confirm", "choice_label": "确认执行"})
+                assert ok
+                result = await task
+                return result
+
+            result = asyncio.run(scenario())
+        finally:
+            set_user_input_emitter(None)
+
+        import json as _json
+
+        data = _json.loads(result)
+        assert data["status"] == "confirmed"
+        assert data["choice_id"] == "confirm"
+
+    def test_tool_cancelled_when_no_channel(self):
+        """Resolver exists but no emitter wired → safe cancelled, never a fake confirm."""
+        import json as _json
+
+        from miqi.agent.user_input_resolver import set_user_input_emitter
+        from miqi.agent.tools.ask_user_confirm import AskUserConfirmCardTool
+
+        set_user_input_emitter(None)
+        tool = AskUserConfirmCardTool(resolver=make_resolver())
+        result = asyncio.run(tool.execute(title="t", message="m"))
+        data = _json.loads(result)
+        assert data["status"] == "cancelled"
+        assert "user-input channel" in data["reason"]
+
+    def test_no_resolver_fallback_error(self):
+        """No resolver at all → structured error, never fabricate a decision."""
+        tool = AskUserConfirmCardTool()
+        result = asyncio.run(tool.execute(title="t", message="m"))
+        assert result.startswith("Error")
+        assert "不要假设用户已同意" in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Regression: gate.request() raising must not mask the original error, and the
+# finally-block cleanup (item resolution + turn status) must still complete
+# (CodeRabbit #666: finally dereferenced result=None → AttributeError).
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAwaitUserInputGateFailure:
+    @pytest.mark.asyncio
+    async def test_gate_error_surfaces_original_and_cleans_up(self, tmp_path):
+        from pathlib import Path as _P
+
+        from miqi.kun_runtime.cancellation import InflightTracker
+        from miqi.kun_runtime.compactor import ContextCompactor
+        from miqi.kun_runtime.event_bus import EventBus
+        from miqi.kun_runtime.event_recorder import RuntimeEventRecorder
+        from miqi.kun_runtime.loop import AgentLoop, AgentLoopOptions
+        from miqi.kun_runtime.model_client import FakeModelClient, ModelStreamChunk
+        from miqi.kun_runtime.stores import FileSessionStore, FileThreadStore
+        from miqi.kun_runtime.tool_host import MiQiToolHost
+        from miqi.kun_runtime.turn_service import TurnService
+        from miqi.kun_runtime.usage import UsageService
+        from miqi.kun_runtime.user_input_gate import UserInputGate
+
+        FIXED = "2026-08-15T00:00:00Z"
+
+        class ExplodingGate(UserInputGate):
+            async def request(self, *args, **kwargs):
+                raise RuntimeError("gate exploded")
+
+        class OneShotToolCallModel(FakeModelClient):
+            """Tool call on the first request only, then plain text."""
+
+            def __init__(self):
+                super().__init__(text_chunks=["完成"])
+                self._n = 0
+
+            async def stream(self, request):
+                self._n += 1
+                if self._n == 1:
+                    yield ModelStreamChunk(
+                        kind="tool_call_complete",
+                        callId="call_1",
+                        toolName="ask_user_confirm_card",
+                        arguments={
+                            "title": "确认执行方案？",
+                            "message": "m",
+                            "choices": [{"id": "confirm", "label": "确认执行"}],
+                        },
+                    )
+                    yield ModelStreamChunk(kind="completed", stopReason="tool_calls")
+                else:
+                    yield ModelStreamChunk(kind="assistant_text_delta", text="完成")
+                    yield ModelStreamChunk(kind="completed", stopReason="stop")
+
+        data_dir = _P(tmp_path) / "data"
+        thread_store = FileThreadStore(data_dir)
+        session_store = FileSessionStore(data_dir)
+        bus = EventBus()
+        events = RuntimeEventRecorder(bus, now_iso=lambda: FIXED)
+        turns = TurnService(
+            thread_store, session_store, events, InflightTracker(), now_iso=lambda: FIXED
+        )
+
+        registry = ToolRegistry()
+        registry.register(AskUserConfirmCardTool())
+        tool_host = MiQiToolHost(registry)
+
+        opts = AgentLoopOptions(
+            thread_store=thread_store,
+            session_store=session_store,
+            model=OneShotToolCallModel(),
+            tool_host=tool_host,
+            usage=UsageService(),
+            events=events,
+            turns=turns,
+            inflight=InflightTracker(),
+            compactor=ContextCompactor(soft_threshold=100, hard_threshold=500),
+            now_iso=lambda: FIXED,
+            user_input_gate=ExplodingGate(),
+        )
+
+        th = {
+            "id": "th1",
+            "title": "Test Thread",
+            "workspace": str(_P(tmp_path) / "ws"),
+            "model": "fake-model",
+            "mode": "agent",
+            "status": "idle",
+            "approvalPolicy": "auto",
+            "sandboxMode": "workspace-write",
+            "relation": "primary",
+            "costBudgetWarningSent": False,
+            "createdAt": FIXED,
+            "updatedAt": FIXED,
+            "turns": [],
+        }
+        await thread_store.upsert(th)
+        started = await turns.start_turn("th1", "hello")
+        turn_id = started["turnId"]
+
+        loop = AgentLoop(opts)
+        status = await loop.run_turn("th1", turn_id)
+        assert status == "completed"
+
+        # The ORIGINAL gate error must surface in the tool result — not a
+        # masked "'NoneType' object has no attribute 'get'".
+        items = await session_store.load_items("th1")
+        outputs = [i.get("output", "") for i in items if isinstance(i, dict)]
+        assert any("gate exploded" in o for o in outputs), outputs
+        assert not any("NoneType" in o for o in outputs)
+
+        # The finally-block cleanup must still have run: user_input_resolved
+        # recorded as cancelled and the turn returned to a finished state.
+        kinds = [e["kind"] for e in bus.history("th1")]
+        assert "user_input_resolved" in kinds
+        resolved = [e for e in bus.history("th1") if e["kind"] == "user_input_resolved"]
+        assert resolved[0]["status"] == "cancelled"
+        turn = await turns.get_turn("th1", turn_id)
+        assert turn["status"] == "completed"

--- a/tests/kun_runtime/test_collab_policy.py
+++ b/tests/kun_runtime/test_collab_policy.py
@@ -1,0 +1,154 @@
+"""Collaboration policy tests (issue #646 design v2).
+
+Two AI reviews converged: the harness — not the model — decides when to ask.
+This policy is the "collaboration gate": risk-classified tool intents mapped
+against the user's autonomy mode. External transfers / payments ALWAYS
+confirm, independent of approval bypass.
+"""
+
+import asyncio
+
+import pytest
+
+from miqi.execution.collab_policy import (
+    AutonomyMode,
+    CollabVerdict,
+    RiskLevel,
+    evaluate,
+    risk_of,
+)
+
+
+class TestRiskClassification:
+    def test_read_tools_are_read(self):
+        assert risk_of("web_search") == RiskLevel.READ
+        assert risk_of("read_file") == RiskLevel.READ
+        assert risk_of("paper_search") == RiskLevel.READ
+        assert risk_of("unknown_tool") == RiskLevel.READ  # 未知默认读
+
+    def test_write_exec_external_payment(self):
+        assert risk_of("write_file") == RiskLevel.WRITE
+        assert risk_of("create_pdf") == RiskLevel.WRITE
+        assert risk_of("exec") == RiskLevel.EXEC
+        assert risk_of("bash") == RiskLevel.EXEC
+        assert risk_of("upload_workflow") == RiskLevel.EXTERNAL
+        assert risk_of("data_upload") == RiskLevel.EXTERNAL
+        assert risk_of("purchase") == RiskLevel.PAYMENT
+
+
+class TestModeMatrix:
+    def test_read_always_allowed(self):
+        for mode in AutonomyMode:
+            assert evaluate("web_search", mode) == CollabVerdict.ALLOW
+            assert evaluate("read_file", mode) == CollabVerdict.ALLOW
+
+    def test_autonomous_writes_auto_but_external_always_confirms(self):
+        # 自动模式：写文件自动（低风险自主），外发/付费必须确认
+        assert evaluate("write_file", AutonomyMode.AUTONOMOUS) == CollabVerdict.ALLOW
+        assert evaluate("exec", AutonomyMode.AUTONOMOUS) == CollabVerdict.ALLOW
+        assert evaluate("upload_workflow", AutonomyMode.AUTONOMOUS) == CollabVerdict.CONFIRM
+        assert evaluate("data_upload", AutonomyMode.AUTONOMOUS) == CollabVerdict.CONFIRM
+        assert evaluate("purchase", AutonomyMode.AUTONOMOUS) == CollabVerdict.CONFIRM
+
+    def test_supervised_confirms_exec(self):
+        # 允许编辑模式：写文件自动，执行/外发确认
+        assert evaluate("write_file", AutonomyMode.SUPERVISED) == CollabVerdict.ALLOW
+        assert evaluate("exec", AutonomyMode.SUPERVISED) == CollabVerdict.CONFIRM
+        assert evaluate("upload_workflow", AutonomyMode.SUPERVISED) == CollabVerdict.CONFIRM
+
+    def test_manual_confirms_writes(self):
+        assert evaluate("write_file", AutonomyMode.MANUAL) == CollabVerdict.CONFIRM
+        assert evaluate("exec", AutonomyMode.MANUAL) == CollabVerdict.CONFIRM
+
+    def test_plan_denies_writes_and_exec(self):
+        assert evaluate("write_file", AutonomyMode.PLAN) == CollabVerdict.DENY
+        assert evaluate("exec", AutonomyMode.PLAN) == CollabVerdict.DENY
+        assert evaluate("upload_workflow", AutonomyMode.PLAN) == CollabVerdict.DENY
+
+    def test_external_never_bypassable(self):
+        """外发/付费在任何执行模式下都确认（PLAN 例外：只分析 → DENY）。
+        协作门不受审批 bypass 影响。"""
+        for mode in AutonomyMode:
+            if mode == AutonomyMode.PLAN:
+                assert evaluate("upload_workflow", mode) == CollabVerdict.DENY
+            else:
+                assert evaluate("upload_workflow", mode) == CollabVerdict.CONFIRM
+                assert evaluate("purchase", mode) == CollabVerdict.CONFIRM
+
+
+class TestToolHostCollabGate:
+    """tool_host 集成：collab gate 在工具执行前强制弹确认卡。"""
+
+    def _ctx(self, mode="supervised", await_user_input=None):
+        from miqi.kun_runtime.tool_host import ToolHostContext
+
+        return ToolHostContext(
+            thread_id="thr",
+            turn_id="turn",
+            workspace="/tmp/ws",
+            autonomy_mode=mode,
+            await_user_input=await_user_input,
+        )
+
+    def _host(self):
+        from pathlib import Path
+
+        from miqi.kun_runtime.tool_host import MiQiToolHost
+        from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+        registry = create_runtime_tool_registry(config={}, workspace=Path("/tmp/ws"))
+        return MiQiToolHost(registry)
+
+    def test_external_tool_blocks_until_confirm(self):
+        from miqi.kun_runtime.tool_host import ToolCallLike
+
+        gate_calls = []
+
+        async def await_user_input(payload):
+            gate_calls.append(payload)
+            return {"status": "submitted", "answers": {"choice_id": "confirm", "choice_label": "确认执行"}}
+
+        host = self._host()
+        # manual 模式下 write_file 需要确认卡（registry 中存在该工具）
+        call = ToolCallLike(call_id="c1", tool_name="write_file", arguments={"path": "/tmp/ws/a.txt", "content": "hi"})
+        result = asyncio.run(host.execute(call, self._ctx(mode="manual", await_user_input=await_user_input)))
+        assert len(gate_calls) == 1, "写文件在 manual 模式必须先经过确认卡"
+        assert gate_calls[0]["title"] == "确认执行：write_file"
+        assert "cancel" in [c["id"] for c in gate_calls[0]["choices"]]
+
+    def test_read_tool_skips_gate(self):
+        from miqi.kun_runtime.tool_host import ToolCallLike
+
+        gate_calls = []
+
+        async def await_user_input(payload):
+            gate_calls.append(payload)
+            return {"status": "submitted", "answers": {"choice_id": "confirm"}}
+
+        host = self._host()
+        call = ToolCallLike(call_id="c1", tool_name="read_file", arguments={"path": "/tmp/x"})
+        result = asyncio.run(host.execute(call, self._ctx(mode="autonomous", await_user_input=await_user_input)))
+        assert gate_calls == [], "读类工具不应触发确认卡"
+
+    def test_user_cancel_returns_cancelled(self):
+        from miqi.kun_runtime.tool_host import ToolCallLike
+
+        async def await_user_input(payload):
+            return {"status": "submitted", "answers": {"choice_id": "cancel", "choice_label": "取消"}}
+
+        host = self._host()
+        call = ToolCallLike(call_id="c1", tool_name="write_file", arguments={"path": "/tmp/ws/a.txt", "content": "x"})
+        result = asyncio.run(host.execute(call, self._ctx(mode="manual", await_user_input=await_user_input)))
+        assert result.item["status"] == "cancelled"
+        assert result.item["isError"] is True
+
+    def test_no_channel_falls_back_to_execute(self):
+        """无 await_user_input 通道（headless）时 collab gate 不阻塞，走正常执行。"""
+        from miqi.kun_runtime.tool_host import ToolCallLike
+
+        host = self._host()
+        call = ToolCallLike(call_id="c1", tool_name="read_file", arguments={"path": "/tmp/nope"})
+        result = asyncio.run(host.execute(call, self._ctx(mode="supervised")))
+        # 无通道 → 不弹卡直接执行（读文件不存在 → 返回错误而非 gate 拦截）
+        assert result.item["status"] == "failed"
+        assert "not found" in result.item.get("output", "") or "No such" in result.item.get("output", "")

--- a/tests/kun_runtime/test_collab_policy.py
+++ b/tests/kun_runtime/test_collab_policy.py
@@ -24,7 +24,14 @@ class TestRiskClassification:
         assert risk_of("web_search") == RiskLevel.READ
         assert risk_of("read_file") == RiskLevel.READ
         assert risk_of("paper_search") == RiskLevel.READ
-        assert risk_of("unknown_tool") == RiskLevel.READ  # 未知默认读
+
+    def test_unknown_tool_fails_closed(self):
+        # Unrecognised tools are UNKNOWN: DENY in plan, CONFIRM in manual
+        # (CodeRabbit #711) — never silently classified as safe read.
+        assert risk_of("unknown_tool") == RiskLevel.UNKNOWN
+        assert evaluate("unknown_tool", AutonomyMode.PLAN) == CollabVerdict.DENY
+        assert evaluate("unknown_tool", AutonomyMode.MANUAL) == CollabVerdict.CONFIRM
+        assert evaluate("unknown_tool", AutonomyMode.SUPERVISED) == CollabVerdict.ALLOW
 
     def test_write_exec_external_payment(self):
         assert risk_of("write_file") == RiskLevel.WRITE
@@ -142,13 +149,14 @@ class TestToolHostCollabGate:
         assert result.item["status"] == "cancelled"
         assert result.item["isError"] is True
 
-    def test_no_channel_falls_back_to_execute(self):
+    def test_no_channel_falls_back_to_execute(self, tmp_path):
         """无 await_user_input 通道（headless）时 collab gate 不阻塞，走正常执行。"""
         from miqi.kun_runtime.tool_host import ToolCallLike
 
         host = self._host()
-        call = ToolCallLike(call_id="c1", tool_name="read_file", arguments={"path": "/tmp/nope"})
+        missing = tmp_path / "nope.txt"
+        call = ToolCallLike(call_id="c1", tool_name="read_file", arguments={"path": str(missing)})
         result = asyncio.run(host.execute(call, self._ctx(mode="supervised")))
-        # 无通道 → 不弹卡直接执行（读文件不存在 → 返回错误而非 gate 拦截）
+        # 无通道 → 不弹卡直接执行（读文件不存在 → 返回错误而非 gate 拦截）。
+        # 不断言具体错误文案：平台间 not found 措辞不同（CodeRabbit #711）。
         assert result.item["status"] == "failed"
-        assert "not found" in result.item.get("output", "") or "No such" in result.item.get("output", "")


### PR DESCRIPTION
### **User description**
## 类型

- [x] ✨ 新功能

## 变更概述

重新引入 #666 的 `ask_user_confirm_card` 确认卡功能（曾被 #685 逆转），修复重新引入后暴露的链路 bug，并附确定性 E2E 测试。

## 背景/问题

#666（aa212192）实现「AI 主动发起的人机握手确认卡」后被 #685 逆转（2026-08-13），issue #646 因此重新开放。本 PR revert 该逆转提交（2a0ae2fe），在最新 develop 上恢复功能，并解决与 #677/#364/#698 等后续变更的冲突。

重新引入后由回归测试和真机 E2E 暴露并修复的问题（#666 评审遗留）：

1. `mock_openai.py` 不支持 SSE — 桌面流式请求解析出 0 chunk，回合空回复、确认卡永不出现
2. KUN `user_input_requested` 事件用 snake_case 键 — `RuntimeEventRecorder` 校验 `threadId` 抛 ValueError
3. `turn_service.update_turn_status` 引用不存在的 `self._opts` — AttributeError
4. `await_user_input` finally 块在 `gate.request()` 抛异常时对 `result=None` 二次解引用 — AttributeError 掩盖原异常且中断清理，回合卡死在 waiting_for_user

## 关联 issue

- Closes #646

## 变更内容

**真实 AI 验证驱动的修复**（confirm-card-real-llm.spec.ts）：
- `agent_registry.py` 主 agent 白名单加入 `ask_user_confirm_card`——此前工具虽注册但模型不可见（mock 脚本化调用掩盖了此缺口）
- `task_runner.py` legacy 系统提示词注入 `ASK_USER_CONFIRM_INSTRUCTION` 使用指引（与 KUN 对齐）
- legacy resolver 补 remember 自动复用（`本次会话不再询问` 勾选后同卡片不再弹卡，含审计记录与 choice_role 分类）

恢复（revert 逆转 2a0ae2fe）：
- `miqi/agent/tools/ask_user_confirm.py` — 工具定义（title/message/steps/choices/allow_remember_choice/timeout_seconds）
- `miqi/kun_runtime/` — UserInputGate 注入、loop `await_user_input`（waiting_for_user 回合状态）、决策审计历史
- `miqi/agent/user_input_resolver.py` — legacy 桌面 resolver 桥（chat.send 主路径）
- `miqi/bridge/loop.py` — `userInput.resolve` handler + `user_input_requested` 事件转发
- 前端：`UserInputContext` + `ConfirmCard`/`ConfirmCardArea`（消息流内嵌三态卡片，阻塞回合）
- `ChatConsole.tsx` 冲突解决：保留 #677 会话活动感知 + #646 确认卡会话隔离两块逻辑

加固（CodeRabbit 评审后）：
- **会话隔离**：emitter 按会话 key 注册 + thread→session 映射（真实流程 thread_id 是 threads.start 铸造的 id），并发会话互不覆盖；userInput.resolve 增加会话归属鉴权；legacy 路径通过 contextvar 注入 thread/turn 上下文，remember 作用域与 turn 取消不再失效
- **KUN Critical**：`await_user_input` 将已宣告的 input_id 传给 gate.request（此前 gate 自生成 id，桌面 resolve 永远 miss，卡片只能等超时）
- **门控收紧**：collab gate 失败关闭（未知工具 UNKNOWN 风险 plan→DENY/manual→CONFIRM）；build_result 中 cancel/adjust 选择返回 cancelled + choice_id
- 其余 nitpick：remember key 纳入 message/steps、审计写入保护、gate 超时竞态守卫、keyframes kebab-case、mock 随机端口 + stdout 就绪判定等

修复：
- `scripts/mock_openai.py` — 流式请求返回 SSE（text/event-stream + [DONE]），日志 flush
- `miqi/kun_runtime/loop.py` — 事件键 camelCase；finally 块统一走 submitted/answers 局部变量，杜绝 None 解引用
- `miqi/kun_runtime/turn_service.py` — `self._opts` → `self._now_iso`

测试：
- `tests/kun_runtime/test_ask_user_confirm_card.py` 新增 `TestAwaitUserInputGateFailure` — gate 异常路径：原错误不掩盖、item 清理、回合收尾
- `apps/desktop/tests/e2e/confirm-card.spec.ts` — mock 状态机驱动五轮全链路 E2E（弹卡 → 点击确认 → tool result 回传 → 工具执行 → 第二张卡 → 完成）
- `electron-setup.ts` 增加可选 `patchConfig` 钩子（E2E 指向本地 mock provider）

## 日志/验证证据
```
# 后端（最终）
pytest tests/ -q --ignore=tests/e2e
→ 2276+ passed

# 前端
tsc --noEmit web + node → 0 errors
vitest → 174 passed / 13 files

# 前端
tsc --noEmit web + node → 0 errors
vitest → 174 passed / 13 files

# E2E ① mock 状态机五轮（确定性，无真实 LLM 依赖）
npx playwright test tests/e2e/confirm-card.spec.ts --project=electron
→ 1 passed (21.9s)
[mock] R1 → 确认执行方案卡 → R2 web_search → R3 write_file
       → R4 上传确认卡 → R5 最终回复（项目入口 + workflow 文件）

# E2E ② 真实 AI 请求（本地 deepseek 真机）
npx playwright test tests/e2e/confirm-card-real-llm.spec.ts --project=electron
→ 1 passed (19.8s)
真实模型收到指令 → 主动调用 ask_user_confirm_card → 桌面弹卡
→ 点击「确认执行」→ tool result 回传 → 模型回复 OK、回合完成
（真实 AI 验证暴露并修复了两个缺口：主 agent 工具白名单缺少该工具、
legacy 系统提示词缺少调用指引）
```
## 测试情况

- 后端全量 1798 passed / 1 skipped，含新增 `TestAwaitUserInputGateFailure` 回归（gate 抛异常时原错误可追溯、`user_input_resolved` 记录 cancelled、回合正常收尾）
- 前端 vitest 174 passed / 13 files，tsc web+node 0 错误
- E2E `confirm-card.spec.ts` 本地通过（确定性 mock；CI 无外网时 web_search 报错不影响状态机推进）
- 真机验证：卡片 pending 态与 resolved 态截图见下

## 截图

确认卡 pending（标题 / 4 步骤 / 三按钮 / 60s 倒计时）：

最终 resolved（两张卡「已选择」决议 + 最终回复与产物文件）
<img width="1264" height="821" alt="mock-模型弹两张确认卡-—-用户点击后-tool-result-回传、回合继续并完成-card1" src="https://github.com/user-attachments/assets/6b3ca9cb-96dc-4108-9d46-6ae01aad05b3" />
<img width="1264" height="821" alt="mock-模型弹两张确认卡-—-用户点击后-tool-result-回传、回合继续并完成-card2" src="https://github.com/user-attachments/assets/39d45a33-119d-4a6c-ac4c-3bdf29aebc7a" />
<img width="1264" height="821" alt="mock-模型弹两张确认卡-—-用户点击后-tool-result-回传、回合继续并完成-final" src="https://github.com/user-attachments/assets/f6e160f4-6d80-4850-8bfb-eceace70f0b1" />

## 后续计划

- #684（legacy collab gate + 确认卡契约扩展 warnings/metadata）可基于本 PR 恢复后的代码继续


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Restore ask_user_confirm_card AI confirmation tool
  - Tool schema, normalization, and safe no-channel fallback
  - KUN gate pauses turn and waits for user choice

- Add collaboration policy gate for risky tools
  - Risk matrix by autonomy mode, external/payment always confirm

- Wire legacy desktop path with resolver and IPC
  - `userInput.resolve`, event forwarding, session isolation

- Add desktop inline ConfirmCard UI and tests
  - Pending/confirmed/cancelled states, steps, countdown, remember
  - Backend unit, frontend component, and E2E coverage


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["LLM calls ask_user_confirm_card"] --> B["ToolHost + Collab Policy"]
  B --> C["UserInputGate + AgentLoop await_user_input"]
  C --> D["Desktop userInput:request + ConfirmCard"]
  D --> E["userInput.resolve choice"]
  E --> F["Tool result confirmed/cancelled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>ask_user_confirm.py</strong><dd><code>Add ask_user_confirm_card tool definition and normalization</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-36f8961070a6366aa94371a21bd9de6e716dc02a979d6fae06f11a9cbc335229">+241/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_input_resolver.py</strong><dd><code>Bridge legacy runtime to shared user-input gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-3e65e2859e908d888fe9f20e3573863aadb686cf4bacf5ebfc194ed8b9f5ebc9">+213/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_input_history.py</strong><dd><code>Record confirm-card decisions for audit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-30e0d4ed6a496a976e18592b974400138dbc5857ba9589ad82ba917f9d664d71">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tool_host.py</strong><dd><code>Intercept confirm-card tool and enforce collab gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-01a08c79fd725c123752bbd114fb6535d190da6cec8253929874e3c9ffe1e1af">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>collab_policy.py</strong><dd><code>Define risk-based autonomy confirmation matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-bf543e1ed644f9738726c5c5139d29ea1f613ce1177f4881892bfe2ab67d9097">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>loop.py</strong><dd><code>Pause turns with await_user_input and remember</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-66879d10dc7f49d95bdef56560b344ec2630f1f78d5d47fc50ee03aafb7d61be">+194/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>user_input_gate.py</strong><dd><code>Add timeout, remember, and explicit input id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-dfcbe258330fe97ad1c6c1fcf28686dad97ecccdf068cca3b964b78f86247d8d">+67/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contracts.py</strong><dd><code>Extend user-input contracts with card fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-e16ed30606dbe938576f99ef9635d84461d316d5599e23ecc636c2da404aca2c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>turn_service.py</strong><dd><code>Add update_turn_status helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-de833c1af5f584a179356bbdc33843ebcf8832fa42a8a2849f3caacdea8672ac">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loop.py</strong><dd><code>Wire userInput.resolve and session emitter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task_runner.py</strong><dd><code>Inject confirm instruction and thread context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+34/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_registry_factory.py</strong><dd><code>Register confirm-card tool for legacy path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-bba7bdac87ba258004e88a6416dd357e77b6ab0c025e4c8134808fbcc37e2eac">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ipc.ts</strong><dd><code>Add user-input IPC channels and types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Forward user input events to renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Expose userInput API to renderer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>UserInputContext.tsx</strong><dd><code>Manage pending/resolved card state and sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-6ab1092592d2ae846715d56a06aae9f81d82a6fc52675d7881375293241cfd1f">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ConfirmCard.tsx</strong><dd><code>Render pending/confirmed/cancelled confirm card</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-43f4a32f8092171aa32380fc5121da556b1b8382eb82574c2d4a54a78036a461">+438/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ConfirmCardArea.tsx</strong><dd><code>Render active and resolved card history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-28b43c69bd46ade805cac39e0f564c667a765ef838d2fb40df51ac94959dd10d">+101/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_ask_user_confirm_card.py</strong><dd><code>Add backend confirm-card and gate tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-e53ddf1cef0e18fe4b731bdb9fddf5f18ec7e62d030530b601db0c1be94275ee">+542/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>confirm-card.spec.ts</strong><dd><code>Add deterministic E2E confirm-card flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-c82a7d2daf20eaee167134b5e5396398bcaadd5b9d2bd2148798f9f156e73ac5">+187/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td><strong>App.tsx</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-4b03b04efb7537be2e18ba0418bc81886c910207148cec6f9e92c88208fc58dd">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+37/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ConfirmCard.test.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-09f94f836a8f3d9a1be4581aad4dda11305bfe7c102f3b595b1d1d3cb70abb54">+175/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TurnStatusBar.tsx</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-7d26e0aa5c61eff90546b83f6431f1a119246b9d39e7ebf7f92612ccaed89b58">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>globals.css</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-3b46a6e64f18766392c2bdfa0757e4d4fd0e54dd0b465f520f9d2af3cc1d8652">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>confirm-card-real-llm.spec.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-d2c8b58f04bb7c03a0c9f98552b677f1ca9925ef71cd6fc961f55ad345e8a77a">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>electron-setup.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-58139259a2a9fb2e044aab7c7354e9c5a55ff21b376fcf99cfbb67b6be072845">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-8190bdabaa30f0e8c6b11a69b3f602e192d3f11458d925a560298fa95aec5ce6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runtime.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-ee40b6c8e28dde373889384af690dd7445bc9cf1608ea0d28c022de423597fcc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_storm_breaker.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-2e57c9ac70769219822292c203843e9c5787a7c747db225147d3bc1dfa5b2564">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent_registry.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-8d3d73c3a0ac6fd7cf49e2861cc73f44dc23df7f6f037ed44382e03b234b24e7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_ask_user_confirm.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-37eb269f64029919c5bb4849922575642061761a82ab79eb6800c600538eabf3">+182/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mock_openai.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-176030c0c9096d8145d6e2f3307b8ec614255c4e04905adf7551eb03e7892d2a">+335/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase69_core_contract_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-5eaf2b6e2acafcb48a57e8074a68da7078ab7ae11da1283d5d697456b20d7b2e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase70_plugin_skill_contract_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-074efb030120965122802fd1b95d9edc2f485afeb66e42a2bb40979eeba4f446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase71_session_contract_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-7589a5293c740ef77b89a414b36581cdf17c8c4d449ed1f84773c0445cb0aaba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase72_thread_contract_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-da6da0639dbf2d8041f89dba158f37a7aec27de1abc363b3b55ceb7f22cf8721">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_protocol_snapshot.v1.json</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-64f26c341ba8a85b08764290f8268986f4ee73e8976e506e879add3d5c3e5a41">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_collab_policy.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/711/files#diff-fa8685973835d64b94e2b203b0b5c4258de442b07681483a7dab683cf6c9670f">+162/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

