### PR TITLE
perf: MessageBubble memo 化——打字机不再每帧全量重渲染（#538 渲染嫌疑点）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo, type ComponentProps } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, memo, type ComponentProps } from 'react';
 import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { ThinkBlock } from './components/ThinkBlock';
@@ -1694,6 +1694,9 @@ export function ChatConsole({
   onWorkspaceLoaded?: (workspace: string | null) => void;
 }) {
   const [messages, setMessages] = useState<Message[]>([]);
+  // sourcesByMsg cache: keyed by a tool-only signature so the map object is
+  // stable across typewriter frames (see sourcesByMsg below).
+  const sourcesCacheRef = useRef<{ sig: string; map: Map<Message, MessageSource[]> } | null>(null);
   // Tracks the latest messages for the session-switch snapshot.  Kept in
   // sync below; the switch effect snapshots the session we're leaving into
   // moduleMessagesSnapshot so switching back restores it instantly.
@@ -3039,6 +3042,7 @@ export function ChatConsole({
         displayed: '',
         animId: null,
         finalDone: false,
+        lastTickTs: null,
       });
     }
     // ── /Optimistic UI ────────────────────────────────────────────────────
@@ -4400,7 +4404,7 @@ export function ChatConsole({
     }
   }, []);
 
-  const handleCopy = async (text: string, idx: number) => {
+  const handleCopy = useCallback(async (text: string, idx: number) => {
     // Electron clipboard bridge via main process — navigator.clipboard fails
     // under file:// (non-secure context) in packaged builds; only show
     // feedback when the write actually succeeded (or the IPC call rejects).
@@ -4412,7 +4416,10 @@ export function ChatConsole({
     }
     setCopiedIdx(idx);
     setTimeout(() => setCopiedIdx(null), 2000);
-  };
+  }, []);
+
+  /** Stable no-arg reload trigger for error bubbles (#570). */
+  const retryLoad = useCallback(() => setRetryTick((t) => t + 1), []);
 
   // Composer right-click edit menu (剪切/复制/粘贴/全选) — restored from
   // #547 after the #577 rewrite dropped it.
@@ -4470,7 +4477,17 @@ export function ChatConsole({
   // Associate each assistant answer with the tool URLs that preceded it in
   // the same turn. Memoized — extractMessageSources scans full tool outputs,
   // which would otherwise re-run on every animation frame while streaming.
+  // Tool-only signature: the typewriter advances the LAST assistant message
+  // on every animation frame (setMessages per frame), which would rebuild
+  // this map and give every bubble a fresh `sources` array — defeating the
+  // React.memo on MessageBubble below.  Tool rows update their content while
+  // streaming, so their content length IS part of the signature; assistant
+  // body length is NOT (extraction never depends on it).
+  const sourcesSig = messages
+    .map((m) => (m.role === 'progress' ? `${m.toolCallId ?? ''}:${m.content?.length ?? 0}` : m.role))
+    .join('|');
   const sourcesByMsg = useMemo(() => {
+    if (sourcesCacheRef.current?.sig === sourcesSig) return sourcesCacheRef.current.map;
     const map = new Map<Message, MessageSource[]>();
     let pending: MessageSource[] = [];
     let seen = new Set<string>();
@@ -4506,7 +4523,10 @@ export function ChatConsole({
       }
     }
     return map;
-  }, [messages]);
+  }, [sourcesSig]);
+  if (sourcesCacheRef.current?.sig !== sourcesSig) {
+    sourcesCacheRef.current = { sig: sourcesSig, map: sourcesByMsg };
+  }
 
   // Number tool rows within each user turn so they render as a workflow
   // chain (1, 2, 3…) instead of anonymous stacked blocks.
@@ -4534,28 +4554,29 @@ export function ChatConsole({
     async (msg: Message) => {
       if (streaming) return;
       cleanupListeners();
-      const idx = messages.indexOf(msg);
+      const idx = messagesRef.current.indexOf(msg);
       if (idx >= 0) setMessages((prev) => prev.slice(0, idx));
       setInput(msg.content);
       setAttachments(msg.attachments ?? []);
     },
-    [streaming, cleanupListeners, messages]
+    [streaming, cleanupListeners]
   );
 
   const handleRegenerate = useCallback(
     async (assistantMsg: Message) => {
       if (streaming) return;
-      const idx = messages.indexOf(assistantMsg);
+      const msgs = messagesRef.current;
+      const idx = msgs.indexOf(assistantMsg);
       if (idx < 0) return;
       let userIdx = -1;
       for (let i = idx - 1; i >= 0; i--) {
-        if (messages[i].role === 'user') {
+        if (msgs[i].role === 'user') {
           userIdx = i;
           break;
         }
       }
       if (userIdx < 0) return;
-      const userMsg = messages[userIdx];
+      const userMsg = msgs[userIdx];
       retryPayloadRef.current = {
         text: userMsg.content,
         attachments: userMsg.attachments ?? [],
@@ -4566,7 +4587,7 @@ export function ChatConsole({
       setAttachments(userMsg.attachments ?? []);
       requestAnimationFrame(() => handleSendRef.current());
     },
-    [streaming, messages]
+    [streaming]
   );
 
   /* session display name — persisted custom title wins, else first user
@@ -5095,7 +5116,8 @@ export function ChatConsole({
                       searchResultsByCallId={searchResultsByCallId}
                       execOutputs={execOutputs}
                       inlineExecOutput={inlineExecOutput}
-                      onCopy={(text) => handleCopy(text, i)}
+                      onCopy={handleCopy}
+                      copyIdx={i}
                       isCopied={copiedIdx === i}
                       onRetry={undefined}
                       onRegenerate={undefined}
@@ -5120,11 +5142,12 @@ export function ChatConsole({
                             ? searchResultsByCallId[group.msg.toolCallId]
                             : undefined
                         }
-                        onCopy={(text) => handleCopy(text, i)}
+                        onCopy={handleCopy}
+                        copyIdx={i}
                         isCopied={copiedIdx === i}
-                        onRetry={() => handleRetry(group.msg)}
-                        onRetryLoad={() => setRetryTick((t) => t + 1)}
-                        onRegenerate={() => handleRegenerate(group.msg)}
+                        onRetry={handleRetry}
+                        onRetryLoad={retryLoad}
+                        onRegenerate={handleRegenerate}
                         onOpenProviderSettings={onOpenProviderSettings}
                         onDownloadPaper={handleDownloadPaper}
                         downloadingPaperId={downloadingPaperId}
@@ -6117,7 +6140,43 @@ function ToolChainGroup({
   );
 }
 
-function MessageBubble({
+interface MessageBubbleProps {
+  msg: Message;
+  /** Current session key — scopes persisted 👍/👎 feedback to this session. */
+  sessionKey: string;
+  /** Stable per-turn index (chatGroups 下标) — reload-stable feedback key. */
+  turnIndex?: number;
+  /** Copy-feedback index — chatGroups index; chain rows reuse the group's. */
+  copyIdx?: number;
+  /** Timestamp of the pending optimistic user bubble (issue #364) — the
+   *  spinner shows only on the bubble whose timestamp matches, so a session
+   *  switch never shows it on another session's messages. */
+  sending?: number | null;
+  execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
+  inlineExecOutput: boolean;
+  isLast: boolean;
+  onCopy: (text: string, idx: number) => void;
+  isCopied: boolean;
+  onRetry?: (msg: Message) => void;
+  /** #570: reload the current session's history (the error bubble's 重试 button). */
+  onRetryLoad?: () => void;
+  onRegenerate?: (msg: Message) => void;
+  onOpenProviderSettings?: () => void;
+  onDownloadPaper?: (paper: PaperItem) => void;
+  downloadingPaperId?: string | null;
+  /** #668 补：论文下载结果反馈（paperId → done/failed） */
+  paperDownloadStates?: Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>;
+  /** Reference URLs collected from the tool calls preceding this answer */
+  sources?: MessageSource[];
+  /** Workflow step number when this progress row is a tool call. */
+  toolStepIndex?: number;
+  /** True when this is the last tool row of the turn — hides the ↓ arrow. */
+  isLastToolRow?: boolean;
+  /** web_search result text for this row (click-to-expand cards). */
+  searchResults?: string;
+}
+
+const MessageBubble = memo(function MessageBubble({
   msg,
   sessionKey,
   execOutputs,
@@ -6137,40 +6196,9 @@ function MessageBubble({
   isLastToolRow,
   searchResults,
   turnIndex,
+  copyIdx,
   sending,
-}: {
-  msg: Message;
-  /** Current session key — scopes persisted 👍/👎 feedback to this session. */
-  sessionKey: string;
-  /** Stable per-turn index (chatGroups 下标) — reload-stable feedback key. */
-  turnIndex?: number;
-  /** Timestamp of the pending optimistic user bubble (issue #364) — the
-   *  spinner shows only on the bubble whose timestamp matches, so a session
-   *  switch never shows it on another session's messages. */
-  sending?: number | null;
-  execOutputs: Record<string, { stdout: string; stderr: string; running: boolean }>;
-  inlineExecOutput: boolean;
-  isLast: boolean;
-  onCopy: (text: string) => void;
-  isCopied: boolean;
-  onRetry?: () => void;
-  /** #570: reload the current session's history (the error bubble's 重试 button). */
-  onRetryLoad?: () => void;
-  onRegenerate?: () => void;
-  onOpenProviderSettings?: () => void;
-  onDownloadPaper?: (paper: PaperItem) => void;
-  downloadingPaperId?: string | null;
-  /** #668 补：论文下载结果反馈（paperId → done/failed） */
-  paperDownloadStates?: Record<string, { status: 'done' | 'failed'; savePath?: string; error?: string }>;
-  /** Reference URLs collected from the tool calls preceding this answer */
-  sources?: MessageSource[];
-  /** Workflow step number when this progress row is a tool call. */
-  toolStepIndex?: number;
-  /** True when this is the last tool row of the turn — hides the ↓ arrow. */
-  isLastToolRow?: boolean;
-  /** web_search result text for this row (click-to-expand cards). */
-  searchResults?: string;
-}) {
+}: MessageBubbleProps) {
   const [expanded, setExpanded] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   // Message action bar (copy/regenerate/feedback/sources) — restored from
@@ -6557,14 +6585,14 @@ function MessageBubble({
   const [copyHovered, setCopyHovered] = useState(false);
   const copyWithSelection = () => {
     const selected = capturedSelectionRef.current;
-    onCopy(selected.length > 0 ? selected : msg.content);
+    onCopy(selected.length > 0 ? selected : msg.content, copyIdx ?? turnIndex ?? 0);
     deselectMessageText();
   };
 
   const contextItems: ContextMenuAction[] = isUser
     ? [
         { label: '复制文本', onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
-        { label: '重试', onSelect: () => onRetry?.() },
+        { label: '重试', onSelect: () => onRetry?.(msg) },
       ]
     : [
         { label: '复制文本', onEnter: selectMessageText, onLeave: deselectMessageText, onSelect: copyWithSelection },
@@ -6775,7 +6803,7 @@ function MessageBubble({
                 data-testid="message-actions"
               >
                 <button
-                  onClick={() => onCopy(msg.content)}
+                  onClick={() => onCopy(msg.content, copyIdx ?? turnIndex ?? 0)}
                   onMouseEnter={() => {
                     setCopyHovered(true);
                     selectMessageText();
@@ -6796,7 +6824,7 @@ function MessageBubble({
                 </button>
                 {onRegenerate && (
                   <button
-                    onClick={onRegenerate}
+                    onClick={() => onRegenerate?.(msg)}
                     title="重新生成"
                     aria-label="重新生成"
                     className="p-1 rounded hover:bg-[var(--surface-muted)] hover:text-[var(--text)] transition-colors"
@@ -6934,6 +6962,42 @@ function MessageBubble({
       </div>
     </Modal>
     </>
+  );
+}, areMessageBubblePropsEqual);
+
+/**
+ * Memo comparator: skip re-render unless a rendering-relevant prop changed.
+ * All callbacks are stable useCallback references; msg/sources/searchResults
+ * stay referentially stable while the typewriter streams (see sourcesByMsg's
+ * tool-only signature), so untouched bubbles skip render entirely during
+ * animation frames — the #538 全量重渲染 fix for long sessions.
+ */
+function areMessageBubblePropsEqual(
+  a: MessageBubbleProps,
+  b: MessageBubbleProps
+): boolean {
+  return (
+    a.msg === b.msg &&
+    a.sessionKey === b.sessionKey &&
+    a.turnIndex === b.turnIndex &&
+    a.copyIdx === b.copyIdx &&
+    a.execOutputs === b.execOutputs &&
+    a.inlineExecOutput === b.inlineExecOutput &&
+    a.isLast === b.isLast &&
+    a.sources === b.sources &&
+    a.toolStepIndex === b.toolStepIndex &&
+    a.isLastToolRow === b.isLastToolRow &&
+    a.searchResults === b.searchResults &&
+    a.downloadingPaperId === b.downloadingPaperId &&
+    a.paperDownloadStates === b.paperDownloadStates &&
+    a.sending === b.sending &&
+    a.isCopied === b.isCopied &&
+    a.onCopy === b.onCopy &&
+    a.onRetry === b.onRetry &&
+    a.onRetryLoad === b.onRetryLoad &&
+    a.onRegenerate === b.onRegenerate &&
+    a.onOpenProviderSettings === b.onOpenProviderSettings &&
+    a.onDownloadPaper === b.onDownloadPaper
   );
 }
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] ♻️ 重构

## 变更概述

MessageBubble 消息气泡 React.memo 化 + sourcesByMsg 改工具签名缓存——打字机流式输出时历史消息不再每帧全量重渲染（长会话渲染开销从 O(N×帧) 降到 O(1×帧)）。纯性能优化，功能零变化。

## 背景/问题

#538「重任务下 Agent 假死不响应」的**渲染嫌疑点**（嫌疑点 1/2）：AI 回复流式输出时打字机每帧执行 setMessages → 整个消息列表全部重渲染（含所有历史消息/工具链气泡）。长会话下渲染开销大，界面卡顿。功能性根因（后端 turn 卡住、final 事件不到前端）已由 #400/#401/#564/#676/#720 系列修复，本 PR 补齐剩余渲染性能部分。

## 关联 issue

- Closes #538 重任务下 Agent 假死不响应（渲染嫌疑点部分）

## 变更内容

- `MessageBubble` 包 `React.memo` + 21 项 prop 自定义比较器——打字机只更新最后一条消息时，其余气泡完全跳过渲染
- `sourcesByMsg` 改**工具签名缓存**（toolCallId + 工具行 content 长度做签名）——打字机帧间 sources 数组引用稳定（memo 生效的前提）；工具行流式更新时签名变化自动重建
- 回调稳定化：`handleCopy`/`retryLoad` 包 useCallback；`handleRetry`/`handleRegenerate` 依赖数组去掉 `messages`（改读已有 `messagesRef`）
- 复制/重试/重新生成改"稳定函数引用 + 索引 prop"（新增 `copyIdx`），行为不变、引用稳定
- 顺手修 #720 遗留类型错误（`RevealState` 初始化缺 `lastTickTs`，typecheck 才通过）

## 日志/验证证据

```
# 渲染量对比（打字机每帧）
- 改前：setMessages → 全量重渲染 N 条消息（长会话卡顿）
- 改后：只重渲染正在打字的那 1 条（其余 memo 跳过）

# 验证
typecheck: 0 errors（web + node）
build: ✓ built in 13.04s
vitest: 252 passed | 2 skipped (19 files)
```

## 测试情况

- `npm run typecheck`（web + node）0 错误
- `npm run build` 成功
- `vitest run` 252 passed
- 与最新 develop（含 #728 Qraft 登录 / #735 OCR / #737 技能缓存等 9 个新 PR）合并后全绿
- dev 实例实机运行正常（复制/重试/重新生成/👍👎/来源功能回归无异常）

## 截图

无 UI 变更（纯性能优化）


___

### **PR Type**
Enhancement


___

### **Description**
- Memoize `MessageBubble` to skip unchanged typewriter re-renders

- Cache `sourcesByMsg` using tool-only signature for stable refs

- Stabilize `handleCopy`, retry, and regenerate callbacks

- Use `messagesRef` and add `copyIdx` prop plumbing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Typewriter setMessages per frame"] -- "triggers" --> B["MessageBubble memo + comparator"]
  C["sourcesByMsg tool-signature cache"] -- "provides stable refs" --> B
  D["Stable callbacks / messagesRef"] -- "prevents prop changes" --> B
  B -- "skips" --> E["Unchanged message re-renders"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Memoize message bubbles and stabilize typewriter dependencies</code></dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>Wraps <code>MessageBubble</code> in <code>memo</code> with a custom <code>areMessageBubblePropsEqual</code> <br>comparator to skip unchanged bubble renders during typewriter frames.<br> <li> Adds <code>sourcesCacheRef</code> and a tool-only signature so <code>sourcesByMsg</code> stays <br>referentially stable unless tool rows grow.<br> <li> Stabilizes <code>handleCopy</code>/<code>retryLoad</code> via <code>useCallback</code>; <br><code>handleRetry</code>/<code>handleRegenerate</code> read <code>messagesRef</code> and drop <code>messages</code> <br>dependency.<br> <li> Adds <code>copyIdx</code> prop, message-aware <code>onRetry</code>/<code>onRegenerate</code> signatures, and <br><code>lastTickTs</code> initialization to support stable props and typewriter <br>state.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/746/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+109/-45</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

