### PR TITLE
fix(agent): PermissionError 前端中文化，附带中文 user_message（#691）

### DIFF
--- a/apps/desktop/tests/e2e/proof-691-error-bubble.spec.ts
+++ b/apps/desktop/tests/e2e/proof-691-error-bubble.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Proof spec for issue #691 — captures a screenshot of the localized
+ * (Chinese) PermissionError bubble in the chat UI.
+ *
+ * The bug (#691): backend tool-layer PermissionErrors rendered their raw
+ * English tech message ("Path 'C:...' resolves outside all legal roots
+ * [...]. tools.extra_roots") in the chat bubble.  The fix attaches a
+ * Chinese `user_message` to the exception; the orchestrator boundary
+ * (_sanitize_exc_for_ui) prefers it, and the renderer shows it verbatim.
+ *
+ * This spec injects a ToolErrorEvent (exactly the shape the backend emits
+ * on chat:progress) from the main process while a send is in flight, then
+ * screenshots the red error bubble.
+ *
+ * Run (not part of CI):
+ *   cd apps/desktop && npm run build
+ *   PLAYWRIGHT_SKIP_WEB_SERVER=1 \
+ *     npx playwright test --config=playwright.config.ts --project=electron \
+ *       proof-691-error-bubble --reporter=line
+ */
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  launchElectronApp,
+  closeElectronApp,
+  waitForInputReady,
+} from './helpers/electron-setup';
+
+const OUT_DIR = join(__dirname, '../../test-results/proof-691');
+
+// Matches the backend's ToolPermissionError user_message for the
+// "outside legal roots" case (filesystem.py / _canonicalize_wsl_mnt_path).
+const CHINESE_MESSAGE =
+  '文件访问被拒绝：该路径不在允许访问的目录范围内（C:\\Users\\demo\\test_bridge.txt）。' +
+  '如需允许访问，请在设置中为该目录添加访问权限（tools.extra_roots）。';
+
+test.describe('Proof #691 error bubble localization', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    mkdirSync(OUT_DIR, { recursive: true });
+  });
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp).catch(() => {});
+  });
+
+  test('capture Chinese PermissionError bubble screenshot', async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+
+    const textarea = await waitForInputReady(page);
+    await textarea.fill('演示 #691：触发一次权限错误气泡');
+    await textarea.press('Enter');
+
+    // handleSend subscribes onProgress only AFTER `await providers.list()`
+    // (ChatConsole.tsx ~3054) — an injection sent immediately after Enter can
+    // land in that async gap and be dropped.  So retry-inject until the bubble
+    // renders: check-first-then-inject guarantees exactly one bubble lands.
+    const bubble = page.getByText(CHINESE_MESSAGE).last();
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      if (await bubble.isVisible().catch(() => false)) break;
+      await electronApp.evaluate(({ BrowserWindow }, args) => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          if (win.isDestroyed() || win.webContents.isDestroyed()) continue;
+          win.webContents.send('chat:progress', {
+            event: 'ToolErrorEvent',
+            data: {
+              // Mirrors the real bridge payload (bridge/loop.py) for a
+              // ToolErrorEvent: asdict(event) carries type/recoverable.
+              type: 'tool_error',
+              message: args.message,
+              turn_id: 'proof-691',
+              tool_name: 'read_file',
+              tool_call_id: 'proof-691',
+              recoverable: true,
+            },
+          });
+        }
+      }, { message: CHINESE_MESSAGE });
+      await page.waitForTimeout(300);
+    }
+
+    // The Chinese message must render as a standalone error bubble.
+    await expect(bubble).toBeVisible({ timeout: 5_000 });
+
+    // Assert the English tech details are NOT on screen.
+    const bodyText = await page.textContent('body');
+    expect(bodyText).not.toContain('outside all legal roots');
+
+    const shot = join(OUT_DIR, 'proof-691-chinese-error-bubble.png');
+    await page.screenshot({ path: shot, timeout: 5000 });
+    console.log(`[proof-691] screenshot → ${shot}`);
+  });
+});

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import permission_error_result
 from miqi.agent.tools.filesystem import (
     _get_active_sandbox,
     _get_session_workspace,
@@ -325,7 +326,7 @@ class ApplyPatchTool(Tool):
             except PatchApplyError as e:
                 return f"Error applying patch to {fp.path}: {e}"
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return permission_error_result(e)
             except Exception as e:
                 return f"Error applying patch to {fp.path}: {type(e).__name__}: {e}"
             if result is not None:

--- a/miqi/agent/tools/errors.py
+++ b/miqi/agent/tools/errors.py
@@ -1,0 +1,44 @@
+"""Tool-layer permission errors with user-facing Chinese messages.
+
+The English technical detail stays in ``str(exc)`` — it is logged
+server-side and matched by existing tests — while ``user_message`` carries
+the Chinese text shown to the user (issue #691).
+"""
+
+
+class ToolPermissionError(PermissionError):
+    """PermissionError carrying a user-facing Chinese message.
+
+    ``str(exc)`` keeps the English technical detail (server logs / existing
+    ``pytest.raises(PermissionError, match=...)`` assertions depend on it);
+    ``user_message`` is what the UI shows and what the model is fed.
+    """
+
+    def __init__(self, user_message: str, tech_message: str):
+        super().__init__(tech_message)
+        self.user_message = user_message
+
+
+def outside_allowed_dir_error(path, effective_dir=None) -> ToolPermissionError:
+    """Uniform "path outside allowed directory" error used by the documents
+    tools (docx / xlsx / pptx / pdf)."""
+    suffix = f" '{effective_dir}'" if effective_dir is not None else ""
+    return ToolPermissionError(
+        user_message=(
+            "文件访问被拒绝：该路径不在允许访问的目录范围内"
+            f"（{path}）。如需允许访问，请在设置中为该目录添加访问权限"
+            "（tools.extra_roots）。"
+        ),
+        tech_message=f"Path '{path}' resolves outside allowed directory{suffix}",
+    )
+
+
+def permission_error_result(e: PermissionError) -> str:
+    """Stringify a caught PermissionError for a tool result.
+
+    Prefer the Chinese ``user_message`` when present; fall back to the
+    historical English form otherwise (e.g. OS-level file-lock errors that
+    are not ToolPermissionError).
+    """
+    user_msg = getattr(e, "user_message", None)
+    return f"错误：{user_msg}" if user_msg else f"Error: Permission denied: {e}"

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import ToolPermissionError, permission_error_result
 
 _log = logging.getLogger(__name__)
 
@@ -306,8 +307,11 @@ def _canonicalize_wsl_mnt_path(
         resolved = Path(normalized).resolve()
     except Exception:
         _log.warning("_canonicalize_wsl_mnt_path: cannot resolve %s, rejecting path", host_str)
-        raise PermissionError(
-            f"Cannot canonicalize path '{host_str}': resolution failed"
+        raise ToolPermissionError(
+            user_message=(
+                f"文件访问被拒绝：路径 '{host_str}' 无法解析，请检查路径是否正确。"
+            ),
+            tech_message=f"Cannot canonicalize path '{host_str}': resolution failed",
         )
 
     # Build the list of legal roots: the per-session workspace plus any
@@ -338,10 +342,17 @@ def _canonicalize_wsl_mnt_path(
             continue
     else:
         roots_str = ", ".join(str(r) for r in roots) if roots else "<none>"
-        raise PermissionError(
-            f"Path '{host_str}' (normalized: '{normalized}') resolves to '{resolved}' "
-            f"which is outside all legal roots [{roots_str}]. "
-            "Add the directory to tools.extra_roots in the MiQi config to allow access."
+        raise ToolPermissionError(
+            user_message=(
+                "文件访问被拒绝：该路径不在允许访问的目录范围内"
+                f"（{host_str}）。如需允许访问，请在设置中为该目录添加"
+                "访问权限（tools.extra_roots）。"
+            ),
+            tech_message=(
+                f"Path '{host_str}' (normalized: '{normalized}') resolves to '{resolved}' "
+                f"which is outside all legal roots [{roots_str}]. "
+                "Add the directory to tools.extra_roots in the MiQi config to allow access."
+            ),
         )
 
     # Per-session isolation: when session isolation is active, a path under
@@ -370,12 +381,19 @@ def _canonicalize_wsl_mnt_path(
                 except ValueError:
                     # Do NOT include the resolved path: it can reveal
                     # another session's identifier and file layout.
-                    raise PermissionError(
-                        "Path is inside another session's files dir — "
-                        "per-session isolation forbids cross-session access. "
-                        "Do not retry or enumerate sessions/; use the current "
-                        "session's workspace instead, or ask the user to share "
-                        "the file via the file panel."
+                    raise ToolPermissionError(
+                        user_message=(
+                            "文件访问被拒绝：该路径位于其他会话的文件目录中，"
+                            "跨会话访问已被禁止。请使用当前会话工作区内的文件，"
+                            "或请用户通过文件面板分享该文件。"
+                        ),
+                        tech_message=(
+                            "Path is inside another session's files dir — "
+                            "per-session isolation forbids cross-session access. "
+                            "Do not retry or enumerate sessions/; use the current "
+                            "session's workspace instead, or ask the user to share "
+                            "the file via the file panel."
+                        ),
                     )
 
     resolved_str = str(resolved).replace("\\", "/")
@@ -602,9 +620,14 @@ def _resolve_path(
 
     # Defense-in-depth: reject symlink components before resolving (SEC-06).
     if allowed_dir and _has_symlink_in_path(p):
-        raise PermissionError(
-            f"Path '{path}' contains a symbolic link, which is not permitted "
-            "in restricted mode."
+        raise ToolPermissionError(
+            user_message=(
+                f"文件访问被拒绝：路径 '{path}' 包含符号链接，受限模式下不允许访问。"
+            ),
+            tech_message=(
+                f"Path '{path}' contains a symbolic link, which is not permitted "
+                "in restricted mode."
+            ),
         )
     resolved = p.resolve()
     if allowed_dir:
@@ -620,7 +643,14 @@ def _resolve_path(
                 except ValueError:
                     continue
             if not allowed:
-                raise PermissionError(f"Path {path} is outside allowed directory {allowed_dir}")
+                raise ToolPermissionError(
+                    user_message=(
+                        "文件访问被拒绝：该路径不在允许访问的目录范围内"
+                        f"（{path}）。如需允许访问，请在设置中为该目录添加"
+                        "访问权限（tools.extra_roots）。"
+                    ),
+                    tech_message=f"Path {path} is outside allowed directory {allowed_dir}",
+                )
     return resolved
 
 
@@ -764,7 +794,7 @@ class ReadFileTool(Tool):
                 content = file_path.read_text(encoding="utf-8")
                 return content
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return permission_error_result(e)
             except Exception as e:
                 return f"Error reading file: {type(e).__name__}: {e}"
 
@@ -879,7 +909,7 @@ class WriteFileTool(Tool):
                     _log.warning("Snapshot failed for %s — revert will not be available", file_path)
                 return result
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return permission_error_result(e)
             except Exception as e:
                 return f"Error writing file: {type(e).__name__}: {e}"
 
@@ -1019,7 +1049,7 @@ class EditFileTool(Tool):
 
                 return f"Successfully edited {file_path}"
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return permission_error_result(e)
             except Exception as e:
                 return f"Error editing file: {type(e).__name__}: {e}"
 
@@ -1138,6 +1168,6 @@ class ListDirTool(Tool):
 
                 return "\n".join(items)
             except PermissionError as e:
-                return f"Error: Permission denied: {e}"
+                return permission_error_result(e)
             except Exception as e:
                 return f"Error listing directory: {type(e).__name__}: {e}"

--- a/miqi/agent/tools/papers.py
+++ b/miqi/agent/tools/papers.py
@@ -14,6 +14,7 @@ import httpx
 from loguru import logger
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import ToolPermissionError
 
 
 def _safe_int(value: Any) -> int | None:
@@ -1165,7 +1166,13 @@ class PaperDownloadTool(Tool):
         try:
             resolved.relative_to(self.workspace)
         except ValueError:
-            raise PermissionError(f"Output path outside workspace is not allowed: {resolved}")
+            raise ToolPermissionError(
+                user_message=(
+                    f"文件访问被拒绝：输出路径 '{resolved}' 不在当前会话工作区内，"
+                    "请将输出文件放在工作区内。"
+                ),
+                tech_message=f"Output path outside workspace is not allowed: {resolved}",
+            )
         return resolved
 
 

--- a/miqi/documents/docx_tool.py
+++ b/miqi/documents/docx_tool.py
@@ -7,6 +7,7 @@ import re
 from typing import Any
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import outside_allowed_dir_error, permission_error_result
 from miqi.agent.tools.filesystem import _persist_tracked_file
 
 
@@ -85,9 +86,7 @@ def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | No
     try:
         path.resolve().relative_to(effective_dir.resolve())
     except ValueError:
-        raise PermissionError(
-            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
-        )
+        raise outside_allowed_dir_error(path, effective_dir)
 
 
 def _add_docx_content(doc: Any, content: Any) -> int:
@@ -390,7 +389,7 @@ class DocxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
@@ -440,10 +439,7 @@ def _resolve_output_path(
         try:
             resolved.relative_to(effective_dir.resolve())
         except ValueError:
-            raise PermissionError(
-                f"Path '{file_path}' resolves outside allowed directory "
-                f"'{effective_dir}'"
-            )
+            raise outside_allowed_dir_error(file_path, effective_dir)
     return resolved
 
 
@@ -567,7 +563,7 @@ class CreateDocxTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if not (
@@ -721,7 +717,7 @@ class EditDocxTool(Tool):
             file_path = _ensure_suffix(file_path, ".docx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
 

--- a/miqi/documents/pdf_create_tool.py
+++ b/miqi/documents/pdf_create_tool.py
@@ -16,6 +16,7 @@ from typing import Any
 from loguru import logger
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import outside_allowed_dir_error, permission_error_result
 from miqi.agent.tools.filesystem import _persist_tracked_file
 
 
@@ -182,10 +183,7 @@ def _resolve_output_path(
         try:
             resolved.relative_to(effective_dir.resolve())
         except ValueError:
-            raise PermissionError(
-                f"Path '{file_path}' resolves outside allowed directory "
-                f"'{effective_dir}'"
-            )
+            raise outside_allowed_dir_error(file_path, effective_dir)
     return resolved
 
 
@@ -196,9 +194,7 @@ def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | No
     try:
         path.resolve().relative_to(effective_dir.resolve())
     except ValueError:
-        raise PermissionError(
-            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
-        )
+        raise outside_allowed_dir_error(path, effective_dir)
 
 
 # ── Style helpers (mirror docx_tool patterns) ──────────────────────────
@@ -674,7 +670,7 @@ class CreatePdfTool(Tool):
             file_path = _ensure_suffix(file_path, ".pdf")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
 

--- a/miqi/documents/pptx_tool.py
+++ b/miqi/documents/pptx_tool.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import outside_allowed_dir_error, permission_error_result
 from miqi.agent.tools.filesystem import _persist_tracked_file
 
 
@@ -33,9 +34,7 @@ def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | No
     try:
         path.resolve().relative_to(effective_dir.resolve())
     except ValueError:
-        raise PermissionError(
-            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
-        )
+        raise outside_allowed_dir_error(path, effective_dir)
 
 
 def _resolve_output_path(
@@ -69,10 +68,7 @@ def _resolve_output_path(
         try:
             resolved.relative_to(effective_dir.resolve())
         except ValueError:
-            raise PermissionError(
-                f"Path '{file_path}' resolves outside allowed directory "
-                f"'{effective_dir}'"
-            )
+            raise outside_allowed_dir_error(file_path, effective_dir)
     return resolved
 
 
@@ -127,7 +123,7 @@ class PptxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".pptx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
@@ -225,7 +221,7 @@ class CreatePptxTool(Tool):
             file_path = _ensure_suffix(file_path, ".pptx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if not slides:

--- a/miqi/documents/xlsx_tool.py
+++ b/miqi/documents/xlsx_tool.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from miqi.agent.tools.base import Tool
+from miqi.agent.tools.errors import outside_allowed_dir_error, permission_error_result
 from miqi.agent.tools.filesystem import _persist_tracked_file
 
 
@@ -33,9 +34,7 @@ def _enforce_boundary(path: Path, allowed_dir: Path | None, workspace: Path | No
     try:
         path.resolve().relative_to(effective_dir.resolve())
     except ValueError:
-        raise PermissionError(
-            f"Path '{path}' resolves outside allowed directory '{effective_dir}'"
-        )
+        raise outside_allowed_dir_error(path, effective_dir)
 
 
 def _resolve_output_path(
@@ -57,10 +56,7 @@ def _resolve_output_path(
         try:
             resolved.relative_to(effective_dir.resolve())
         except ValueError:
-            raise PermissionError(
-                f"Path '{file_path}' resolves outside allowed directory "
-                f"'{effective_dir}'"
-            )
+            raise outside_allowed_dir_error(file_path, effective_dir)
     return resolved
 
 
@@ -233,7 +229,7 @@ class XlsxReadTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if not file_path.exists():
@@ -346,7 +342,7 @@ class CreateXlsxTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
         if sheets is None and rows is None:
@@ -479,7 +475,7 @@ class AppendXlsxTool(Tool):
             file_path = _ensure_suffix(file_path, ".xlsx")
             _enforce_boundary(file_path, self._allowed_dir, self._workspace)
         except PermissionError as e:
-            return f"Error: Permission denied: {e}"
+            return permission_error_result(e)
         except ValueError as e:
             return f"Error: {e}"
 

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -119,6 +119,12 @@ def _sanitize_exc_for_ui(exc: BaseException) -> str:
     emission to the frontend and model context — truncated and stripped
     of potential path / URL / credential leakage.
     """
+    # Tool-layer permission errors (ToolPermissionError) carry a user-facing
+    # Chinese message — prefer it over the English tech summary (issue #691).
+    # Full details stay in the server logs (logger.warning / logger.exception).
+    user_msg = getattr(exc, "user_message", None)
+    if user_msg:
+        return user_msg
     raw = str(exc)
     # Truncate to a reasonable length
     if len(raw) > 300:

--- a/tests/agent/tools/test_apply_patch.py
+++ b/tests/agent/tools/test_apply_patch.py
@@ -157,8 +157,8 @@ async def test_tool_rejects_traversal(tmp_path):
     tool = ApplyPatchTool(workspace=tmp_path, allowed_dir=tmp_path)
     patch = "--- a/../etc/passwd\n+++ b/../etc/passwd\n@@ -1 +1 @@\n-x\n+y\n"
     result = await tool.execute(patch=patch)
-    assert "Error" in result
-    assert "Permission denied" in result
+    assert "错误" in result
+    assert "文件访问被拒绝" in result
 
 
 @pytest.mark.asyncio

--- a/tests/documents/test_office_create_tools.py
+++ b/tests/documents/test_office_create_tools.py
@@ -436,7 +436,7 @@ async def test_create_office_tools_reject_path_traversal(
 
     result = await tool.execute(**kwargs)
 
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path / expected_name).exists()
 
 
@@ -537,7 +537,7 @@ async def test_create_pdf_errors(tmp_path):
 
     # Permission denied (path traversal)
     result = await tool.execute(filename="../../escape.pdf", content="test")
-    assert "Error: Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -571,5 +571,5 @@ async def test_create_pdf_reject_path_traversal(
 
     result = await tool.execute(**kwargs)
 
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path / expected_name).exists()

--- a/tests/documents/test_permission_localization.py
+++ b/tests/documents/test_permission_localization.py
@@ -1,0 +1,42 @@
+"""Documents-tool PermissionError localization (issue #691).
+
+The documents tools (docx/xlsx/pptx/pdf) swallow PermissionError and
+return a string as the tool result; that string must be Chinese/actionable
+when the error is a ToolPermissionError, and keep the English fallback
+otherwise.
+"""
+
+import pytest
+
+from miqi.agent.tools.errors import (
+    outside_allowed_dir_error,
+    permission_error_result,
+)
+from miqi.documents.docx_tool import _enforce_boundary
+
+
+def test_enforce_boundary_raises_tool_permission_error(tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside.txt"
+    with pytest.raises(PermissionError) as exc_info:
+        _enforce_boundary(outside, allowed, None)
+    err = exc_info.value
+    assert type(err).__name__ == "ToolPermissionError"
+    assert "文件访问被拒绝" in err.user_message
+    assert "tools.extra_roots" in err.user_message
+    # str(exc) keeps the English tech detail for server logs.
+    assert "outside allowed directory" in str(err)
+
+
+def test_permission_error_result_prefers_chinese():
+    err = outside_allowed_dir_error("C:/x/test.pdf", "C:/ws")
+    out = permission_error_result(err)
+    assert out.startswith("错误：")
+    assert "文件访问被拒绝" in out
+    assert "tools.extra_roots" in out
+
+
+def test_permission_error_result_falls_back_to_english():
+    out = permission_error_result(PermissionError("OS-level lock"))
+    assert out == "Error: Permission denied: OS-level lock"

--- a/tests/execution/test_phase32_office_path_enforcement.py
+++ b/tests/execution/test_phase32_office_path_enforcement.py
@@ -71,8 +71,8 @@ async def test_docx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.docx"),
         content="test",
     )
-    assert "Permission denied" in result
-    assert "Error" not in result.lower() or "Permission denied" in result
+    assert "文件访问被拒绝" in result
+    assert "错误" in result
 
 
 @pytest.mark.asyncio
@@ -84,7 +84,7 @@ async def test_pptx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.pptx"),
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,7 @@ async def test_xlsx_write_absolute_path_outside_workspace_denied(tmp_path):
         file_path=str(outside / "should_not_exist.xlsx"),
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 # ── Path traversal: ../outside.docx must be denied ───────────────────────────
@@ -110,7 +110,7 @@ async def test_docx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.docx",
         content="test",
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     # The file must not exist outside
     parent_dir = tmp_path.parent
     assert not (parent_dir / "outside.docx").exists(), (
@@ -126,7 +126,7 @@ async def test_pptx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.pptx",
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 @pytest.mark.asyncio
@@ -137,7 +137,7 @@ async def test_xlsx_write_path_traversal_rejected(tmp_path):
         file_path="../outside.xlsx",
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 # ── Denial must not create/modify files ──────────────────────────────────────
@@ -153,7 +153,7 @@ async def test_docx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.docx",  # relative to workspace, but outside allowed_dir
         content="test",
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path / "outside.docx").exists()
     assert not (allowed_sub / "outside.docx").exists()
 
@@ -168,7 +168,7 @@ async def test_pptx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.pptx",
         slides=[],
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path / "outside.pptx").exists()
 
 
@@ -182,7 +182,7 @@ async def test_xlsx_write_denied_does_not_create_file(tmp_path):
         file_path="outside.xlsx",
         sheets={},
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path / "outside.xlsx").exists()
 
 
@@ -203,7 +203,7 @@ async def test_docx_write_approval_allow_still_denies_workspace_outside(tmp_path
         file_path=str(outside / "still_denied.docx"),
         content="test",
     )
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
 
 
 # ── ToolRegistry.execute_concurrent: no production call sites ────────────────

--- a/tests/execution/test_sanitize_exc_for_ui.py
+++ b/tests/execution/test_sanitize_exc_for_ui.py
@@ -1,0 +1,48 @@
+"""Tests for orchestrator._sanitize_exc_for_ui (issue #691).
+
+The function decides what error text reaches the frontend: tool-layer
+PermissionErrors carry a Chinese ``user_message`` which must be preferred
+over the English tech summary; all other exceptions keep the historical
+sanitized-English behavior.
+"""
+
+import pytest
+
+from miqi.agent.tools.errors import ToolPermissionError
+from miqi.execution.orchestrator import _sanitize_exc_for_ui
+
+
+def test_tool_permission_error_returns_chinese_user_message():
+    err = ToolPermissionError(
+        user_message="文件访问被拒绝：该路径不在允许访问的目录范围内（C:/x）。如需允许访问，请在设置中为该目录添加访问权限（tools.extra_roots）。",
+        tech_message="Path 'C:/x' resolves outside all legal roots. tools.extra_roots",
+    )
+    out = _sanitize_exc_for_ui(err)
+    assert out == err.user_message
+    assert "文件访问被拒绝" in out
+    # The English tech detail must NOT leak to the UI.
+    assert "legal roots" not in out
+
+
+def test_plain_permission_error_keeps_english_sanitized():
+    out = _sanitize_exc_for_ui(
+        PermissionError("Path C:/Users/foo/secret.txt resolves outside all legal roots")
+    )
+    assert out.startswith("PermissionError:")
+    assert "legal roots" in out
+
+
+def test_path_and_url_redaction_still_applies_to_plain_errors():
+    out = _sanitize_exc_for_ui(
+        PermissionError("Failed at /Users/foo/secret/read with https://api.example.com/v1")
+    )
+    # The path regex eats the URL after `https:` (existing behavior), so both
+    # the local path and the remote host are redacted into [path].
+    assert "[path]" in out
+    assert "/Users/foo/secret/read" not in out
+    assert "api.example.com" not in out
+
+
+def test_exception_without_message_uses_type_name():
+    out = _sanitize_exc_for_ui(ValueError())
+    assert out == "ValueError"

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -148,7 +148,7 @@ async def test_factory_docx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_d.docx"
     result = await tool.execute(file_path=str(outside), content="test")
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not outside.exists()
 
 
@@ -167,7 +167,7 @@ async def test_factory_pptx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_p.pptx"
     result = await tool.execute(file_path=str(outside), slides=[])
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not outside.exists()
 
 
@@ -186,7 +186,7 @@ async def test_factory_xlsx_write_rejects_outside_workspace_default_config(
 
     outside = tmp_path.parent / "outside_x.xlsx"
     result = await tool.execute(file_path=str(outside), sheets={})
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not outside.exists()
 
 
@@ -222,7 +222,7 @@ async def test_factory_docx_write_path_traversal_rejected_default_config(
     assert tool is not None
 
     result = await tool.execute(file_path="../escape.docx", content="test")
-    assert "Permission denied" in result
+    assert "文件访问被拒绝" in result
     assert not (tmp_path.parent / "escape.docx").exists()
 
 

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -177,6 +177,22 @@ class TestCanonicalizeWslMntPath:
         with pytest.raises(PermissionError, match=r"tools\.extra_roots"):
             _canonicalize_wsl_mnt_path(_as_mnt_path(other, "file.txt"), ws)
 
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    def test_permission_error_carries_chinese_user_message(self, tmp_path):
+        """Issue #691: the raised error also carries a Chinese user_message
+        for the UI, while str(exc) keeps the English tech detail."""
+        ws = tmp_path / "sub"
+        ws.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        with pytest.raises(PermissionError) as exc_info:
+            _canonicalize_wsl_mnt_path(_as_mnt_path(other, "file.txt"), ws)
+        user_message = getattr(exc_info.value, "user_message", "")
+        assert user_message
+        assert "文件访问被拒绝" in user_message
+        # str(exc) still exposes the technical English for the server logs.
+        assert "outside" in str(exc_info.value)
+
 
 # ── _resolve_sandbox_path ────────────────────────────────────────────────
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

后端 tool 层抛出的 PermissionError 由英文技术原文改为中文可读错误 + 可操作提示，前端聊天气泡原样展示中文。

## 背景/问题

Issue #691：后端 tool 层的 `PermissionError` 以原始英文显示在聊天气泡中，例如：

```
PermissionError: Path 'C:...' (normalized: ...) resolves outside all legal roots [...]. Add the directory to tools.extra_roots in the MiQi config to allow access.
```

普通中文用户看不懂也无法据此操作。期望显示中文 + 可操作提示（tools.extra_roots）。

根因链路：filesystem.py / papers.py 抛 `PermissionError` → orchestrator `_sanitize_exc_for_ui` → `ToolErrorEvent.message` → bridge → `chat:progress` → 渲染器原样显示。前端零改动，只需后端产出中文消息。

## 关联 issue

- Closes #691

## 变更内容

- 新增 `miqi/agent/tools/errors.py`：`ToolPermissionError(PermissionError)` 携带中文 `user_message`，`str(exc)` 保持英文技术字节（服务端日志与既有断言不受影响）；`permission_error_result` 供吞异常路径优先返回中文。
- `miqi/execution/orchestrator.py`：`_sanitize_exc_for_ui` 优先返回 `user_message`，否则退回原有英文 sanitize。
- `miqi/agent/tools/filesystem.py`：5 处 raise → `ToolPermissionError`；4 处 execute 层 `except PermissionError: return "Error: Permission denied: ..."` → `permission_error_result(e)`。
- `miqi/agent/tools/apply_patch.py`：apply_patch 层吞异常 → `permission_error_result(e)`。
- `miqi/agent/tools/papers.py`：输出路径越界 → 中文 user_message。
- documents 工具（docx/xlsx/pptx/pdf_create）：8 处 raise → `outside_allowed_dir_error`；9 处 handler → `permission_error_result`。
- 测试：新增 `test_sanitize_exc_for_ui.py` / `test_permission_localization.py`；更新 apply_patch、office_create、phase32、tool_registry_factory、wsl_sandbox_path_mapping 断言。

## 日志/验证证据

```text
# 受影响套件
$ python -m pytest tests/agent/tools/test_apply_patch.py tests/agent/tools/test_papers.py \
    tests/execution/test_sanitize_exc_for_ui.py tests/execution/test_phase32_office_path_enforcement.py \
    tests/documents/test_permission_localization.py tests/documents/test_office_create_tools.py \
    tests/documents/test_docx_tool.py tests/sandbox/test_wsl_sandbox_path_mapping.py -q
123 passed in 2.18s

# 全量套件
$ python -m pytest tests/ -q
2832 passed, 20 skipped in 503.99s

# 修复前后对比（触发 read_file 越权）
修复前: Error: Permission denied: Path '...' resolves outside all legal roots [...]. Add the directory to tools.extra_roots
修复后: 错误：文件访问被拒绝：该路径不在允许访问的目录范围内（...）。如需允许访问，请在设置中为该目录添加访问权限（tools.extra_roots）。
```

## 测试情况

- 受影响套件 123 passed（apply_patch / papers / sanitize / documents 边界 / wsl 映射）
- 全量后端套件 2832 passed, 20 skipped，0 失败
- E2E proof spec `apps/desktop/tests/e2e/proof-691-error-bubble.spec.ts`（本地运行，不进 CI）：注入 ToolErrorEvent 断言中文气泡可见 + 页面无英文技术文案

## 截图

<img width="1264" height="821" alt="image" src="https://github.com/user-attachments/assets/849ac212-f410-4262-a616-4a1994a890b4" />

## 后续计划

无
