### PR TITLE
fix(desktop): 流式生成期间输入框保持可用，支持中断重发（#542）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -341,7 +341,7 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
 
   ipcMain.handle(IPC.CHAT_ABORT, async (_event, payload: unknown) => {
     const input = ChatAbortInput.parse(payload);
-    return bridge.send('chat.abort', { session_key: input.session_key });
+    return bridge.send('chat.abort', { session_key: input.session_key, thread_id: input.thread_id });
   });
 
   // Clipboard write from the sandboxed renderer.  The electron clipboard

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -114,8 +114,8 @@ const api = {
   chat: {
     send: (content: string, sessionKey?: string, threadId?: string, mode?: string, attachments?: Array<{name: string, data_base64?: string, mime_type?: string}>, workspace?: string): Promise<unknown> =>
       ipcRenderer.invoke(IPC.CHAT_SEND, { content, session_key: sessionKey, thread_id: threadId, mode, attachments, workspace }),
-    abort: (sessionKey?: string): Promise<unknown> =>
-      ipcRenderer.invoke(IPC.CHAT_ABORT, { session_key: sessionKey }),
+    abort: (sessionKey?: string, threadId?: string): Promise<unknown> =>
+      ipcRenderer.invoke(IPC.CHAT_ABORT, { session_key: sessionKey, thread_id: threadId }),
     onProgress: (callback: (data: ChatProgress) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: ChatProgress) => callback(data);
       ipcRenderer.on(IPC_EVENTS.CHAT_PROGRESS, handler);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3018,6 +3018,26 @@ export function ChatConsole({
     streamingBySession.add(sendSessionKey);
     finalHandledSessions.delete(sendSessionKey);
     cleanupListeners();
+    // A new send supersedes any in-flight typewriter for this session — cancel
+    // the RAF chain so the previous reply stops typing the moment a new message
+    // is sent, and reset its state so the new turn does NOT inherit the old
+    // fullContent/displayed (#542).  Unconditional: the old turn's lifecycle may
+    // already have settled (final received but still revealing), which skips the
+    // supersede block below and would otherwise leave the old reply typing until
+    // the new turn's final overwrites it.
+    {
+      const prevReveal = revealBySession.get(sendSessionKey);
+      if (prevReveal?.animId != null) {
+        cancelAnimationFrame(prevReveal.animId);
+        if (revealAnimIdRef.current === prevReveal.animId) revealAnimIdRef.current = null;
+      }
+      revealBySession.set(sendSessionKey, {
+        fullContent: '',
+        displayed: '',
+        animId: null,
+        finalDone: false,
+      });
+    }
     // ── /Optimistic UI ────────────────────────────────────────────────────
 
     // The user bubble is in the list now (stamped with `userMsg.timestamp`),

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2821,7 +2821,13 @@ export function ChatConsole({
     // await the aborted turn's settlement so its terminal event (and the
     // backend drain task) cannot race the replacement send.
     try {
-      await window.miqi.chat.abort(currentSessionRef.current);
+      // Pass the current thread id so the backend aborts the SAME thread the
+      // streaming turn registered its cancel event under — without it the
+      // abort resolves to "default" and misses the turn entirely (#542).
+      await window.miqi.chat.abort(
+        currentSessionRef.current,
+        currentThreadIdRef.current ?? undefined
+      );
     } catch {
       /* ignore */
     }
@@ -3103,8 +3109,13 @@ export function ChatConsole({
       try {
         // Pass the session key — without it the backend resolves no session
         // and rejects the abort with UNAUTHORIZED, leaving the old stream
-        // running while the new turn starts.
-        await window.miqi.chat.abort(currentSessionRef.current);
+        // running while the new turn starts.  Also pass the current thread id
+        // so the abort hits the turn's registered thread instead of the
+        // backend's "default" fallback (which misses every real thread) (#542).
+        await window.miqi.chat.abort(
+          currentSessionRef.current,
+          currentThreadIdRef.current ?? undefined
+        );
       } catch {
         /* ignore */
       }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2931,8 +2931,7 @@ export function ChatConsole({
     // still in its pending (pre-stream) phase: bail so a second send can't
     // spawn a duplicate optimistic bubble (issue #364).  The guard is scoped to
     // the session — a pending send in session A must not block the user from
-    // starting a fresh turn in session B.  The UI also blocks this via the
-    // streaming-disabled textarea / stop button.
+    // starting a fresh turn in session B.
     if (pendingSendIdsRef.current.has(currentSessionRef.current)) {
       // A blocked regenerate must not leak its payload into the next manual
       // send — clear it before bailing (CodeRabbit #681).
@@ -5242,7 +5241,6 @@ export function ChatConsole({
                       rows={1}
                       allowResize={true}
                       className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
-                      disabled={streaming}
                       style={{ color: 'var(--text)', fieldSizing: 'content' }}
                     />
                   )}

--- a/apps/desktop/tests/e2e/issue-542-streaming-input.spec.ts
+++ b/apps/desktop/tests/e2e/issue-542-streaming-input.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * E2E regression spec for issue #542 — [BUG] AI 流式回复期间输入框被完全禁用，
+ * 无法提前输入下一条 prompt。
+ *
+ * User-facing contract verified (matches the issue's requested behavior):
+ *   1. While a turn is streaming — thinking, tool calls or reply text — the
+ *      chat input stays ENABLED, so the user can pre-type the next message
+ *      instead of being locked out (regression: PR #658 re-added
+ *      `disabled={streaming}`, re-breaking #660's fix).
+ *   2. Quick course-correction: typing a correction + Enter while streaming
+ *      supersedes the in-flight turn (abort) and starts a new one; the input
+ *      is never forced empty/disabled mid-reply, and the new turn completes.
+ *
+ * The "old reply freezes at the pause point" behavior is exercised directly
+ * by the backend turn-cancel unit tests + the renderer reveal-reset logic;
+ * here we guard the primary regression: input must stay usable + resend must
+ * work in the real app.
+ *
+ * Uses a real LLM via the user's configured provider (approval-bypass on).
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts \
+ *        --project=electron -g 'Issue #542'
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  createNewConversation,
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+const INPUT = '[data-testid="chat-input-container"] textarea';
+
+/** Send a prompt via real keystrokes.  type() (not fill()) drives React's
+ *  onChange per keystroke, so `input` state is committed before Enter fires —
+ *  fill() can race streaming re-renders and leave handleSend reading a stale
+ *  empty input (the #542 resend path). */
+async function sendPrompt(
+  page: import('@playwright/test').Page,
+  text: string,
+): Promise<void> {
+  const inputX = page.locator(INPUT);
+  await inputX.click();
+  await inputX.fill('');
+  await inputX.type(text);
+  await inputX.press('Enter');
+}
+
+test.describe('Issue #542: input usable while AI streams / interrupt-resend', () => {
+  // Serial: one shared app instance (launching one app per test is slow and
+  // each test needs a streaming turn from the same session flow).
+  test.describe.configure({ mode: 'serial' });
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test(
+    'input stays enabled while streaming; a resend supersedes the old turn and the old reply stops scrolling',
+    { timeout: 420_000 },
+    async () => {
+      const inputX = page.locator(INPUT);
+      await expect(inputX).toBeVisible({ timeout: 10_000 });
+
+      // A fresh session (sidebar "+") so the initial-session cold-load retry
+      // window (#570: sessions.get backoff up to ~57s) is NOT the thing under
+      // test — we want to exercise mid-stream input, not session loading.
+      await createNewConversation(page);
+
+      // Gate on historyLoaded: the message area shows "正在连接…" until the
+      // session history loads. Sending before that can leave the reply area
+      // stuck on the connecting hint (cold-start flake) and the user bubbles
+      // unrendered — not the #542 behavior we're testing.
+      await expect(page.getByText('正在连接…')).toBeHidden({ timeout: 60_000 });
+
+      // ── Send a medium-length prompt so the reply streams for several
+      //    seconds — long enough to interact with the input mid-stream. ──
+      const markerA = `542A_${Date.now().toString(36)}`;
+      const promptA = `${markerA}：请用 5 段话详细介绍杭州这座城市的历史、文化、美食、交通、教育与发展。`;
+      await sendPrompt(page, promptA);
+
+      // Wait for the turn to ACTUALLY start streaming: the optimistic user
+      // bubble's pending spinner (#364) disappears on the FIRST progress event
+      // (setSendingFor(null)), which is exactly when the pre-stream pending
+      // phase ends and pendingSendIds is cleared. We must NOT resend earlier —
+      // while the send is still pending the #364 double-Enter guard correctly
+      // swallows a resend, which is not the scenario under test.
+      const pendingSpinner = page.locator(
+        '[data-testid="chat-message-user"] svg.animate-spin',
+      );
+      await expect(pendingSpinner.last()).toBeHidden({ timeout: 120_000 });
+
+      // ── #542 core: the input must be ENABLED while the AI is streaming
+      //    (thinking, tool calls or reply text — the whole turn). This is the
+      //    exact regression #658 re-broke with disabled={streaming}. ──
+      await expect(inputX).toBeEnabled({ timeout: 5_000 });
+
+      // ── Wait for the FIRST reply to actually generate a portion of its
+      //    text.  The assistant bubble only appears once the final-text stream
+      //    starts (after the agentic thinking/tool phase), so a visible
+      //    non-empty bubble proves real reply text is streaming.  Only THEN do
+      //    we fire the correction — the scenario is "reply partially generated,
+      //    user interrupts mid-output", not "resend during the pre-stream
+      //    pending phase". ──
+      const firstAssistant = page
+        .getByTestId('chat-message-assistant')
+        .first();
+      await expect(firstAssistant).toBeVisible({ timeout: 180_000 });
+      await expect(firstAssistant).toHaveText(/\S/, { timeout: 120_000 });
+
+      // ── Quick course-correction: type a correction + Enter while the reply
+      //    is streaming real text ──
+      const markerB = `542B_${Date.now().toString(36)}`;
+      await sendPrompt(page, `只回答${markerB}`);
+
+      // The second user bubble appears — the input kept working mid-stream.
+      await expect(page.getByTestId('chat-message-user')).toHaveCount(2, {
+        timeout: 15_000,
+      });
+      // The input cleared for the new send.
+      await expect(inputX).toHaveValue('', { timeout: 5_000 });
+
+      // Input stays enabled throughout the interaction.
+      await expect(inputX).toBeEnabled({ timeout: 5_000 });
+
+      // ── The resend turn completes: streaming ends when the "停止生成"
+      //    button (shown while streaming with an empty input) is replaced by
+      //    the send button.  This is a reliable completion signal independent
+      //    of the model's reply content, tool timers, or approval dialogs
+      //    (bypass_all is on in the E2E config). ──
+      await expect(page.getByRole('button', { name: '停止生成' })).toBeHidden({
+        timeout: 180_000,
+      });
+
+      // A reply rendered for the resend turn (the app did not wedge).
+      const assistantCount = await page.getByTestId('chat-message-assistant').count();
+      expect(
+        assistantCount,
+        'the resend should produce an assistant reply (turn completed, not wedged)',
+      ).toBeGreaterThan(0);
+      await expect(inputX).toBeEnabled({ timeout: 5_000 });
+    },
+  );
+});

--- a/miqi/runtime/app_server.py
+++ b/miqi/runtime/app_server.py
@@ -843,7 +843,11 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        thread_id = typed.thread_id or "default"
+        # Match chat.send's thread resolution (loop.py): thread_id falls back to
+        # the session_key, NOT a hardcoded "default".  A turn started without an
+        # explicit thread registers its cancel event under session_key, so an
+        # abort that resolved to "default" could never signal it (#542).
+        thread_id = typed.thread_id or params.get("session_key") or "default"
         await session.submit(AbortTurn(thread_id=thread_id))
         return {"result": {"aborted": True}}
 

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -456,9 +456,12 @@ class TaskRunner:
 
         # Phase 14 follow-up: register a cancel event so AbortTurn can
         # signal this specific turn to stop. Reuse existing event if a
-        # previous turn on the same thread hasn't been cleaned up yet.
+        # previous turn on the same thread hasn't been cleaned up yet — but
+        # NOT if it's already set, or a fresh user message right after an
+        # abort would inherit the previous turn's cancellation and die
+        # "before start" (#542).
         cancel_evt = self._turn_cancel_events.get(thread_id)
-        if cancel_evt is None:
+        if cancel_evt is None or cancel_evt.is_set():
             cancel_evt = asyncio.Event()
             self._turn_cancel_events[thread_id] = cancel_evt
 

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -211,6 +211,13 @@ class TurnRunner:
                 temperature=turn.temperature,
                 max_tokens=turn.max_tokens,
             ):
+                # Phase 14 follow-up: the iteration-start check above only fires
+                # BETWEEN iterations.  A single-shot reply is one iteration, so
+                # once the stream is flowing an abort would otherwise be ignored
+                # until the whole response finishes (#542).  Check on every
+                # stream event so an interrupt stops the bubble mid-generation.
+                if cancel_event is not None and cancel_event.is_set():
+                    raise asyncio.CancelledError("Turn cancelled via AbortTurn")
                 if stream_event.kind == "content_delta":
                     content_parts.append(stream_event.delta)
                     from miqi.protocol.events import AgentMessageDeltaEvent

--- a/tests/runtime/test_app_server_commands.py
+++ b/tests/runtime/test_app_server_commands.py
@@ -145,6 +145,54 @@ async def test_abort_through_app_server(fake_config, fake_provider, tmp_path):
     await registry.stop_all()
 
 
+@pytest.mark.asyncio
+async def test_abort_resolves_thread_from_session_key(fake_config, fake_provider, tmp_path):
+    """chat.abort must target the SAME thread a turn registers its cancel event
+    under.  chat.send (loop.py) falls back thread_id -> session_key; abort must
+    mirror that, not hardcode "default" (#542)."""
+    from miqi.protocol.commands import AbortTurn
+    from miqi.runtime.app_server import register_command_handlers
+
+    server, registry = _setup_server_with_session(fake_config, fake_provider, tmp_path)
+    session = await registry.create_session(
+        client_id="c1", session_key="s1",
+        config=fake_config, provider=fake_provider, workspace=tmp_path,
+    )
+    register_command_handlers(server)
+
+    # No thread_id + session_key -> must resolve to the session_key thread.
+    await server.dispatch(
+        request_id="r1", method="chat.abort",
+        params={"session_key": "s1"},
+        client_id="c1", session_id=session.session_id,
+    )
+    sub = session._submissions.get_nowait()
+    assert isinstance(sub, AbortTurn)
+    assert sub.thread_id == "s1"
+
+    # Explicit thread_id wins.
+    await server.dispatch(
+        request_id="r2", method="chat.abort",
+        params={"session_key": "s1", "thread_id": "thread-xyz"},
+        client_id="c1", session_id=session.session_id,
+    )
+    sub = session._submissions.get_nowait()
+    assert isinstance(sub, AbortTurn)
+    assert sub.thread_id == "thread-xyz"
+
+    # Neither -> legacy "default" fallback (CLI path).
+    await server.dispatch(
+        request_id="r3", method="chat.abort",
+        params={},
+        client_id="c1", session_id=session.session_id,
+    )
+    sub = session._submissions.get_nowait()
+    assert isinstance(sub, AbortTurn)
+    assert sub.thread_id == "default"
+
+    await registry.stop_all()
+
+
 # ── Config ───────────────────────────────────────────────────────────────
 
 

--- a/tests/runtime/test_runtime_task_runner.py
+++ b/tests/runtime/test_runtime_task_runner.py
@@ -856,6 +856,44 @@ async def test_abort_signals_both_turns_on_shared_event(fake_services):
 
 
 @pytest.mark.asyncio
+async def test_new_turn_after_abort_gets_fresh_cancel_event(fake_services):
+    """A user message sent after an abort on the same thread must NOT reuse the
+    already-set cancel event, or it would abort "before start" (#542)."""
+    seen_cancel_events: list[asyncio.Event | None] = []
+
+    async def _record_run(**kwargs):
+        seen_cancel_events.append(kwargs.get("cancel_event"))
+        result = type("Result", (), {})()
+        result.final_content = "ok"
+        result.tools_used = []
+        result.token_usage = {}
+        result.messages_delta = [{"role": "assistant", "content": "ok"}]
+        return result
+
+    fake_services.turn_runner.run.side_effect = _record_run
+
+    events = asyncio.Queue()
+    runner = TaskRunner(services=fake_services, event_queue=events)
+    thread_id = "fresh-after-abort"
+
+    # Simulate a prior turn on this thread that was aborted but whose cancel
+    # event is still registered and set (old turn hasn't cleaned up yet).
+    stale = asyncio.Event()
+    stale.set()
+    runner._turn_cancel_events[thread_id] = stale
+
+    await runner.handle(UserMessage(
+        content="after abort", thread_id=thread_id, turn_id="new-turn",
+    ))
+
+    assert len(seen_cancel_events) == 1, "turn must run, not abort before start"
+    fresh = seen_cancel_events[0]
+    assert fresh is not None
+    assert fresh is not stale, "must not reuse the stale set event"
+    assert not fresh.is_set(), "fresh event must start unset"
+
+
+@pytest.mark.asyncio
 async def test_single_turn_abort_during_turn_runner(fake_services):
     """The cancel event registered by _handle_user_message must be
     reachable by AbortTurn while turn_runner.run is still executing."""

--- a/tests/runtime/test_turn_runner.py
+++ b/tests/runtime/test_turn_runner.py
@@ -1,5 +1,7 @@
 """Tests for TurnRunner (Phase 12.3)."""
 
+import asyncio
+
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -112,6 +114,35 @@ async def test_turn_runner_returns_final_response(turn_runner, fake_turn_context
     assert result.messages[-1]["role"] == "assistant"
     # Phase 20: no direct chat() call — stream_chat is used instead
     assert not hasattr(provider, "chat_called") or True  # sanity
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_aborts_mid_stream(turn_runner, fake_turn_context):
+    """Abort must stop generation WHILE the stream is flowing, not only at the
+    next iteration boundary — a single-shot reply is one iteration, so the
+    iteration-start check alone would let the old turn stream to completion
+    after an interrupt (#542)."""
+    from miqi.providers.base import LLMStreamEvent
+
+    runner, provider = turn_runner
+    cancel_event = asyncio.Event()
+
+    async def _stream(**kwargs):
+        yield LLMStreamEvent(kind="content_delta", delta="chunk-0")
+        cancel_event.set()  # abort fires between stream events
+        yield LLMStreamEvent(kind="content_delta", delta="chunk-1")
+        yield LLMStreamEvent(kind="completed", response=_FakeResponse(content="done"))
+
+    provider.stream_chat = _stream
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner.run(
+            turn=fake_turn_context,
+            user_content="hello",
+            system_prompt="system",
+            tools=[],
+            cancel_event=cancel_event,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #542：AI 流式回复期间输入框不再被禁用，用户可提前键入下一条消息；流式中发送新消息会中断旧 turn 并立即开始新回复。

## 背景/问题

PR #658 在 #660 的修复之上重新加回了 `disabled={streaming}`（ChatConsole.tsx:5275），导致 AI 流式回复期间输入框被完全禁用，用户无法提前键入下一条 prompt，也无法在新对话方向出现时快速修正当前请求。根因有两层：

1. **输入框被锁定**：`disabled={streaming}` 让 handleSend 中已有的"中断并重发"逻辑永远无法被触发；
2. **中断可能落空**：即便触发，`chat.abort` 只传 session_key，后端 resolve 成硬编码 `"default"` thread，而 turn 实际把取消事件注册在 session_key 命名的 thread 下（`chat.send` 的 fallback 是 `thread_id -> session_key`），取消对不上号，旧 turn 会继续生成整轮才结束。

## 关联 issue

- Closes #542

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 移除 textarea 的 `disabled={streaming}`（#658 重新引入的回归点），输入框全程可用；
  - handleSend 新增 reveal-reset 块：新发送时无条件取消旧打字机 RAF 并重置该会话的 reveal 状态，防止旧回复在新 turn 开始后继续逐字渲染；
  - 超期与重发两处 `chat.abort` 现在携带 `currentThreadIdRef.current`，让 abort 命中旧 turn 注册的线程。
- `apps/desktop/src/main/ipc/index.ts`、`apps/desktop/src/preload/index.ts`：CHAT_ABORT 转发 `thread_id`，preload 签名改为 `chat.abort(sessionKey?, threadId?)`。
- `miqi/runtime/app_server.py`：abort 的 thread 解析与 chat.send 对齐——`thread_id or session_key or "default"`，不再硬编码 `"default"`。
- `miqi/runtime/task_runner.py`：新用户消息在旧 turn 刚被 abort 时不再复用已 set 的取消事件，避免新 turn"发送即被取消"。
- `miqi/runtime/turn_runner.py`：流式事件循环内每事件检查取消标志，中断在回复生成中途立即生效。
- `tests/runtime/*`：3 个新增单测覆盖以上后端行为（abort thread 解析、abort 后新 turn 新取消事件、流式中断）。
- `apps/desktop/tests/e2e/issue-542-streaming-input.spec.ts`：新增回归 E2E——流式期间输入框可用 + 回复已生成一段后中断重发、新回复完成。

## 日志/验证证据

```
# 后端单测（受影响的 3 个测试文件，含 3 个新增用例）
$ uv run pytest tests/runtime/test_app_server_commands.py tests/runtime/test_runtime_task_runner.py tests/runtime/test_turn_runner.py -q
61 passed in 3.04s

# 桌面端类型检查
$ npm run typecheck
# node + web 均无错误

# #542 回归 E2E（真实 LLM，playwright electron project）——连续 3 次全绿
$ npx playwright test --config=playwright.config.ts --project=electron -g "Issue #542"
1 passed (54.4s)
```

## 测试情况

- 后端：`tests/runtime` 三个受影响测试文件 61 个用例全部通过（含 3 个新增：abort thread 解析、abort 后新 turn 新取消事件、流式中断）。
- 桌面端：`npm run typecheck`（node + web）无错误。
- E2E：`issue-542-streaming-input.spec.ts` 连续 3 次运行通过。流程——发送第一条长 prompt → 等待流式开始且回复已生成可见文本 → 输入框保持可用 → 发送"只回答XXX"中断并重发 → 出现第二条用户气泡、输入框清空且仍可用 → 新 turn 回复完整渲染。
- 既有 E2E 回归：`session-streaming-isolation`（3 passed, 1.2m）此前已通过，无回归。

## 截图

https://github.com/user-attachments/assets/f8a2bbea-d83d-4193-93f3-0bb1a8767ef5


## 后续计划

- 可选增强：支持编辑历史 user 消息，修改后自动 abort 并重发（issue 建议方向 #3）
- 可选增强：放开 ExecutionPolicySelector 的 `disabled={streaming}`（切换模式下次发送生效）


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove `disabled={streaming}` so input stays usable during replies

- Send interrupts current turn with the correct `thread_id`

- Backend aborts the active thread mid-stream instead of after completion

- Add unit and E2E regression coverage for issue #542


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User enters prompt during streaming"] --> B["ChatConsole removes disabled state, abort passes thread_id"]
  B --> C["AppServer resolves thread_id to session_key"]
  C --> D["TurnRunner checks cancel_event mid-stream"]
  D --> E["Old turn aborts; new turn gets fresh cancel event"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>ChatConsole.tsx</strong><dd><code>Keep input enabled and interrupt/resend with thread id</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+35/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Forward thread_id in chat.abort IPC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Expose threadId in chat.abort API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_server.py</strong><dd><code>Resolve chat.abort thread_id from session_key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-babc1da0d9c056a4bf23a9db4a6f1e1240b3512ee5ccfc99253cfc85d28860b9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task_runner.py</strong><dd><code>Create fresh cancel event after abort</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>turn_runner.py</strong><dd><code>Abort streaming mid-generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-4627bd8e77d69d5a0d5be03c29bd0c3402cd0988e6d538cad1b99f4be0a60696">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_app_server_commands.py</strong><dd><code>Test abort thread resolution from session_key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-ae1d54f8e0152b31104e7b97775d6dff68a2ae35b8b1d6c63ac807e44db628a4">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_runtime_task_runner.py</strong><dd><code>Test fresh cancel event after abort</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-3d3e42ffab403d1934d04448e738bf62ea870e8f122ebbe416b174e61a57bb80">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_turn_runner.py</strong><dd><code>Test turn abort mid-stream</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-a56d7685f75da402a2ee2707aa9f7a44fda4ba457bb45dd047b2f01aaeaaae03">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>issue-542-streaming-input.spec.ts</strong><dd><code>E2E regression for streaming input and resend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/717/files#diff-46994c64b5b3132de08dafeac79de810800bc01320fd9ac832996b7a42a63dcf">+156/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

