### PR TITLE
feat(documents): 扫描版 PDF OCR 改用 PyMuPDF + RapidOCR — 打包版可用（#704 最后一环）

### DIFF
--- a/miqi/documents/document_parser.py
+++ b/miqi/documents/document_parser.py
@@ -357,74 +357,52 @@ def _parse_pdf(
 
 
 def _pdf_ocr(file_path: Path) -> str:
-    """OCR a PDF using pdftoppm + tesseract.
+    """OCR a PDF with PyMuPDF + RapidOCR (packaging-friendly, #704).
 
-    Searches for TESSDATA_PREFIX in environment variables first,
-    then common system paths, then ~/.local/share/tessdata.
-    Supports chi_sim+eng language pack (auto-detect Chinese characters).
+    Mirrors RapidAI/RapidOCRPDF's approach: extract the embedded text layer
+    first (digital PDFs need no OCR), then render scanned pages with PyMuPDF
+    and recognize with the same RapidOCR engine used for images — no external
+    pdftoppm/tesseract binaries, so it works in the packaged exe too.
     """
-    import os as _os
-
-    # Resolve tessdata prefix — needed for custom installs where
-    # tesseract lang data is not in the default /usr/share path.
-    _tessdata_prefix = _os.environ.get("TESSDATA_PREFIX", "")
-    if not _tessdata_prefix:
-        for _candidate in (
-            "/usr/share/tesseract-ocr/4.00",
-            "/usr/share/tesseract-ocr",
-            str(Path.home() / ".local" / "share" / "tessdata"),
-        ):
-            if Path(_candidate, "tessdata", "eng.traineddata").exists() or \
-               Path(_candidate, "eng.traineddata").exists():
-                _tessdata_prefix = _candidate
-                break
-
-    _env = dict(_os.environ)
-    if _tessdata_prefix:
-        _env["TESSDATA_PREFIX"] = _tessdata_prefix
-        logger.info(f"OCR: TESSDATA_PREFIX={_tessdata_prefix}")
-
     try:
-        # Convert PDF pages to images
-        pages_dir = tempfile.mkdtemp(prefix="miqi_ocr_")
-        try:
-            subprocess.run(
-                ["pdftoppm", "-r", "200", "-png", str(file_path), f"{pages_dir}/page"],
-                capture_output=True, timeout=120,
-            )
-
-            page_images = sorted(Path(pages_dir).glob("page-*.png"))
-            if not page_images:
-                logger.warning("pdftoppm produced no images")
-                return ""
-
-            # OCR each page
-            full_text_parts = []
-            for img_path in page_images:
-                try:
-                    result = subprocess.run(
-                        ["tesseract", str(img_path), "stdout", "-l", "chi_sim+eng"],
-                        capture_output=True, text=True, timeout=30,
-                        env=_env,
-                    )
-                    if result.returncode == 0 and result.stdout.strip():
-                        full_text_parts.append(result.stdout.strip())
-                except Exception as exc:
-                    logger.warning(f"Tesseract OCR failed for {img_path}: {exc}")
-
-            return "\n\n".join(full_text_parts)
-        finally:
-            # Guarantee cleanup on every exit path (including no-images + OCR failures)
-            shutil.rmtree(pages_dir, ignore_errors=True)
-    except FileNotFoundError:
-        logger.warning("pdftoppm or tesseract not found, OCR unavailable")
+        import pymupdf as fitz  # PyMuPDF (new API name; `fitz` is deprecated)
+    except ImportError:
+        logger.warning("PyMuPDF not installed, PDF OCR unavailable")
         return ""
-    except subprocess.TimeoutExpired:
-        logger.warning("PDF OCR timed out (too many pages or complex layout)")
-        return ""
+    try:
+        from rapidocr_onnxruntime import RapidOCR
+
+        engine = RapidOCR()
     except Exception as exc:
-        logger.error(f"OCR pipeline failed: {exc}")
+        logger.warning(f"RapidOCR unavailable for {file_path}: {exc}")
         return ""
+
+    import numpy as np
+
+    full_text: list[str] = []
+    try:
+        with fitz.open(file_path) as doc:
+            for page in doc:
+                text = page.get_text("text", sort=True)
+                if text.strip():
+                    full_text.append(text.strip())
+                    continue
+                # Scanned page (no text layer) → render + OCR.
+                pix = page.get_pixmap(dpi=200)
+                img = np.frombuffer(pix.samples, dtype=np.uint8)
+                img = img.reshape(pix.h, pix.w, pix.n)
+                try:
+                    result, _ = engine(img)
+                    if result:
+                        lines = [line[1] for line in result if len(line) > 1 and line[1].strip()]
+                        if lines:
+                            full_text.append("\n".join(lines))
+                except Exception as exc:
+                    logger.warning(f"RapidOCR page OCR failed: {exc}")
+    except Exception as exc:
+        logger.error(f"PDF OCR pipeline failed: {exc}")
+        return ""
+    return "\n\n".join(full_text)
 
 
 # ── Images (OCR) ─────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "json-repair>=0.60.1,<1.0.0",
     "lark-oapi>=1.5.0,<2.0.0",
     "rapidocr-onnxruntime>=1.4.4,<2.0.0",
+    "PyMuPDF>=1.24.0",  # PDF text-layer extraction + scanned-page rendering for OCR (#704)
     "tzdata>=2024.1 ; sys_platform == 'win32'",
     "pyinstaller>=6.20.0",
     "pyyaml>=6.0.3",

--- a/tests/documents/test_image_parser.py
+++ b/tests/documents/test_image_parser.py
@@ -65,3 +65,47 @@ def test_parse_image_bmp(bmp_image: Path) -> None:
 def test_parse_image_missing_file_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         parse_document(tmp_path / "nope.png", max_chars=500)
+
+
+def _make_digital_pdf(path: Path) -> None:
+    """A PDF with an embedded text layer (no OCR needed)."""
+    import pymupdf as fitz
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello MiQi OCR 2026")
+    doc.save(path)
+    doc.close()
+
+
+def _make_scanned_pdf(path: Path) -> None:
+    """A PDF whose page is a rendered image (no text layer) — needs OCR."""
+    import pymupdf as fitz
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Scanned Page Text 12345")
+    pix = page.get_pixmap(dpi=150)
+    scan = fitz.open()
+    spage = scan.new_page(width=pix.width / 2, height=pix.height / 2)
+    spage.insert_image(spage.rect, pixmap=pix)
+    scan.save(path)
+    scan.close()
+    doc.close()
+
+
+def test_parse_pdf_digital_text_layer(tmp_path: Path) -> None:
+    """Digital PDFs go through the PyMuPDF text-layer fast path (#704)."""
+    pdf = tmp_path / "digital.pdf"
+    _make_digital_pdf(pdf)
+    result = parse_document(pdf, max_chars=2000)
+    assert "Hello MiQi OCR" in result["text"]
+
+
+def test_parse_pdf_scanned_page_ocr(tmp_path: Path) -> None:
+    """Scanned PDFs (image-only pages) are OCR'd via PyMuPDF render + RapidOCR."""
+    pdf = tmp_path / "scanned.pdf"
+    _make_scanned_pdf(pdf)
+    result = parse_document(pdf, max_chars=2000)
+    # RapidOCR must pick up the text rendered into the page image.
+    assert "Scanned" in result["text"] or "Text" in result["text"], result["text"]

--- a/uv.lock
+++ b/uv.lock
@@ -1322,6 +1322,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyinstaller" },
+    { name = "pymupdf" },
     { name = "pypdfium2" },
     { name = "python-docx" },
     { name = "python-pptx" },
@@ -1384,6 +1385,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<3.0.0" },
     { name = "pyinstaller", specifier = ">=6.20.0" },
+    { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pypdfium2", specifier = ">=5.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2.0.0" },
@@ -2401,6 +2403,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/b6761fa2d5266f2cdb24c3b91f4023070ab7848381417678e7a289a1d52a/pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249", size = 87903557, upload-time = "2026-08-06T21:43:23.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/51/550c9a75c4ff3245cb4ecb7bb95cbe2ab7374230b8e2b7a1f7259444150b/pymupdf-1.28.2-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:5fc315b425ff1f7afdd1ea2f348205cb19b806767daae7ce4d64115799c2bae1", size = 24645079, upload-time = "2026-08-06T21:37:25.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/3591f781b417b382a8487a2356e927acfe858b1043bab0ec47f6805bb109/pymupdf-1.28.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7113846b35dbf0a033f088e4f4fb543dabeb4b0b12c112966a1ca1ee2d5eacae", size = 23875605, upload-time = "2026-08-06T21:37:40.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/86/4a68f080b71b46802178346af46486e1697508e760855ff5f3b218a6dff7/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3050a233dde1211efe89ada74e2add6238436434159f46097a1423aad2842545", size = 25095554, upload-time = "2026-08-06T21:37:58.485Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/06/dace3e27af26690cb20bead80dbac42941b0841eb689b8aabbd67dde16f0/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:397d6715c1f0df7548a92d0afd8ce370fc48fa47aeefac16be2bc04a16a8227f", size = 25762500, upload-time = "2026-08-06T21:38:17.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/4146dfa1d8172a1ce8d59f0eed94896ddefb8deb2274534d0522fbb8abf5/pymupdf-1.28.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f89fb2d86d07d643a269f17a093105057e20c79c1d06c103b53600067b6d2b01", size = 25986309, upload-time = "2026-08-06T21:38:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/52/60/1fb6e64676f7500ebe89054b9e5bbbe14d3101c92d5f1a40ac9a35227673/pymupdf-1.28.2-cp310-abi3-win32.whl", hash = "sha256:530ef543a3885b3b81cb72a854e7c5a625a9233201221132bb6c31698c6a2bdb", size = 18525353, upload-time = "2026-08-06T21:38:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/61/d563bbccba262f9dd6d2d35ccb72593648184d886188efb12d9ce8f34dd6/pymupdf-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd244918798502d7b4504c90410d1711a4d7675a32584ca30f1bab419ecbffe", size = 19826532, upload-time = "2026-08-06T21:39:00.213Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/93/08f404a1f0155fe24137cf2d3aabd3e2b4b08c62053ed89c60f2611be3e9/pymupdf-1.28.2-cp310-abi3-win_arm64.whl", hash = "sha256:ffe91a24edc75c80da2a4b62f50fc0f54632d34fc8fe4cbc48e5c7ff07cf8fb4", size = 19759252, upload-time = "2026-08-06T21:39:12.937Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8c/d897dcd32a25b58186c968b15ce4324ca029e9d96460de12325314e390be/pymupdf-1.28.2-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2e1b574c0fd2cb238021033fd3c0f9c4388816638df064e4bfb56d9d81736dc8", size = 18399403, upload-time = "2026-08-06T21:39:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f1/de34a1c53fe2bf8c6e71db84b0ced782d408970c9810d2b456a2ae96814c/pymupdf-1.28.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:fd481ed48bef56305c41fb7e05a055c03345c899c7b101dad086258b438f8168", size = 25802333, upload-time = "2026-08-06T21:39:41.426Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **User description**
## 类型

- [x] ✨ 功能

## 变更概述

扫描版 PDF 的 OCR 从 `pdftoppm + tesseract`（外部二进制）改为 **PyMuPDF 渲染 + RapidOCR**（纯 Python，打包友好）——exe 打包版也能识别扫描 PDF（#704 的最后一环）。

## 背景/问题

#704（exe 打包版 OCR 不可用）之前只修了**图片** OCR（#708：rapidocr onnx 模型打包）。**扫描版 PDF** 仍走 `_pdf_ocr` 的 `pdftoppm + tesseract`——两者都是外部二进制，打包版里不存在 → 上传扫描 PDF 依旧"无文字"（#704 当时标注的已知限制）。

## 变更内容

- `miqi/documents/document_parser.py`：`_pdf_ocr` 重写，**抄 RapidAI/RapidOCRPDF 的官方实现模式**（https://github.com/RapidAI/RapidOCRPDF）：
  1. **文本层快路径**：`page.get_text("text", sort=True)`——数字 PDF 直接取内嵌文字，零 OCR 开销
  2. **扫描页 OCR**：`page.get_pixmap(dpi=200)` 渲染 → numpy 数组 → **复用已有的 RapidOCR 引擎**（与图片 OCR 同一实例模式，onnx 模型打包 #708 已解决）
  3. 页序合并，无外部二进制依赖
- `pyproject.toml`：新增 `PyMuPDF>=1.24.0`（唯一新依赖；刻意不引入 rapidocr-pdf 包——它依赖新包名 `rapidocr`，与项目已有的 `rapidocr-onnxruntime` 双包并存会重复模型、打包体积翻倍）
- `tests/documents/test_image_parser.py`：新增 2 个测试——数字 PDF 文本层快路径 + 扫描 PDF（图片页无文本层）RapidOCR 识别

## 日志/验证证据

```
$ uv sync   → + pymupdf==1.28.2
$ pytest tests/documents  → 41 passed（含 2 个新 PDF OCR 测试）
  数字 PDF：parse_document 提取文本层 → "Hello MiQi OCR" ✓
  扫描 PDF：渲染页 → RapidOCR → "Scanned Page Text" ✓
```

## 测试情况

- `tests/documents`：41 passed（新增 test_parse_pdf_digital_text_layer + test_parse_pdf_scanned_page_ocr）
- 打包：PyMuPDF 有 PyInstaller 官方 hook（pyinstaller-hooks-contrib），无需改 miqi.spec；onnx 模型沿用 #708 的打包

## 截图

无需截图。


___

### **PR Type**
Bug fix


___

### **Description**
- Replace external PDF OCR with PyMuPDF + RapidOCR

- Use text-layer fast path for digital PDFs

- Render scanned pages for RapidOCR recognition

- Add PyMuPDF dependency and OCR tests


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>document_parser.py</strong><dd><code>Rewrite `_pdf_ocr` to use PyMuPDF + RapidOCR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/documents/document_parser.py

<ul><li>Replace <code>pdftoppm + tesseract</code> pipeline with PyMuPDF text extraction and <br>scanned-page rendering + RapidOCR<br> <li> Add text-layer fast path for digital PDFs, render image-only pages at <br>200 DPI for RapidOCR<br> <li> Remove external binary dependency and hardcoded <code>TESSDATA_PREFIX</code> lookup<br> <li> Log warnings and return empty string if PyMuPDF or RapidOCR <br>unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/735/files#diff-42edcb3bdb887cb051f706bfd568845779b60340f9abe99d076b3e04b1f11d2e">+36/-58</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_image_parser.py</strong><dd><code>Add PDF OCR tests for digital and scanned pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/documents/test_image_parser.py

<ul><li>Add helpers to create digital and scanned PDFs with embedded/rendered <br>text<br> <li> Add test for digital PDF text-layer fast path<br> <li> Add test for scanned PDF OCR via RapidOCR</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/735/files#diff-4c95a996118cd0b8bd10b1f15d211fca165e1d46de754690619f7aaf8b3d4185">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add PyMuPDF dependency for PDF OCR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>PyMuPDF>=1.24.0</code> dependency for PDF text extraction and rendering<br> <li> Comment notes purpose for #704</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/735/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

