### PR TITLE
fix(agent): 文件写入重定向到会话隔离工作区

### DIFF
--- a/apps/desktop/tests/e2e/session-workspace-isolation.spec.ts
+++ b/apps/desktop/tests/e2e/session-workspace-isolation.spec.ts
@@ -172,12 +172,18 @@ test.describe('Session Workspace Isolation E2E', () => {
     const content = `# ${marker}\n\nIsolation check.`;
 
     await createNewConversation(page);
-    await sendMessageWithRetry(
-      page,
-      `必须调用 write_file 工具创建文件，path 参数必须是绝对路径 "${join(workspaceRoot, filename)}"，content="${content}"。` +
-        `创建完成后只回复"完成"。`,
-    );
-    await waitForResponseComplete(page, 240_000);
+    const createMessage = `必须调用 write_file 工具创建文件，path 参数必须是绝对路径 "${join(workspaceRoot, filename)}"，content="${content}"。` +
+      `创建完成后只回复"完成"。`;
+    // Same no-op retry loop as the first test (CodeRabbit #731 review).
+    let created = false;
+    for (let attempt = 0; attempt < 2 && !created; attempt++) {
+      await sendMessageWithRetry(page, createMessage);
+      await waitForResponseComplete(page, 240_000);
+      created = findFileInSessionDirs(miqiHome, filename) !== null;
+      if (!created) {
+        console.log(`[test] ⚠️ write_file not executed (attempt ${attempt + 1}) — retrying send`);
+      }
+    }
     await expect
       .poll(() => findFileInSessionDirs(miqiHome, filename), { timeout: 30_000 })
       .not.toBeNull();

--- a/apps/desktop/tests/e2e/session-workspace-isolation.spec.ts
+++ b/apps/desktop/tests/e2e/session-workspace-isolation.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * E2E: Session workspace isolation for file writes.
+ *
+ * Regression coverage for the bug where write_file with an ABSOLUTE path
+ * under the default workspace root (the directory the system prompt
+ * advertises as the working directory) landed the file in the SHARED root
+ * instead of the per-session workspace `<workspace>/sessions/<key>/files/`.
+ *
+ * Verifies:
+ *   1. Agent writes with an absolute workspace-root path → file lands in
+ *      sessions/<safe_key>/files/, NOT at the workspace root.
+ *   2. The file still appears in the Task Assets panel.
+ *   3. A second session starts with an empty Task Assets panel (isolation).
+ *
+ * The sandbox is disabled via patchConfig so the native (no-sandbox) path
+ * is exercised deterministically — that path previously had NO session
+ * isolation at all because the factory never wired the per-session dir.
+ *
+ * Run:
+ *   cd apps/desktop
+ *   npx playwright test --config=playwright.config.ts --project=electron session-workspace-isolation.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { join, resolve } from 'node:path';
+import { existsSync, readdirSync } from 'node:fs';
+import {
+  LLM_TIMEOUT,
+  waitForInputReady,
+  sendMessage,
+  waitForResponseComplete,
+  waitForBridgeInitialized,
+  launchElectronApp,
+  closeElectronApp,
+  createNewConversation,
+} from './helpers/electron-setup';
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+/** Find the first session files dir containing *filename* under
+ *  <miqiHome>/workspace/sessions/. Returns the full path or null. */
+function findFileInSessionDirs(miqiHome: string, filename: string): string | null {
+  const sessionsDir = join(miqiHome, 'workspace', 'sessions');
+  if (!existsSync(sessionsDir)) return null;
+  for (const entry of readdirSync(sessionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = join(sessionsDir, entry.name, 'files', filename);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function waitForFileInPanel(page: Page, filename: string, timeout = 30_000) {
+  const assetsPanel = page.getByTestId('task-assets-panel');
+  const card = assetsPanel.locator('[class*="rounded"][class*="p-"]').filter({ hasText: filename.slice(0, 20) }).first();
+  try {
+    await expect(card).toBeVisible({ timeout });
+  } catch {
+    const fallback = assetsPanel.locator('.rounded-lg.p-2\\.5').filter({ hasText: filename.slice(0, 20) }).first();
+    await expect(fallback).toBeVisible({ timeout });
+    return fallback;
+  }
+  return card;
+}
+
+/** Dismiss stale Radix overlays that can swallow the first Enter (cold-start). */
+async function dismissOverlays(page: Page) {
+  await page.evaluate(() => {
+    document.querySelectorAll('[data-radix-focus-guard]').forEach((e) => e.remove());
+    document.querySelectorAll('[data-aria-hidden="true"]').forEach((e) => {
+      if (e.classList.contains('fixed') && e.classList.contains('inset-0')) {
+        (e as HTMLElement).style.display = 'none';
+      }
+    });
+  });
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(300);
+}
+
+/** sendMessage with one retry — the first Enter of a cold app can race the
+ *  optimistic-UI bubble mount (same class as workspace-selection flakes). */
+async function sendMessageWithRetry(page: Page, text: string) {
+  await dismissOverlays(page);
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await sendMessage(page, text);
+      return;
+    } catch {
+      if (attempt >= 1) throw new Error('sendMessage failed after retries');
+      console.log(`[test] send failed (attempt ${attempt + 1}) — retrying`);
+      await page.waitForTimeout(1000);
+      const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+      await textarea.fill('').catch(() => {});
+      await dismissOverlays(page);
+    }
+  }
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────
+
+test.describe('Session Workspace Isolation E2E', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp((config) => {
+      // Deterministic native path: no WSL sandbox in this spec.
+      config.tools = { ...config.tools, sandbox: { ...config.tools?.sandbox, enabled: false } };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+
+    await waitForBridgeInitialized(page);
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test('absolute workspace-root write lands in the session workspace', async () => {
+    test.setTimeout(LLM_TIMEOUT * 2);
+    const marker = `E2E_WSISO_${Date.now()}`;
+    const filename = `e2e_wsiso_${Date.now()}.md`;
+    const workspaceRoot = resolve(join(miqiHome, 'workspace'));
+    const absoluteTarget = join(workspaceRoot, filename);
+    const content = `# ${marker}\n\nSession workspace isolation test.`;
+
+    await createNewConversation(page);
+
+    // Reproduce the original bug scenario: the system prompt advertises the
+    // workspace ROOT as the working directory, so the model writes an
+    // absolute root path.  The write must be redirected into the session's
+    // isolated files dir.  Retry the send once — deepseek no-op turns (the
+    // model replies without calling write_file) are a known flake class.
+    const message = `必须调用 write_file 工具创建文件，path 参数必须是绝对路径 "${absoluteTarget}"，content="${content}"。` +
+      `创建完成后只回复"完成"。`;
+    let created = false;
+    for (let attempt = 0; attempt < 2 && !created; attempt++) {
+      await sendMessageWithRetry(page, message);
+      await waitForResponseComplete(page, 240_000);
+      created = findFileInSessionDirs(miqiHome, filename) !== null;
+      if (!created) {
+        console.log(`[test] ⚠️ write_file not executed (attempt ${attempt + 1}) — retrying send`);
+      }
+    }
+
+    // The file must land in <workspace>/sessions/<key>/files/ (key derived
+    // from the frontend session key "desktop:<ts>").
+    await expect
+      .poll(() => findFileInSessionDirs(miqiHome, filename), { timeout: 30_000 })
+      .not.toBeNull();
+    console.log(`[test] ✅ File "${filename}" found under sessions/*/files/`);
+
+    // …and NOT at the shared workspace root.
+    expect(existsSync(absoluteTarget), `file must not exist at workspace root: ${absoluteTarget}`).toBe(false);
+    console.log('[test] ✅ Workspace root is clean');
+
+    // The Task Assets panel still shows the file (tracked_files bookkeeping
+    // keeps pointing at the session-scoped location).
+    await waitForFileInPanel(page, filename);
+    console.log('[test] ✅ File appears in Task Assets panel');
+  });
+
+  test('a new session does not see the previous session files', async () => {
+    test.setTimeout(LLM_TIMEOUT);
+    const marker = `E2E_WSISO_B_${Date.now()}`;
+    const filename = `e2e_wsiso_b_${Date.now()}.md`;
+    const workspaceRoot = resolve(join(miqiHome, 'workspace'));
+    const content = `# ${marker}\n\nIsolation check.`;
+
+    await createNewConversation(page);
+    await sendMessageWithRetry(
+      page,
+      `必须调用 write_file 工具创建文件，path 参数必须是绝对路径 "${join(workspaceRoot, filename)}"，content="${content}"。` +
+        `创建完成后只回复"完成"。`,
+    );
+    await waitForResponseComplete(page, 240_000);
+    await expect
+      .poll(() => findFileInSessionDirs(miqiHome, filename), { timeout: 30_000 })
+      .not.toBeNull();
+
+    // Switch to a fresh session — its Task Assets panel must start empty
+    // (no cross-session leakage).
+    await createNewConversation(page);
+    await expect(page.locator('[data-testid="task-assets-empty"]')).toBeVisible({ timeout: 15_000 });
+    console.log('[test] ✅ New session shows empty Task Assets');
+  });
+});

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -361,7 +361,7 @@ class ApplyPatchTool(Tool):
         )
         path = await _redirect_new_file_write(
             path, base_ws, session_dir,
-            _make_exists_check(self._shared_roots, sandbox, session_ws),
+            _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
         )
 
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -21,6 +21,7 @@ from miqi.agent.tools.filesystem import (
     _redirect_new_file_write,
     _resolve_path,
     _resolve_sandbox_path,
+    _resolve_session_dir,
     _sandbox_file_exists,
     _sandbox_read_file,
     _sandbox_write_file,
@@ -318,6 +319,7 @@ class ApplyPatchTool(Tool):
         patch = kwargs.get("patch", "")
         if not isinstance(patch, str) or not patch:
             return "Error: Missing required parameter 'patch'"
+        _sess_key = kwargs.pop("_session_key", None)
         try:
             file_patches = parse_patch(patch)
         except PatchParseError as e:
@@ -328,7 +330,7 @@ class ApplyPatchTool(Tool):
 
         for fp in file_patches:
             try:
-                result = await self._apply_one_file(fp, sandbox)
+                result = await self._apply_one_file(fp, sandbox, _sess_key)
             except PatchApplyError as e:
                 return f"Error applying patch to {fp.path}: {e}"
             except PermissionError as e:
@@ -342,7 +344,7 @@ class ApplyPatchTool(Tool):
             return "No files changed"
         return f"Applied patch to: {', '.join(changed)}"
 
-    async def _apply_one_file(self, file_patch: FilePatch, sandbox):
+    async def _apply_one_file(self, file_patch: FilePatch, sandbox, _sess_key: str | None = None):
         path = file_patch.path
 
         # Session isolation (#221 / #613 follow-up): patch targets written
@@ -350,9 +352,11 @@ class ApplyPatchTool(Tool):
         # prompt advertises) must land in the per-session files dir.  Existing
         # shared files are patched in place.
         session_ws = _get_session_workspace(self._workspace, sandbox)
-        session_dir = self._session_files_dir or session_ws
         base_ws = self._base_workspace or (
             self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        session_dir = _resolve_session_dir(
+            self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
         path = await _redirect_new_file_write(
             path, base_ws, session_dir,

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -15,7 +15,10 @@ from miqi.agent.tools.base import Tool
 from miqi.agent.tools.filesystem import (
     _get_active_sandbox,
     _get_session_workspace,
+    _is_default_workspace,
+    _make_exists_check,
     _maybe_snapshot,
+    _redirect_new_file_write,
     _resolve_path,
     _resolve_sandbox_path,
     _sandbox_file_exists,
@@ -276,12 +279,16 @@ class ApplyPatchTool(Tool):
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
+        session_files_dir: Path | None = None,
+        base_workspace: Path | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
+        self._session_files_dir = session_files_dir
+        self._base_workspace = base_workspace
 
     @property
     def name(self) -> str:
@@ -338,11 +345,24 @@ class ApplyPatchTool(Tool):
     async def _apply_one_file(self, file_patch: FilePatch, sandbox):
         path = file_patch.path
 
+        # Session isolation (#221 / #613 follow-up): patch targets written
+        # under the default workspace root by the model (the dir the system
+        # prompt advertises) must land in the per-session files dir.  Existing
+        # shared files are patched in place.
+        session_ws = _get_session_workspace(self._workspace, sandbox)
+        session_dir = self._session_files_dir or session_ws
+        base_ws = self._base_workspace or (
+            self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        path = await _redirect_new_file_write(
+            path, base_ws, session_dir,
+            _make_exists_check(self._shared_roots, sandbox, session_ws),
+        )
+
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # session_files_dir enforces per-session isolation (#689): the
             # shared roots now include the workspace root, so without it a
             # patch could target another session's files dir.
-            session_ws = _get_session_workspace(self._workspace, sandbox)
             sandbox_path = _resolve_sandbox_path(
                 path, self._workspace, sandbox,
                 extra_roots=self._shared_roots,

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -19,6 +19,7 @@ from miqi.agent.tools.filesystem import (
     _make_exists_check,
     _maybe_snapshot,
     _redirect_new_file_write,
+    _reject_foreign_session_path,
     _resolve_path,
     _resolve_sandbox_path,
     _resolve_session_dir,
@@ -370,7 +371,7 @@ class ApplyPatchTool(Tool):
             sandbox_path = _resolve_sandbox_path(
                 path, self._workspace, sandbox,
                 extra_roots=self._shared_roots,
-                session_files_dir=session_ws,
+                session_files_dir=session_dir or session_ws,
             )
             _log.info("apply_patch [sandbox]: %s → %s", path, sandbox_path)
 
@@ -400,11 +401,12 @@ class ApplyPatchTool(Tool):
         # Native / no sandbox
         file_path = _resolve_path(
             path,
-            self._workspace,
+            session_dir or self._workspace,
             self._allowed_dir,
             self._sandbox_manager,
             shared_roots=self._shared_roots,
         )
+        _reject_foreign_session_path(file_path, base_ws, session_dir)
         snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
 
         if file_path.exists():

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -685,13 +685,15 @@ def _reject_foreign_session_path(
         pass  # unresolvable path — later operations will surface the error
 
 
-def _make_exists_check(shared_roots, sandbox, session_ws):
+def _make_exists_check(shared_roots, sandbox, session_ws, native_base_dir=None):
     """Async 'does *path* exist?' callable for ``_redirect_new_file_write``.
 
     Sandbox-aware when a WSL sandbox is active; otherwise a native
-    ``Path.exists()`` probe (Windows/posix).  Probe failures PROPAGATE so
-    ``_redirect_new_file_write`` keeps the original path instead of treating
-    an existing shared file as new (CodeRabbit #731).
+    ``Path.exists()`` probe (Windows/posix).  Relative paths are resolved
+    against ``native_base_dir`` (the tool's workspace) — never the process
+    CWD.  Probe failures PROPAGATE so ``_redirect_new_file_write`` keeps the
+    original path instead of treating an existing shared file as new
+    (CodeRabbit #731).
     """
     if sandbox is not None and getattr(sandbox, "_use_wsl", False):
 
@@ -704,6 +706,8 @@ def _make_exists_check(shared_roots, sandbox, session_ws):
         return _check
 
     async def _check(p: str) -> bool:
+        if not _is_absolute_host_path(p) and native_base_dir:
+            p = str(Path(native_base_dir) / p)
         return Path(_norm_host_path(p)).exists()
 
     return _check
@@ -1150,7 +1154,7 @@ class WriteFileTool(Tool):
         # root (the dir the system prompt advertises) land in the session
         # files dir instead of the shared root.
         path = await _redirect_new_file_write(
-            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
+            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
@@ -1286,7 +1290,7 @@ class EditFileTool(Tool):
         # Session isolation: edits of files that only exist in the session
         # dir resolve there; shared root files are edited in place.
         path = await _redirect_new_file_write(
-            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
+            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -447,34 +447,78 @@ def _get_session_workspace(base_workspace: Path | None, sandbox) -> Path | None:
     """
     if base_workspace is None or sandbox is None:
         return base_workspace
-    if not _is_default_workspace(base_workspace):
-        _log.debug("Custom workspace, skipping session-files isolation: %s", base_workspace)
-        return base_workspace
     session_key = getattr(sandbox, "session_key", None) or ""
-    key = session_key.split(":", 1)[-1] if ":" in session_key else session_key
-    if not key:
+    if not session_key:
         return base_workspace
-    from miqi.utils.helpers import safe_filename
-    safe_key = safe_filename(key.replace(":", "_"))
-    session_ws = base_workspace / "sessions" / safe_key / "files"
-    session_ws.mkdir(parents=True, exist_ok=True)
-    _log.debug("Session workspace: %s → %s", session_key, session_ws)
-    return session_ws
+    session_ws = _session_files_dir_for_key(base_workspace, session_key)
+    return session_ws if session_ws is not None else base_workspace
+
+
+def _resolve_session_dir(
+    factory_session_dir: Path | None,
+    sandbox_session_ws: Path | None,
+    tool_workspace: Path | None,
+    session_key: str | None,
+    base_workspace: Path | None,
+) -> Path | None:
+    """Resolve the per-session files dir for one tool call.
+
+    Precedence: factory-provided dir (single-session runtimes) → sandbox-
+    derived dir → per-call derivation from the injected ``_session_key``
+    (KUN multi-thread runtime / native no-sandbox path).  Returns None when
+    no isolation applies; callers then keep the tool's base workspace.
+
+    Note: the factory dir is per-REGISTRY, so a runtime that builds one
+    registry for many sessions should not pass ``session_id`` to the
+    factory — the per-call ``_session_key`` derivation covers that case.
+    """
+    if factory_session_dir is not None:
+        return factory_session_dir
+    if sandbox_session_ws is not None and sandbox_session_ws != tool_workspace:
+        return sandbox_session_ws
+    if session_key:
+        return _session_files_dir_for_key(base_workspace, session_key)
+    return None
 
 
 def _session_files_dir_key(session_key: str) -> str:
     """Derive the on-disk per-session directory key from a session key.
 
-    Mirrors ``_get_session_workspace``: strip the client_id prefix (first
-    colon segment, e.g. ``miqi-desktop:desktop:1786...`` → ``desktop:1786...``)
-    and sanitize for the filesystem.  The naive ``replace(":", "_")`` over the
-    full key would produce a different directory than the one
-    ``files.read`` / attachment saving use (``sessions/desktop_1786.../files``).
+    Strips the client_id prefix only for fully namespaced keys (three or
+    more colon segments, e.g. ``miqi-desktop:desktop:1786...`` →
+    ``desktop_1786...``) and keeps the whole key for two-segment channel
+    keys (``desktop:1786...`` → ``desktop_1786...``) — matching the disk
+    convention used by ``files.read`` and attachment saving.
     """
     from miqi.utils.helpers import safe_filename
 
-    key = session_key.split(":", 1)[-1] if ":" in session_key else session_key
-    return safe_filename(key.replace(":", "_"))
+    parts = session_key.split(":")
+    if len(parts) >= 3:
+        parts = parts[1:]
+    return safe_filename("_".join(parts))
+
+
+def _session_files_dir_for_key(
+    base_workspace: Path | None, session_key: str | None,
+) -> Path | None:
+    """Compute ``<base>/sessions/<safe_key>/files`` for a session key.
+
+    Returns None for a custom (non-default) workspace or an empty key —
+    per-session isolation only applies to the default workspace.  Used by
+    ``_get_session_workspace`` (sandbox-derived) and by the file tools as a
+    per-call fallback when the injected ``_session_key`` is the only source
+    (KUN multi-thread runtime, native no-sandbox path).
+    """
+    if base_workspace is None or not session_key:
+        return None
+    if not _is_default_workspace(base_workspace):
+        _log.debug("Custom workspace, skipping session-files isolation: %s", base_workspace)
+        return None
+    safe_key = _session_files_dir_key(session_key)
+    session_ws = base_workspace / "sessions" / safe_key / "files"
+    session_ws.mkdir(parents=True, exist_ok=True)
+    _log.debug("Session workspace: %s → %s", session_key, session_ws)
+    return session_ws
 
 
 # Sub-directories of the default workspace that stay SHARED across sessions
@@ -895,8 +939,14 @@ class ReadFileTool(Tool):
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         # Factory-provided session dir wins over the sandbox-derived one: it
-        # exists even when no sandbox is active (native/macOS path).
-        session_dir = self._session_files_dir or session_ws
+        # exists even when no sandbox is active (native/macOS path).  The
+        # injected _session_key is the last source (KUN multi-thread runtime).
+        # Reads resolve against the root workspace (self._workspace IS the
+        # default root for read tools), which is also the redirect base.
+        base_ws = self._workspace if _is_default_workspace(self._workspace) else None
+        session_dir = _resolve_session_dir(
+            self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
+        )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # Read tools resolve against the ROOT workspace (the working dir
@@ -1048,9 +1098,13 @@ class WriteFileTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
-        session_dir = self._session_files_dir or session_ws
         base_ws = self._base_workspace or (
             self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        # Session isolation: factory dir → sandbox dir → per-call derivation
+        # from the injected _session_key (KUN multi-thread / native path).
+        session_dir = _resolve_session_dir(
+            self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
         # Session isolation: new files written under the default workspace
         # root (the dir the system prompt advertises) land in the session
@@ -1179,9 +1233,11 @@ class EditFileTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
-        session_dir = self._session_files_dir or session_ws
         base_ws = self._base_workspace or (
             self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        session_dir = _resolve_session_dir(
+            self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
         # Session isolation: edits of files that only exist in the session
         # dir resolve there; shared root files are edited in place.

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -594,7 +594,15 @@ def _redirect_path_to_session(
     sess_norm = _norm_host_path(str(session_files_dir.resolve())).rstrip("/")
 
     if not _is_absolute_host_path(path):
-        return str(session_files_dir / path)
+        # Relative paths are re-anchored to the session dir; reject any that
+        # would climb out of it (../) — those must be handled (and usually
+        # denied) by the callers' containment checks instead.
+        import os as _os
+
+        norm_rel = _os.path.normpath(str(path).replace("\\", "/"))
+        if norm_rel == ".." or norm_rel.startswith("../"):
+            return None
+        return str(session_files_dir / norm_rel)
 
     norm = _norm_host_path(path)
     base_norm = _norm_host_path(str(base_workspace.resolve())).rstrip("/")
@@ -648,30 +656,55 @@ async def _redirect_new_file_write(
     return redirected
 
 
+def _reject_foreign_session_path(
+    resolved: Path, base_workspace: Path | None, session_files_dir: Path | None,
+) -> None:
+    """Raise PermissionError when *resolved* lands in another session's dir.
+
+    The default workspace's ``sessions/`` tree is per-session isolated: when
+    isolation is active, any target inside ``<base>/sessions/`` must be the
+    CURRENT session's files dir (its snapshots dir is covered by the same
+    ancestor check).  Native (no-sandbox) resolution has no other
+    enforcement point, and the WSL path enforces this via
+    ``_canonicalize_wsl_mnt_path(session_files_dir=...)``.
+    """
+    if base_workspace is None or session_files_dir is None:
+        return
+    try:
+        sessions_root = base_workspace.resolve() / "sessions"
+        if resolved == sessions_root or resolved.is_relative_to(sessions_root):
+            sess = session_files_dir.resolve()
+            if resolved != sess and not resolved.is_relative_to(sess):
+                raise PermissionError(
+                    f"Path '{resolved}' is inside another session's files "
+                    f"directory (current session dir: {sess})"
+                )
+    except PermissionError:
+        raise
+    except OSError:
+        pass  # unresolvable path — later operations will surface the error
+
+
 def _make_exists_check(shared_roots, sandbox, session_ws):
     """Async 'does *path* exist?' callable for ``_redirect_new_file_write``.
 
     Sandbox-aware when a WSL sandbox is active; otherwise a native
-    ``Path.exists()`` probe (Windows/posix).
+    ``Path.exists()`` probe (Windows/posix).  Probe failures PROPAGATE so
+    ``_redirect_new_file_write`` keeps the original path instead of treating
+    an existing shared file as new (CodeRabbit #731).
     """
     if sandbox is not None and getattr(sandbox, "_use_wsl", False):
 
         async def _check(p: str) -> bool:
-            try:
-                sb = _resolve_sandbox_path(
-                    p, session_ws, sandbox, extra_roots=shared_roots,
-                )
-                return await _sandbox_file_exists(sandbox, sb)
-            except Exception:
-                return False  # fail-safe: unknown → treat as not-exists → redirect
+            sb = _resolve_sandbox_path(
+                p, session_ws, sandbox, extra_roots=shared_roots,
+            )
+            return await _sandbox_file_exists(sandbox, sb)
 
         return _check
 
     async def _check(p: str) -> bool:
-        try:
-            return Path(_norm_host_path(p)).exists()
-        except Exception:
-            return False
+        return Path(_norm_host_path(p)).exists()
 
     return _check
 
@@ -1003,18 +1036,25 @@ class ReadFileTool(Tool):
                     self._sandbox_manager,
                     shared_roots=self._shared_roots,
                 )
+                # Cross-session isolation for native reads too: another
+                # session's files dir must not be readable (CodeRabbit #731).
+                if file_path.exists():
+                    _reject_foreign_session_path(file_path, base_ws, session_dir)
                 if not file_path.exists():
-                    # Session-dir fallback (mirrors the sandbox branch).
+                    # Session-dir fallback (mirrors the sandbox branch).  The
+                    # fallback resolves against the SESSION workspace so the
+                    # native-sandbox remap matches where writes landed.
                     alt = _redirect_path_to_session(path, self._workspace, session_dir)
                     if alt:
                         alt_path = _resolve_path(
                             alt,
-                            self._workspace,
+                            session_dir or self._workspace,
                             self._allowed_dir,
                             self._sandbox_manager,
                             shared_roots=self._shared_roots,
                         )
                         if alt_path != file_path and alt_path.exists():
+                            _reject_foreign_session_path(alt_path, base_ws, session_dir)
                             return alt_path.read_text(encoding="utf-8")
                     return f"Error: File not found: {path}"
                 if not file_path.is_file():
@@ -1113,9 +1153,12 @@ class WriteFileTool(Tool):
             path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-            # WSL sandbox — route file operations through the sandbox
+            # WSL sandbox — route file operations through the sandbox.
+            # session_files_dir enforces cross-session isolation: a path
+            # under another session's files dir is rejected (CodeRabbit #731).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots
+                path, session_ws, sandbox, extra_roots=self._shared_roots,
+                session_files_dir=session_dir,
             )
             _log.info("write_file [sandbox]: %s → %s", path, sandbox_path)
             try:
@@ -1151,11 +1194,12 @@ class WriteFileTool(Tool):
             try:
                 file_path = _resolve_path(
                     path,
-                    self._workspace,
+                    session_dir or self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
                     shared_roots=self._shared_roots,
                 )
+                _reject_foreign_session_path(file_path, base_ws, session_dir)
                 # Snapshot original content before first write (enables non-git diff/revert)
                 snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)
                 file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1245,9 +1289,12 @@ class EditFileTool(Tool):
             path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
-            # WSL sandbox — route file operations through the sandbox
+            # WSL sandbox — route file operations through the sandbox.
+            # session_files_dir enforces cross-session isolation: a path
+            # under another session's files dir is rejected (CodeRabbit #731).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots
+                path, session_ws, sandbox, extra_roots=self._shared_roots,
+                session_files_dir=session_dir,
             )
             _log.info("edit_file [sandbox]: %s → %s", path, sandbox_path)
             try:
@@ -1299,11 +1346,12 @@ class EditFileTool(Tool):
             try:
                 file_path = _resolve_path(
                     path,
-                    self._workspace,
+                    session_dir or self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
                     shared_roots=self._shared_roots,
                 )
+                _reject_foreign_session_path(file_path, base_ws, session_dir)
                 if not file_path.exists():
                     return f"Error: File not found: {path}"
 

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -462,6 +462,176 @@ def _get_session_workspace(base_workspace: Path | None, sandbox) -> Path | None:
     return session_ws
 
 
+def _session_files_dir_key(session_key: str) -> str:
+    """Derive the on-disk per-session directory key from a session key.
+
+    Mirrors ``_get_session_workspace``: strip the client_id prefix (first
+    colon segment, e.g. ``miqi-desktop:desktop:1786...`` → ``desktop:1786...``)
+    and sanitize for the filesystem.  The naive ``replace(":", "_")`` over the
+    full key would produce a different directory than the one
+    ``files.read`` / attachment saving use (``sessions/desktop_1786.../files``).
+    """
+    from miqi.utils.helpers import safe_filename
+
+    key = session_key.split(":", 1)[-1] if ":" in session_key else session_key
+    return safe_filename(key.replace(":", "_"))
+
+
+# Sub-directories of the default workspace that stay SHARED across sessions
+# (issue #516 / #689): the system prompt legitimately directs the agent to
+# read/write these, so session-isolation redirection must not touch them.
+# "sessions" holds the per-session dirs themselves — cross-session access is
+# enforced by the containment checks, never by re-anchoring into the current
+# session's dir.
+_ROOT_EXEMPT_SUBDIRS = ("memory", "skills", ".skills", "sessions")
+
+
+def _norm_host_path(path: str) -> str:
+    """Normalize a host path for prefix comparison.
+
+    Converts Windows backslashes and WSL ``/mnt/c/...`` forms to a single
+    ``C:/...`` representation and canonicalizes through ``Path.resolve()``
+    (when the path is absolute on the current platform).  The resolve step is
+    what makes comparisons robust against Windows 8.3 short names (e.g. a
+    temp dir handed out as ``C:\\Users\\INTERS~1\\...`` while the workspace
+    resolves to ``C:\\Users\\Intership003\\...``) and case differences.
+    ``..`` segments are collapsed lexically.
+    """
+    import os as _os
+    import re as _re
+
+    s = str(path).replace("\\", "/")
+    m = _re.match(r"^/mnt/([a-zA-Z])/(.*)$", s)
+    if m:
+        s = f"{m.group(1).upper()}:/{m.group(2)}"
+    m = _re.match(r"^([a-zA-Z]):/(.*)$", s)
+    if m:
+        s = f"{m.group(1).upper()}:/{m.group(2)}"
+    if Path(s).is_absolute():
+        try:
+            s = str(Path(s).resolve()).replace("\\", "/")
+        except Exception:
+            pass
+    return _os.path.normpath(s).replace("\\", "/")
+
+
+def _is_absolute_host_path(path: str) -> bool:
+    """Return True when *path* is absolute in host terms (Windows drive,
+    ``/mnt/<drive>/``, or a POSIX absolute path)."""
+    import re as _re
+
+    s = str(path).replace("\\", "/")
+    return bool(
+        _re.match(r"^[a-zA-Z]:/", s)
+        or _re.match(r"^/mnt/[a-zA-Z]/", s)
+        or s.startswith("/")
+    )
+
+
+def _redirect_path_to_session(
+    path: str,
+    base_workspace: Path | None,
+    session_files_dir: Path | None,
+) -> str | None:
+    """Map *path* into the per-session files dir; return None when it does not apply.
+
+    Applies to:
+      - absolute host paths under *base_workspace* (the directory the system
+        prompt advertises as the working directory) — they are re-anchored to
+        the session dir, except for the shared sub-roots (memory/ skills/ .skills/);
+      - relative paths — re-anchored to *session_files_dir*.
+
+    Paths already inside the session dir, outside the base workspace, or with
+    no session dir configured return None.
+    """
+    if not base_workspace or not session_files_dir:
+        return None
+
+    sess_norm = _norm_host_path(str(session_files_dir.resolve())).rstrip("/")
+
+    if not _is_absolute_host_path(path):
+        return str(session_files_dir / path)
+
+    norm = _norm_host_path(path)
+    base_norm = _norm_host_path(str(base_workspace.resolve())).rstrip("/")
+    if norm == base_norm or norm.startswith(base_norm + "/"):
+        pass
+    else:
+        return None  # outside the default workspace root
+    if norm == sess_norm or norm.startswith(sess_norm + "/"):
+        return None  # already session-scoped
+    rel = norm[len(base_norm):].lstrip("/")
+    if not rel:
+        return None  # the workspace root itself is not a file target
+    if rel.split("/", 1)[0] in _ROOT_EXEMPT_SUBDIRS:
+        return None  # shared sub-roots stay shared
+
+    # Preserve /mnt/<drive>/ input style for WSL callers
+    if str(path).replace("\\", "/").startswith("/mnt/"):
+        import re as _re
+
+        m = _re.match(r"^/mnt/([a-zA-Z])/(.*)$", str(path).replace("\\", "/"))
+        sm = _re.match(r"^([A-Za-z]):/(.*)$", sess_norm)
+        if m and sm:
+            return f"/mnt/{m.group(1).lower()}/{sm.group(2)}/{rel}"
+    return str(session_files_dir / Path(*rel.split("/")))
+
+
+async def _redirect_new_file_write(
+    path: str,
+    base_workspace: Path | None,
+    session_files_dir: Path | None,
+    exists_check,
+) -> str:
+    """Redirect a NEW-file write under the default workspace root into the
+    per-session files dir (session isolation, #221 / #613 follow-up).
+
+    The system prompt advertises the workspace root as the working directory,
+    so models write absolute root paths (e.g. ``C:\\Users\\...\\.miqi\\workspace\\x.md``).
+    Those must land in ``sessions/<key>/files/`` instead of the shared root.
+    Files that already exist at the target are edited in place (shared
+    bootstrap files such as AGENTS.md), and shared sub-roots (memory/,
+    skills/, .skills/) are never redirected.
+    """
+    redirected = _redirect_path_to_session(path, base_workspace, session_files_dir)
+    if redirected is None or redirected == path:
+        return path
+    try:
+        if await exists_check(path):
+            return path  # edit-in-place of an existing shared file
+    except Exception:
+        return path  # existence unknown — never redirect blindly
+    return redirected
+
+
+def _make_exists_check(shared_roots, sandbox, session_ws):
+    """Async 'does *path* exist?' callable for ``_redirect_new_file_write``.
+
+    Sandbox-aware when a WSL sandbox is active; otherwise a native
+    ``Path.exists()`` probe (Windows/posix).
+    """
+    if sandbox is not None and getattr(sandbox, "_use_wsl", False):
+
+        async def _check(p: str) -> bool:
+            try:
+                sb = _resolve_sandbox_path(
+                    p, session_ws, sandbox, extra_roots=shared_roots,
+                )
+                return await _sandbox_file_exists(sandbox, sb)
+            except Exception:
+                return False  # fail-safe: unknown → treat as not-exists → redirect
+
+        return _check
+
+    async def _check(p: str) -> bool:
+        try:
+            return Path(_norm_host_path(p)).exists()
+        except Exception:
+            return False
+
+    return _check
+
+
 def _resolve_sandbox_path(
     path: str,
     workspace: Path | None,
@@ -691,11 +861,13 @@ class ReadFileTool(Tool):
         allowed_dir: Path | None = None,
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
+        session_files_dir: Path | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
+        self._session_files_dir = session_files_dir
 
     @property
     def name(self) -> str:
@@ -722,6 +894,9 @@ class ReadFileTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
+        # Factory-provided session dir wins over the sandbox-derived one: it
+        # exists even when no sandbox is active (native/macOS path).
+        session_dir = self._session_files_dir or session_ws
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # Read tools resolve against the ROOT workspace (the working dir
@@ -738,6 +913,28 @@ class ReadFileTool(Tool):
             except Exception as e:
                 return f"Error: Failed to check file existence in sandbox (path={sandbox_path}): {e}"
             if not exists:
+                # Session-dir fallback: writes are redirected into
+                # sessions/<key>/files, so a path that misses at the root may
+                # live there (relative paths resolve against the root).
+                alt = _redirect_path_to_session(path, self._workspace, session_dir)
+                if alt:
+                    alt_sandbox = _resolve_sandbox_path(
+                        alt, self._workspace, sandbox,
+                        extra_roots=self._shared_roots,
+                        session_files_dir=session_ws,
+                    )
+                    if alt_sandbox != sandbox_path:
+                        try:
+                            if await _sandbox_file_exists(sandbox, alt_sandbox):
+                                content = await _sandbox_read_file(sandbox, alt_sandbox)
+                                _log.info(
+                                    "read_file [sandbox fallback]: %s → %s", path, alt_sandbox,
+                                )
+                                return content
+                        except Exception as e:
+                            _log.warning(
+                                "read_file [sandbox fallback] failed (%s): %s", alt_sandbox, e,
+                            )
                 return f"Error: File not found: {path} (sandbox path: {sandbox_path})"
             try:
                 content = await _sandbox_read_file(sandbox, sandbox_path)
@@ -757,6 +954,18 @@ class ReadFileTool(Tool):
                     shared_roots=self._shared_roots,
                 )
                 if not file_path.exists():
+                    # Session-dir fallback (mirrors the sandbox branch).
+                    alt = _redirect_path_to_session(path, self._workspace, session_dir)
+                    if alt:
+                        alt_path = _resolve_path(
+                            alt,
+                            self._workspace,
+                            self._allowed_dir,
+                            self._sandbox_manager,
+                            shared_roots=self._shared_roots,
+                        )
+                        if alt_path != file_path and alt_path.exists():
+                            return alt_path.read_text(encoding="utf-8")
                     return f"Error: File not found: {path}"
                 if not file_path.is_file():
                     return f"Error: Not a file: {path}"
@@ -779,12 +988,29 @@ class WriteFileTool(Tool):
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
+        session_files_dir: Path | None = None,
+        base_workspace: Path | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
+        # Session isolation (#221 / #613): factory-provided per-session files
+        # dir (works without a sandbox) and the default workspace root used to
+        # re-anchor absolute root paths into the session dir.
+        self._session_files_dir = session_files_dir
+        self._base_workspace = base_workspace
+
+    @property
+    def _tracking_workspace(self) -> Path | None:
+        """Workspace root used for tracked_files.json bookkeeping.
+
+        Tracked files are stored per-session under the DEFAULT workspace
+        (``sessions/<key>/tracked_files.json``), never under the per-session
+        files dir itself.
+        """
+        return self._base_workspace or self._workspace
 
     @property
     def name(self) -> str:
@@ -822,6 +1048,16 @@ class WriteFileTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
+        session_dir = self._session_files_dir or session_ws
+        base_ws = self._base_workspace or (
+            self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        # Session isolation: new files written under the default workspace
+        # root (the dir the system prompt advertises) land in the session
+        # files dir instead of the shared root.
+        path = await _redirect_new_file_write(
+            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
+        )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
             sandbox_path = _resolve_sandbox_path(
@@ -852,7 +1088,7 @@ class WriteFileTool(Tool):
             # Persist to tracked_files.json so the Task Assets panel
             # survives session switches.
             _persist_tracked_file(
-                self._workspace, host_path, op="write", session_key=_sess_key,
+                self._tracking_workspace, host_path, op="write", session_key=_sess_key,
             )
 
             return f"Successfully wrote {len(content)} bytes to {host_path}"
@@ -872,7 +1108,7 @@ class WriteFileTool(Tool):
                 file_path.write_text(content, encoding="utf-8")
                 # Persist to tracked_files.json for session switch survival
                 _persist_tracked_file(
-                    self._workspace, file_path, op="write", session_key=_sess_key,
+                    self._tracking_workspace, file_path, op="write", session_key=_sess_key,
                 )
                 result = f"Successfully wrote {len(content)} bytes to {file_path}"
                 if not snap_ok:
@@ -894,12 +1130,21 @@ class EditFileTool(Tool):
         snapshot_dir: Path | None = None,
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
+        session_files_dir: Path | None = None,
+        base_workspace: Path | None = None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._snapshot_dir = snapshot_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
+        self._session_files_dir = session_files_dir
+        self._base_workspace = base_workspace
+
+    @property
+    def _tracking_workspace(self) -> Path | None:
+        """Workspace root used for tracked_files.json bookkeeping."""
+        return self._base_workspace or self._workspace
 
     @property
     def name(self) -> str:
@@ -934,6 +1179,15 @@ class EditFileTool(Tool):
         _sess_key = kwargs.pop("_session_key", None)
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
+        session_dir = self._session_files_dir or session_ws
+        base_ws = self._base_workspace or (
+            self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        # Session isolation: edits of files that only exist in the session
+        # dir resolve there; shared root files are edited in place.
+        path = await _redirect_new_file_write(
+            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws),
+        )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox
             sandbox_path = _resolve_sandbox_path(
@@ -980,7 +1234,7 @@ class EditFileTool(Tool):
                     _log.warning("edit_file [mirror] failed for %s: %s", host_path, exc)
 
             _persist_tracked_file(
-                self._workspace, host_path, op="edit", session_key=_sess_key,
+                self._tracking_workspace, host_path, op="edit", session_key=_sess_key,
             )
 
             return f"Successfully edited {host_path}"
@@ -1014,7 +1268,7 @@ class EditFileTool(Tool):
                 file_path.write_text(new_content, encoding="utf-8")
 
                 _persist_tracked_file(
-                    self._workspace, file_path, op="edit", session_key=_sess_key,
+                    self._tracking_workspace, file_path, op="edit", session_key=_sess_key,
                 )
 
                 return f"Successfully edited {file_path}"

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -74,6 +74,22 @@ _MAX_PARALLEL_TOOL_CALLS = 3
 # AI-initiated user confirmation (issue #646): blocking human-in-the-loop tool
 ASK_USER_CONFIRM_TOOL = "ask_user_confirm_card"
 
+# Tools that receive the injected ``_session_key`` (mirrors the legacy
+# ToolOrchestrator._execute_in_sandbox set).  Session isolation
+# (sessions/<key>/files) can only engage when the tool knows which session
+# is executing — the KUN tool host is the single execution point here, so it
+# must do the same injection or file writes land in the shared root.
+_SESSION_KEY_TOOLS = frozenset({
+    "exec",
+    "write_file", "edit_file", "delete_file", "apply_patch",
+    "read_file", "list_dir",
+    "docx_write", "pptx_write", "xlsx_write",
+    "create_docx", "create_pptx", "create_xlsx",
+    "create_pdf", "pdf_write", "pdf_read",
+    "edit_docx", "append_xlsx",
+    "paper_download",
+})
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # MiQiToolHost
@@ -277,7 +293,19 @@ class MiQiToolHost:
 
         # Execute
         try:
-            result = await self._registry.execute(tool_name, args)
+            # Session isolation: inject the session key for file/exec tools so
+            # per-session workspace isolation engages on the KUN runtime (the
+            # legacy orchestrator does the same via _execute_in_sandbox).
+            # thread_id → session_key mapping when registered (gateway flows),
+            # otherwise the thread id itself is the session key.
+            extra: dict[str, Any] = {}
+            if tool_name in _SESSION_KEY_TOOLS:
+                from miqi.kun_runtime.migration_adapter import thread_id_to_session_key
+
+                session_key = thread_id_to_session_key(context.thread_id) or context.thread_id
+                if session_key:
+                    extra["_session_key"] = session_key
+            result = await self._registry.execute(tool_name, args, **extra)
             is_error = isinstance(result, str) and result.startswith("Error")
         except asyncio.TimeoutError:
             result = f"Tool '{tool_name}' timed out"

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -128,6 +128,7 @@ class RuntimeServices:
         tool_registry = create_runtime_tool_registry(
             config=config,
             workspace=workspace,
+            session_id=session_id,
             provider=provider,
             bus=bus,
             approval_callback=None,

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -63,6 +63,7 @@ def create_runtime_tool_registry(
     *,
     config: Any,
     workspace: Path,
+    session_id: str = "",
     provider: Any = None,
     bus: Any = None,
     approval_callback: Any = None,
@@ -83,6 +84,9 @@ def create_runtime_tool_registry(
     Args:
         config: MiQi Config object (config.schema.Config).
         workspace: Session workspace directory.
+        session_id: Namespaced session key (``<client_id>:<session_key>``)
+            used to derive the per-session files dir.  Falls back to
+            ``config._session_key`` for legacy callers.
         provider: LLM provider (needed for SubagentManager if spawn is desired).
         bus: MessageBus (needed for MessageTool).
         approval_callback: Optional approval callback for ExecTool.
@@ -104,7 +108,7 @@ def create_runtime_tool_registry(
 
     # Resolve session-key-dependent paths (Historical: mirrors the legacy
     # AgentLoop._register_default_tools)
-    _session_key = getattr(config, "_session_key", "") or ""
+    _session_key = session_id or getattr(config, "_session_key", "") or ""
     _snap_dir: Path | None = None
     _work_dir: Path | None = None
     _write_workspace: Path = workspace
@@ -115,7 +119,13 @@ def create_runtime_tool_registry(
         session_config = getattr(session_config, "sessions", None) if session_config is not None else None
 
     if _session_key:
-        safe_key = safe_filename(_session_key.replace(":", "_"))
+        from miqi.agent.tools.filesystem import _session_files_dir_key
+
+        # Strip the client_id prefix (first colon segment) so the directory
+        # key matches what files.read / attachment saving use on disk
+        # (sessions/<safe_key>/files) — the naive replace(":", "_") over the
+        # full namespaced key produced a divergent directory.
+        safe_key = _session_files_dir_key(_session_key)
         _snap_dir = workspace / "sessions" / safe_key / "snapshots"
         _snap_dir.mkdir(parents=True, exist_ok=True)
         # A custom (non-default) workspace is the project directory the user
@@ -212,8 +222,26 @@ def create_runtime_tool_registry(
     registry.register(AskUserConfirmCardTool(resolver=make_resolver()))
 
     # 1. Filesystem tools
-    for cls in (ReadFileTool, ListDirTool):
-        registry.register(cls(workspace=workspace, allowed_dir=allowed_dir, sandbox_manager=_sbm, shared_roots=_read_shared_roots))
+    registry.register(
+        ListDirTool(
+            workspace=workspace,
+            allowed_dir=allowed_dir,
+            sandbox_manager=_sbm,
+            shared_roots=_read_shared_roots,
+        )
+    )
+    # ReadFileTool additionally gets the per-session files dir so reads of
+    # files the agent wrote (redirected into sessions/<key>/files) fall back
+    # to the session dir when they miss at the root.
+    registry.register(
+        ReadFileTool(
+            workspace=workspace,
+            allowed_dir=allowed_dir,
+            sandbox_manager=_sbm,
+            shared_roots=_read_shared_roots,
+            session_files_dir=_work_dir,
+        )
+    )
     registry.register(
         WriteFileTool(
             workspace=_write_workspace,
@@ -221,6 +249,8 @@ def create_runtime_tool_registry(
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
             shared_roots=_shared_roots,
+            session_files_dir=_work_dir,
+            base_workspace=workspace,
         )
     )
     registry.register(
@@ -230,6 +260,8 @@ def create_runtime_tool_registry(
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
             shared_roots=_shared_roots,
+            session_files_dir=_work_dir,
+            base_workspace=workspace,
         )
     )
     registry.register(
@@ -239,6 +271,8 @@ def create_runtime_tool_registry(
             snapshot_dir=_snap_dir,
             sandbox_manager=_sbm,
             shared_roots=_shared_roots,
+            session_files_dir=_work_dir,
+            base_workspace=workspace,
         )
     )
 

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -1,0 +1,384 @@
+"""Session workspace isolation for file tools (#221 / #613 follow-up).
+
+Regression coverage for the bug where ``write_file`` with an absolute path
+under the default workspace root (the directory the system prompt advertises
+as the working directory) landed the file in the SHARED root instead of the
+per-session files dir ``sessions/<key>/files/``.
+
+Behaviour under test:
+- NEW files written under the default workspace root are redirected into the
+  session files dir (native and WSL sandbox paths).
+- Existing root files (bootstrap AGENTS.md etc.) are edited in place.
+- Shared sub-roots (memory/ skills/ .skills/) are never redirected.
+- read_file falls back to the session files dir when the root misses.
+- The registry factory wires the per-session dir from ``session_id``.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import (
+    EditFileTool,
+    ReadFileTool,
+    WriteFileTool,
+    _redirect_new_file_write,
+    _redirect_path_to_session,
+    _session_files_dir_key,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _mk_env(tmp_path):
+    root = tmp_path / "ws"
+    root.mkdir()
+    key = "miqi-desktop:desktop:1786807046853"
+    session_dir = root / "sessions" / _session_files_dir_key(key) / "files"
+    session_dir.mkdir(parents=True)
+    write = WriteFileTool(
+        workspace=session_dir,
+        base_workspace=root,
+        session_files_dir=session_dir,
+    )
+    read = ReadFileTool(workspace=root, session_files_dir=session_dir)
+    return root, session_dir, write, read
+
+
+# ── Key derivation ─────────────────────────────────────────────────────────
+
+
+def test_session_files_dir_key_strips_client_prefix():
+    # Namespaced session_id (client_id:session_key) → client prefix dropped.
+    assert _session_files_dir_key("miqi-desktop:desktop:1786807046853") == "desktop_1786807046853"
+    assert _session_files_dir_key("cli:direct") == "direct"
+    assert _session_files_dir_key("gateway:default") == "default"
+    # Bare keys (no client prefix) follow the same first-segment rule —
+    # mirrors _get_session_workspace (production always passes the
+    # namespaced session_id).
+    assert _session_files_dir_key("desktop:1786807046853") == "1786807046853"
+    assert _session_files_dir_key("plainkey") == "plainkey"
+
+
+# ── Path redirection helpers ───────────────────────────────────────────────
+
+
+def test_redirect_path_absolute_root_new_file(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    target = str(root / "welcome.md")
+    out = _redirect_path_to_session(target, root, session_dir)
+    assert out == str(session_dir / "welcome.md")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="WSL /mnt/ form is Windows-specific")
+def test_redirect_path_preserves_mnt_style(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    target = "/mnt/c" + str(root / "report.md").replace("\\", "/")[2:]
+    out = _redirect_path_to_session(target, root, session_dir)
+    assert out is not None
+    assert out.startswith("/mnt/c/")
+    assert out.endswith("/sessions/desktop_1786807046853/files/report.md")
+
+
+@pytest.mark.skipif(os.name != "nt", reason="8.3 short names are Windows-only")
+def test_redirect_path_handles_windows_83_short_names(tmp_path):
+    """A temp dir handed out as ``C:\\Users\\INTERS~1\\...`` must still be
+    recognized as being under the workspace (whose canonical form uses the
+    long name ``C:\\Users\\Intership003\\...``).  This exact mismatch made
+    the E2E temp-home scenario skip the redirect and write to the root."""
+    import ctypes
+
+    GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
+
+    def short_name(p: Path) -> str:
+        buf = ctypes.create_unicode_buffer(512)
+        GetShortPathNameW(str(p), buf, 512)
+        return buf.value
+
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    short_root = short_name(root)
+    assert short_root and short_root.lower() != str(root).lower()  # short form differs
+    target = short_root + "\\welcome.md"
+    out = _redirect_path_to_session(target, root, session_dir)
+    assert out == str(session_dir / "welcome.md")
+
+
+def test_redirect_path_relative_maps_to_session_dir(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    out = _redirect_path_to_session("notes.txt", root, session_dir)
+    assert out == str(session_dir / "notes.txt")
+
+
+def test_redirect_path_skips_shared_subdirs(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    for sub in ("memory", "skills", ".skills"):
+        assert _redirect_path_to_session(str(root / sub / "x.md"), root, session_dir) is None
+        assert _redirect_path_to_session(str(root / sub), root, session_dir) is None
+
+
+def test_redirect_path_skips_outside_root_and_session_dir(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    outside = tmp_path / "elsewhere" / "x.md"
+    assert _redirect_path_to_session(str(outside), root, session_dir) is None
+    already = session_dir / "inner" / "x.md"
+    assert _redirect_path_to_session(str(already), root, session_dir) is None
+    assert _redirect_path_to_session(str(root / "sessions"), root, session_dir) is None
+
+
+async def _exists_true(_p):
+    return True
+
+
+async def _exists_false(_p):
+    return False
+
+
+@pytest.mark.asyncio
+async def test_redirect_new_file_write_keeps_existing_root_file(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    existing = root / "AGENTS.md"
+    existing.write_text("old", encoding="utf-8")
+    out = await _redirect_new_file_write(str(existing), root, session_dir, _exists_true)
+    assert out == str(existing)
+
+
+@pytest.mark.asyncio
+async def test_redirect_new_file_write_redirects_when_missing(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    out = await _redirect_new_file_write(str(root / "new.md"), root, session_dir, _exists_false)
+    assert out == str(session_dir / "new.md")
+
+
+@pytest.mark.asyncio
+async def test_redirect_new_file_write_noop_without_dirs(tmp_path):
+    out = await _redirect_new_file_write("C:/Users/x/.miqi/workspace/a.md", None, None, _exists_false)
+    assert out == "C:/Users/x/.miqi/workspace/a.md"
+
+
+# ── write_file (native, no sandbox) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_file_absolute_root_path_lands_in_session_dir(tmp_path):
+    root, session_dir, write, _ = _mk_env(tmp_path)
+    target = str(root / "welcome.md")
+    result = await write.execute(path=target, content="hi")
+    assert "Successfully wrote" in result
+    assert str(session_dir) in result
+    assert (session_dir / "welcome.md").read_text(encoding="utf-8") == "hi"
+    assert not (root / "welcome.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_relative_path_lands_in_session_dir(tmp_path):
+    root, session_dir, write, _ = _mk_env(tmp_path)
+    result = await write.execute(path="rel.md", content="hi")
+    assert "Successfully wrote" in result
+    assert (session_dir / "rel.md").exists()
+    assert not (root / "rel.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_existing_root_file_edited_in_place(tmp_path):
+    root, session_dir, write, _ = _mk_env(tmp_path)
+    bootstrap = root / "AGENTS.md"
+    bootstrap.write_text("old", encoding="utf-8")
+    result = await write.execute(path=str(bootstrap), content="new")
+    assert "Successfully wrote" in result
+    assert bootstrap.read_text(encoding="utf-8") == "new"
+    assert not (session_dir / "AGENTS.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_shared_subdir_not_redirected(tmp_path):
+    root, session_dir, write, _ = _mk_env(tmp_path)
+    (root / "memory").mkdir()
+    target = root / "memory" / "MEMORY.md"
+    result = await write.execute(path=str(target), content="mem")
+    assert "Successfully wrote" in result
+    assert target.read_text(encoding="utf-8") == "mem"
+    assert not (session_dir / "memory" / "MEMORY.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_outside_workspace_untouched(tmp_path):
+    root, _, write, _ = _mk_env(tmp_path)
+    outside = tmp_path / "out.md"
+    await write.execute(path=str(outside), content="x")
+    assert outside.read_text(encoding="utf-8") == "x"  # no restriction configured
+
+
+# ── edit_file (native) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_edit_file_by_original_root_path_edits_session_copy(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    (session_dir / "note.md").write_text("hello world", encoding="utf-8")
+    edit = EditFileTool(
+        workspace=session_dir, base_workspace=root, session_files_dir=session_dir,
+    )
+    result = await edit.execute(
+        path=str(root / "note.md"), old_text="hello", new_text="bye",
+    )
+    assert "Successfully edited" in result
+    assert (session_dir / "note.md").read_text(encoding="utf-8") == "bye world"
+    assert not (root / "note.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_edit_file_existing_root_file_edited_in_place(tmp_path):
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    bootstrap = root / "AGENTS.md"
+    bootstrap.write_text("alpha beta", encoding="utf-8")
+    edit = EditFileTool(
+        workspace=session_dir, base_workspace=root, session_files_dir=session_dir,
+    )
+    result = await edit.execute(
+        path=str(bootstrap), old_text="alpha", new_text="gamma",
+    )
+    assert "Successfully edited" in result
+    assert bootstrap.read_text(encoding="utf-8") == "gamma beta"
+
+
+# ── read_file fallback ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_file_falls_back_to_session_dir_absolute(tmp_path):
+    root, session_dir, _, read = _mk_env(tmp_path)
+    (session_dir / "welcome.md").write_text("session content", encoding="utf-8")
+    result = await read.execute(path=str(root / "welcome.md"))
+    assert result == "session content"
+
+
+@pytest.mark.asyncio
+async def test_read_file_falls_back_to_session_dir_relative(tmp_path):
+    root, session_dir, _, read = _mk_env(tmp_path)
+    (session_dir / "rel.md").write_text("rel content", encoding="utf-8")
+    result = await read.execute(path="rel.md")
+    assert result == "rel content"
+
+
+@pytest.mark.asyncio
+async def test_read_file_root_file_still_readable(tmp_path):
+    root, session_dir, _, read = _mk_env(tmp_path)
+    (root / "AGENTS.md").write_text("bootstrap", encoding="utf-8")
+    result = await read.execute(path="AGENTS.md")
+    assert result == "bootstrap"
+
+
+# ── Factory wiring ─────────────────────────────────────────────────────────
+
+
+def test_factory_wires_session_files_dir_for_default_workspace(fake_config, tmp_path):
+    from miqi.paths import get_miqi_home
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    ws = Path(get_miqi_home()) / "workspace"
+    ws.mkdir(parents=True)
+    fake_config.agents.defaults.workspace = str(ws)
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=ws, session_id="miqi-desktop:desktop:1786807046853",
+    )
+    session_dir = ws / "sessions" / "desktop_1786807046853" / "files"
+
+    write = registry.get("write_file")
+    assert write._workspace == session_dir
+    assert write._session_files_dir == session_dir
+    assert write._base_workspace == ws
+
+    edit = registry.get("edit_file")
+    assert edit._workspace == session_dir
+
+    patch = registry.get("apply_patch")
+    assert patch._workspace == session_dir
+
+    read = registry.get("read_file")
+    assert read._workspace == ws  # reads stay rooted at the workspace
+    assert read._session_files_dir == session_dir
+
+
+def test_factory_no_isolation_for_custom_workspace(fake_config, tmp_path):
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    custom = tmp_path / "project"
+    custom.mkdir()
+    fake_config.agents.defaults.workspace = str(custom)
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=custom, session_id="miqi-desktop:desktop:123",
+    )
+    write = registry.get("write_file")
+    assert write._workspace == custom
+    assert write._session_files_dir is None
+    assert write._base_workspace == custom
+
+
+def test_factory_no_session_id_keeps_legacy_behavior(fake_config, tmp_path):
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path,
+    )
+    write = registry.get("write_file")
+    assert write._workspace == tmp_path
+    assert write._session_files_dir is None
+
+
+# ── WSL sandbox branch (Windows-only) ─────────────────────────────────────
+
+
+@pytest.mark.skipif(os.name != "nt", reason="WSL /mnt/ mapping is Windows-specific")
+@pytest.mark.asyncio
+async def test_write_file_wsl_sandbox_redirects_absolute_root_path(tmp_path):
+    """The sandbox write command must target sessions/<key>/files, not the root."""
+    from unittest.mock import MagicMock
+
+    root, session_dir, _, _ = _mk_env(tmp_path)
+
+    class FakeSandbox:
+        _use_wsl = True
+        is_running = True
+        session_key = "miqi-desktop:desktop:1786807046853"
+        workspace = str(root)
+        workspace_path = str(root)
+
+        def __init__(self):
+            self.calls = []
+
+        async def run_command(self, cmd, timeout=30):
+            self.calls.append(cmd)
+            if cmd.startswith("test "):
+                return (1, "", "")  # target does not exist yet
+            return (0, "", "")
+
+    sandbox = FakeSandbox()
+    manager = MagicMock()
+    manager.get_or_create = MagicMock()
+
+    async def _get_or_create(key):
+        return sandbox
+
+    manager.get_or_create.side_effect = _get_or_create
+
+    write = WriteFileTool(
+        workspace=session_dir,
+        base_workspace=root,
+        session_files_dir=session_dir,
+        sandbox_manager=manager,
+        shared_roots=[root],  # production factory whitelists the workspace root (#689)
+    )
+    result = await write.execute(
+        path=str(root / "welcome.md"),
+        content="hi",
+        _session_key="miqi-desktop:desktop:1786807046853",
+    )
+    assert "Successfully wrote" in result
+    write_cmds = [c for c in sandbox.calls if "base64" in c]
+    assert write_cmds, "expected a sandbox write command"
+    assert "/sessions/desktop_1786807046853/files/welcome.md" in write_cmds[0]
+    assert not any("workspace/welcome.md'" in c for c in write_cmds)

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -50,16 +50,15 @@ def _mk_env(tmp_path):
 # ── Key derivation ─────────────────────────────────────────────────────────
 
 
-def test_session_files_dir_key_strips_client_prefix():
-    # Namespaced session_id (client_id:session_key) → client prefix dropped.
+def test_session_files_dir_key_derivation():
+    # Namespaced session_id (client_id:session_key, ≥3 segments) → client dropped.
     assert _session_files_dir_key("miqi-desktop:desktop:1786807046853") == "desktop_1786807046853"
-    assert _session_files_dir_key("cli:direct") == "direct"
-    assert _session_files_dir_key("gateway:default") == "default"
-    # Bare keys (no client prefix) follow the same first-segment rule —
-    # mirrors _get_session_workspace (production always passes the
-    # namespaced session_id).
-    assert _session_files_dir_key("desktop:1786807046853") == "1786807046853"
-    assert _session_files_dir_key("plainkey") == "plainkey"
+    # Two-segment channel keys keep the channel — matches the disk convention
+    # used by files.read / attachment saving.
+    assert _session_files_dir_key("desktop:1786807046853") == "desktop_1786807046853"
+    assert _session_files_dir_key("cli:direct") == "cli_direct"
+    assert _session_files_dir_key("gateway:default") == "gateway_default"
+    assert _session_files_dir_key("thread_nomap") == "thread_nomap"
 
 
 # ── Path redirection helpers ───────────────────────────────────────────────
@@ -331,6 +330,84 @@ def test_factory_no_session_id_keeps_legacy_behavior(fake_config, tmp_path):
     write = registry.get("write_file")
     assert write._workspace == tmp_path
     assert write._session_files_dir is None
+
+
+# ── KUN runtime path ───────────────────────────────────────────────────────
+
+
+def _default_ws() -> Path:
+    from miqi.paths import get_miqi_home
+
+    ws = Path(get_miqi_home()) / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_kun_tool_host_injects_session_key(fake_config):
+    """KUN MiQiToolHost must inject _session_key (mirroring the legacy
+    orchestrator) or per-session isolation never engages on the KUN runtime."""
+    from miqi.kun_runtime.migration_adapter import clear_mapping, register_mapping
+    from miqi.kun_runtime.tool_host import MiQiToolHost, ToolCallLike, ToolHostContext
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    ws = _default_ws()
+    fake_config.agents.defaults.workspace = str(ws)
+    registry = create_runtime_tool_registry(config=fake_config, workspace=ws)
+    host = MiQiToolHost(registry)
+
+    try:
+        register_mapping("desktop:456", "thread_abc")
+        ctx = ToolHostContext(thread_id="thread_abc", turn_id="t1", workspace=str(ws))
+        result = await host.execute(
+            ToolCallLike(call_id="c1", tool_name="write_file",
+                         arguments={"path": str(ws / "k.md"), "content": "kun"}),
+            ctx,
+        )
+        assert "Successfully wrote" in result.item["output"]
+        assert (ws / "sessions" / "desktop_456" / "files" / "k.md").read_text(encoding="utf-8") == "kun"
+        assert not (ws / "k.md").exists()
+    finally:
+        clear_mapping("desktop:456")
+
+
+@pytest.mark.asyncio
+async def test_kun_tool_host_uses_thread_id_without_mapping(fake_config):
+    """Without a registered mapping the thread id itself is the session key."""
+    from miqi.kun_runtime.tool_host import MiQiToolHost, ToolCallLike, ToolHostContext
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    ws = _default_ws()
+    fake_config.agents.defaults.workspace = str(ws)
+    registry = create_runtime_tool_registry(config=fake_config, workspace=ws)
+    host = MiQiToolHost(registry)
+
+    ctx = ToolHostContext(thread_id="thread_nomap", turn_id="t1", workspace=str(ws))
+    result = await host.execute(
+        ToolCallLike(call_id="c1", tool_name="write_file",
+                     arguments={"path": str(ws / "n.md"), "content": "kun"}),
+        ctx,
+    )
+    assert "Successfully wrote" in result.item["output"]
+    assert (ws / "sessions" / "thread_nomap" / "files" / "n.md").exists()
+    assert not (ws / "n.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_native_write_with_session_key_derives_session_dir(tmp_path):
+    """Even a directly-constructed tool (no factory) isolates native writes
+    when _session_key is injected — the per-call fallback."""
+    from miqi.paths import get_miqi_home
+
+    ws = Path(get_miqi_home()) / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    write = WriteFileTool(workspace=ws)  # no factory plumbing at all
+    result = await write.execute(
+        path=str(ws / "native.md"), content="hi", _session_key="desktop:789",
+    )
+    assert "Successfully wrote" in result
+    assert (ws / "sessions" / "desktop_789" / "files" / "native.md").exists()
+    assert not (ws / "native.md").exists()
 
 
 # ── WSL sandbox branch (Windows-only) ─────────────────────────────────────

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -75,10 +75,11 @@ def test_redirect_path_absolute_root_new_file(tmp_path):
 @pytest.mark.skipif(os.name != "nt", reason="WSL /mnt/ form is Windows-specific")
 def test_redirect_path_preserves_mnt_style(tmp_path):
     root, session_dir, _, _ = _mk_env(tmp_path)
-    target = "/mnt/c" + str(root / "report.md").replace("\\", "/")[2:]
+    drive = str(root)[0].lower()  # CI runners may use D: — never hardcode c:
+    target = f"/mnt/{drive}" + str(root).replace("\\", "/")[2:] + "/report.md"
     out = _redirect_path_to_session(target, root, session_dir)
     assert out is not None
-    assert out.startswith("/mnt/c/")
+    assert out.startswith(f"/mnt/{drive}/")
     assert out.endswith("/sessions/desktop_1786807046853/files/report.md")
 
 
@@ -87,7 +88,10 @@ def test_redirect_path_handles_windows_83_short_names(tmp_path):
     """A temp dir handed out as ``C:\\Users\\INTERS~1\\...`` must still be
     recognized as being under the workspace (whose canonical form uses the
     long name ``C:\\Users\\Intership003\\...``).  This exact mismatch made
-    the E2E temp-home scenario skip the redirect and write to the root."""
+    the E2E temp-home scenario skip the redirect and write to the root.
+
+    On CI runners the short form may equal the long form (short paths with
+    no spaces need no 8.3 munging) — the redirect assertion still holds."""
     import ctypes
 
     GetShortPathNameW = ctypes.windll.kernel32.GetShortPathNameW
@@ -99,7 +103,7 @@ def test_redirect_path_handles_windows_83_short_names(tmp_path):
 
     root, session_dir, _, _ = _mk_env(tmp_path)
     short_root = short_name(root)
-    assert short_root and short_root.lower() != str(root).lower()  # short form differs
+    assert short_root  # API must return a usable path
     target = short_root + "\\welcome.md"
     out = _redirect_path_to_session(target, root, session_dir)
     assert out == str(session_dir / "welcome.md")

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -207,7 +207,7 @@ async def test_write_file_shared_subdir_not_redirected(tmp_path):
 
 @pytest.mark.asyncio
 async def test_write_file_outside_workspace_untouched(tmp_path):
-    root, _, write, _ = _mk_env(tmp_path)
+    _root, _, write, _ = _mk_env(tmp_path)
     outside = tmp_path / "out.md"
     await write.execute(path=str(outside), content="x")
     assert outside.read_text(encoding="utf-8") == "x"  # no restriction configured
@@ -259,7 +259,7 @@ async def test_read_file_falls_back_to_session_dir_absolute(tmp_path):
 
 @pytest.mark.asyncio
 async def test_read_file_falls_back_to_session_dir_relative(tmp_path):
-    root, session_dir, _, read = _mk_env(tmp_path)
+    _root, session_dir, _, read = _mk_env(tmp_path)
     (session_dir / "rel.md").write_text("rel content", encoding="utf-8")
     result = await read.execute(path="rel.md")
     assert result == "rel content"
@@ -267,7 +267,7 @@ async def test_read_file_falls_back_to_session_dir_relative(tmp_path):
 
 @pytest.mark.asyncio
 async def test_read_file_root_file_still_readable(tmp_path):
-    root, session_dir, _, read = _mk_env(tmp_path)
+    root, _session_dir, _, read = _mk_env(tmp_path)
     (root / "AGENTS.md").write_text("bootstrap", encoding="utf-8")
     result = await read.execute(path="AGENTS.md")
     assert result == "bootstrap"
@@ -330,6 +330,80 @@ def test_factory_no_session_id_keeps_legacy_behavior(fake_config, tmp_path):
     write = registry.get("write_file")
     assert write._workspace == tmp_path
     assert write._session_files_dir is None
+
+
+# ── Cross-session containment (CodeRabbit #731) ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_foreign_session_dir(tmp_path):
+    """A write targeting another session's files dir must be denied (native)."""
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    other = root / "sessions" / "other_session" / "files"
+    other.mkdir(parents=True)
+    write = WriteFileTool(
+        workspace=session_dir, base_workspace=root, session_files_dir=session_dir,
+    )
+    result = await write.execute(path=str(other / "x.md"), content="sneak")
+    assert "Permission denied" in result
+    assert not (other / "x.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_rejects_relative_escape_into_sessions(tmp_path):
+    """../ traversal cannot climb out of the session dir into sessions/."""
+    root, session_dir, write, _ = _mk_env(tmp_path)
+    other = root / "sessions" / "other_session" / "files"
+    other.mkdir(parents=True)
+    result = await write.execute(path="../other_session/files/x.md", content="sneak")
+    assert "Permission denied" in result or "Error" in result
+    assert not (other / "x.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_read_file_rejects_foreign_session_dir(tmp_path):
+    # Read containment derives its base from the DEFAULT workspace (read
+    # tools resolve against the root); a tmp root is treated as custom.
+    ws = _default_ws()
+    session_dir = ws / "sessions" / _session_files_dir_key("desktop:456") / "files"
+    session_dir.mkdir(parents=True)
+    other = ws / "sessions" / "other_session" / "files"
+    other.mkdir(parents=True)
+    (other / "secret.md").write_text("secret", encoding="utf-8")
+    read = ReadFileTool(workspace=ws, session_files_dir=session_dir)
+    result = await read.execute(path=str(other / "secret.md"))
+    assert "Permission denied" in result or "File not found" in result
+
+
+@pytest.mark.asyncio
+async def test_read_fallback_uses_session_workspace_with_native_sandbox(tmp_path):
+    """Non-WSL (native) sandbox: the read fallback must resolve against the
+    session workspace so it matches where writes landed (CodeRabbit #731)."""
+    from unittest.mock import MagicMock
+
+    root, session_dir, _, _ = _mk_env(tmp_path)
+    sandbox_ws = tmp_path / "sandbox-ws"
+    sandbox_ws.mkdir()
+
+    sandbox = MagicMock()
+    sandbox.is_running = True
+    sandbox.workspace_path = str(sandbox_ws)
+    manager = MagicMock()
+    manager.active_sandbox = sandbox
+
+    write = WriteFileTool(
+        workspace=session_dir, base_workspace=root, session_files_dir=session_dir,
+        sandbox_manager=manager,
+    )
+    result = await write.execute(path="note.md", content="native sb")
+    assert "Successfully wrote" in result
+    assert (sandbox_ws / "note.md").read_text(encoding="utf-8") == "native sb"
+
+    read = ReadFileTool(
+        workspace=root, session_files_dir=session_dir, sandbox_manager=manager,
+    )
+    result = await read.execute(path="note.md")
+    assert result == "native sb"
 
 
 # ── KUN runtime path ───────────────────────────────────────────────────────

--- a/tests/kun_runtime/test_tool_host.py
+++ b/tests/kun_runtime/test_tool_host.py
@@ -42,7 +42,7 @@ class _ReadTool(Tool):
     description = "Read a file"
     parameters = {"type": "object", "properties": {"path": {"type": "string"}}}
 
-    async def execute(self, path: str = "") -> str:
+    async def execute(self, path: str = "", **kwargs) -> str:
         return f"content of {path}"
 
 
@@ -51,7 +51,7 @@ class _WriteTool(Tool):
     description = "Write a file"
     parameters = {"type": "object", "properties": {"path": {"type": "string"}, "content": {"type": "string"}}}
 
-    async def execute(self, path: str = "", content: str = "") -> str:
+    async def execute(self, path: str = "", content: str = "", **kwargs) -> str:
         return f"wrote {path}"
 
 
@@ -72,7 +72,7 @@ class _CountingWriteTool(Tool):
     def __init__(self) -> None:
         self.calls = 0
 
-    async def execute(self, path: str = "", content: str = "") -> str:
+    async def execute(self, path: str = "", content: str = "", **kwargs) -> str:
         self.calls += 1
         return f"wrote {path}"
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

agent 用绝对工作区根路径写文件时，文件落入共享根 `~/.miqi/workspace/` 而非会话隔离目录 `sessions/<key>/files/`，本 PR 将其重定向到会话工作区，并补齐 KUN runtime 上的同一缺陷。

## 背景/问题

**现象**：用户让 MiQi「随意生成一个文件」，确认卡通过后模型调用 `write_file` 写入 `C:\Users\Intership003\.miqi\workspace\welcome.md` —— 文件出现在所有会话共享的工作区根目录，而不是该会话的隔离工作区。根目录已积累大量此类散落文件（H2O_*、DFT_*、hello.txt 等）。

**根因**（三层叠加，桌面 app_server 路径）：

1. **系统提示词**（task_runner.py）告诉模型「工作目录 = workspace 根目录」，模型因此写绝对根路径（welcome.md 会话记录中的 tool_call 参数为 `C:\Users\...\.miqi\workspace\welcome.md`）。
2. **工具层放行**：workspace 根在 shared_roots 白名单（#689），`_resolve_sandbox_path` 对绝对路径走 `/mnt/c/...` 直接写宿主，`sessions/<key>/files` 的重映射只对相对路径生效。
3. **工厂死代码**：`create_runtime_tool_registry` 依赖 `config._session_key` 计算 `_work_dir`，但该属性全代码库从未被赋值 → 写工具的 workspace 永远是根目录；无沙箱环境下（macOS/沙箱关闭）完全没有会话隔离。

**KUN runtime 上的同一缺陷**：`MiQiToolHost.execute` 以模型原始参数直接执行工具，从不注入 `_session_key`，沙箱隔离与重定向在 KUN 路径完全不生效；KUN 调用方构建 registry 时也不传 `session_id`。桌面未来切 KUN 后 bug 会复现，一并补齐。

## 变更内容

- `miqi/runtime/tool_registry_factory.py`：新增 `session_id` 参数（`RuntimeServices.from_config` 传入），计算 `sessions/<safe_key>/files`；write/edit/apply_patch 的 workspace 指向会话目录并携带 `base_workspace`，read 工具携带 `session_files_dir` 回退。
- `miqi/agent/tools/filesystem.py`：新增 `_redirect_new_file_write` / `_redirect_path_to_session` —— 会话隔离生效时，指向默认工作区根目录的**新文件**绝对路径重定向到会话目录；已存在的共享文件（AGENTS.md 等）原地编辑；`memory/`、`skills/`、`.skills/`、`sessions/` 豁免。`_norm_host_path` 经 `Path.resolve()` 规范化，兼容 Windows 8.3 短名（`C:\Users\INTERS~1\...` vs 长名 `Intership003`）与大小写。`_resolve_session_dir` 三级解析（工厂目录 → 沙箱目录 → 按注入 `_session_key` 逐调用推导），覆盖无沙箱原生路径与 KUN 多线程 runtime。`_session_files_dir_key` 改为 ≥3 段才剥 client 前缀，与 `files.read`/附件落盘的磁盘命名一致。read_file 主路径未命中时回退会话目录。tracked_files 记账仍锚定 workspace 根。
- `miqi/kun_runtime/tool_host.py`：`MiQiToolHost.execute` 对 exec/文件工具注入 `_session_key`（thread_id → session key 映射，无映射用 thread_id 本身），镜像 legacy orchestrator 的 `_execute_in_sandbox`。
- `miqi/agent/tools/apply_patch.py`：同样重定向，`_session_key` 贯通到 `_apply_one_file`。
- `miqi/runtime/services.py`：向工厂传递 `session_id`。

## 日志/验证证据

```
修复前（真实用户会话，sandbox 日志）：write_file 经 WSL 沙箱写入共享根
[sandbox] cmd [miqi-desktop:desktop:1786807046853] exit=0: mkdir -p '$(dirname "/mnt/c/Users/Intership003/.miqi/workspace/welcome.md")' && echo '...' | base64 -d > '/mnt/c/Users/Intership003/.miqi/workspace/welcome.md'

修复后（完整链路模拟：load_config → RuntimeServices → registry write_file，MIQI_HOME 为 8.3 短名临时目录）：
workspace_path: C:\Users\Intership003\AppData\Local\Temp\miqi-bridge-sim\workspace
write._workspace: C:\Users\Intership003\...\workspace\sessions\desktop_1786\files
RESULT: Successfully wrote 2 bytes to C:\Users\Intership003\...\workspace\sessions\desktop_1786\files\welcome.md
root copy: False
session copy: True

E2E 输出（apps/desktop electron 项目，本地运行）：
[test] ✅ File "e2e_wsiso_1786965047746.md" found under sessions/*/files/
[test] ✅ Workspace root is clean
[test] ✅ File appears in Task Assets panel
[test] ✅ New session shows empty Task Assets
2 passed (1.7m)
```

## 测试情况

- 新增单测 `tests/agent/tools/test_session_workspace_isolation.py`：27 passed（绝对根路径重定向、相对路径、共享子目录豁免、已存在文件原地编辑、读回退、8.3 短名、WSL 沙箱路径、工厂接线、自定义 workspace 无隔离、KUN 注入、无映射回退、原生 `_session_key` 回退）
- `tests/kun_runtime/test_tool_host.py`：stub 工具兼容 `**kwargs`，全过
- 新增 E2E `apps/desktop/tests/e2e/session-workspace-isolation.spec.ts`：2 passed（本地 electron 项目，沙箱关闭走原生路径）
- 回归：`tests/agent/tools` + `tests/runtime` + `tests/kun_runtime` + `tests/session` + `tests/bridge` 及 execution 相关 2011 passed, 1 skipped

## 截图


<img width="980" height="800" alt="image" src="https://github.com/user-attachments/assets/23f645e9-10ad-4860-9e26-65d1d688ea2c" />

___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Redirect new root-path writes to per-session `sessions/<key>/files`

- Keep existing root/shared subdirectories editable in place

- Inject `_session_key` in KUN tool host

- Add unit and E2E session isolation tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tool Registry Factory"] -- "session_id" --> B["Per-session files dir"]
  C["Write/Edit/ApplyPatch"] -- "redirect new root writes" --> B
  D["KUN MiQiToolHost"] -- "inject _session_key" --> C
  E["ReadFile"] -- "session fallback" --> B
  F["Foreign session paths"] -- "rejected" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>apply_patch.py</strong><dd><code>Redirect patch writes to session workspace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-55c4775c822bbd6942ead6b0e254f2740b7658ef37a0cd6acb19423f6fceba64">+31/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>filesystem.py</strong><dd><code>Add session isolation helpers and apply to file tools</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-6c3eff194c25d100a9f460ef546b5a98fa6451d6dc4317befb668032c079d014">+378/-16</a></td>

</tr>

<tr>
  <td><strong>tool_host.py</strong><dd><code>Inject session key for file tools on KUN runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-01a08c79fd725c123752bbd114fb6535d190da6cec8253929874e3c9ffe1e1af">+29/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tool_registry_factory.py</strong><dd><code>Wire per-session files dir into filesystem tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-bba7bdac87ba258004e88a6416dd357e77b6ab0c025e4c8134808fbcc37e2eac">+38/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>services.py</strong><dd><code>Pass session_id to runtime tool registry factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-3f67e147cf7f5f862ddf78772f3a728ac8fbf3637b5950375ff997084db27dbc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_session_workspace_isolation.py</strong><dd><code>Add unit tests for session workspace isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-d6ff26bf4abcfa48112cc31c8172b5ce72f035e322fa51c253649db47dad13f3">+539/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_tool_host.py</strong><dd><code>Update KUN tool tests for injected kwargs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-6139a956205260ae7c351e19a712dbb1f32e0d7b4fdd2fea07e411b4a22fdbdb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>session-workspace-isolation.spec.ts</strong><dd><code>Add E2E test for session workspace isolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/731/files#diff-ac76196cb61e601258585dbee82ad5292cd7e9e5582a80fdefa3269461dd2827">+197/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

