### PR TITLE
fix: TaskRunner 等 34 处 getattr 字符串访问改直接属性——字段改名即暴露（#487）

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1257,7 +1257,7 @@ class BridgeRuntimeLoop:
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
 
-        ac = getattr(session.services, "agent_control", None)
+        ac = session.services.agent_control
         if ac is None:
             raise AppServerError(
                 "Agent control not initialized", code="INTERNAL",
@@ -1283,7 +1283,7 @@ class BridgeRuntimeLoop:
 
         agent_id = params.get("agent_id", "")
         if agent_id:
-            ac = getattr(session.services, "agent_control", None)
+            ac = session.services.agent_control
             if ac is not None:
                 await ac.kill(agent_id)
         return {"result": {"killed": bool(agent_id)}}

--- a/miqi/runtime/agent_jobs.py
+++ b/miqi/runtime/agent_jobs.py
@@ -193,7 +193,7 @@ class AgentJobRuntime:
             # `chat:subagent_result`).  The job path bypasses
             # AgentControl._run_agent, so its completion hook never fires —
             # this is the only notification point for AgentJobRuntime agents.
-            ac = getattr(self.services, "agent_control", None)
+            ac = self.services.agent_control
             if ac is not None:
                 try:
                     await ac.notify_completed(job.job_id, job.status)

--- a/miqi/runtime/app_server.py
+++ b/miqi/runtime/app_server.py
@@ -771,7 +771,7 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        threads = getattr(session.services, "thread_runtime", None)
+        threads = session.services.thread_runtime
         if threads is None:
             raise AppServerError("Thread runtime not available", code="INTERNAL")
         thread = await threads.create_thread(
@@ -790,7 +790,7 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        threads = getattr(session.services, "thread_runtime", None)
+        threads = session.services.thread_runtime
         if threads is None:
             return {"result": {"threads": []}}
         result = await threads.list_threads()
@@ -805,7 +805,7 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        threads = getattr(session.services, "thread_runtime", None)
+        threads = session.services.thread_runtime
         if threads is None:
             raise AppServerError("Thread runtime not available", code="INTERNAL")
         thread = await threads.rename_thread(typed.thread_id, typed.title)
@@ -817,7 +817,7 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        threads = getattr(session.services, "thread_runtime", None)
+        threads = session.services.thread_runtime
         if threads is None:
             raise AppServerError("Thread runtime not available", code="INTERNAL")
         thread = await threads.archive_thread(typed.thread_id)
@@ -829,7 +829,7 @@ def register_command_handlers(server: "AppServer") -> None:
         session = await registry.get_session(client_id, session_id)
         if session is None:
             raise AppServerError("Not authorized", code="UNAUTHORIZED")
-        threads = getattr(session.services, "thread_runtime", None)
+        threads = session.services.thread_runtime
         if threads is None:
             raise AppServerError("Thread runtime not available", code="INTERNAL")
         await threads.delete_thread(typed.thread_id)

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -96,7 +96,7 @@ class TaskRunner:
             if ":" not in session_id:
                 return  # Unknown format — skip
             client_id, session_key = session_id.split(":", 1)
-            workspace = getattr(self.services, "workspace", None)
+            workspace = self.services.workspace
             if workspace is None:
                 return
             from miqi.session.manager import SessionManager
@@ -170,7 +170,7 @@ class TaskRunner:
             # Phase 31.4: cancel any pending approvals for this thread
             # so waiting tool calls are unblocked and no orphan approvals
             # remain in the pending set.
-            orchestrator = getattr(self.services, "orchestrator", None)
+            orchestrator = self.services.orchestrator
             cancel_fn = getattr(orchestrator, "cancel_approvals_for_thread", None)
             if callable(cancel_fn) and inspect.iscoroutinefunction(cancel_fn):
                 await cancel_fn(thread_id, reason="Turn aborted by user.")
@@ -184,7 +184,7 @@ class TaskRunner:
             return
         if isinstance(submission, ApprovalResponse):
             # Phase 18: resolve orchestrator approval
-            orchestrator = getattr(self.services, "orchestrator", None)
+            orchestrator = self.services.orchestrator
             if orchestrator is None or not hasattr(orchestrator, "resolve_approval"):
                 await self._events.put(CommandRejectedEvent(
                     command_type="ApprovalResponse",
@@ -218,7 +218,7 @@ class TaskRunner:
         if isinstance(submission, ConfigUpdate):
             # Phase 18: mutate session state and emit ConfigUpdatedEvent.
             # All failure paths must emit CommandRejectedEvent, never crash.
-            state = getattr(self.services, "session_state", None)
+            state = self.services.session_state
             if state is None or not hasattr(state, "apply_config_update"):
                 await self._events.put(CommandRejectedEvent(
                     command_type="ConfigUpdate",
@@ -242,8 +242,8 @@ class TaskRunner:
             return
         if isinstance(submission, CompactCommand):
             # Phase 19: trigger context compaction via ContextRuntime
-            ctx_runtime = getattr(self.services, "context_runtime", None)
-            history_runtime = getattr(self.services, "history_runtime", None)
+            ctx_runtime = self.services.context_runtime
+            history_runtime = self.services.history_runtime
             if ctx_runtime is None or history_runtime is None:
                 await self._events.put(CommandRejectedEvent(
                     command_type="CompactCommand",
@@ -257,7 +257,7 @@ class TaskRunner:
                     history_runtime=history_runtime,
                     thread_id=submission.thread_id,
                     turn_id=compact_turn_id,
-                    model=getattr(self.services.model_settings, "model", "default"),
+                    model=self.services.model_settings.model,
                 )
             except Exception as exc:
                 await self._events.put(CommandRejectedEvent(
@@ -317,7 +317,7 @@ class TaskRunner:
         from miqi.runtime.turn_context import TurnContext
 
         metadata = AgentRegistry().resolve("main")
-        session_id = getattr(self.services, "session_id", "")
+        session_id = self.services.session_id
         client_id = session_id.split(":")[0] if ":" in session_id else ""
         turn = TurnContext(
             turn_id=turn_id,
@@ -338,7 +338,7 @@ class TaskRunner:
         if cancel_evt is not None:
             turn.cancel_event = cancel_evt
 
-        ledger = getattr(self.services, "ledger_runtime", None)
+        ledger = self.services.ledger_runtime
 
         try:
             if cmd.standalone:
@@ -366,7 +366,7 @@ class TaskRunner:
                     "_exec_source": "userShell",
                 },
             )
-            tool_runtime = getattr(self.services, "tool_runtime", None)
+            tool_runtime = self.services.tool_runtime
             if tool_runtime is None:
                 err_msg = "Runtime has no tool runtime"
                 if cmd.standalone:
@@ -471,9 +471,9 @@ class TaskRunner:
         self._turn_steer_queues[turn_id] = steer_queue
 
         # Phase 17: get history runtime for persistence and loading
-        history_runtime = getattr(self.services, "history_runtime", None)
+        history_runtime = self.services.history_runtime
         # Phase 24: get ledger runtime for append-only event recording
-        ledger = getattr(self.services, "ledger_runtime", None)
+        ledger = self.services.ledger_runtime
 
         # Build TurnContext and run through TurnRunner (Phase 12)
         from miqi.runtime.agent_registry import AgentRegistry
@@ -483,7 +483,7 @@ class TaskRunner:
         # Phase 31.4: extract client_id from session_id (format: client_id:session_key).
         # This is a best-effort derivation; a dedicated client_id field on
         # RuntimeServices would be a future improvement.
-        session_id = getattr(self.services, "session_id", "")
+        session_id = self.services.session_id
         client_id = session_id.split(":")[0] if ":" in session_id else ""
         turn = TurnContext(
             turn_id=turn_id,
@@ -501,7 +501,7 @@ class TaskRunner:
 
         # Phase 13: resolve capabilities and permission profile
         tools: list[dict[str, Any]] = []
-        capability_resolver = getattr(self.services, "capability_resolver", None)
+        capability_resolver = self.services.capability_resolver
         if capability_resolver is not None:
             capabilities = capability_resolver.resolve(agent_metadata=metadata)
             turn.capabilities = capabilities
@@ -593,7 +593,7 @@ class TaskRunner:
         # (/home/miqi/workspace), which hides the user's chosen project
         # directory. State it explicitly so the AI reports the real
         # workspace (mirrors agent_control's subagent prompt).
-        _ws = getattr(self.services, "workspace", None)
+        _ws = self.services.workspace
         if _ws is not None:
             effective_system_prompt = (
                 effective_system_prompt
@@ -665,7 +665,7 @@ class TaskRunner:
         # The user-visible content is stripped of the /cmd prefix.
         slash_content: str | None = None
         if msg.content and msg.content.startswith("/"):
-            pm = getattr(self.services, "plugin_manager", None)
+            pm = self.services.plugin_manager
             if pm is not None and hasattr(pm, "get_slash_command"):
                 parts = msg.content[1:].split(None, 1)
                 # Allow namespacing: "/product-management:brainstorm"
@@ -722,8 +722,8 @@ class TaskRunner:
                 )
 
             # Phase 19: auto-compact before turn if history exceeds budget
-            ctx_runtime = getattr(self.services, "context_runtime", None)
-            auto_limit = getattr(self.services.model_settings, "context_limit_chars", 0)
+            ctx_runtime = self.services.context_runtime
+            auto_limit = self.services.model_settings.context_limit_chars
             if history_runtime is not None and ctx_runtime is not None and auto_limit:
                 token_limit = max(1, int(int(auto_limit) / 2.5))
                 if ctx_runtime.should_auto_compact(history, token_limit):
@@ -1047,7 +1047,7 @@ class TaskRunner:
             ThreadUpdatedEvent,
         )
 
-        threads = getattr(self.services, "thread_runtime", None)
+        threads = self.services.thread_runtime
         if threads is None:
             await self._events.put(CommandRejectedEvent(
                 command_type="ThreadCommand",

--- a/miqi/runtime/turn_app_handlers.py
+++ b/miqi/runtime/turn_app_handlers.py
@@ -102,7 +102,7 @@ async def drain_turn_events(
     finally:
         # Phase 41 hardening v2: release the turn reservation so the
         # next turn/start for this thread can proceed.
-        release = getattr(session, "release_turn_reservation", None)
+        release = session.release_turn_reservation
         if callable(release):
             await release(thread_id)
 
@@ -133,7 +133,7 @@ def register_codex_turn_handlers(server: AppServer) -> None:
 
         try:
             # Phase 41 hardening: validate thread exists before starting a turn
-            thread_runtime = getattr(session.services, "thread_runtime", None)
+            thread_runtime = session.services.thread_runtime
             if thread_runtime is not None:
                 thread = await thread_runtime.get_thread(thread_id)
                 if thread is None:
@@ -215,8 +215,8 @@ def register_codex_turn_handlers(server: AppServer) -> None:
 
         session = await _require_session(registry, client_id, session_id)
 
-        history = getattr(session.services, "history_runtime", None)
-        ledger = getattr(session.services, "ledger_runtime", None)
+        history = session.services.history_runtime
+        ledger = session.services.ledger_runtime
         if history is None or ledger is None:
             raise AppServerError("Runtime history is not available", code="INTERNAL")
 
@@ -303,15 +303,15 @@ async def _run_thread_compaction(
         request_id=request_id,
     )
     try:
-        ctx_runtime = getattr(session.services, "context_runtime", None)
-        history = getattr(session.services, "history_runtime", None)
+        ctx_runtime = session.services.context_runtime
+        history = session.services.history_runtime
         if ctx_runtime is None or history is None:
             raise RuntimeError("Context runtime is not available")
         await ctx_runtime.compact_thread(
             history_runtime=history,
             thread_id=thread_id,
             turn_id=turn_id,
-            model=getattr(session.services.model_settings, "model", "default"),
+            model=session.services.model_settings.model,
         )
         completed = context_compaction_item(turn_id, status="completed")
         await server.emit_event(


### PR DESCRIPTION
### **User description**
## 类型

- [x] ♻️ 重构

## 变更概述

TaskRunner 及同类 5 个文件的 34 处 `getattr(self.services, "...", None)` 字符串访问改为直接属性访问——字段名错误从此在 Python 层直接抛 `AttributeError`（易排查），不再静默返回 None 导致功能退化。

## 背景/问题

#487：TaskRunner 有 21+ 处通过字符串 `getattr(self.services, "X", None)` 访问 RuntimeServices 字段。如果字段名被修改、删除或拼写错误，代码不报错、静默返回 None，历史记录、线程管理、ledger 等功能悄悄失效（无日志、无崩溃）。实测扫描发现同类问题实际分布在 **5 个文件 34 处**（比 issue 记录的更多）。

## 关联 issue

- Closes #487 TaskRunner 中 getattr 字符串访问无编译期类型保护导致功能静默退化

## 变更内容

- `miqi/runtime/task_runner.py`（19 处）：workspace/orchestrator/session_state/context_runtime/history_runtime/session_id/ledger_runtime/tool_runtime/capability_resolver/plugin_manager/thread_runtime/model_settings.model 全部改直接属性访问
- `miqi/runtime/turn_app_handlers.py`（7 处）：release_turn_reservation 方法 + services 字段改直接访问
- `miqi/bridge/loop.py`（2 处）、`miqi/runtime/agent_jobs.py`（1 处）、`miqi/runtime/app_server.py`（5 处）：同类 getattr 一并清除
- 语义说明：RuntimeServices 中这些字段均已定义（含 Optional 字段），`getattr(x, k, None)` 与 `x.k` 在字段存在时完全等价；`if x is None` 的容错逻辑全部保留。字段不存在时从"静默 None"变为"AttributeError 立即暴露"

## 日志/验证证据

```
# 改造前后对比
- 前：getattr(self.services, "session_state", None)   # 拼错 session_stat → None，静默
- 后：self.services.session_state                     # 拼错 → AttributeError 立即暴露

# 残留扫描（5 文件清零）
grep -c 'getattr(self.services\|getattr(session.services' → 全部 0
```

## 测试情况

- 全量 `pytest tests -q`：**2868 passed, 20 skipped, 0 failed**（13 分 19 秒，零回归）
- 定向：test_runtime_task_runner（30 passed）+ test_runtime_session + test_app_server_commands 全过
- 语法校验：ast.parse 5 文件全部通过

## 截图

无 UI 变更（纯代码健壮性重构）


___

### **PR Type**
Bug fix


___

### **Description**
- Replace 34 string `getattr` service accesses with direct attributes.

- Direct access surfaces missing fields as `AttributeError`.

- Preserve existing `None` checks and fallback behavior.

- Covers TaskRunner, app_server, turn handlers, loop, agent jobs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String getattr service access"] --> B["Direct attribute access"]
  B --> C["TaskRunner"]
  B --> D["app_server"]
  B --> E["turn_app_handlers"]
  B --> F["loop.py / agent_jobs.py"]
  B --> G["AttributeError on missing field"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loop.py</strong><dd><code>Direct agent_control access in bridge loop handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/bridge/loop.py

<ul><li>Replace <code>getattr(session.services, "agent_control", None)</code> with <br><code>session.services.agent_control</code> in <code>_agent_spawn_handler</code>.<br> <li> Replace same pattern in <code>_agent_kill_handler</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/742/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_jobs.py</strong><dd><code>Direct agent_control access in job completion notification</code></dd></summary>
<hr>

miqi/runtime/agent_jobs.py

<ul><li>Replace <code>getattr(self.services, "agent_control", None)</code> with <br><code>self.services.agent_control</code> in <code>_run</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/742/files#diff-6da76feb74f9d0123b001225ff12cbb3b5b7295cd52f7b8805e5df8f785e132c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app_server.py</strong><dd><code>Direct thread_runtime access in thread handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/app_server.py

<ul><li>Replace five <code>getattr(session.services, "thread_runtime", None)</code> calls <br>with <code>session.services.thread_runtime</code>.<br> <li> Affected handlers: thread create, list, rename, archive, delete.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/742/files#diff-babc1da0d9c056a4bf23a9db4a6f1e1240b3512ee5ccfc99253cfc85d28860b9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_runner.py</strong><dd><code>Direct RuntimeServices attribute access in TaskRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/task_runner.py

<ul><li>Replace numerous <code>getattr(self.services, "...", None)</code> calls with direct <br>attribute access.<br> <li> Services covered: workspace, orchestrator, session_state, <br>context_runtime, history_runtime, ledger_runtime, tool_runtime, <br>capability_resolver, plugin_manager, thread_runtime.<br> <li> Use direct <code>self.services.session_id</code>, <br><code>self.services.model_settings.model</code>, and <br><code>self.services.model_settings.context_limit_chars</code>.<br> <li> Preserve all existing <code>None</code> checks and fallback logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/742/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>turn_app_handlers.py</strong><dd><code>Direct session service and method access in turn handlers</code></dd></summary>
<hr>

miqi/runtime/turn_app_handlers.py

<ul><li>Replace <code>getattr(session, "release_turn_reservation", None)</code> with <br><code>session.release_turn_reservation</code>.<br> <li> Replace getattr for <code>thread_runtime</code>, <code>history_runtime</code>, <code>ledger_runtime</code>, <br><code>context_runtime</code>, and <code>model_settings.model</code> with direct access.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/742/files#diff-7e59c1d9dbfb12c069d771faef3f0a4d324b5f0b49ab0a51bced10e009d116b7">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

