### PR TITLE
test(e2e): regression-480 放宽总预算与 Phase 4 等待 — 修复 macos-e2e 唯一失败点

### DIFF
--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -58,7 +58,10 @@ test.describe('Regression #480: Session loads on startup', () => {
 
   test(
     'session history visible on restart without switching sessions',
-    { timeout: LLM_TIMEOUT * 3 },
+    // Slow macOS runners burn most of the budget in Phase 1 (AI reply up to
+    // 240s) + relaunch cold start — LLM_TIMEOUT*3 (720s) was cutting the test
+    // off mid-Phase-4 on macos-e2e (42/43 green, only this one dying).
+    { timeout: LLM_TIMEOUT * 5 },
     async () => {
       // ── Phase 1: Launch, create a session with known content ──
       const fixture = await launchElectronApp();
@@ -104,10 +107,11 @@ test.describe('Regression #480: Session loads on startup', () => {
       // ── Phase 4: Verify marker is visible WITHOUT session switching ──
       // ChatConsole.load() retries up to ~55s.  Use a web-first assertion
       // with a generous timeout so the test self-heals regardless of bridge
-      // startup speed — no fixed delay, no null-safety edge case.
+      // startup speed — no fixed delay, no null-safety edge case.  240s to
+      // match waitForResponseComplete (slow macOS cold start, #709).
       await expect(
         page2.locator('main').getByText(marker, { exact: false }).first(),
-      ).toBeVisible({ timeout: 120_000 });
+      ).toBeVisible({ timeout: 240_000 });
       console.log(`[test] ✅ Phase 3: History loaded after restart — no session switch needed`);
 
       // Clean up: close second app, then delete miqiHome

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -112,6 +112,8 @@ test.describe('Regression #480: Session loads on startup', () => {
       await expect(
         page2.locator('main').getByText(marker, { exact: false }).first(),
       ).toBeVisible({ timeout: 240_000 });
+      // Note: marker text comes from the persisted session history (Phase 1
+      // reply), so this assertion also proves cross-restart history loading.
       console.log(`[test] ✅ Phase 3: History loaded after restart — no session switch needed`);
 
       // Clean up: close second app, then delete miqiHome


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🧪 测试

## 变更概述

放宽 regression-480 Test 1（重启后历史可见）的测试总预算与 Phase 4 等待——修复 macos-e2e 上唯一确定性失败点。

## 背景/问题

macos-e2e 当前 42/43 绿，唯一红：regression-480「session history visible on restart」。慢 macOS runner 上：
- Phase 1 的 AI 回复（waitForResponseComplete 240s）+ 重启冷启动占掉大部分时间
- 测试总预算 LLM_TIMEOUT*3（720s）被 Phase 1 烧穿 → 测试级超时中断（Phase 4 截图只是中断点，非断言失败）
- Phase 4 的 120s marker 可见性等待对慢冷启动也不够

## 变更内容

- 测试总预算：LLM_TIMEOUT*3（720s）→ LLM_TIMEOUT*5（1200s）
- Phase 4 marker 可见性等待：120s → 240s（与 waitForResponseComplete 对齐，#709）

## 日志/验证证据

```
修复前（macos-e2e 08:17 run，develop d62b08a7）：
  唯一失败：regression-480「session history visible on restart」
  42 passed + 1 failed（3 次重试全挂同一测试）

修复后（本分支）：
  npm run typecheck → 0 错误
  npx playwright test --list → 2 tests 收集正常
  行为验证由 CI macos-e2e 执行
```

## 测试情况

typecheck 0 错；改动仅为超时放宽，不改变断言语义。


___

### **PR Type**
Tests


___

### **Description**
- Increase regression-480 test timeout from 720s to 1200s

- Extend Phase 4 marker visibility wait to 240s

- Add comments clarifying slow macOS cold start behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLM_TIMEOUT * 3 (720s)"] -- "increase to" --> B["LLM_TIMEOUT * 5 (1200s)"]
  C["Phase 4 toBeVisible timeout 120s"] -- "increase to" --> D["240s for slow macOS"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>regression-480-startup-history.spec.ts</strong><dd><code>Relax regression-480 e2e timeouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/regression-480-startup-history.spec.ts

<ul><li>Increase per-test timeout from <code>LLM_TIMEOUT * 3</code> to <code>LLM_TIMEOUT * 5</code>.<br> <li> Raise Phase 4 <code>toBeVisible</code> timeout from 120s to 240s.<br> <li> Add explanatory comments about slow macOS cold start and history <br>assertion.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/725/files#diff-747a811277a39c83a94a4b3a78a8702e9bb76364dfb253375e8d55b0e99d5bbf">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

