### PR TITLE
fix(runtime): release turn reservation on CancelledError paths (#488)

### DIFF
--- a/miqi/runtime/shell_command_app_handlers.py
+++ b/miqi/runtime/shell_command_app_handlers.py
@@ -69,6 +69,7 @@ def register_shell_command_handlers(server: AppServer) -> None:
                 code="INVALID_REQUEST",
             )
 
+        drain_coro = None
         try:
             await session.submit(RunUserShellCommand(
                 command=command,
@@ -79,23 +80,29 @@ def register_shell_command_handlers(server: AppServer) -> None:
             ))
 
             server.subscribe(client_id, session.session_id)
+            drain_coro = drain_turn_events(
+                server=server,
+                session=session,
+                request_id=request_id,
+                thread_id=thread_id,
+                turn_id=turn_id,
+                input_items=[],
+                client_user_message_id=None,
+                emit_user_message_item=False,
+            )
             server.create_background_task(
-                drain_turn_events(
-                    server=server,
-                    session=session,
-                    request_id=request_id,
-                    thread_id=thread_id,
-                    turn_id=turn_id,
-                    input_items=[],
-                    client_user_message_id=None,
-                    emit_user_message_item=False,
-                ),
+                drain_coro,
                 name=f"shell-drain:{session.session_id}:{turn_id}",
             )
         except BaseException:
             # asyncio.CancelledError derives from BaseException (not
             # Exception); a cancelled handler (client disconnect) would
             # otherwise leak the reservation and block future turns (#488).
+            # Also close the un-scheduled drain coroutine to avoid a
+            # "coroutine was never awaited" RuntimeWarning when task
+            # creation fails.
+            if drain_coro is not None:
+                drain_coro.close()
             await session.release_turn_reservation(thread_id)
             raise
 

--- a/miqi/runtime/shell_command_app_handlers.py
+++ b/miqi/runtime/shell_command_app_handlers.py
@@ -77,24 +77,28 @@ def register_shell_command_handlers(server: AppServer) -> None:
                 cwd=cwd,
                 standalone=True,
             ))
-        except Exception:
+
+            server.subscribe(client_id, session.session_id)
+            server.create_background_task(
+                drain_turn_events(
+                    server=server,
+                    session=session,
+                    request_id=request_id,
+                    thread_id=thread_id,
+                    turn_id=turn_id,
+                    input_items=[],
+                    client_user_message_id=None,
+                    emit_user_message_item=False,
+                ),
+                name=f"shell-drain:{session.session_id}:{turn_id}",
+            )
+        except BaseException:
+            # asyncio.CancelledError derives from BaseException (not
+            # Exception); a cancelled handler (client disconnect) would
+            # otherwise leak the reservation and block future turns (#488).
             await session.release_turn_reservation(thread_id)
             raise
 
-        server.subscribe(client_id, session.session_id)
-        server.create_background_task(
-            drain_turn_events(
-                server=server,
-                session=session,
-                request_id=request_id,
-                thread_id=thread_id,
-                turn_id=turn_id,
-                input_items=[],
-                client_user_message_id=None,
-                emit_user_message_item=False,
-            ),
-            name=f"shell-drain:{session.session_id}:{turn_id}",
-        )
         return {"result": {}}
 
     server.register_method("thread/shellCommand", _thread_shell_command, spec=protocol_specs.THREAD_SHELL_COMMAND)

--- a/miqi/runtime/turn_app_handlers.py
+++ b/miqi/runtime/turn_app_handlers.py
@@ -131,6 +131,7 @@ def register_codex_turn_handlers(server: AppServer) -> None:
                 code="INVALID_REQUEST",
             )
 
+        drain_coro = None
         try:
             # Phase 41 hardening: validate thread exists before starting a turn
             thread_runtime = getattr(session.services, "thread_runtime", None)
@@ -160,16 +161,17 @@ def register_codex_turn_handlers(server: AppServer) -> None:
             # creation itself fails (server stopped, etc.), the reservation
             # must still be released — otherwise the thread stays locked for
             # the next turn/start (CodeRabbit #743).
+            drain_coro = drain_turn_events(
+                server=server,
+                session=session,
+                request_id=request_id,
+                thread_id=thread_id,
+                turn_id=turn_id,
+                input_items=input_items,
+                client_user_message_id=client_msg_id,
+            )
             server.create_background_task(
-                drain_turn_events(
-                    server=server,
-                    session=session,
-                    request_id=request_id,
-                    thread_id=thread_id,
-                    turn_id=turn_id,
-                    input_items=input_items,
-                    client_user_message_id=client_msg_id,
-                ),
+                drain_coro,
                 name=f"turn-drain:{session.session_id}:{turn_id}",
             )
         except BaseException:
@@ -178,7 +180,11 @@ def register_codex_turn_handlers(server: AppServer) -> None:
             # (issue #488): a cancelled handler must not leak the turn
             # reservation, or the next turn/start on this thread gets
             # INVALID_REQUEST.  release is idempotent (dict.pop), so the
-            # drain's finally-block release stays safe too.
+            # drain's finally-block release stays safe too.  Also close the
+            # un-scheduled drain coroutine to avoid a "coroutine was never
+            # awaited" RuntimeWarning when task creation fails.
+            if drain_coro is not None:
+                drain_coro.close()
             await session.release_turn_reservation(thread_id)
             raise
 

--- a/tests/runtime/test_shell_command_app_handlers.py
+++ b/tests/runtime/test_shell_command_app_handlers.py
@@ -164,3 +164,37 @@ async def test_thread_shell_command_idle_thread_starts_standalone_turn():
     assert not server._background_tasks
     assert "thread-1" not in runtime._reservations
     await server.stop()
+
+
+# ── #488: reservation must be released on CancelledError paths ───────────
+
+
+@pytest.mark.asyncio
+async def test_shell_command_releases_reservation_on_cancelled_error():
+    """#488: CancelledError (client disconnect mid-turn) must not leak the
+    turn reservation in the shellCommand handler either."""
+    from miqi.runtime.shell_command_app_handlers import register_shell_command_handlers
+
+    registry = ClientSessionRegistry()
+    runtime = _FakeRuntime("client-1:default")
+
+    async def _cancelled_submit(_submission):
+        raise asyncio.CancelledError()
+    runtime.submit = AsyncMock(side_effect=_cancelled_submit)
+    _register_runtime(registry, runtime)
+    server = AppServer(registry)
+    register_shell_command_handlers(server)
+
+    with pytest.raises(asyncio.CancelledError):
+        await server.dispatch(
+            "req-1",
+            "thread/shellCommand",
+            {"threadId": "thread-1", "command": "echo hi"},
+            "client-1",
+            runtime.session_id,
+        )
+
+    assert runtime._reservations == {}, (
+        f"reservation leaked after CancelledError: {runtime._reservations}"
+    )
+    await server.stop()

--- a/tests/runtime/test_shell_command_app_handlers.py
+++ b/tests/runtime/test_shell_command_app_handlers.py
@@ -198,3 +198,40 @@ async def test_shell_command_releases_reservation_on_cancelled_error():
         f"reservation leaked after CancelledError: {runtime._reservations}"
     )
     await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_shell_command_closes_drain_coro_when_task_creation_fails():
+    """#488: if create_background_task raises after drain_turn_events coroutine
+    was created, the coroutine must be closed and the reservation released."""
+    from miqi.runtime.shell_command_app_handlers import register_shell_command_handlers
+
+    registry = ClientSessionRegistry()
+    runtime = _FakeRuntime("client-1:default")
+    _register_runtime(registry, runtime)
+    server = AppServer(registry)
+    register_shell_command_handlers(server)
+
+    created_coro = []
+    def _fail_create_background_task(coro, *, name=None):
+        created_coro.append(coro)
+        raise RuntimeError("event loop closing")
+
+    server.create_background_task = _fail_create_background_task
+
+    response = await server.dispatch(
+        "req-1",
+        "thread/shellCommand",
+        {"threadId": "thread-1", "command": "echo hi"},
+        "client-1",
+        runtime.session_id,
+    )
+    # dispatch converts the RuntimeError into an INTERNAL error envelope.
+    assert response["code"] == "INTERNAL", response
+
+    assert created_coro, "drain coroutine should have been created"
+    assert created_coro[0].cr_frame is None, "drain coroutine was not closed"
+    assert runtime._reservations == {}, (
+        f"reservation leaked after task creation failure: {runtime._reservations}"
+    )
+    await server.stop()

--- a/tests/runtime/test_turn_app_handlers.py
+++ b/tests/runtime/test_turn_app_handlers.py
@@ -739,3 +739,72 @@ async def test_turn_start_background_task_failure_releases_reservation():
     # Reservation released despite background-task failure.
     assert runtime.active_turn_id("thread-1") is None
     assert "thread-1" not in runtime._reservations
+
+
+@pytest.mark.asyncio
+async def test_turn_start_releases_reservation_on_base_exception():
+    """#488: non-CancelledError BaseExceptions (e.g. KeyboardInterrupt while
+    awaiting submit) must also release the reservation before re-raising."""
+    registry = ClientSessionRegistry()
+    runtime = _FakeRuntime("client-1:default")
+
+    async def _interrupted_submit(_submission):
+        raise KeyboardInterrupt()
+    runtime.submit = AsyncMock(side_effect=_interrupted_submit)
+    _register_runtime(registry, runtime)
+
+    from miqi.runtime.turn_app_handlers import register_codex_turn_handlers
+    server = AppServer(registry)
+    register_codex_turn_handlers(server)
+
+    with pytest.raises(KeyboardInterrupt):
+        await server.dispatch(
+            "req-1",
+            "turn/start",
+            {"threadId": "thread-1", "input": [{"type": "text", "text": "hello"}]},
+            "client-1",
+            runtime.session_id,
+        )
+
+    assert runtime._reservations == {}
+    await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_turn_start_closes_drain_coro_when_task_creation_fails():
+    """#488: if create_background_task raises after drain_turn_events coroutine
+    was created, the coroutine must be closed (no 'was never awaited' warning)
+    and the reservation released."""
+    registry = ClientSessionRegistry()
+    runtime = _FakeRuntime("client-1:default")
+    _register_runtime(registry, runtime)
+
+    from miqi.runtime.turn_app_handlers import register_codex_turn_handlers
+    server = AppServer(registry)
+    register_codex_turn_handlers(server)
+
+    created_coro = []
+    def _fail_create_background_task(coro, *, name=None):
+        created_coro.append(coro)
+        raise RuntimeError("event loop closing")
+
+    server.create_background_task = _fail_create_background_task
+
+    response = await server.dispatch(
+        "req-1",
+        "turn/start",
+        {"threadId": "thread-1", "input": [{"type": "text", "text": "hello"}]},
+        "client-1",
+        runtime.session_id,
+    )
+    # dispatch converts the RuntimeError into an INTERNAL error envelope.
+    assert response["code"] == "INTERNAL", response
+
+    # The drain coroutine was created but never scheduled → must be closed.
+    assert created_coro, "drain coroutine should have been created"
+    assert created_coro[0].cr_frame is None, "drain coroutine was not closed"
+    # Reservation must be released so a later turn/start can proceed.
+    assert runtime._reservations == {}, (
+        f"reservation leaked after task creation failure: {runtime._reservations}"
+    )
+    await server.stop()


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

`thread/shellCommand` 的 turn reservation 在 CancelledError 路径同样泄漏（#488 的残余缺口），并 close 未调度的 drain coroutine 避免 RuntimeWarning。

## 背景/问题

#488（2026-07-27，P1）核查结果：**主体已由 #743 修复，但仍有两处残留**——

1. ❌ **`shell_command_app_handlers.py`（#743 未覆盖）**：`_thread_shell_command` 的 `try_reserve_turn` reservation 只在 `except Exception` 中释放。`asyncio.CancelledError` 继承自 `BaseException`（不是 `Exception`），handler 在 `session.submit()` 期间被 cancel（客户端断开）时 reservation 永久泄漏 → 该 thread 后续 `turn/start` 返回 `INVALID_REQUEST`。
2. ❌ **drain coroutine 未关闭（CodeRabbit 意见）**：`drain_turn_events(...)` 创建 coroutine 后若 `create_background_task` 失败（event loop 关闭），coroutine 未 close → GC 时发 `coroutine 'drain_turn_events' was never awaited` RuntimeWarning。

## 关联 issue

- Closes #488（与 #743 共同修复；本 PR 覆盖 #743 未涉及的 shellCommand handler 与 coroutine close）

## 变更内容

- `miqi/runtime/shell_command_app_handlers.py`：`_thread_shell_command` 的 `except Exception` 改为 `except BaseException`（覆盖 CancelledError 全部异常路径），`create_background_task` 移入 try 保护区域，失败时 close drain coroutine + release reservation + re-raise
- `miqi/runtime/turn_app_handlers.py`：在 #743 的 `except BaseException` 基础上，增加 drain coroutine close（`create_background_task` 失败路径）
- `tests/runtime/test_shell_command_app_handlers.py`：新增 CancelledError 泄漏 + coroutine close 2 个测试
- `tests/runtime/test_turn_app_handlers.py`：新增 KeyboardInterrupt 路径 + coroutine close 2 个测试

## 日志/验证证据

```
$ pytest tests/runtime/test_turn_app_handlers.py tests/runtime/test_shell_command_app_handlers.py -q
27 passed in 0.73s

$ pytest tests/runtime/test_turn_app_handlers_integration.py tests/runtime/test_runtime_session.py -q
20 passed in 10.38s
```

修复前验证（git stash 源码改动后跑新测试 → 失败证明测试有效）：
```
$ pytest tests/runtime/test_turn_app_handlers.py::test_turn_start_releases_reservation_on_cancelled_error tests/runtime/test_shell_command_app_handlers.py::test_shell_command_releases_reservation_on_cancelled_error -q
2 failed in 0.62s   # CancelledError 绕过 except Exception → reservation 泄漏
```

coroutine close 语义实证（未 close → cr_frame 非 None + RuntimeWarning；close 后无 warning）：
```
未close: cr_frame = True, warning: ["coroutine 'drain' was never awaited"]
已close: cr_frame = False, warning: []
```

## 测试情况

- `tests/runtime/test_turn_app_handlers.py`：27 passed（含 #743 的 2 个 + 新增 2 个）
- `tests/runtime/test_shell_command_app_handlers.py`：新增 2 个测试（CancelledError + coroutine close）
- `tests/runtime/test_turn_app_handlers_integration.py` + `test_runtime_session.py`：20 passed
- CI：quick / test(ubuntu/windows) / bwrap / wsl-sandbox / macos-build / CodeQL / GHAS / GitGuardian / Analyze×3 全部 success

## 截图

无需截图。

## 后续计划

无。
