### PR TITLE
fix(agent): 技能摘要构建缓存与嵌套索引 — turn 启动延迟 8.8s→0.6s（#729）

### DIFF
--- a/miqi/agent/skills.py
+++ b/miqi/agent/skills.py
@@ -22,6 +22,31 @@ class SkillsLoader:
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
+        # #729: metadata/content 缓存——一次摘要构建内同一技能被查 450 次，
+        # 每次无缓存都重读文件 + 全树 glob，实测单回合 5.7s。
+        self._meta_cache: dict[str, dict | None] = {}
+        self._content_cache: dict[str, str | None] = {}
+        # nested 技能 name→SKILL.md 索引（懒构建，替代 load_skill 里的全树 glob）
+        self._nested_index: dict[str, Path] | None = None
+
+    def _get_nested_index(self) -> dict[str, Path]:
+        """Build (once) a name → SKILL.md path index for nested builtin skills.
+
+        Replaces the per-lookup ``glob("**/<name>/SKILL.md")`` which walks the
+        whole builtin tree on every call (issue #729: 1100 globs / 5.7s per
+        turn). Mirrors ``_discover_nested_skills`` depth: flat dirs plus up to
+        2 levels of nesting.
+        """
+        if self._nested_index is None:
+            index: dict[str, Path] = {}
+            if self.builtin_skills and self.builtin_skills.exists():
+                for entry in sorted(self.builtin_skills.rglob("SKILL.md")):
+                    rel = entry.relative_to(self.builtin_skills)
+                    # _discover_nested_skills 深度上限：最多 4 层目录 + SKILL.md
+                    if len(rel.parts) <= 5:
+                        index.setdefault(entry.parent.name, entry)
+            self._nested_index = index
+        return self._nested_index
 
     def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
         """
@@ -118,9 +143,9 @@ class SkillsLoader:
                 return builtin_skill
 
         # Search nested built-in skills (e.g. kwp/<plugin>/<skill>/SKILL.md)
-        if self.builtin_skills:
-            for entry in self.builtin_skills.glob("**/" + name + "/SKILL.md"):
-                return entry
+        entry = self._get_nested_index().get(name)
+        if entry is not None:
+            return entry
 
         return None
 
@@ -134,6 +159,14 @@ class SkillsLoader:
         Returns:
             Skill content or None if not found.
         """
+        if name in self._content_cache:
+            return self._content_cache[name]
+
+        content = self._load_skill_uncached(name)
+        self._content_cache[name] = content
+        return content
+
+    def _load_skill_uncached(self, name: str) -> str | None:
         # Check workspace first
         workspace_skill = self.workspace_skills / name / "SKILL.md"
         if workspace_skill.exists():
@@ -145,10 +178,10 @@ class SkillsLoader:
             if builtin_skill.exists():
                 return builtin_skill.read_text(encoding="utf-8")
 
-        # Check built-in (nested — kwp/<plugin>/<skill>/SKILL.md)
-        if self.builtin_skills:
-            for entry in self.builtin_skills.glob("**/" + name + "/SKILL.md"):
-                return entry.read_text(encoding="utf-8")
+        # Check built-in (nested — kwp/<plugin>/<skill>/SKILL.md) via index
+        entry = self._get_nested_index().get(name)
+        if entry is not None:
+            return entry.read_text(encoding="utf-8")
 
         return None
 
@@ -343,6 +376,14 @@ class SkillsLoader:
         Returns:
             Metadata dict or None.
         """
+        if name in self._meta_cache:
+            return self._meta_cache[name]
+
+        metadata = self._load_skill_metadata_uncached(name)
+        self._meta_cache[name] = metadata
+        return metadata
+
+    def _load_skill_metadata_uncached(self, name: str) -> dict | None:
         content = self.load_skill(name)
         if not content:
             return None

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -159,6 +160,11 @@ class TurnRunner:
         max_iterations: int | None = None,
     ) -> TurnResult:
         """Core turn loop implementation."""
+        # #729: first-token observability — log latency from turn start to the
+        # first streamed delta (content or reasoning)，使端到端首字延迟可观测。
+        _turn_started = time.perf_counter()
+        _first_token_logged = False
+
         messages = self._context.build_initial_messages(
             turn=turn,
             user_content=user_content,
@@ -219,6 +225,12 @@ class TurnRunner:
                 if cancel_event is not None and cancel_event.is_set():
                     raise asyncio.CancelledError("Turn cancelled via AbortTurn")
                 if stream_event.kind == "content_delta":
+                    if not _first_token_logged:
+                        _first_token_logged = True
+                        logger.info(
+                            "turn_runner: first_token_latency_ms={:.0f} for turn={}",
+                            (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
+                        )
                     content_parts.append(stream_event.delta)
                     from miqi.protocol.events import AgentMessageDeltaEvent
                     await self._events.emit(AgentMessageDeltaEvent(
@@ -235,6 +247,12 @@ class TurnRunner:
                             payload={"index": len(content_parts) - 1},
                         )
                 elif stream_event.kind == "reasoning_delta":
+                    if not _first_token_logged:
+                        _first_token_logged = True
+                        logger.info(
+                            "turn_runner: first_token_latency_ms={:.0f} for turn={} (reasoning)",
+                            (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
+                        )
                     reasoning_parts.append(stream_event.delta)
                     from miqi.protocol.events import AgentReasoningEvent
                     logger.info(


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

技能摘要构建（build_skills_summary）加元数据缓存与嵌套技能索引，消除每回合 turn 启动 5.7s 的扫描延迟；并补充 turn 首 token 延迟计时日志（#729 问题 1）。

## 背景/问题

issue #729 问题 1：发送消息后首字延迟数秒。分层实测（真实 deepseek-v4-flash + dev 桌面 CDP）定位：

- 模型侧正常：首个 reasoning delta 1.0~1.2s 到达，流式逐块正常
- 前端正常：delta 到达后 ~100ms 思考块即渲染
- **延迟全在 turn 启动链路**（chat.send → TurnStartedEvent 到 renderer 8.8s）

cProfile 定位根因：`miqi/agent/skills.py` 每回合调用 `build_skills_summary()`（task_runner 注入技能清单）：
- `get_skill_metadata`/`load_skill` 无缓存，一次摘要构建内被调 450 次（同一批技能反复读文件）
- 嵌套技能查找每次执行 `builtin_skills.glob("**/<name>/SKILL.md")` 递归全树（共 1100 次 glob、35K+ 次 scandir/stat）
- 单次 `build_skills_summary` 实测 5.7s，占 turn 启动 65%

## 关联 issue

- Closes #729（问题 1 的 backend 延迟部分本 PR 修复；问题 2 切 session 思考保留已随后续合入 develop 的 #539/#711 验证通过；#729 其余验收项见「变更内容」范围声明与「后续计划」）

## 变更内容

**范围声明（Included / Not included）**：

- Included:
  - ✅ skill scan 缓存 + 嵌套索引（`miqi/agent/skills.py`，5.7s→0.28s）
  - ✅ first-token 延迟计时日志（`miqi/runtime/turn_runner.py`，turn 开始→首个流式 delta 的毫秒延迟）
- Not included（独立跟踪，见「后续计划」）:
  - ❌ AI 侧「正在思考」占位 UI（前端产品行为，backend 性能 PR 不掺 UI）
  - ❌ 新会话首次 RuntimeSession 冷启动 ~5s（另一层优化）

具体改动：

- `miqi/agent/skills.py`
  - `load_skill`/`get_skill_metadata` 增加实例级缓存（`_content_cache`/`_meta_cache`）：一次摘要构建内同一技能只读一次文件
  - 新增 `_get_nested_index()`：rglob 一次构建嵌套技能 name→SKILL.md 索引（深度上限与 `_discover_nested_skills` 对齐，≤5 段路径），`load_skill`/`get_skill_path` 的 per-lookup 全树 glob 改为 O(1) 查表
  - 原 flat（workspace/builtin 直接子目录）查找路径不变，行为兼容
- `miqi/runtime/turn_runner.py`
  - 新增 `first_token_latency_ms` 日志（首个 content/reasoning delta 到达时打点，`logger.info` 无行为变更）

## 日志/验证证据

```
修复前: [2] skills build_skills_summary: 6.003s (43359 chars)
修复后: [2] skills build_skills_summary: 0.281s (43359 chars)
```

修复前 vs 修复后（`scripts/diag-729-startup.py` 计时，同环境）。

真实桌面 CDP 全链路（发送 → turn 帧 → 思考块，同会话热启动）：

| 指标 | 修复前 | 修复后 |
|---|---|---|
| turn 启动（首次，新会话） | 8.82s | 3.24s |
| turn 启动（热，同会话） | — | 0.64~0.91s |
| 首个思考块出现（热） | 9~16s | ~1.7s |
| 乐观气泡（#364） | — | 0.13~0.29s（1s 内视觉反馈满足） |

模型侧对照（直连 provider）：首个 reasoning delta 1.0~1.2s——延迟确认为技能扫描，非模型/前端。新增 `first_token_latency_ms` 日志将在后续运行中持续提供量化依据。

## 测试情况

```
pytest tests/skills tests/agent tests/runtime/test_skill_handlers.py \
       tests/runtime/test_skills_app_handlers.py \
       tests/bridge/test_phase70_plugin_skill_contract_audit.py \
       tests/bridge/test_phase70_plugin_skill_validation_before_runtime.py -q
210 passed in 7.85s
```

```
pytest tests/runtime/test_turn_runner.py tests/runtime/test_turn_error_propagation.py -q
39 passed in 17.12s
```

（含嵌套技能发现、元数据解析、插件/技能契约审计、turn_runner 回归；修复后摘要 43359 字符与修复前一致，嵌套技能无丢失。）

## 截图

无需截图（后端性能修复，无 UI 变更）。

## 后续计划

- #729 遗留拆分：
  - AI 侧「正在思考」占位 UI → 独立 UI PR（前端产品行为）
  - 新会话首次 RuntimeSession 冷启动 ~5s（工具注册/服务初始化）→ 独立 issue 优化（懒初始化/预热）
- #740 可恢复 Agent Run（ExecutionSnapshot + Resume）：独立新功能，与本 PR 无关


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add per-instance metadata/content caches for skill summaries.

- Build nested skill name index once to replace repeated globs.

- Log first-token latency for content and reasoning deltas.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["build_skills_summary"] -- "uses" --> B["metadata/content cache"]
  A -- "uses" --> C["nested skill index"]
  D["TurnRunner stream loop"] -- "logs" --> E["first_token_latency_ms"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>skills.py</strong><dd><code>Cache skill metadata, content, and nested skill index</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/agent/skills.py

<ul><li>Add <code>_meta_cache</code> and <code>_content_cache</code> instance caches for <br><code>get_skill_metadata</code> and <code>load_skill</code>.<br> <li> Add <code>_nested_index</code> lazy name-to-SKILL.md index built once via <code>rglob</code>, <br>with depth limit matching <code>_discover_nested_skills</code>.<br> <li> Refactor <code>load_skill</code> and <code>get_skill_metadata</code> to check cache before <br>uncached loaders.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/737/files#diff-471dba4e296c4c858342f613776b8a057c8cfe3ac6a33d0917eba9ede2cabb94">+48/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>turn_runner.py</strong><dd><code>Add first-token latency observability logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/turn_runner.py

<ul><li>Import <code>time</code> and record turn start time in <code>_run_impl</code>.<br> <li> Log <code>first_token_latency_ms</code> on first <code>content_delta</code> or <code>reasoning_delta</code>.<br> <li> Include <code>turn_id</code> and reasoning marker in the log message.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/737/files#diff-4627bd8e77d69d5a0d5be03c29bd0c3402cd0988e6d538cad1b99f4be0a60696">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

