### PR TITLE
fix: 工具层错误文案中文化——160+ 处 Error:/异常英文转中文（#721）

### DIFF
--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -454,8 +454,13 @@ export async function launchElectronApp(
     }
   }
 
+  // Isolated Electron userData per launch: without it every test instance
+  // (and the dev app) shares the default profile, so sessions/UI state leak
+  // between runs and tests "continue" a previous conversation (#721 实测).
+  const userDataDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-ud-'));
+
   const electronApp = await electron.launch({
-    args: [APPS_DESKTOP],
+    args: [`--user-data-dir=${userDataDir}`, APPS_DESKTOP],
     executablePath: require('electron') as string,
     env: env as Record<string, string>,
     // chromiumSandbox: false covers --no-sandbox + --disable-gpu
@@ -567,8 +572,13 @@ export async function relaunchElectronApp(
     }
   }
 
+  // Isolated Electron userData per launch: without it every test instance
+  // (and the dev app) shares the default profile, so sessions/UI state leak
+  // between runs and tests "continue" a previous conversation (#721 实测).
+  const userDataDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-ud-'));
+
   const electronApp = await electron.launch({
-    args: [APPS_DESKTOP],
+    args: [`--user-data-dir=${userDataDir}`, APPS_DESKTOP],
     executablePath: require('electron') as string,
     env: env as Record<string, string>,
     chromiumSandbox: false,

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -457,7 +457,7 @@ export async function launchElectronApp(
   // Isolated Electron userData per launch: without it every test instance
   // (and the dev app) shares the default profile, so sessions/UI state leak
   // between runs and tests "continue" a previous conversation (#721 实测).
-  const userDataDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-ud-'));
+  const userDataDir = join(miqiHome, 'userdata');
 
   const electronApp = await electron.launch({
     args: [`--user-data-dir=${userDataDir}`, APPS_DESKTOP],
@@ -575,7 +575,7 @@ export async function relaunchElectronApp(
   // Isolated Electron userData per launch: without it every test instance
   // (and the dev app) shares the default profile, so sessions/UI state leak
   // between runs and tests "continue" a previous conversation (#721 实测).
-  const userDataDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-ud-'));
+  const userDataDir = join(miqiHome, 'userdata');
 
   const electronApp = await electron.launch({
     args: [`--user-data-dir=${userDataDir}`, APPS_DESKTOP],

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -310,11 +310,11 @@ class ApplyPatchTool(Tool):
     async def execute(self, **kwargs: Any) -> str:  # type: ignore[override]
         patch = kwargs.get("patch", "")
         if not isinstance(patch, str) or not patch:
-            return "Error: Missing required parameter 'patch'"
+            return "Error: 缺少必要参数 'patch'"
         try:
             file_patches = parse_patch(patch)
         except PatchParseError as e:
-            return f"Error: Invalid patch: {e}"
+            return f"Error: 补丁格式无效：{e}"
 
         changed: list[str] = []
         sandbox = _get_active_sandbox(self._sandbox_manager)
@@ -325,7 +325,7 @@ class ApplyPatchTool(Tool):
             except PatchApplyError as e:
                 return f"Error applying patch to {fp.path}: {e}"
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return f"Error: 权限被拒绝：{e}"
             except Exception as e:
                 return f"Error applying patch to {fp.path}: {type(e).__name__}: {e}"
             if result is not None:

--- a/miqi/agent/tools/ask_user_confirm.py
+++ b/miqi/agent/tools/ask_user_confirm.py
@@ -147,7 +147,7 @@ class AskUserConfirmCardTool(Tool):
                 gate_result = await self._resolver(payload)
                 return self.build_result(gate_result)
             except Exception as exc:  # noqa: BLE001 - surface as tool error
-                return f"Error: ask_user_confirm_card failed: {exc}"
+                return f"Error: ask_user_confirm_card 执行失败：{exc}"
         return (
             "Error: ask_user_confirm_card 需要桌面端用户输入通道（KUN runtime），"
             "当前环境未接线。不要假设用户已同意；请说明需要确认的内容并请用户在聊天中回复。"

--- a/miqi/agent/tools/base.py
+++ b/miqi/agent/tools/base.py
@@ -66,7 +66,7 @@ class Tool(ABC):
         """Validate tool parameters against JSON schema. Returns error list (empty if valid)."""
         schema = self.parameters or {}
         if schema.get("type", "object") != "object":
-            raise ValueError(f"Schema must be object type, got {schema.get('type')!r}")
+            raise ValueError(f"Schema 必须是对象类型，实际为 {schema.get('type')!r}")
         return self._validate(params, {**schema, "type": "object"}, "")
 
     def _validate(self, val: Any, schema: dict[str, Any], path: str) -> list[str]:

--- a/miqi/agent/tools/cron.py
+++ b/miqi/agent/tools/cron.py
@@ -94,17 +94,17 @@ class CronTool(Tool):
         at: str | None,
     ) -> str:
         if not message:
-            return "Error: message is required for add"
+            return "Error: 添加任务必须提供 message"
         if not self._channel or not self._chat_id:
-            return "Error: no session context (channel/chat_id)"
+            return "Error: 缺少会话上下文（channel/chat_id）"
         if tz and not cron_expr and not at:
-            return "Error: tz can only be used with cron_expr or at"
+            return "Error: tz 只能与 cron_expr 或 at 搭配使用"
         if tz:
             from zoneinfo import ZoneInfo
             try:
                 ZoneInfo(tz)
             except (KeyError, Exception):
-                return f"Error: unknown timezone '{tz}'"
+                return f"Error: 未知时区 '{tz}'"
 
         # Build schedule
         delete_after = False
@@ -127,7 +127,7 @@ class CronTool(Tool):
             schedule = CronSchedule(kind="at", at_ms=at_ms)
             delete_after = True
         else:
-            return "Error: either every_seconds, cron_expr, or at is required"
+            return "Error: 必须提供 every_seconds、cron_expr 或 at 之一"
 
         job = self._cron.add_job(
             name=message[:30],
@@ -149,7 +149,7 @@ class CronTool(Tool):
 
     def _remove_job(self, job_id: str | None) -> str:
         if not job_id:
-            return "Error: job_id is required for remove"
+            return "Error: 删除任务必须提供 job_id"
         if self._cron.remove_job(job_id):
             return f"Removed job {job_id}"
         return f"Job {job_id} not found"

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -307,7 +307,7 @@ def _canonicalize_wsl_mnt_path(
     except Exception:
         _log.warning("_canonicalize_wsl_mnt_path: cannot resolve %s, rejecting path", host_str)
         raise PermissionError(
-            f"Cannot canonicalize path '{host_str}': resolution failed"
+            f"无法规范化路径 '{host_str}'：解析失败"
         )
 
     # Build the list of legal roots: the per-session workspace plus any
@@ -339,9 +339,9 @@ def _canonicalize_wsl_mnt_path(
     else:
         roots_str = ", ".join(str(r) for r in roots) if roots else "<none>"
         raise PermissionError(
-            f"Path '{host_str}' (normalized: '{normalized}') resolves to '{resolved}' "
-            f"which is outside all legal roots [{roots_str}]. "
-            "Add the directory to tools.extra_roots in the MiQi config to allow access."
+            f"路径 '{host_str}'（规范化后：'{normalized}'）解析为 '{resolved}'，"
+            f"不在任何合法根目录 [{roots_str}] 内。 "
+            "如需访问，请在 MiQi 配置的 tools.extra_roots 中添加该目录。"
         )
 
     # Per-session isolation: when session isolation is active, a path under
@@ -371,11 +371,10 @@ def _canonicalize_wsl_mnt_path(
                     # Do NOT include the resolved path: it can reveal
                     # another session's identifier and file layout.
                     raise PermissionError(
-                        "Path is inside another session's files dir — "
-                        "per-session isolation forbids cross-session access. "
-                        "Do not retry or enumerate sessions/; use the current "
-                        "session's workspace instead, or ask the user to share "
-                        "the file via the file panel."
+                        "路径位于其他会话的 files 目录内——"
+                        "会话隔离禁止跨会话访问。 "
+                        "不要重试或枚举 sessions/；请使用当前会话的工作区，"
+                        "或请用户通过文件面板分享文件。"
                     )
 
     resolved_str = str(resolved).replace("\\", "/")
@@ -603,8 +602,7 @@ def _resolve_path(
     # Defense-in-depth: reject symlink components before resolving (SEC-06).
     if allowed_dir and _has_symlink_in_path(p):
         raise PermissionError(
-            f"Path '{path}' contains a symbolic link, which is not permitted "
-            "in restricted mode."
+            f"路径 '{path}' 包含符号链接，受限模式下不允许。"
         )
     resolved = p.resolve()
     if allowed_dir:
@@ -620,7 +618,7 @@ def _resolve_path(
                 except ValueError:
                     continue
             if not allowed:
-                raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
+                raise PermissionError(f"路径 {path} 超出允许目录 {allowed_dir}")
     return resolved
 
 
@@ -629,7 +627,7 @@ async def _sandbox_read_file(sandbox, sandbox_path: str) -> str:
     escaped = sandbox_path.replace("'", "'\\''")
     rc, stdout, stderr = await sandbox.run_command(f"cat '{escaped}'")
     if rc != 0:
-        raise FileNotFoundError(f"Cannot read {sandbox_path}: {stderr}")
+        raise FileNotFoundError(f"无法读取 {sandbox_path}：{stderr}")
     return stdout
 
 
@@ -736,16 +734,16 @@ class ReadFileTool(Tool):
             try:
                 exists = await _sandbox_file_exists(sandbox, sandbox_path)
             except Exception as e:
-                return f"Error: Failed to check file existence in sandbox (path={sandbox_path}): {e}"
+                return f"Error: 沙箱中检查文件是否存在失败（path={sandbox_path}）：{e}"
             if not exists:
-                return f"Error: File not found: {path} (sandbox path: {sandbox_path})"
+                return f"Error: 文件不存在：{path}（沙箱路径：{sandbox_path}）"
             try:
                 content = await _sandbox_read_file(sandbox, sandbox_path)
                 return content
             except FileNotFoundError as e:
-                return f"Error: File not found in sandbox: {sandbox_path}: {e}"
+                return f"Error: 沙箱中文件不存在：{sandbox_path}：{e}"
             except Exception as e:
-                return f"Error: Failed to read file in sandbox (path={sandbox_path}): {type(e).__name__}: {e}"
+                return f"Error: 沙箱中读取文件失败（path={sandbox_path}）：{type(e).__name__}：{e}"
         else:
             # Native sandbox or no sandbox — use local filesystem
             try:
@@ -757,14 +755,14 @@ class ReadFileTool(Tool):
                     shared_roots=self._shared_roots,
                 )
                 if not file_path.exists():
-                    return f"Error: File not found: {path}"
+                    return f"Error: 文件不存在：{path}"
                 if not file_path.is_file():
-                    return f"Error: Not a file: {path}"
+                    return f"Error: 不是文件：{path}"
 
                 content = file_path.read_text(encoding="utf-8")
                 return content
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return f"Error: 权限被拒绝：{e}"
             except Exception as e:
                 return f"Error reading file: {type(e).__name__}: {e}"
 
@@ -815,7 +813,7 @@ class WriteFileTool(Tool):
         office_suffixes = {".docx", ".xlsx", ".pptx"}
         if Path(path).suffix.lower() in office_suffixes:
             return (
-                "Error: write_file cannot create Office binary files. "
+                "Error: write_file 无法创建 Office 二进制文件。 "
                 "Use create_docx, create_xlsx, or create_pptx instead."
             )
 
@@ -831,9 +829,9 @@ class WriteFileTool(Tool):
             try:
                 await _sandbox_write_file(sandbox, sandbox_path, content)
             except IOError as e:
-                return f"Error: Failed to write file in sandbox (path={sandbox_path}): {e}"
+                return f"Error: 沙箱中写入文件失败（path={sandbox_path}）：{e}"
             except Exception as e:
-                return f"Error: Failed to write file in sandbox (path={sandbox_path}): {type(e).__name__}: {e}"
+                return f"Error: 沙箱中写入文件失败（path={sandbox_path}）：{type(e).__name__}：{e}"
 
             # Mirror the file to the host workspace so that files.read
             # (which resolves against the host workspace) can find it.
@@ -879,7 +877,7 @@ class WriteFileTool(Tool):
                     _log.warning("Snapshot failed for %s — revert will not be available", file_path)
                 return result
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return f"Error: 权限被拒绝：{e}"
             except Exception as e:
                 return f"Error writing file: {type(e).__name__}: {e}"
 
@@ -943,14 +941,14 @@ class EditFileTool(Tool):
             try:
                 exists = await _sandbox_file_exists(sandbox, sandbox_path)
             except Exception as e:
-                return f"Error: Failed to check file existence in sandbox (path={sandbox_path}): {e}"
+                return f"Error: 沙箱中检查文件是否存在失败（path={sandbox_path}）：{e}"
             if not exists:
-                return f"Error: File not found: {path} (sandbox path: {sandbox_path})"
+                return f"Error: 文件不存在：{path}（沙箱路径：{sandbox_path}）"
 
             try:
                 content = await _sandbox_read_file(sandbox, sandbox_path)
             except Exception as e:
-                return f"Error: Failed to read file in sandbox for editing (path={sandbox_path}): {type(e).__name__}: {e}"
+                return f"Error: 沙箱中读取文件用于编辑失败（path={sandbox_path}）：{type(e).__name__}：{e}"
 
             if old_text not in content:
                 return self._not_found_message(old_text, content, path)
@@ -964,7 +962,7 @@ class EditFileTool(Tool):
             try:
                 await _sandbox_write_file(sandbox, sandbox_path, new_content)
             except Exception as e:
-                return f"Error: Failed to write edited file in sandbox (path={sandbox_path}): {type(e).__name__}: {e}"
+                return f"Error: 沙箱中写入编辑后文件失败（path={sandbox_path}）：{type(e).__name__}：{e}"
 
             # Mirror the file to the host workspace so files.read can find it.
             # Skip mirror for /mnt/ paths: the sandbox already wrote directly
@@ -995,7 +993,7 @@ class EditFileTool(Tool):
                     shared_roots=self._shared_roots,
                 )
                 if not file_path.exists():
-                    return f"Error: File not found: {path}"
+                    return f"Error: 文件不存在：{path}"
 
                 # Snapshot original content before first edit (enables non-git diff/revert)
                 _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
@@ -1019,7 +1017,7 @@ class EditFileTool(Tool):
 
                 return f"Successfully edited {file_path}"
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return f"Error: 权限被拒绝：{e}"
             except Exception as e:
                 return f"Error editing file: {type(e).__name__}: {e}"
 
@@ -1044,8 +1042,8 @@ class EditFileTool(Tool):
                 fromfile="old_text (provided)", tofile=f"{path} (actual, line {best_start + 1})",
                 lineterm="",
             ))
-            return f"Error: old_text not found in {path}.\nBest match ({best_ratio:.0%} similar) at line {best_start + 1}:\n{diff}"
-        return f"Error: old_text not found in {path}. No similar text found. Verify the file content."
+            return f"Error: 在 {path} 中未找到 old_text。\n最佳匹配（相似度 {best_ratio:.0%}）位于第 {best_start + 1} 行：\n{diff}"
+        return f"Error: 在 {path} 中未找到 old_text，也没有相似文本。请核对文件内容。"
 
 
 class ListDirTool(Tool):
@@ -1101,15 +1099,15 @@ class ListDirTool(Tool):
             try:
                 exists = await _sandbox_dir_exists(sandbox, sandbox_path)
             except Exception as e:
-                return f"Error: Failed to check directory existence in sandbox (path={sandbox_path}): {e}"
+                return f"Error: 沙箱中检查目录是否存在失败（path={sandbox_path}）：{e}"
             if not exists:
-                return f"Error: Directory not found: {path} (sandbox path: {sandbox_path})"
+                return f"Error: 目录不存在：{path}（沙箱路径：{sandbox_path}）"
             try:
                 content = await _sandbox_list_dir(sandbox, sandbox_path)
             except IOError as e:
-                return f"Error: Failed to list directory in sandbox (path={sandbox_path}): {e}"
+                return f"Error: 沙箱中列出目录失败（path={sandbox_path}）：{e}"
             except Exception as e:
-                return f"Error: Failed to list directory in sandbox (path={sandbox_path}): {type(e).__name__}: {e}"
+                return f"Error: 沙箱中列出目录失败（path={sandbox_path}）：{type(e).__name__}：{e}"
             if not content.strip():
                 return f"Directory {path} is empty"
             return content
@@ -1124,9 +1122,9 @@ class ListDirTool(Tool):
                     shared_roots=self._shared_roots,
                 )
                 if not dir_path.exists():
-                    return f"Error: Directory not found: {path}"
+                    return f"Error: 目录不存在：{path}"
                 if not dir_path.is_dir():
-                    return f"Error: Not a directory: {path}"
+                    return f"Error: 不是目录：{path}"
 
                 items = []
                 for item in sorted(dir_path.iterdir()):
@@ -1138,6 +1136,6 @@ class ListDirTool(Tool):
 
                 return "\n".join(items)
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return f"Error: 权限被拒绝：{e}"
             except Exception as e:
                 return f"Error listing directory: {type(e).__name__}: {e}"

--- a/miqi/agent/tools/memory.py
+++ b/miqi/agent/tools/memory.py
@@ -63,7 +63,7 @@ class MemoryTool(Tool):
         old_text: str = "",
     ) -> str:
         if target not in self.VALID_TARGETS:
-            return f"Error: invalid target '{target}'. Valid targets are: {', '.join(sorted(self.VALID_TARGETS))}"
+            return f"Error: 无效的 target '{target}'。有效 target：{', '.join(sorted(self.VALID_TARGETS))}"
         file_path = self._get_path(target)
 
         if action == "add":
@@ -73,7 +73,7 @@ class MemoryTool(Tool):
         elif action == "remove":
             return self._do_remove(file_path, old_text)
         else:
-            return f"Error: unknown action '{action}'"
+            return f"Error: 未知操作 '{action}'"
 
     def _get_path(self, target: str) -> Path:
         if target == "user":
@@ -82,7 +82,7 @@ class MemoryTool(Tool):
 
     def _do_add(self, file_path: Path, content: str) -> str:
         if not content.strip():
-            return "Error: 'content' is required for add action"
+            return "Error: add 操作必须提供 'content'"
         existing = ""
         if file_path.exists():
             existing = file_path.read_text(encoding="utf-8")
@@ -102,14 +102,14 @@ class MemoryTool(Tool):
 
     def _do_replace(self, file_path: Path, old_text: str, content: str) -> str:
         if not old_text:
-            return "Error: 'old_text' is required for replace action"
+            return "Error: replace 操作必须提供 'old_text'"
         if not content.strip():
-            return "Error: 'content' is required for replace action"
+            return "Error: replace 操作必须提供 'content'"
         if not file_path.exists():
-            return f"Error: file {file_path} does not exist"
+            return f"Error: 文件 {file_path} 不存在"
         text = file_path.read_text(encoding="utf-8")
         if old_text not in text:
-            return f"Error: 'old_text' not found in {file_path.name}"
+            return f"Error: 在 {file_path.name} 中未找到 'old_text'"
         new_text = text.replace(old_text, content, 1)
         if file_path.name == "MEMORY.md":
             self._store.write_memory_md(new_text)
@@ -119,12 +119,12 @@ class MemoryTool(Tool):
 
     def _do_remove(self, file_path: Path, old_text: str) -> str:
         if not old_text:
-            return "Error: 'old_text' is required for remove action"
+            return "Error: remove 操作必须提供 'old_text'"
         if not file_path.exists():
-            return f"Error: file {file_path} does not exist"
+            return f"Error: 文件 {file_path} 不存在"
         text = file_path.read_text(encoding="utf-8")
         if old_text not in text:
-            return f"Error: 'old_text' not found in {file_path.name}"
+            return f"Error: 在 {file_path.name} 中未找到 'old_text'"
         lines = text.split("\n")
         new_lines = [line for line in lines if old_text.strip() not in line]
         new_content = "\n".join(new_lines)

--- a/miqi/agent/tools/message.py
+++ b/miqi/agent/tools/message.py
@@ -84,10 +84,10 @@ class MessageTool(Tool):
         message_id = message_id or self._default_message_id
 
         if not channel or not chat_id:
-            return "Error: No target channel/chat specified"
+            return "Error: 未指定目标 channel/chat"
 
         if not self._send_callback:
-            return "Error: Message sending not configured"
+            return "Error: 消息发送未配置"
 
         msg = OutboundMessage(
             channel=channel,

--- a/miqi/agent/tools/papers.py
+++ b/miqi/agent/tools/papers.py
@@ -1165,7 +1165,7 @@ class PaperDownloadTool(Tool):
         try:
             resolved.relative_to(self.workspace)
         except ValueError:
-            raise PermissionError(f"Output path outside workspace is not allowed: {resolved}")
+            raise PermissionError(f"输出路径超出工作区，不允许：{resolved}")
         return resolved
 
 

--- a/miqi/agent/tools/registry.py
+++ b/miqi/agent/tools/registry.py
@@ -166,12 +166,12 @@ class ToolRegistry:
 
         tool = self._tools.get(name)
         if not tool:
-            return f"Error: Tool '{name}' not found. Available: {', '.join(self.tool_names)}"
+            return f"Error: 未找到工具 '{name}'。可用工具：{', '.join(self.tool_names)}"
 
         try:
             errors = tool.validate_params(params)
             if errors:
-                return f"Error: Invalid parameters for tool '{name}': " + "; ".join(errors) + hint
+                return f"Error: 工具 '{name}' 参数无效：" + "; ".join(errors) + hint
             # Per-tool timeout takes priority (e.g. MCPToolWrapper exposes its
             # own configured toolTimeout); fall back to the registry-level default.
             timeout = tool.execution_timeout if tool.execution_timeout is not None else self.tool_timeout
@@ -183,7 +183,7 @@ class ToolRegistry:
                 return result + hint
             return result
         except asyncio.TimeoutError:
-            return f"Error: Tool '{name}' timed out after {timeout}s" + hint
+            return f"Error: 工具 '{name}' 在 {timeout} 秒后超时" + hint
         except Exception as e:
             tb = traceback.format_exc()
             logger.error(

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -174,7 +174,7 @@ class ExecTool(Tool):
                 if not approval_result.get("approved", True):
                     msg = approval_result.get(
                         "message",
-                        "Error: Command blocked — user denied approval.",
+                        "Error: 命令被拦截——用户拒绝了审批。",
                     )
                     return _ExecResult(output=msg, exit_code=1)
             else:
@@ -186,7 +186,7 @@ class ExecTool(Tool):
             # return immediately without spawning a subprocess.
             if cancel_event is not None and cancel_event.is_set():
                 return _ExecResult(
-                    output="Error: Command cancelled before start.",
+                    output="Error: 命令在启动前被取消。",
                     exit_code=-1, cancelled=True,
                 )
 
@@ -325,7 +325,7 @@ class ExecTool(Tool):
         # Phase 31.6: honour cancel_event before starting sandbox work.
         if cancel_event is not None and cancel_event.is_set():
             return _ExecResult(
-                output="Error: Command cancelled before sandbox start.",
+                output="Error: 命令在沙箱启动前被取消。",
                 exit_code=-1, cancelled=True,
             )
 
@@ -350,7 +350,7 @@ class ExecTool(Tool):
             logger.error("Sandbox execution failed: {} — {}", type(e).__name__, e)
             return _ExecResult(
                 output=(
-                    f"Error: Sandbox execution failed — {type(e).__name__}: {e}\n"
+                    f"Error: 沙箱执行失败——{type(e).__name__}：{e}\n"
                     f"Hint: You are running inside a Linux sandbox. Use Linux-style "
                     f"paths (e.g. /home/miqi/workspace/) and Linux commands."
                 ),
@@ -454,7 +454,7 @@ class ExecTool(Tool):
         if cancelled:
             logger.info("Sandbox command cancelled after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
-                output="Error: Command cancelled by user.",
+                output="Error: 命令已被用户取消。",
                 exit_code=exit_code, duration_ms=duration_ms,
                 cancelled=True,
             )
@@ -462,8 +462,8 @@ class ExecTool(Tool):
             logger.error("Sandbox command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output=(
-                    f"Error: Command timed out after "
-                    f"{effective_timeout:.0f} seconds"
+                    f"Error: 命令在 "
+                    f"{effective_timeout:.0f} 秒后超时"
                 ),
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
@@ -628,8 +628,8 @@ class ExecTool(Tool):
         if st == SandboxType.LANDLOCK:
             return _ExecResult(
                 output=(
-                    "Error: LANDLOCK sandbox is not yet implemented in MiQi. "
-                    "The command was NOT executed."
+                    "Error: MiQi 尚未实现 LANDLOCK 沙箱。 "
+                    "命令未执行。"
                 ),
                 exit_code=1,
             )
@@ -641,7 +641,7 @@ class ExecTool(Tool):
             )
 
         return _ExecResult(
-            output=f"Error: Unknown sandbox type '{st}'",
+            output=f"Error: 未知沙箱类型 '{st}'",
             exit_code=1,
         )
 
@@ -671,8 +671,8 @@ class ExecTool(Tool):
         if not self.working_dir:
             return _ExecResult(
                 output=(
-                    "Error: RESTRICTED sandbox requires a workspace but "
-                    "none is configured.  Command was NOT executed."
+                    "Error: RESTRICTED 沙箱需要工作区，但 "
+                    "未配置任何工作区。命令未执行。"
                 ),
                 exit_code=1,
             )
@@ -685,9 +685,9 @@ class ExecTool(Tool):
         except ValueError:
             return _ExecResult(
                 output=(
-                    f"Error: RESTRICTED sandbox policy requires cwd to "
-                    f"be within the workspace.  cwd={cwd} is outside "
-                    f"workspace={workspace}.  Command was NOT executed."
+                    f"Error: RESTRICTED 沙箱策略要求 cwd "
+                    f"必须位于工作区内。cwd={cwd} 超出 "
+                    f"workspace={workspace}。命令未执行。"
                 ),
                 exit_code=1,
             )
@@ -700,10 +700,9 @@ class ExecTool(Tool):
         if unsafe:
             return _ExecResult(
                 output=(
-                    f"Error: RESTRICTED sandbox policy: command "
-                    f"references paths outside workspace: "
-                    f"{', '.join(unsafe[:5])}.  Command was NOT "
-                    f"executed."
+                    f"Error: RESTRICTED 沙箱策略：命令 "
+                    f"引用了工作区外的路径："
+                    f"{', '.join(unsafe[:5])}。命令未执行。"
                 ),
                 exit_code=1,
             )
@@ -713,12 +712,10 @@ class ExecTool(Tool):
         if sandbox_selection.network_policy == NetworkSandboxPolicy.BLOCK_ALL:
             return _ExecResult(
                 output=(
-                    "Error: RESTRICTED sandbox cannot enforce network "
-                    "isolation in direct host execution.  Set "
-                    "network_allowed=True in the permission profile to "
-                    "allow network access under RESTRICTED, or use "
-                    "BWRAP sandbox for full isolation.  Command was "
-                    "NOT executed."
+                    "Error: RESTRICTED 沙箱无法强制网络 "
+                    "隔离（直接主机执行）。如需在 RESTRICTED 下允许网络访问，"
+                    "请在权限配置中设置 network_allowed=True，"
+                    "或使用 BWRAP 沙箱获得完整隔离。命令未执行。"
                 ),
                 exit_code=1,
             )
@@ -1088,7 +1085,7 @@ class ExecTool(Tool):
         if cancelled:
             logger.info("Direct command cancelled after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
-                output="Error: Command cancelled by user.",
+                output="Error: 命令已被用户取消。",
                 exit_code=exit_code, duration_ms=duration_ms,
                 cancelled=True,
             )
@@ -1096,8 +1093,8 @@ class ExecTool(Tool):
             logger.error("Direct command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
                 output=(
-                    f"Error: Command timed out after "
-                    f"{effective_timeout:.0f} seconds"
+                    f"Error: 命令在 "
+                    f"{effective_timeout:.0f} 秒后超时"
                 ),
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
@@ -1178,15 +1175,15 @@ class ExecTool(Tool):
 
         for pattern in self.deny_patterns:
             if re.search(pattern, lower):
-                return "Error: Command blocked by safety guard (dangerous pattern detected)"
+                return "Error: 命令被安全护栏拦截（检测到危险模式）"
 
         if self.allow_patterns:
             if not any(re.search(p, lower) for p in self.allow_patterns):
-                return "Error: Command blocked by safety guard (not in allowlist)"
+                return "Error: 命令被安全护栏拦截（不在白名单中）"
 
         if self.restrict_to_workspace:
             if "..\\" in cmd or "../" in cmd:
-                return "Error: Command blocked by safety guard (path traversal detected)"
+                return "Error: 命令被安全护栏拦截（检测到路径穿越）"
 
             cwd_path = Path(cwd).resolve()
 
@@ -1202,7 +1199,7 @@ class ExecTool(Tool):
                 except Exception:
                     continue
                 if p.is_absolute() and cwd_path not in p.parents and p != cwd_path:
-                    return "Error: Command blocked by safety guard (path outside working dir)"
+                    return "Error: 命令被安全护栏拦截（路径超出工作目录）"
 
         return None
 

--- a/miqi/agent/tools/skill_manage.py
+++ b/miqi/agent/tools/skill_manage.py
@@ -94,7 +94,7 @@ class SkillManageTool(Tool):
         elif action == "archive":
             return self._do_archive(name)
         else:
-            return f"Error: unknown action '{action}'"
+            return f"Error: 未知操作 '{action}'"
 
     def _do_list(self) -> str:
         skills = self._skills.list_skills(filter_unavailable=False)
@@ -111,22 +111,22 @@ class SkillManageTool(Tool):
 
     def _do_view(self, name: str) -> str:
         if not name:
-            return "Error: 'name' is required for view action"
+            return "Error: view 操作必须提供 'name'"
         content = self._skills.load_skill(name)
         if content is None:
-            return f"Error: skill '{name}' not found"
+            return f"Error: 未找到技能 '{name}'"
         return content
 
     def _do_create(self, name: str, content: str) -> str:
         if not name:
-            return "Error: 'name' is required for create action"
+            return "Error: create 操作必须提供 'name'"
         if not content.strip():
-            return "Error: 'content' is required for create action"
+            return "Error: create 操作必须提供 'content'"
 
         # Only allow creation in workspace skills
         skill_dir = self.workspace / "skills" / name
         if skill_dir.exists():
-            return f"Error: skill '{name}' already exists"
+            return f"Error: 技能 '{name}' 已存在"
 
         skill_dir.mkdir(parents=True, exist_ok=True)
         (skill_dir / "SKILL.md").write_text(content.strip() + "\n", encoding="utf-8")
@@ -134,14 +134,14 @@ class SkillManageTool(Tool):
 
     def _do_patch(self, name: str, patch_text: str) -> str:
         if not name:
-            return "Error: 'name' is required for patch action"
+            return "Error: patch 操作必须提供 'name'"
         if not patch_text.strip():
-            return "Error: 'patch_text' is required for patch action"
+            return "Error: patch 操作必须提供 'patch_text'"
 
         # Only allow patching workspace skills
         workspace_skill = self.workspace / "skills" / name / "SKILL.md"
         if not workspace_skill.exists():
-            return f"Error: skill '{name}' not found in workspace (cannot patch built-in skills)"
+            return f"Error: 工作区中未找到技能 '{name}'（无法修改内置技能）"
 
         existing = workspace_skill.read_text(encoding="utf-8")
         new_content = existing.rstrip("\n") + "\n\n" + patch_text.strip() + "\n"
@@ -150,12 +150,12 @@ class SkillManageTool(Tool):
 
     def _do_archive(self, name: str) -> str:
         if not name:
-            return "Error: 'name' is required for archive action"
+            return "Error: archive 操作必须提供 'name'"
 
         # Only allow archiving workspace skills
         workspace_skill = self.workspace / "skills" / name / "SKILL.md"
         if not workspace_skill.exists():
-            return f"Error: skill '{name}' not found in workspace (cannot archive built-in skills)"
+            return f"Error: 工作区中未找到技能 '{name}'（无法归档内置技能）"
 
         content = workspace_skill.read_text(encoding="utf-8")
         new_content = _set_frontmatter_key(content, "archived", "true")

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -221,7 +221,7 @@ class WebSearchTool(Tool):
         try:
             from ddgs import DDGS
         except ImportError:
-            return "Error: ddgs package not installed"
+            return "Error: 未安装 ddgs 包"
 
         try:
             results = await asyncio.to_thread(
@@ -241,14 +241,14 @@ class WebSearchTool(Tool):
             return "\n".join(lines)
         except Exception as e:
             return (
-                f"Error: web search failed: {e}. 搜索服务暂不可用——请勿尝试用 "
+                f"Error: 网络搜索失败：{e}。搜索服务暂不可用——请勿尝试用 "
                 "web_fetch 抓取搜索引擎页面（会被拒绝且结果不可用）。"
                 "直接告知用户搜索暂不可用，或建议稍后重试。"
             )
 
     async def _brave_search(self, query: str, n: int) -> str:
         if not self.api_key:
-            return "Error: BRAVE_API_KEY not configured"
+            return "Error: 未配置 BRAVE_API_KEY"
 
         try:
             async with httpx.AsyncClient() as client:

--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -101,7 +101,7 @@ def parse_document(
     elif suffix in _RTF_SUFFIXES:
         return _parse_rtf(file_path, max_chars=max_chars)
     else:
-        raise ValueError(f"Unsupported document format: {suffix}")
+        raise ValueError(f"不支持的文件格式：{suffix}")
 
 
 def is_supported_document(path: Path | str) -> bool:
@@ -918,7 +918,7 @@ def _parse_markdown(file_path: Path, *, max_chars: int = MAX_CONTEXT_CHARS) -> d
 def _parse_html(file_path: Path, max_chars: int = 50000) -> dict:
     """Extract text from HTML files using lxml."""
     if not _HAS_LXML_HTML:
-        raise RuntimeError("lxml is required for HTML parsing")
+        raise RuntimeError("解析 HTML 需要 lxml")
 
     t0 = time.perf_counter()
     raw = file_path.read_text(encoding="utf-8", errors="replace")

--- a/miqi/documents/docx_tool.py
+++ b/miqi/documents/docx_tool.py
@@ -72,7 +72,7 @@ def _raw_output_path(kwargs: dict[str, Any]) -> str:
 
 def _ensure_suffix(path: Path, suffix: str) -> Path:
     if not path.name or path.name in {".", ".."}:
-        raise ValueError("output filename is required")
+        raise ValueError("必须提供输出文件名")
     if path.suffix.lower() == suffix:
         return path
     return path.with_suffix(suffix)
@@ -382,7 +382,7 @@ class DocxReadTool(Tool):
     async def execute(self, **kwargs: Any) -> str:
         raw_path = _raw_output_path(kwargs)
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
@@ -390,11 +390,11 @@ class DocxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
-            return f"Error: file not found: {file_path}"
+            return f"Error: 文件不存在：{file_path}"
         try:
             from docx import Document
             doc = Document(str(file_path))
@@ -558,7 +558,7 @@ class CreateDocxTool(Tool):
         raw_path = _raw_output_path(kwargs)
         content = kwargs.get("content", "")
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         try:
             file_path = _resolve_output_path(
@@ -567,7 +567,7 @@ class CreateDocxTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if not (
@@ -576,7 +576,7 @@ class CreateDocxTool(Tool):
             or kwargs.get("paragraphs")
             or kwargs.get("tables")
         ):
-            return "Error: provide title, content, paragraphs, or tables"
+            return "Error: 必须提供 title、content、paragraphs 或 tables"
 
         try:
             doc = Document()
@@ -712,7 +712,7 @@ class EditDocxTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         raw_path = _raw_output_path(kwargs)
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         try:
             file_path = _resolve_output_path(
@@ -721,12 +721,12 @@ class EditDocxTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
 
         if not file_path.exists():
-            return f"Error: file not found: {file_path}"
+            return f"Error: 文件不存在：{file_path}"
 
         old_text = kwargs.get("old_text")
         new_text = kwargs.get("new_text")
@@ -742,7 +742,7 @@ class EditDocxTool(Tool):
 
         if not (old_text and new_text is not None) and not append_paragraphs and not has_formatting:
             return (
-                "Error: provide old_text/new_text, append_paragraphs/content, "
+                "Error: 必须提供 old_text/new_text、append_paragraphs/content，"
                 "or formatting instructions"
             )
 
@@ -762,7 +762,7 @@ class EditDocxTool(Tool):
                                     paragraph.text = paragraph.text.replace(old_text, str(new_text))
                                     replacements += 1
                 if replacements == 0:
-                    return f"Error: old_text not found in {file_path}"
+                    return f"Error: 在 {file_path} 中未找到 old_text"
 
             for paragraph in append_paragraphs:
                 doc.add_paragraph(str(paragraph))

--- a/miqi/documents/pdf_create_tool.py
+++ b/miqi/documents/pdf_create_tool.py
@@ -157,7 +157,7 @@ def _raw_output_path(kwargs: dict[str, Any]) -> str:
 
 def _ensure_suffix(path: Path, suffix: str) -> Path:
     if not path.name or path.name in {".", ".."}:
-        raise ValueError("output filename is required")
+        raise ValueError("必须提供输出文件名")
     if path.suffix.lower() == suffix:
         return path
     return path.with_suffix(suffix)
@@ -666,7 +666,7 @@ class CreatePdfTool(Tool):
         content = kwargs.get("content", "")
 
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         # Resolve path
         try:
@@ -674,7 +674,7 @@ class CreatePdfTool(Tool):
             file_path = _ensure_suffix(file_path, ".pdf")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
 
@@ -690,7 +690,7 @@ class CreatePdfTool(Tool):
         has_title = bool(kwargs.get("title"))
         has_content = bool(content)
         if not has_title and not has_content:
-            return "Error: provide at least a title or content"
+            return "Error: 至少提供 title 或 content"
 
         # Parse styles
         title_style, body_style = _style_from_kwargs(kwargs)
@@ -700,7 +700,7 @@ class CreatePdfTool(Tool):
             import reportlab  # noqa: F401 — verify importable
         except ImportError:
             return (
-                "Error: reportlab is not installed. "
+                "Error: 未安装 reportlab。 "
                 "Run: pip install reportlab"
             )
 

--- a/miqi/documents/pdf_read_tool.py
+++ b/miqi/documents/pdf_read_tool.py
@@ -58,14 +58,14 @@ class PdfReadTool(Tool):
         force_ocr = kwargs.get("force_ocr", False)
 
         if not file_path:
-            return "Error: file_path is required"
+            return "Error: 必须提供 file_path"
 
         path = Path(file_path)
         if not path.is_absolute() and self._workspace is not None:
             path = self._workspace / path
 
         if not is_supported_document(path):
-            return f"Error: unsupported file type: {path.suffix}. pdf_read only supports PDF files."
+            return f"Error: 不支持的文件类型：{path.suffix}。pdf_read 仅支持 PDF 文件。"
 
         if not path.exists():
             # Try uploads/ subdirectory
@@ -74,7 +74,7 @@ class PdfReadTool(Tool):
                 path = alt
             else:
                 return (
-                    f"Error: file not found: {file_path}. "
+                    f"Error: 文件不存在：{file_path}。 "
                     f"Tried: {path}" + (f" and {alt}" if alt else "")
                 )
 

--- a/miqi/documents/pptx_tool.py
+++ b/miqi/documents/pptx_tool.py
@@ -20,7 +20,7 @@ def _raw_output_path(kwargs: dict[str, Any]) -> str:
 
 def _ensure_suffix(path: Path, suffix: str) -> Path:
     if not path.name or path.name in {".", ".."}:
-        raise ValueError("output filename is required")
+        raise ValueError("必须提供输出文件名")
     if path.suffix.lower() == suffix:
         return path
     return path.with_suffix(suffix)
@@ -119,7 +119,7 @@ class PptxReadTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         raw_path = _raw_output_path(kwargs)
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
@@ -127,11 +127,11 @@ class PptxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".pptx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
-            return f"Error: file not found: {file_path}"
+            return f"Error: 文件不存在：{file_path}"
         try:
             from pptx import Presentation
             prs = Presentation(str(file_path))
@@ -216,7 +216,7 @@ class CreatePptxTool(Tool):
         raw_path = _raw_output_path(kwargs)
         slides = kwargs.get("slides") or []
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         try:
             file_path = _resolve_output_path(
@@ -225,11 +225,11 @@ class CreatePptxTool(Tool):
             file_path = _ensure_suffix(file_path, ".pptx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if not slides:
-            return "Error: slides is required"
+            return "Error: 必须提供 slides"
 
         try:
             prs = Presentation()

--- a/miqi/documents/xlsx_tool.py
+++ b/miqi/documents/xlsx_tool.py
@@ -20,7 +20,7 @@ def _raw_output_path(kwargs: dict[str, Any]) -> str:
 
 def _ensure_suffix(path: Path, suffix: str) -> Path:
     if not path.name or path.name in {".", ".."}:
-        raise ValueError("output filename is required")
+        raise ValueError("必须提供输出文件名")
     if path.suffix.lower() == suffix:
         return path
     return path.with_suffix(suffix)
@@ -225,7 +225,7 @@ class XlsxReadTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         raw_path = _raw_output_path(kwargs)
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
         try:
             file_path = _resolve_output_path(
                 raw_path, self._workspace, self._allowed_dir,
@@ -233,11 +233,11 @@ class XlsxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
-            return f"Error: file not found: {file_path}"
+            return f"Error: 文件不存在：{file_path}"
         try:
             from openpyxl import load_workbook
 
@@ -337,7 +337,7 @@ class CreateXlsxTool(Tool):
         sheets = kwargs.get("sheets")
         rows = kwargs.get("rows")
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         try:
             file_path = _resolve_output_path(
@@ -346,11 +346,11 @@ class CreateXlsxTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
         if sheets is None and rows is None:
-            return "Error: sheets or rows is required"
+            return "Error: 必须提供 sheets 或 rows"
 
         try:
             wb = Workbook()
@@ -372,10 +372,10 @@ class CreateXlsxTool(Tool):
             elif isinstance(sheets, list):
                 sheet_specs = sheets
             else:
-                return "Error: sheets must be an object or array"
+                return "Error: sheets 必须是对象或数组"
 
             if not sheet_specs:
-                return "Error: sheets must contain at least one sheet"
+                return "Error: sheets 至少需要包含一个工作表"
 
             created_sheets = 0
             for index, spec in enumerate(sheet_specs):
@@ -392,7 +392,7 @@ class CreateXlsxTool(Tool):
                     _add_chart(ws, chart_spec)
 
             if created_sheets == 0:
-                return "Error: sheets must contain sheet objects"
+                return "Error: sheets 必须包含工作表对象"
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
             wb.save(str(file_path))
@@ -470,7 +470,7 @@ class AppendXlsxTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         raw_path = _raw_output_path(kwargs)
         if not raw_path.strip():
-            return "Error: filename is required"
+            return "Error: 必须提供 filename"
 
         try:
             file_path = _resolve_output_path(
@@ -479,16 +479,16 @@ class AppendXlsxTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return f"Error: 权限被拒绝：{e}"
         except ValueError as e:
             return f"Error: {e}"
 
         if not file_path.exists():
-            return f"Error: file not found: {file_path}"
+            return f"Error: 文件不存在：{file_path}"
 
         rows = kwargs.get("rows") or []
         if not rows:
-            return "Error: rows is required"
+            return "Error: 必须提供 rows"
 
         try:
             wb = load_workbook(str(file_path))
@@ -500,7 +500,7 @@ class AppendXlsxTool(Tool):
                     ws = wb.create_sheet(str(sheet_name)[:31])
                 else:
                     wb.close()
-                    return f"Error: sheet not found: {sheet_name}"
+                    return f"Error: 未找到工作表：{sheet_name}"
             else:
                 ws = wb.active
 

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -331,7 +331,7 @@ class MiQiToolHost:
             raise
         except Exception as exc:
             logger.exception("ask_user_confirm_card failed")
-            result = f"Error: user confirmation failed: {exc}"
+            result = f"Error: 用户确认失败：{exc}"
             is_error = True
 
         return ToolHostResult(item={

--- a/miqi/plan/plan_tool.py
+++ b/miqi/plan/plan_tool.py
@@ -87,5 +87,5 @@ class PlanUpdateTool(Tool):
         status = kwargs["status"]
         step = self._tracker.update_step(plan_id, step_id, status)
         if step is None:
-            return f"Error: plan {plan_id} or step {step_id} not found"
+            return f"Error: 未找到 plan {plan_id} 或 step {step_id}"
         return f"Step '{step.description}' → {status}"

--- a/miqi/skills/docx/scripts/accept_changes.py
+++ b/miqi/skills/docx/scripts/accept_changes.py
@@ -41,19 +41,19 @@ def accept_changes(
     output_path = Path(output_file)
 
     if not input_path.exists():
-        return None, f"Error: Input file not found: {input_file}"
+        return None, f"Error: 输入文件不存在：{input_file}"
 
     if not input_path.suffix.lower() == ".docx":
-        return None, f"Error: Input file is not a DOCX file: {input_file}"
+        return None, f"Error: 输入文件不是 DOCX 文件：{input_file}"
 
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(input_path, output_path)
     except Exception as e:
-        return None, f"Error: Failed to copy input file to output location: {e}"
+        return None, f"Error: 复制输入文件到输出位置失败：{e}"
 
     if not _setup_libreoffice_macro():
-        return None, "Error: Failed to setup LibreOffice macro"
+        return None, "Error: 设置 LibreOffice 宏失败"
 
     cmd = [
         "soffice",
@@ -80,7 +80,7 @@ def accept_changes(
         )
 
     if result.returncode != 0:
-        return None, f"Error: LibreOffice failed: {result.stderr}"
+        return None, f"Error: LibreOffice 执行失败：{result.stderr}"
 
     return (
         None,

--- a/miqi/skills/docx/scripts/comment.py
+++ b/miqi/skills/docx/scripts/comment.py
@@ -225,7 +225,7 @@ def add_comment(
 ) -> tuple[str, str]:
     word = Path(unpacked_dir) / "word"
     if not word.exists():
-        return "", f"Error: {word} not found"
+        return "", f"Error: 未找到 {word}"
 
     para_id, durable_id = _generate_hex_id(), _generate_hex_id()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -255,7 +255,7 @@ def add_comment(
     if parent_id is not None:
         parent_para = _find_para_id(comments, parent_id)
         if not parent_para:
-            return "", f"Error: Parent comment {parent_id} not found"
+            return "", f"Error: 未找到父评论 {parent_id}"
         _append_xml(
             ext,
             "w15:commentsEx",

--- a/miqi/skills/docx/scripts/office/pack.py
+++ b/miqi/skills/docx/scripts/office/pack.py
@@ -33,10 +33,10 @@ def pack(
     suffix = output_path.suffix.lower()
 
     if not input_dir.is_dir():
-        return None, f"Error: {input_dir} is not a directory"
+        return None, f"Error: {input_dir} 不是目录"
 
     if suffix not in {".docx", ".pptx", ".xlsx"}:
-        return None, f"Error: {output_file} must be a .docx, .pptx, or .xlsx file"
+        return None, f"Error: {output_file} 必须是 .docx、.pptx 或 .xlsx 文件"
 
     if validate and original_file:
         original_path = Path(original_file)
@@ -47,7 +47,7 @@ def pack(
             if output:
                 print(output)
             if not success:
-                return None, f"Error: Validation failed for {input_dir}"
+                return None, f"Error: 校验失败：{input_dir}"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_content_dir = Path(temp_dir) / "content"

--- a/miqi/skills/docx/scripts/office/unpack.py
+++ b/miqi/skills/docx/scripts/office/unpack.py
@@ -42,10 +42,10 @@ def unpack(
     suffix = input_path.suffix.lower()
 
     if not input_path.exists():
-        return None, f"Error: {input_file} does not exist"
+        return None, f"Error: {input_file} 不存在"
 
     if suffix not in {".docx", ".pptx", ".xlsx"}:
-        return None, f"Error: {input_file} must be a .docx, .pptx, or .xlsx file"
+        return None, f"Error: {input_file} 必须是 .docx、.pptx 或 .xlsx 文件"
 
     try:
         output_path.mkdir(parents=True, exist_ok=True)
@@ -74,7 +74,7 @@ def unpack(
         return None, message
 
     except zipfile.BadZipFile:
-        return None, f"Error: {input_file} is not a valid Office file"
+        return None, f"Error: {input_file} 不是有效的 Office 文件"
     except Exception as e:
         return None, f"Error unpacking: {e}"
 

--- a/miqi/skills/docx/scripts/office/validate.py
+++ b/miqi/skills/docx/scripts/office/validate.py
@@ -53,19 +53,19 @@ def main():
     args = parser.parse_args()
 
     path = Path(args.path)
-    assert path.exists(), f"Error: {path} does not exist"
+    assert path.exists(), f"Error: {path} 不存在"
 
     original_file = None
     if args.original:
         original_file = Path(args.original)
-        assert original_file.is_file(), f"Error: {original_file} is not a file"
+        assert original_file.is_file(), f"Error: {original_file} 不是文件"
         assert original_file.suffix.lower() in [".docx", ".pptx", ".xlsx"], (
-            f"Error: {original_file} must be a .docx, .pptx, or .xlsx file"
+            f"Error: {original_file} 必须是 .docx、.pptx 或 .xlsx 文件"
         )
 
     file_extension = (original_file or path).suffix.lower()
     assert file_extension in [".docx", ".pptx", ".xlsx"], (
-        f"Error: Cannot determine file type from {path}. Use --original or provide a .docx/.pptx/.xlsx file."
+        f"Error: 无法从 {path} 判断文件类型。请使用 --original 或提供 .docx/.pptx/.xlsx 文件。"
     )
 
     if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
@@ -74,7 +74,7 @@ def main():
             zf.extractall(temp_dir)
         unpacked_dir = Path(temp_dir)
     else:
-        assert path.is_dir(), f"Error: {path} is not a directory or Office file"
+        assert path.is_dir(), f"Error: {path} 不是目录或 Office 文件"
         unpacked_dir = path
 
     match file_extension:
@@ -91,7 +91,7 @@ def main():
                 PPTXSchemaValidator(unpacked_dir, original_file, verbose=args.verbose),
             ]
         case _:
-            print(f"Error: Validation not supported for file type {file_extension}")
+            print(f"Error: 不支持的文件类型 {file_extension} 校验")
             sys.exit(1)
 
     if args.auto_repair:

--- a/miqi/skills/xlsx/scripts/office/pack.py
+++ b/miqi/skills/xlsx/scripts/office/pack.py
@@ -33,10 +33,10 @@ def pack(
     suffix = output_path.suffix.lower()
 
     if not input_dir.is_dir():
-        return None, f"Error: {input_dir} is not a directory"
+        return None, f"Error: {input_dir} 不是目录"
 
     if suffix not in {".docx", ".pptx", ".xlsx"}:
-        return None, f"Error: {output_file} must be a .docx, .pptx, or .xlsx file"
+        return None, f"Error: {output_file} 必须是 .docx、.pptx 或 .xlsx 文件"
 
     if validate and original_file:
         original_path = Path(original_file)
@@ -47,7 +47,7 @@ def pack(
             if output:
                 print(output)
             if not success:
-                return None, f"Error: Validation failed for {input_dir}"
+                return None, f"Error: 校验失败：{input_dir}"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_content_dir = Path(temp_dir) / "content"

--- a/miqi/skills/xlsx/scripts/office/validate.py
+++ b/miqi/skills/xlsx/scripts/office/validate.py
@@ -53,19 +53,19 @@ def main():
     args = parser.parse_args()
 
     path = Path(args.path)
-    assert path.exists(), f"Error: {path} does not exist"
+    assert path.exists(), f"Error: {path} 不存在"
 
     original_file = None
     if args.original:
         original_file = Path(args.original)
-        assert original_file.is_file(), f"Error: {original_file} is not a file"
+        assert original_file.is_file(), f"Error: {original_file} 不是文件"
         assert original_file.suffix.lower() in [".docx", ".pptx", ".xlsx"], (
-            f"Error: {original_file} must be a .docx, .pptx, or .xlsx file"
+            f"Error: {original_file} 必须是 .docx、.pptx 或 .xlsx 文件"
         )
 
     file_extension = (original_file or path).suffix.lower()
     assert file_extension in [".docx", ".pptx", ".xlsx"], (
-        f"Error: Cannot determine file type from {path}. Use --original or provide a .docx/.pptx/.xlsx file."
+        f"Error: 无法从 {path} 判断文件类型。请使用 --original 或提供 .docx/.pptx/.xlsx 文件。"
     )
 
     if path.is_file() and path.suffix.lower() in [".docx", ".pptx", ".xlsx"]:
@@ -74,7 +74,7 @@ def main():
             zf.extractall(temp_dir)
         unpacked_dir = Path(temp_dir)
     else:
-        assert path.is_dir(), f"Error: {path} is not a directory or Office file"
+        assert path.is_dir(), f"Error: {path} 不是目录或 Office 文件"
         unpacked_dir = path
 
     match file_extension:
@@ -91,7 +91,7 @@ def main():
                 PPTXSchemaValidator(unpacked_dir, original_file, verbose=args.verbose),
             ]
         case _:
-            print(f"Error: Validation not supported for file type {file_extension}")
+            print(f"Error: 不支持的文件类型 {file_extension} 校验")
             sys.exit(1)
 
     if args.auto_repair:

--- a/tests/agent/tools/test_apply_patch.py
+++ b/tests/agent/tools/test_apply_patch.py
@@ -158,7 +158,7 @@ async def test_tool_rejects_traversal(tmp_path):
     patch = "--- a/../etc/passwd\n+++ b/../etc/passwd\n@@ -1 +1 @@\n-x\n+y\n"
     result = await tool.execute(patch=patch)
     assert "Error" in result
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -177,4 +177,4 @@ async def test_tool_returns_error_on_context_mismatch(tmp_path):
 async def test_tool_returns_error_on_garbage_patch(tmp_path):
     tool = ApplyPatchTool(workspace=tmp_path, allowed_dir=tmp_path)
     result = await tool.execute(patch="not a patch")
-    assert "Error: Invalid patch" in result
+    assert "Error: 补丁格式无效" in result

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -345,7 +345,7 @@ async def test_write_file_rejects_foreign_session_dir(tmp_path):
         workspace=session_dir, base_workspace=root, session_files_dir=session_dir,
     )
     result = await write.execute(path=str(other / "x.md"), content="sneak")
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (other / "x.md").exists()
 
 
@@ -356,7 +356,7 @@ async def test_write_file_rejects_relative_escape_into_sessions(tmp_path):
     other = root / "sessions" / "other_session" / "files"
     other.mkdir(parents=True)
     result = await write.execute(path="../other_session/files/x.md", content="sneak")
-    assert "Permission denied" in result or "Error" in result
+    assert "权限被拒绝" in result or "Error" in result
     assert not (other / "x.md").exists()
 
 
@@ -372,7 +372,7 @@ async def test_read_file_rejects_foreign_session_dir(tmp_path):
     (other / "secret.md").write_text("secret", encoding="utf-8")
     read = ReadFileTool(workspace=ws, session_files_dir=session_dir)
     result = await read.execute(path=str(other / "secret.md"))
-    assert "Permission denied" in result or "File not found" in result
+    assert "权限被拒绝" in result or "文件不存在" in result
 
 
 @pytest.mark.asyncio

--- a/tests/documents/test_docx_tool.py
+++ b/tests/documents/test_docx_tool.py
@@ -15,7 +15,7 @@ def test_docx_read_file_not_found():
     tool = DocxReadTool()
     result = asyncio.run(tool.execute(file_path="/nonexistent/doc.docx"))
     assert "Error" in result
-    assert "not found" in result
+    assert "不存在" in result
 
 
 def test_docx_read_valid_file():

--- a/tests/documents/test_office_create_tools.py
+++ b/tests/documents/test_office_create_tools.py
@@ -285,7 +285,7 @@ async def test_create_xlsx_accepts_top_level_rows_and_rejects_invalid_sheets(tmp
     assert "1 | 2" in read_result
 
     invalid = await tool.execute(filename="bad", sheets="not valid", rows=[["A"]])
-    assert "sheets must be an object or array" in invalid
+    assert "sheets 必须是对象或数组" in invalid
 
 
 @pytest.mark.asyncio
@@ -436,7 +436,7 @@ async def test_create_office_tools_reject_path_traversal(
 
     result = await tool.execute(**kwargs)
 
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path / expected_name).exists()
 
 
@@ -529,15 +529,15 @@ async def test_create_pdf_errors(tmp_path):
 
     # Missing filename
     result = await tool.execute(content="test")
-    assert "Error: filename is required" in result
+    assert "Error: 必须提供 filename" in result
 
     # Missing content
     result = await tool.execute(filename="empty.pdf")
-    assert "Error: provide at least a title or content" in result
+    assert "Error: 至少提供 title 或 content" in result
 
     # Permission denied (path traversal)
     result = await tool.execute(filename="../../escape.pdf", content="test")
-    assert "Error: Permission denied" in result
+    assert "Error: 权限被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -571,5 +571,5 @@ async def test_create_pdf_reject_path_traversal(
 
     result = await tool.execute(**kwargs)
 
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path / expected_name).exists()

--- a/tests/execution/test_exec_events.py
+++ b/tests/execution/test_exec_events.py
@@ -192,7 +192,7 @@ async def test_timeout_kills_subprocess(require_subprocess, tmp_path):
         _sandbox=_make_none_selection(timeout_ms=50),
     )
 
-    assert "timed out" in output.lower()
+    assert "超时" in output
 
     end_events = [e for e in emitter.events
                   if isinstance(e, ExecCommandEndEvent)]
@@ -231,7 +231,7 @@ async def test_cancel_event_kills_running_subprocess(require_subprocess, tmp_pat
 
     await cancel_task
 
-    assert "cancelled" in output.lower()
+    assert "取消" in output
 
     end_events = [e for e in emitter.events
                   if isinstance(e, ExecCommandEndEvent)]
@@ -261,7 +261,7 @@ async def test_cancel_before_start_returns_safely(tmp_path):
         _cancel_event=cancel_event,
     )
 
-    assert "cancelled" in output.lower()
+    assert "取消" in output
 
     # Should still get begin + end events
     begin_events = [e for e in emitter.events
@@ -391,7 +391,7 @@ async def test_timeout_no_pending_tasks(require_subprocess, tmp_path):
         _sandbox=_make_none_selection(timeout_ms=50),
     )
 
-    assert "timed out" in output.lower()
+    assert "超时" in output
 
 
 @pytest.mark.subprocess
@@ -419,7 +419,7 @@ async def test_cancel_no_pending_tasks(require_subprocess, tmp_path):
 
     await cancel_task
 
-    assert "cancelled" in output.lower()
+    assert "取消" in output
     end_events = [e for e in emitter.events
                   if isinstance(e, ExecCommandEndEvent)]
     assert len(end_events) == 1
@@ -599,7 +599,7 @@ async def test_exec_tool_cancelled_before_start_recorded(tmp_path):
         _thread_id="thread-cancel",
     )
 
-    assert "cancelled" in result.lower()
+    assert "取消" in result
 
     # exec_completed should have cancelled=True
     completed = [it for it in fake_ledger.items if it["item_type"] == "exec_completed"]
@@ -906,7 +906,7 @@ async def test_bwrap_timeout_kills_and_one_end_event(require_subprocess):
         _sandbox=sel,
     )
 
-    assert "timed out" in result.lower()
+    assert "超时" in result
     assert handle.kill_called, "handle.kill() must be called on timeout"
 
     end_events = [e for e in emitter.events
@@ -956,7 +956,7 @@ async def test_bwrap_cancel_kills_and_one_end_event(require_subprocess):
 
     await cancel_task
 
-    assert "cancelled" in result.lower()
+    assert "取消" in result
     assert handle.kill_called, "handle.kill() must be called on cancel"
 
     end_events = [e for e in emitter.events
@@ -1046,7 +1046,7 @@ async def test_bwrap_no_pending_tasks_on_timeout(require_subprocess):
         _sandbox=sel,
     )
 
-    assert "timed out" in result.lower()
+    assert "超时" in result
     assert handle.kill_called
     assert handle.cleanup_called, (
         "handle.cleanup() must be called even after timeout"
@@ -1085,7 +1085,7 @@ async def test_bwrap_no_pending_tasks_on_cancel(require_subprocess):
 
     await cancel_task
 
-    assert "cancelled" in result.lower()
+    assert "取消" in result
     assert handle.kill_called
     assert handle.cleanup_called, (
         "handle.cleanup() must be called even after cancel"

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -249,7 +249,7 @@ async def test_sandbox_selection_landlock_unsupported():
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     assert "LANDLOCK" in result
 
 
@@ -427,7 +427,7 @@ async def test_sandbox_selection_timeout_ms_consumed():
         _sandbox=sel,
     )
 
-    assert "timed out" in result.lower()
+    assert "超时" in result
 
 
 @pytest.mark.asyncio
@@ -442,7 +442,7 @@ async def test_sandbox_selection_timeout_ms_not_exceeded():
     )
 
     assert "completed" in result
-    assert "timed out" not in result.lower()
+    assert "超时" not in result
 
 
 # ── 31.3: SandboxSelection.env_passthrough enforcement ─────────────────
@@ -537,8 +537,8 @@ async def test_restricted_cwd_outside_workspace_fails(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside" in result.lower() or "workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -665,8 +665,8 @@ async def test_restricted_cwd_enforced_even_without_restrict_config(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside" in result.lower() or "workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -699,8 +699,8 @@ async def test_restricted_no_working_dir_fails_closed():
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "workspace" in result.lower()
+    assert "未执行" in result
+    assert "工作区" in result
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -722,8 +722,8 @@ async def test_restricted_rejects_outside_windows_absolute_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -739,8 +739,8 @@ async def test_restricted_rejects_outside_posix_absolute_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -755,8 +755,8 @@ async def test_restricted_rejects_wsl_absolute_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -810,8 +810,8 @@ async def test_restricted_rejects_traversal_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -827,8 +827,8 @@ async def test_restricted_rejects_redirect_to_outside(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -844,8 +844,8 @@ async def test_restricted_rejects_append_redirect_to_outside(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -861,8 +861,8 @@ async def test_restricted_rejects_input_redirect_from_outside(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -886,7 +886,7 @@ async def test_restricted_network_block_all_fails_closed(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     assert "network" in result.lower()
 
 
@@ -989,7 +989,7 @@ async def test_restricted_fail_produces_no_output_delta_events(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     deltas = [
         e for e in emitter.events
         if isinstance(e, ExecCommandOutputDeltaEvent)
@@ -1078,7 +1078,7 @@ async def test_landlock_unsupported_fail_closed_unchanged():
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     assert "LANDLOCK" in result
 
 
@@ -1099,8 +1099,8 @@ async def test_restricted_rejects_shell_var_with_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -1115,8 +1115,8 @@ async def test_restricted_rejects_braced_shell_var_with_path(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -1131,8 +1131,8 @@ async def test_restricted_rejects_tilde_expansion(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -1147,8 +1147,8 @@ async def test_restricted_rejects_tilde_user_expansion(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -1163,8 +1163,8 @@ async def test_restricted_rejects_shell_var_with_traversal(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1185,9 +1185,9 @@ async def test_landlock_explicit_selection_still_fail_closed():
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     assert "LANDLOCK" in result
-    assert "not yet implemented" in result
+    assert "尚未实现" in result
 
 
 @pytest.mark.asyncio
@@ -1374,8 +1374,8 @@ async def test_regression_restricted_rejects_outside_workspace_unchanged(tmp_pat
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
-    assert "outside workspace" in result.lower()
+    assert "未执行" in result
+    assert "超出" in result or "工作区" in result
 
 
 @pytest.mark.asyncio
@@ -1393,5 +1393,5 @@ async def test_regression_restricted_network_block_all_unchanged(tmp_path):
         _sandbox=sel,
     )
 
-    assert "NOT executed" in result
+    assert "未执行" in result
     assert "network" in result.lower()

--- a/tests/execution/test_phase32_office_path_enforcement.py
+++ b/tests/execution/test_phase32_office_path_enforcement.py
@@ -71,8 +71,8 @@ async def test_docx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.docx"),
         content="test",
     )
-    assert "Permission denied" in result
-    assert "Error" not in result.lower() or "Permission denied" in result
+    assert "权限被拒绝" in result
+    assert "Error" not in result or "权限被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -84,7 +84,7 @@ async def test_pptx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.pptx"),
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,7 @@ async def test_xlsx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.xlsx"),
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 # ── Path traversal: ../outside.docx must be denied ───────────────────────────
@@ -110,7 +110,7 @@ async def test_docx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.docx",
         content="test",
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     # The file must not exist outside
     parent_dir = tmp_path.parent
     assert not (parent_dir / "outside.docx").exists(), (
@@ -126,7 +126,7 @@ async def test_pptx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.pptx",
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -137,7 +137,7 @@ async def test_xlsx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.xlsx",
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 # ── Denial must not create/modify files ──────────────────────────────────────
@@ -153,7 +153,7 @@ async def test_docx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.docx",  # relative to workspace, but outside allowed_dir
         content="test",
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path / "outside.docx").exists()
     assert not (allowed_sub / "outside.docx").exists()
 
@@ -168,7 +168,7 @@ async def test_pptx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.pptx",
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path / "outside.pptx").exists()
 
 
@@ -182,7 +182,7 @@ async def test_xlsx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.xlsx",
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path / "outside.xlsx").exists()
 
 
@@ -203,7 +203,7 @@ async def test_docx_write_approval_allow_still_denies_workspace_outside(tmp_path
         file_path=str(outside / "still_denied.docx"),
         content="test",
     )
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
 
 
 # ── ToolRegistry.execute_concurrent: no production call sites ────────────────

--- a/tests/execution/test_phase33_sandbox_acceptance.py
+++ b/tests/execution/test_phase33_sandbox_acceptance.py
@@ -135,7 +135,7 @@ async def test_acceptance_restricted_rejects_outside_workspace_path(tmp_path):
         _tool_call_id="call-unsafe",
     )
     assert "Error" in result
-    assert "path" in result.lower() or "outside" in result.lower()
+    assert "路径" in result or "超出" in result
 
 
 @pytest.mark.asyncio
@@ -313,7 +313,7 @@ async def test_acceptance_explicit_landlock_fail_closed():
         _tool_call_id="call-landlock-fc",
     )
     assert "Error" in result
-    assert "not yet implemented" in result.lower()
+    assert "尚未实现" in result
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/plan/test_plan_tool.py
+++ b/tests/plan/test_plan_tool.py
@@ -69,4 +69,4 @@ def test_plan_update_not_found():
         step_id="s1",
         status="completed",
     ))
-    assert "not found" in result.lower()
+    assert "未找到" in result

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -148,7 +148,7 @@ async def test_factory_docx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_d.docx"
     result = await tool.execute(file_path=str(outside), content="test")
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not outside.exists()
 
 
@@ -167,7 +167,7 @@ async def test_factory_pptx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_p.pptx"
     result = await tool.execute(file_path=str(outside), slides=[])
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not outside.exists()
 
 
@@ -186,7 +186,7 @@ async def test_factory_xlsx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_x.xlsx"
     result = await tool.execute(file_path=str(outside), sheets={})
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not outside.exists()
 
 
@@ -222,7 +222,7 @@ async def test_factory_docx_write_path_traversal_rejected_default_config(
     assert tool is not None
 
     result = await tool.execute(file_path="../escape.docx", content="test")
-    assert "Permission denied" in result
+    assert "权限被拒绝" in result
     assert not (tmp_path.parent / "escape.docx").exists()
 
 

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -67,7 +67,7 @@ class TestCanonicalizeWslMntPath:
         ws = tmp_path / "sub"
         ws.mkdir()
         mnt = _as_mnt_path(ws, "..", "secret.txt")
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _canonicalize_wsl_mnt_path(mnt, ws)
 
     @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
@@ -76,7 +76,7 @@ class TestCanonicalizeWslMntPath:
         ws.mkdir()
         other = tmp_path / "other"
         other.mkdir()
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _canonicalize_wsl_mnt_path(_as_mnt_path(other, "file.txt"), ws)
 
     def test_no_workspace_returns_unchanged(self):
@@ -147,7 +147,7 @@ class TestCanonicalizeWslMntPath:
         host_skills.mkdir()
         other_session = tmp_path / "sessions" / "other" / "files"
         other_session.mkdir(parents=True)
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _canonicalize_wsl_mnt_path(
                 _as_mnt_path(other_session, "secret.md"),
                 session_ws,
@@ -164,7 +164,7 @@ class TestCanonicalizeWslMntPath:
         host_memory.mkdir()
         # From inside memory, traverse up via .. into an unrelated dir.
         mnt = _as_mnt_path(host_memory, "..", "evil.txt")
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _canonicalize_wsl_mnt_path(mnt, session_ws, extra_roots=[host_memory])
 
     @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
@@ -203,7 +203,7 @@ class TestResolveSandboxPathWSL:
         sb = _make_wsl_sandbox()
         other = tmp_path / "other"
         other.mkdir()
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _resolve_sandbox_path(str(other.resolve() / "file.txt"), ws, sb)
 
     def test_relative_path_under_wsl(self, tmp_path):
@@ -219,7 +219,7 @@ class TestResolveSandboxPathWSL:
         ws = tmp_path / "sub"
         ws.mkdir()
         sb = _make_wsl_sandbox()
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _resolve_sandbox_path("../../secret.txt", ws, sb)
 
     def test_linux_path_kept_as_is(self, tmp_path):
@@ -246,7 +246,7 @@ class TestResolveSandboxPathWSL:
         other = tmp_path / "other"
         other.mkdir()
         sb = _make_wsl_sandbox()
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _resolve_sandbox_path(_as_mnt_path(other, "file.txt"), ws, sb)
 
     def test_native_sandbox_uses_workspace_remap(self, tmp_path):
@@ -288,7 +288,7 @@ class TestResolveSandboxPathWSL:
         assert "MEMORY.md" in ok
 
         # foreign session path still rejected
-        with pytest.raises(PermissionError, match="outside"):
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
             _resolve_sandbox_path(
                 str(other_session / "secret.md"),
                 session_ws,
@@ -329,7 +329,7 @@ class TestResolveSandboxPathWSL:
         assert "x.txt" in ok_own
 
         # Other session dir: still rejected — isolation red line.
-        with pytest.raises(PermissionError, match="isolation"):
+        with pytest.raises(PermissionError, match="隔离"):
             _resolve_sandbox_path(
                 str(other_session / "secret.md"),
                 ws,

--- a/tests/test_tool_validation.py
+++ b/tests/test_tool_validation.py
@@ -91,7 +91,7 @@ async def test_registry_returns_validation_error() -> None:
     reg = ToolRegistry()
     reg.register(SampleTool())
     result = await reg.execute("sample", {"query": "hi"})
-    assert "Invalid parameters" in result
+    assert "参数无效" in result
 
 
 def test_memory_store_explicit_memory_flushes_immediately(tmp_path) -> None:
@@ -270,7 +270,7 @@ def test_memory_store_tool_feedback_learns_lessons(tmp_path) -> None:
     changed = store.record_tool_feedback(
         session_key="cli:lesson",
         tool_name="read_file",
-        result="Error: File not found: /tmp/missing.txt",
+        result="Error: 文件不存在：/tmp/missing.txt",
     )
     assert changed is True
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

工具层 160+ 处 `Error:`/异常英文错误文案中文化（cron/memory/message/apply_patch/filesystem/shell/文档工具/技能脚本等 39 个文件），保留 `Error:` 前缀与英文技术术语，仅文案变更、不动错误处理逻辑。

## 背景/问题

实机测试 #646-v2 时发现 `chat:send` 报错为英文（用户直接可见的 4 处已在 #719 修复）。但工具层 `Error: ...` 仍大量为英文——这些文案返回给模型后可能被原样转述给用户。实测还发现**冒泡异常**（如 `PermissionError: Path ... outside all legal roots`）会直接显示在工具行，也是英文。

## 关联 issue

- Closes #721 工具层错误文案未中文化（20+ 处 Error: 英文——cron/memory/message/apply_patch 等）

## 变更内容

- `miqi/agent/tools/`（12 文件）：apply_patch/ask_user_confirm/base/cron/filesystem/memory/message/papers/registry/shell/skill_manage/web 的参数校验、失败、权限、沙箱错误文案中文化（如 `Error: 缺少必要参数 'patch'`、`Error: 权限被拒绝：{e}`、`Error: 命令在 {n} 秒后超时`）
- `miqi/documents/`（6 文件）：docx/pdf_create/pdf_read/pptx/xlsx + document_parser 错误文案中文化
- `miqi/kun_runtime/tool_host.py`、`miqi/plan/plan_tool.py`：用户确认失败/plan 查找错误中文化
- `miqi/skills/docx|xlsx/scripts/`（7 文件）：pack/unpack/validate/accept_changes/comment 错误中文化
- **冒泡异常 message 中文化**（14 处 raise，filesystem.py 的 PermissionError/FileNotFoundError、papers.py、base.py、document_parser.py 等）——工具行会原样显示这类异常，实测用户可见
- shell.py **多行字符串续行英文残留补齐**（LANDLOCK/RESTRICTED 沙箱错误，如 `cwd be within the workspace` → `cwd 必须位于工作区内`）
- 测试断言同步中文（11 个测试文件，如 `Permission denied` → `权限被拒绝`、`timed out` → `超时`）
- `tests/e2e/helpers/electron-setup.ts`：e2e 测试实例 userData 隔离（`--user-data-dir`）——修测试实例与 dev 实例共享 electron 配置导致会话互串（#721 实机验证时发现旧会话被恢复）

## 日志/验证证据

```
# E2E 实机验证（Playwright + 真实 LLM，verify-721.spec.ts 通过 3.9 分钟）：
工具行显示：PermissionError: 路径 'C:[path]'（规范化后：'C:\definitely_not_exists_721\readme.txt'）解析为 '...'，不在任何合法根目录 [...] 内
AI 转述：工具执行失败 read_file：PermissionError: 路径 ... 不在任何合法根目录内 [Hint: ...]
→ 中文文案实机生效，Error: 前缀保留

# 全量 pytest：2831 passed（2 个 bwrap 基线失败经 git stash 验证与本次改动无关，干净 develop 同样失败）
```

## 测试情况

- 全量 `pytest tests -q`：**2831 passed, 20 skipped**（wsl sandbox 6 个断言同步后全过；剩余 2 个 bwrap 基线失败已用 `git stash` 验证改动前后一致，属既有环境问题）
- 定向测试：tests/tool_validation + tests/documents + tests/agent/tools + tests/execution + tests/sandbox 全部通过
- E2E 实机验证：工具错误中文文案显示（截图见下）

## 截图

![工具错误中文文案](https://github.com/user-attachments/assets/placeholder)
（E2E 实机截图 721-tool-error-cn.png：对话中工具行与 AI 转述均为中文错误文案，含「不在任何合法根目录内」）


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- 将工具层、文档工具和技能脚本中 160+ 处 `Error:`/异常英文文案中文化，保留 `Error:` 前缀与技术术语

- 同步更新相关测试断言为中文预期（`权限被拒绝`、`超时`、`取消`、`未执行` 等）

- 为 Electron E2E 启动添加基于 `miqiHome` 的独立 `--user-data-dir`，避免会话状态跨测试泄漏


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["工具层/文档/技能脚本英文错误"] --> B["翻译为中文，保留 Error: 前缀"]
  B --> C["更新测试断言"]
  D["Electron E2E 启动"] --> E["按 miqiHome 隔离 userData"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>filesystem.py</strong><dd><code>中文化文件读写、沙箱、权限及会话隔离错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+38/-40</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shell.py</strong><dd><code>中文化命令执行、沙箱与安全护栏错误消息</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-3cc5757485ddb3df794186684ead9e7294ad0648552d9d298091abdafc38ca92">+29/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cron.py</strong><dd><code>中文化定时任务参数与调度校验错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-d0664ea571460203771733f041be759a314157e98c88d864d51d1db0b0bb85e4">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>memory.py</strong><dd><code>中文化记忆写入、替换与删除参数错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-c48678ab474ba4398929709bb3303c43497ad8e166ad520076ca5c6dab666163">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>skill_manage.py</strong><dd><code>中文化技能管理参数与操作错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-89c81cea3f349aa72520308962968a2fc4c0be1925a9160d3f96ed56fd94a0ae">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>apply_patch.py</strong><dd><code>中文化补丁参数、格式与权限错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-55c4775c822bbd6942ead6b0e254f2740b7658ef37a0cd6acb19423f6fceba64">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>message.py</strong><dd><code>中文化消息目标通道未指定与发送未配置错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-2f06b20d64bed98b10d6168454fd165eac157d97b2e15c0d0f478393f30d27bd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.py</strong><dd><code>中文化工具未找到、参数无效与超时错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-8190bdabaa30f0e8c6b11a69b3f602e192d3f11458d925a560298fa95aec5ce6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ask_user_confirm.py</strong><dd><code>中文化确认卡执行失败提示</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-36f8961070a6366aa94371a21bd9de6e716dc02a979d6fae06f11a9cbc335229">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>web.py</strong><dd><code>中文化搜索依赖缺失、未配置与搜索失败错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-e9ac9012d9f53f0d1e4bd1cdd0faa9d5cbc50a6101ab752bfd45ce3d8855341a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docx_tool.py</strong><dd><code>中文化 DOCX 读写参数、文件与权限错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-68ba46097a582a112352d2e03fe8b0fcd30ee21c543d45369532b81ce9534be1">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pdf_create_tool.py</strong><dd><code>中文化 PDF 创建文件名、内容与权限错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-3b164bda1ab8a7b5e16f1afbc351423bd3ac0453e646ede39d0e1d18a98a3d46">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pdf_read_tool.py</strong><dd><code>中文化 PDF 读取参数、类型与文件缺失错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-f3f63a3672760dd75b4ad61d207103dfda08cfd42c921ebe2b4ed90df3ce5ab9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pptx_tool.py</strong><dd><code>中文化 PPTX 读写参数、文件与权限错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-c03deb9e26be681d056d84c02c3b975db5dd1013282d6dbbb0ba5e7b2d87f333">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>xlsx_tool.py</strong><dd><code>中文化 XLSX 读写参数、工作表与权限错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-3e3ffdd99a22d67ca6d87f1766de867b08a769b7f2554a6177e3d3a0104b91ed">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>document_parser.py</strong><dd><code>中文化文档格式支持与 HTML 解析错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-42edcb3bdb887cb051f706bfd568845779b60340f9abe99d076b3e04b1f11d2e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_host.py</strong><dd><code>中文化用户确认失败错误消息</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-01a08c79fd725c123752bbd114fb6535d190da6cec8253929874e3c9ffe1e1af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plan_tool.py</strong><dd><code>中文化计划或步骤未找到错误</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-a5879cf9a24ae8e6e8c768257579637b2bd9f4d62de957e43d7d1edc4fc4d5ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>electron-setup.ts</strong><dd><code>为 E2E 启动添加独立 user-data-dir 隔离配置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-58139259a2a9fb2e044aab7c7354e9c5a55ff21b376fcf99cfbb67b6be072845">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_exec_events.py</strong><dd><code>更新执行工具超时与取消断言为中文预期</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-4c20b28e48d2d5594c494094998b923f113360aa7956b9018166a04f06992124">+10/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>base.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-1c44c4fe9260e1d69938239867e71b43cdfddc2a3a83ab0782e3ac3098121a5b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>papers.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-517db4721a14d4f48bce6ae5359696c09ae07a100f1661811bb06ff20d284f1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>accept_changes.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-190edd81cc8663df951e6da07938b2722334360e32c6ff84c67a439569f06efe">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>comment.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-99e585f4ec6d740bbb240b6f5e07a11e40eb21f201c7ab433e91c46ed165bef7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pack.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-509ab9da8ff12c53e8d2c00c85b8631b8e13ea81c0510983f5a40e42aedffc0b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unpack.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-51e22c4a3c7e25efc49b34ef2ff9e1c61f35de9dd367cfaac5d736e76b7e17b0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validate.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-f5c6dec105904408efdf5eeb6977f62bde8a1a264ce4202868b4359e2f865c2b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pack.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-273baa1d14e67da1db9c38babd749371817b74450343a517737708c25c3f8d88">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validate.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-9262e712c6571fbcb8739b0b32d9883b8f8cb14197c2bdf2cfb61eca0261f7cf">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_apply_patch.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-194639216f204e11c45ae70f1fc7951ae2603533b92d06642f1858af74c40203">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_session_workspace_isolation.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-d6ff26bf4abcfa48112cc31c8172b5ce72f035e322fa51c253649db47dad13f3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_docx_tool.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-e55c113bd3d300b459010b2a0403ba8a0f41c70e30a6e59e6498fcfa913d58ba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_office_create_tools.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-8b2cb452313a6c44fd045907a30111b7edf41a2129aa48935f24a2448ff5d25d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_exec_tool_sandbox_selection.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-55732125979efedb409a208500e422978adcb4037180fc7c840111f402b7d323">+41/-41</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase32_office_path_enforcement.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-3ec290dc5697b4896c981629f8da5c8748972e2bde7cbd8d995495d1d9ad4251">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase33_sandbox_acceptance.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-d622fd153444da002a2e18764861bcad8793070681b9be19911d73b0ae4e18d2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_plan_tool.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-a5690953aa9dcf125dfb5d181b48bccb16a1bb0db5df41f444223104ccd88113">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_registry_factory.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-cff948657ad1cde008668a0a7eb25c696683f9617be95503514386c9f4a4937c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_wsl_sandbox_path_mapping.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-78b5181b165bbad81de1a66f652928946f7591f6e7749456c67ac45e78d80c0b">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_validation.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/730/files#diff-273dfb09cb584b893e43a694288346b7c31ac27f1d936927c6d41ebe0237c893">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

