### PR TITLE
feat(desktop): Qraft token 文件通道 + 生产环境 client_secret 默认值（#726 跟进）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -131,7 +131,7 @@ function resolveWorkspacePath(raw: string): string {
   return resolved;
 }
 
-function getWorkspacePath(): string {
+export function getWorkspacePath(): string {
   const config = readLocalConfig();
   const agents = (config['agents'] as Record<string, unknown> | undefined) ?? {};
   const defaults = (agents['defaults'] as Record<string, unknown> | undefined) ?? {};

--- a/apps/desktop/src/main/qraft/ipc.ts
+++ b/apps/desktop/src/main/qraft/ipc.ts
@@ -8,6 +8,7 @@
 
 import { electron } from '../../shared/electron';
 import { join } from 'path';
+import { getWorkspacePath } from '../ipc';
 import {
   IPC,
   IPC_EVENTS,
@@ -55,6 +56,15 @@ function getService(): QraftService {
     onStatusChanged: (status: QraftStatus) => {
       for (const win of BrowserWindow.getAllWindows()) {
         if (!win.isDestroyed()) win.webContents.send(IPC_EVENTS.QRAFT_STATUS_CHANGED, status);
+      }
+    },
+    // Skill/agent 读取 access_token 的通道：workspace 在沙箱中 bind-mount，
+    // 文件放 workspace 下即可被沙箱内 Skill 读取（见 docs qraft-oauth2-login.md 第 6 节）。
+    tokenFilePath: () => {
+      try {
+        return join(getWorkspacePath(), '.qraft', 'token.json');
+      } catch {
+        return null;
       }
     },
   });

--- a/apps/desktop/src/main/qraft/service.test.ts
+++ b/apps/desktop/src/main/qraft/service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { QraftService, resolveConfig, defaultRedirectUri } from './service';
@@ -75,6 +75,7 @@ function makeService(clientStub: ClientStub): QraftService {
     store,
     log: noopLog,
     makeRedirectUri: () => 'http://localhost:38000/callback',
+    tokenFilePath: () => join(dir, 'qraft-token.json'),
     onStatusChanged: (status) => statusEvents.push(status),
   });
 }
@@ -95,11 +96,21 @@ describe('resolveConfig', () => {
     expect(config.clientSecret).toBe('miqi123456');
   });
 
-  it('生产环境默认 client_secret 为空、不自动生成 redirect_uri（需注册值）', () => {
+  it('生产环境默认 client_secret 使用硬编码默认值（测试阶段开箱即用）、不自动生成 redirect_uri', () => {
     const config = resolveConfig({ env: 'prod' }, null, () => 'http://localhost:1/callback');
     expect(config.baseUrl).toBe('https://forge.miqroera.com/api');
-    expect(config.clientSecret).toBe('');
+    expect(config.clientSecret).toBe('miqi123456');
     expect(config.redirectUri).toBe('');
+  });
+
+  it('QRAFT_PROD_CLIENT_SECRET 环境变量可覆盖生产默认值', () => {
+    process.env.QRAFT_PROD_CLIENT_SECRET = 'prod-override';
+    try {
+      const config = resolveConfig({ env: 'prod' }, null, () => 'http://localhost:1/callback');
+      expect(config.clientSecret).toBe('prod-override');
+    } finally {
+      delete process.env.QRAFT_PROD_CLIENT_SECRET;
+    }
   });
 
   it('用户覆盖优先于环境默认与上次存储', () => {
@@ -129,7 +140,7 @@ describe('resolveConfig', () => {
     });
     const config = resolveConfig({ env: 'prod' }, stored, () => 'http://localhost:9/callback');
     expect(config.baseUrl).toBe('https://forge.miqroera.com/api');
-    expect(config.clientSecret).toBe('');
+    expect(config.clientSecret).toBe('miqi123456'); // 生产默认值，非测试环境存储值
     expect(config.redirectUri).toBe('');
   });
 });
@@ -191,15 +202,6 @@ describe('QraftService.login', () => {
     const result = await service.login('18500000000', 'p');
     expect(result.ok).toBe(true);
     expect(result.account?.nickname).toBe('登录昵称');
-  });
-
-  it('client_secret 缺失（生产默认）报 INVALID_CONFIG，不发任何请求', async () => {
-    const stub = makeClientStub();
-    const service = makeService(stub);
-    const result = await service.login('18500000000', 'p', { env: 'prod' });
-    expect(result.ok).toBe(false);
-    expect(result.code).toBe('INVALID_CONFIG');
-    expect(stub.platformLogin).not.toHaveBeenCalled();
   });
 
   it('生产环境未填注册 redirect_uri 报 INVALID_CONFIG（不自动生成 loopback）', async () => {
@@ -389,5 +391,69 @@ describe('QraftService 手动刷新与退出', () => {
     expect(service.status().loggedIn).toBe(false);
     expect(store.current).toBeNull();
     expect(statusEvents.some((s) => (s as { loggedIn: boolean }).loggedIn === false)).toBe(true);
+  });
+});
+
+describe('QraftService token 文件通道（供 Skill/agent 读取 access_token）', () => {
+  const tokenPath = () => join(dir, 'qraft-token.json');
+
+  it('登录成功后写入 token 文件（仅 accessToken + expiresAt，无 refreshToken）', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = makeService(stub);
+
+    await service.login('18500000000', 'p');
+    expect(existsSync(tokenPath())).toBe(true);
+    const content = JSON.parse(readFileSync(tokenPath(), 'utf8'));
+    expect(content.accessToken).toBe('ACCESS-TOKEN');
+    expect(content.expiresAt).toBeGreaterThan(Date.now());
+    expect(content).not.toHaveProperty('refreshToken');
+  });
+
+  it('自动刷新成功后更新 token 文件中的 accessToken', async () => {
+    vi.useFakeTimers();
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '1', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '1', username: 'u', nickname: 'n' });
+    stub.refreshTokens.mockImplementation(async () =>
+      makeTokens({ accessToken: 'ACCESS-NEW', expiresAt: Date.now() + 7_199_000 })
+    );
+    const service = makeService(stub);
+    await service.login('18500000000', 'p');
+
+    await vi.advanceTimersByTimeAsync(7_199_000 - 15 * 60_000 + 100);
+    const content = JSON.parse(readFileSync(tokenPath(), 'utf8'));
+    expect(content.accessToken).toBe('ACCESS-NEW');
+  });
+
+  it('退出登录删除 token 文件', async () => {
+    const stub = makeClientStub();
+    store.save(makeStoredState());
+    const service = makeService(stub);
+    expect(existsSync(tokenPath())).toBe(true); // 构造时从磁盘恢复并同步
+
+    service.logout();
+    expect(existsSync(tokenPath())).toBe(false);
+  });
+
+  it('tokenFilePath 返回 null 时静默跳过（workspace 不可解析不报错）', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => null,
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    service.logout();
   });
 });

--- a/apps/desktop/src/main/qraft/service.test.ts
+++ b/apps/desktop/src/main/qraft/service.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { QraftService, resolveConfig, defaultRedirectUri } from './service';
@@ -455,5 +463,75 @@ describe('QraftService token 文件通道（供 Skill/agent 读取 access_token�
     const result = await service.login('18500000000', 'p');
     expect(result.ok).toBe(true);
     service.logout();
+  });
+});
+
+describe('QraftService 登出竞态与 token 文件防护', () => {
+  it('在途刷新完成于退出登录之后：丢弃结果，不写回 store 与 token 文件', async () => {
+    let resolveRefresh!: (t: QraftTokens) => void;
+    const refreshPromise = new Promise<QraftTokens>((r) => {
+      resolveRefresh = r;
+    });
+    const stub = makeClientStub();
+    stub.refreshTokens.mockReturnValue(refreshPromise);
+    store.save(makeStoredState());
+    const service = makeService(stub);
+    const tokenPath = join(dir, 'qraft-token.json');
+    expect(existsSync(tokenPath)).toBe(true); // 启动恢复时已同步
+
+    const pendingRefresh = service.refreshNow();
+    service.logout();
+    expect(existsSync(tokenPath)).toBe(false);
+
+    // 刷新在登出后才完成 —— 结果必须被代际校验丢弃
+    resolveRefresh(makeTokens({ accessToken: 'LATE-RESULT' }));
+    await pendingRefresh;
+    expect(store.current).toBeNull();
+    expect(existsSync(tokenPath)).toBe(false);
+    expect(service.status().loggedIn).toBe(false);
+  });
+
+  it('.qraft 路径被普通文件占用时跳过写入且不崩溃', async () => {
+    const blockedDir = join(dir, 'blocked-dir');
+    writeFileSync(blockedDir, 'not-a-dir', 'utf8');
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => join(blockedDir, 'token.json'),
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true); // 登录不受 token 文件失败影响
+    expect(store.current?.tokens.accessToken).toBe('ACCESS-TOKEN');
+  });
+
+  it.skipIf(process.platform === 'win32')('.qraft 为符号链接时拒绝写入目标位置', async () => {
+    const targetDir = join(dir, 'target-dir');
+    mkdirSync(targetDir, { recursive: true });
+    const linkDir = join(dir, 'qraft-link');
+    symlinkSync(targetDir, linkDir, 'dir');
+
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => join(linkDir, 'token.json'),
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    // 凭据绝不能写到 symlink 指向的目标目录
+    expect(existsSync(join(targetDir, 'token.json'))).toBe(false);
   });
 });

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -8,12 +8,15 @@
  * 由设置页引导用户重新登录。
  */
 
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
 import { CookieJar } from './cookie-jar';
 import { QraftClient, QraftError, type QraftLogger, type ResolvedQraftConfig } from './client';
 import { maskSecret } from './rsa';
 import { QraftStore } from './store';
 import {
   QRAFT_ENV_DEFAULTS,
+  prodEnvClientSecret,
   testEnvClientSecret,
   type QraftAccount,
   type QraftEnv,
@@ -38,6 +41,12 @@ export interface QraftServiceOptions {
   onStatusChanged?: (status: QraftStatus) => void;
   /** 生成 loopback 回调地址（随机端口），测试可注入固定值。 */
   makeRedirectUri?: () => string;
+  /**
+   * 供 Skill/agent 读取 access_token 的 token 文件路径解析器。
+   * 登录/刷新成功后写入 { accessToken, expiresAt }（0600），退出登录删除；
+   * 返回 null 表示不启用 token 文件（如 workspace 不可解析时）。
+   */
+  tokenFilePath?: () => string | null;
 }
 
 export function defaultRedirectUri(): string {
@@ -66,7 +75,7 @@ export function resolveConfig(
     clientSecret:
       opts.clientSecret ??
       storedMatches?.clientSecret ??
-      (env === 'test' ? testEnvClientSecret() : ''),
+      (env === 'test' ? testEnvClientSecret() : prodEnvClientSecret()),
     redirectUri:
       opts.redirectUri ??
       storedMatches?.redirectUri ??
@@ -108,11 +117,13 @@ export class QraftService {
   private requiresRelogin = false;
 
   constructor(private readonly options: QraftServiceOptions) {
-    // 应用启动时恢复登录态并重建刷新调度。
+    // 应用启动时恢复登录态、重建刷新调度，并同步 token 文件
+    //（应用重启后文件可能已过期/被清理，按当前存储重写）。
     const stored = this.options.store.load();
     if (stored) {
       this.restoreJar(stored);
       this.scheduleRefresh(stored);
+      this.syncTokenFile(stored);
     }
   }
 
@@ -255,6 +266,7 @@ export class QraftService {
     this.refreshError = null;
     this.requiresRelogin = false;
     this.scheduleRefresh(state);
+    this.syncTokenFile(state);
     this.emitStatus();
   }
 
@@ -265,6 +277,45 @@ export class QraftService {
       code: 'INTERNAL',
       message: err instanceof Error ? err.message : String(err),
     };
+  }
+
+  // ── token 文件（供 Skill/agent 读取 access_token） ─────────────────────
+
+  /** 登录/刷新成功后写入 token 文件：仅含 accessToken + expiresAt（0600）。 */
+  private syncTokenFile(state: QraftStoredState): void {
+    const filePath = this.options.tokenFilePath?.();
+    if (!filePath) return;
+    try {
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(
+        filePath,
+        JSON.stringify({
+          accessToken: state.tokens.accessToken,
+          expiresAt: state.tokens.expiresAt,
+        }),
+        { encoding: 'utf8', mode: 0o600 }
+      );
+      chmodSync(filePath, 0o600);
+    } catch (err) {
+      this.options.log(
+        'WARN',
+        `qraft: 同步 token 文件失败（${err instanceof Error ? err.message : err}）`
+      );
+    }
+  }
+
+  /** 退出登录时删除 token 文件，避免过期凭据残留。 */
+  private deleteTokenFile(): void {
+    const filePath = this.options.tokenFilePath?.();
+    if (!filePath) return;
+    try {
+      rmSync(filePath, { force: true });
+    } catch (err) {
+      this.options.log(
+        'WARN',
+        `qraft: 删除 token 文件失败（${err instanceof Error ? err.message : err}）`
+      );
+    }
   }
 
   status(): QraftStatus {
@@ -290,6 +341,7 @@ export class QraftService {
     this.cancelRefresh();
     this.jar.clear();
     this.options.store.clear();
+    this.deleteTokenFile();
     this.refreshError = null;
     this.requiresRelogin = false;
     this.options.log('INFO', 'qraft: 已退出登录（cookie 与 token 均已清除）');
@@ -395,6 +447,7 @@ export class QraftService {
     const next: QraftStoredState = { ...state, tokens };
     this.options.store.save(next);
     this.scheduleRefresh(next);
+    this.syncTokenFile(next);
   }
 
   private emitStatus(): void {

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -8,7 +8,7 @@
  * 由设置页引导用户重新登录。
  */
 
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
 import { CookieJar } from './cookie-jar';
 import { QraftClient, QraftError, type QraftLogger, type ResolvedQraftConfig } from './client';
@@ -115,6 +115,9 @@ export class QraftService {
   private refreshScheduledAt: number | null = null;
   private refreshError: QraftErrorCode | null = null;
   private requiresRelogin = false;
+  /** 登录代际：退出登录时递增，用于丢弃登出前发起的在途刷新结果，
+   *  防止"刷新完成于登出之后"把凭据写回磁盘/内存。 */
+  private authGeneration = 0;
 
   constructor(private readonly options: QraftServiceOptions) {
     // 应用启动时恢复登录态、重建刷新调度，并同步 token 文件
@@ -281,12 +284,27 @@ export class QraftService {
 
   // ── token 文件（供 Skill/agent 读取 access_token） ─────────────────────
 
-  /** 登录/刷新成功后写入 token 文件：仅含 accessToken + expiresAt（0600）。 */
+  /** 登录/刷新成功后写入 token 文件：仅含 accessToken + expiresAt（0600）。
+   *  防符号链接重定向：.qraft 目录必须是真实目录、token 文件必须是真实
+   *  常规文件，否则跳过写入并告警（workspace 对 agent 可写，恶意/意外
+   *  替换成 symlink 时不能把凭据写到重定向目标）。 */
   private syncTokenFile(state: QraftStoredState): void {
     const filePath = this.options.tokenFilePath?.();
     if (!filePath) return;
     try {
-      mkdirSync(dirname(filePath), { recursive: true });
+      const dir = dirname(filePath);
+      mkdirSync(dir, { recursive: true });
+      const dirStat = lstatSync(dir);
+      if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+        throw new Error('.qraft 不是真实目录（可能被符号链接替换），跳过写入');
+      }
+      // mkdir 后目录若被替换为 symlink，lstat 会拿到链接本身 → 上面已拦截。
+      if (existsSync(filePath)) {
+        const fileStat = lstatSync(filePath);
+        if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+          throw new Error('token 文件路径被非常规文件/symlink 占用，跳过写入');
+        }
+      }
       writeFileSync(
         filePath,
         JSON.stringify({
@@ -339,6 +357,9 @@ export class QraftService {
 
   logout(): void {
     this.cancelRefresh();
+    // 使登出前发起的在途刷新结果作废（runRefresh 代际校验丢弃）。
+    this.authGeneration += 1;
+    this.inFlightRefresh = null;
     this.jar.clear();
     this.options.store.clear();
     this.deleteTokenFile();
@@ -406,12 +427,15 @@ export class QraftService {
   }
 
   private async tickRefresh(state: QraftStoredState): Promise<void> {
+    // 已退出登录（store 已清）时丢弃过期定时任务，不重试也不写回任何状态。
+    if (!this.options.store.current) return;
     try {
       await this.doRefresh(state);
       this.refreshError = null;
       this.requiresRelogin = false;
       this.emitStatus();
     } catch (err) {
+      if (!this.options.store.current) return; // 失败发生在登出前后：同样丢弃
       const code = err instanceof QraftError ? err.code : 'REFRESH_FAILED';
       this.options.log('ERROR', `qraft: 自动刷新失败（${code}），30 分钟后重试`);
       this.refreshError = code;
@@ -428,13 +452,16 @@ export class QraftService {
 
   private doRefresh(state: QraftStoredState): Promise<void> {
     if (this.inFlightRefresh) return this.inFlightRefresh;
-    this.inFlightRefresh = this.runRefresh(state).finally(() => {
-      this.inFlightRefresh = null;
+    const generation = this.authGeneration;
+    this.inFlightRefresh = this.runRefresh(state, generation).finally(() => {
+      // 只有代际未变（未退出登录）才清理；登出后新登录创建的刷新
+      // 不被旧请求的 finally 误清。
+      if (this.authGeneration === generation) this.inFlightRefresh = null;
     });
     return this.inFlightRefresh;
   }
 
-  private async runRefresh(state: QraftStoredState): Promise<void> {
+  private async runRefresh(state: QraftStoredState, generation: number): Promise<void> {
     const config: ResolvedQraftConfig = {
       baseUrl: state.baseUrl,
       clientId: state.clientId,
@@ -442,6 +469,11 @@ export class QraftService {
       redirectUri: state.redirectUri,
     };
     const tokens = await this.options.client.refreshTokens(config, state.tokens.refreshToken);
+    if (this.authGeneration !== generation) {
+      // 退出登录发生在刷新完成前：丢弃本次结果，不落盘、不写 token 文件。
+      this.options.log('WARN', 'qraft: 刷新完成前已退出登录，丢弃本次刷新结果');
+      return;
+    }
     // 实测 refresh_token 不轮换（返回同一个）；若服务端未来启用轮换，
     // 以响应中的新值为准，旧值在服务端已失效。
     const next: QraftStoredState = { ...state, tokens };

--- a/apps/desktop/src/main/qraft/types.ts
+++ b/apps/desktop/src/main/qraft/types.ts
@@ -43,6 +43,15 @@ export function testEnvClientSecret(): string {
   return process.env.QRAFT_TEST_CLIENT_SECRET?.trim() || 'miqi123456';
 }
 
+/**
+ * 生产环境 client_secret。测试阶段同样提供硬编码默认值（开箱即用），
+ * 可经 QRAFT_PROD_CLIENT_SECRET 环境变量覆盖（转正式环境接入前应移除默认值）。
+ * 注意：生产环境仍必须填写在平台注册的 redirect_uri（见 service.validateConfig）。
+ */
+export function prodEnvClientSecret(): string {
+  return process.env.QRAFT_PROD_CLIENT_SECRET?.trim() || 'miqi123456';
+}
+
 /** 登录请求携带的可选覆盖项（设置页"高级设置"）。 */
 export interface QraftLoginOptions {
   env?: QraftEnv;

--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -393,7 +393,7 @@ export function QraftPage() {
                       type={showPassword ? 'text' : 'password'}
                       value={clientSecret}
                       onChange={(e) => setClientSecret(e.target.value)}
-                      placeholder="生产环境必填"
+                      placeholder="留空用默认值（测试阶段）"
                       className="font-mono text-xs"
                       data-testid="qraft-client-secret-input"
                     />

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -151,6 +151,21 @@ test.describe('Qraft 平台登录 E2E (issue #726)', () => {
       .toContain('e2e-fake-access-token');
     expect(JSON.parse(readFileSync(tokenFile, 'utf8'))).not.toHaveProperty('refreshToken');
 
+    // agent 视角：走 agent 文件工具同一条链路（files.read，workspace 相对路径）
+    // 读取 token 文件 —— 验证 MiQi agent（Python 后端）确实拿得到 access_token。
+    const agentRead = await page.evaluate(async () => {
+      try {
+        const r: { path?: string; content?: string; size?: number } =
+          await (window as any).miqi.files.read('.qraft/token.json');
+        return { ok: true, content: r?.content ?? '', size: r?.size ?? 0 };
+      } catch (e) {
+        return { ok: false, error: String(e) };
+      }
+    });
+    expect(agentRead.ok, `agent 读取 token 文件失败：${JSON.stringify(agentRead)}`).toBe(true);
+    expect(agentRead.content).toContain('e2e-fake-access-token');
+    expect(agentRead.content).toContain('expiresAt');
+
     await page.screenshot({
       path: 'test-results/qraft-e2e-logged-in.png',
       fullPage: true,

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -141,12 +141,22 @@ test.describe('Qraft 平台登录 E2E (issue #726)', () => {
     await expect(page.getByText('access_token 到期：')).toBeVisible();
     await expect(page.getByTestId('qraft-logout-btn')).toBeVisible();
 
+    // token 文件通道：登录态恢复时同步写入 workspace/.qraft/token.json
+    //（供 Skill/agent 读取，仅含 accessToken + expiresAt）
+    const tokenFile = join(fixture.miqiHome, 'workspace', '.qraft', 'token.json');
+    await expect
+      .poll(() => (existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8') : ''), {
+        timeout: 10_000,
+      })
+      .toContain('e2e-fake-access-token');
+    expect(JSON.parse(readFileSync(tokenFile, 'utf8'))).not.toHaveProperty('refreshToken');
+
     await page.screenshot({
       path: 'test-results/qraft-e2e-logged-in.png',
       fullPage: true,
     });
 
-    // 退出登录：界面回到登录表单，磁盘文件被清空（凭据不残留）。
+    // 退出登录：界面回到登录表单，磁盘凭据清空（store 文件与 token 文件）
     // IPC 返回与磁盘写入存在竞态，轮询文件直到为空。
     await page.getByTestId('qraft-logout-btn').click();
     await expect(page.getByTestId('qraft-phone-input')).toBeVisible({ timeout: 15_000 });
@@ -156,5 +166,6 @@ test.describe('Qraft 平台登录 E2E (issue #726)', () => {
         timeout: 10_000,
       })
       .toBe('');
+    await expect.poll(() => existsSync(tokenFile), { timeout: 10_000 }).toBe(false);
   });
 });

--- a/docs/frontend/qraft-oauth2-login.md
+++ b/docs/frontend/qraft-oauth2-login.md
@@ -20,8 +20,8 @@ access_token（安全存储 + 到期自动刷新），供后续以用户身份�
 「立即刷新」手动续期，「退出登录」清除 cookie 与 token。
 
 **高级设置**（接入配置，按环境预填）：API 基础地址、client_id、client_secret、
-redirect_uri。测试环境默认可用；生产环境必须填写在 Qraft 平台注册的
-redirect_uri 与分配的 client_secret。
+redirect_uri。测试阶段 client_secret 有默认值（开箱即用）；生产环境必须填写在
+Qraft 平台注册的 redirect_uri。
 
 ## 2. 代码位置
 
@@ -90,41 +90,41 @@ IPC 通道：`qraft:login` / `qraft:browserLogin` / `qraft:status` / `qraft:refr
   Keychain）；安全存储不可用时降级 Base64 并写 WARN 日志；退出登录即清空。
 - **密码**：仅经 IPC 提交主进程，RSA 加密后传输；前端不落存储、不打日志。
 - **日志脱敏**：token/code 只记首尾片段（`maskSecret`）；手机号脱敏展示。
-- **client_secret**：当前测试阶段为硬编码默认值（开箱即用），可经
-  `QRAFT_TEST_CLIENT_SECRET` 环境变量覆盖；转正式接入前应移除默认值。
-  生产环境 secret 由用户在高级设置填写。
+- **client_secret**：测试阶段测试/生产环境均提供硬编码默认值（开箱即用），
+  可分别经 `QRAFT_TEST_CLIENT_SECRET` / `QRAFT_PROD_CLIENT_SECRET` 环境变量
+  覆盖；转正式接入前应移除默认值。生产环境 secret 也可在高级设置填写。
 - **授权窗口**：独立 `qraft-login` partition（无持久化），完成后清理，
   不残留平台登录态。
 
 ## 6. 给 Skill/Agent 提供 token（收敛通道设计）
 
 > 本节是 [#674](https://github.com/14790897/MiQi/issues/674) 凭据方案收敛目标的
-> 设计建议，供 Skill 侧 `auth.py` 实现时对齐。当前 #674 按「Skill 自管凭据」
-> 独立交付，两者并存是**有意为之的临时状态**。
+> 设计落地说明，供 Skill 侧 `auth.py` 实现时对齐。
 
-现状：access_token 只存在于主进程内存 + safeStorage 加密文件，agent（Python
-后端）拿不到。
+### 已实现：token 文件（方案 A）
 
-### 方案对比
+主进程在登录成功、自动/手动刷新成功后，将
+`{ "accessToken": "…", "expiresAt": <epoch 毫秒> }` 写入
+**`<workspace>/.qraft/token.json`**（0600 权限，仅含 access_token，不含
+refresh_token）；退出登录即删除；应用启动恢复登录态时同步重写。
 
-| 方案 | 改动面 | 安全性 | 结论 |
-| ---- | ------ | ------ | ---- |
-| A. token 文件：主进程在登录/刷新时同步写 `<workspace>/.qraft/token.json`（0600，含 access_token + expiresAt），登出删除；Skill 读取并检查剩余有效期 | 仅主进程 ~30 行 + Skill 读取逻辑，零核心协议改动 | 明文 2 小时 token；workspace 本就是 agent 任意执行代码的信任域，风险可接受 | **推荐** |
-| B. bridge 反向调用：Python 侧向主进程发请求获取 token | 需改 bridge 协议（当前只有主→Python 请求、Python→主事件，无反向 RPC），改动核心链路 | 最好（不落盘） | 长期目标，暂不做 |
+- 沙箱可达性：KUN 沙箱将自定义 workspace bind-mount 到
+  `/home/miqi/workspace`（bwrap.py），沙箱内 Skill 直接读
+  `/home/miqi/workspace/.qraft/token.json`；
+- 安全权衡：明文 2 小时 token + 0600 + 登出删除；workspace 本就是 agent
+  任意执行代码的信任域，风险可接受。方案 B（bridge 反向调用，不落盘）
+  需要改核心协议（当前只有主→Python 请求、Python→主事件，无反向 RPC），
+  作为长期目标暂不做。
 
-### A 的读取策略（auth.py）
+### auth.py 的读取策略（Skill 侧，待 #674 落地）
 
 1. 读取 token 文件 → 存在且 `expiresAt - now > 5min` → 直接使用；
 2. 已过期/不存在 → 若配置了凭据（env）→ 走自管登录兜底；
 3. 否则提示用户「请到 设置 → Qraft 平台 完成登录」，不阻断流程。
 
-沙箱可达性：KUN 沙箱将自定义 workspace bind-mount 到 `/home/miqi/workspace`
-（bwrap.py），token 文件放在 workspace 下即可被沙箱内 Skill 读取。
-
 ### 实施顺序
 
-1. Desktop 侧：#728 跟进 —— `QraftService` 在 persistLogin/doRefresh 时写
-   token 文件、logout 删除（建议放独立 PR）；
+1. ~~Desktop 侧：token 文件写入/删除~~（已实现，随 #728 叠放 PR 交付）；
 2. Skill 侧（#674 后续）：`auth.py` 优先读 token 文件，自管凭据降级为兜底；
 3. 稳定后删除 Skill 自管凭据，auth.py 收敛为纯「取 token + 过期检测」。
 
@@ -140,8 +140,9 @@ IPC 通道：`qraft:login` / `qraft:browserLogin` / `qraft:status` / `qraft:refr
 
 ## 8. 已知限制与后续计划
 
-- 生产环境 client_secret 默认空，需高级设置填写（有意为之：凭据不入库）；
-- token 获取通道（第 6 节方案 A）尚未实现，是 #674 收敛的前提；
-- 测试环境 client_secret 为硬编码默认值，转正式接入前移除（types.ts 已标注）；
+- token 文件通道（第 6 节方案 A）已实现；Skill 侧 `auth.py` 的读取与收敛
+  是 #674 的后续步骤；
+- 测试阶段 client_secret 为硬编码默认值（测试/生产环境），转正式接入前移除
+  （types.ts 已标注）；生产环境仍必须填写注册的 redirect_uri；
 - Qraft 授权页修复后，密码路径仍保留 doConfirm 流程（对已确认授权用户两者
   等价；对未确认用户 doConfirm 依然可用，多一条兜底路径）。


### PR DESCRIPTION
### **User description**
## 类型

<!-- 必选，勾一个 -->
- [x] ✨ 新功能

## 变更概述

Qraft 登录态 token 文件通道落地（供 Skill/agent 读取 access_token）+ 生产环境 client_secret 增加测试阶段默认值。

## 背景/问题

#726（PR #728）内置 Qraft OAuth2 登录后，access_token 只存在于主进程内存与 safeStorage 加密文件中，agent（Python 后端）无法获取。#674 方案上传 Skill 的凭据方案需要一条「从 MiQi 获取 access_token 的通道」作为后续收敛目标（详见 docs/frontend/qraft-oauth2-login.md 第 6 节）。同时用户要求生产环境 client_secret 在测试阶段同样开箱即用。

## 关联 issue

<!-- 可选。本 PR 解决的 issue。写 `Closes #xxx` / `Fixes #xxx` / `Resolves #xxx` 会在 PR 合入 develop 后自动关闭对应 issue；裸 `#xxx` 只生成链接、不会自动关闭。无关联 issue 可整节删除 -->
- #726 的跟进（token 通道是 #674 凭据方案收敛的前提）

## 变更内容

- `apps/desktop/src/main/qraft/service.ts`：QraftServiceOptions 新增 `tokenFilePath` 注入；登录/刷新成功后写 `<workspace>/.qraft/token.json`（0600，仅含 accessToken + expiresAt，不含 refresh_token），退出登录删除，应用启动恢复登录态时同步重写
- `apps/desktop/src/main/qraft/ipc.ts`：按 config 解析 workspace 作为 token 文件位置（workspace 在 KUN 沙箱中 bind-mount 到 /home/miqi/workspace，沙箱内 Skill 可直接读取）；`apps/desktop/src/main/ipc/index.ts` 导出 getWorkspacePath 供复用
- `apps/desktop/src/main/qraft/types.ts`：生产环境 client_secret 硬编码默认值（测试阶段开箱即用），`QRAFT_PROD_CLIENT_SECRET` 环境变量可覆盖；生产环境仍强制注册 redirect_uri（validateConfig 不变）
- `apps/desktop/src/renderer/features/settings/components/QraftPage.tsx`：client_secret 输入框占位文案更新（留空用默认值）
- `docs/frontend/qraft-oauth2-login.md`：第 6 节 token 通道由设计建议改为已实现落地说明（文件格式/沙箱可达性/auth.py 读取策略/实施顺序）
- 测试：token 文件生命周期单测 4 例（登录写入/自动刷新更新/登出删除/tokenFilePath 为 null 时静默跳过）+ 生产 secret 默认值与覆盖单测；离线 Electron E2E 增加 token 文件存在性、不含 refresh_token、登出删除断言

## 日志/验证证据

```
$ npx vitest run
Test Files  18 passed | 1 skipped (19)
     Tests  256 passed | 2 skipped (258)

$ npm run typecheck && npm run build
（通过）

$ PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test tests/e2e/qraft-login.spec.ts --project=electron
3 passed（含 token 文件存在性/登出删除断言）
```

## 测试情况

- 全量单测 256 例通过（新增 token 文件通道 4 例、生产 secret 2 例）
- typecheck（node/web）+ electron-vite build 通过
- 离线 Electron E2E 3 例通过：预置登录态启动后 token 文件出现在临时 workspace/.qraft/token.json（含 e2e accessToken、无 refresh_token），退出登录后文件删除
- 真实环境浏览器登录 E2E 与本 PR 无关，未重跑

## 截图

无需截图（无 UI 视觉变更，仅占位文案微调）

## 后续计划

- #674 的 auth.py 按文档第 6 节读取策略落地：优先读 token 文件，自管凭据降级为兜底，稳定后收敛为纯「取 token + 过期检测」
- #749：token 文件「宿主目录存储 + 沙箱只读挂载」隔离加固（CodeRabbit 评审提出的完整隔离方案，本 PR 维持 workspace 内 lstat 防护 + 登出代际校验）
- 转正式环境接入前移除测试/生产 client_secret 硬编码默认值（types.ts 已标注）

> ⚠️ 叠放 PR：base 为 `claude/elastic-dewdney-fbf858`（PR #728 分支）。#728 合入 develop 后需把本 PR 的 base 改回 develop。


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add token file at `workspace/.qraft/token.json` for Skill/agent access

- Introduce production `client_secret` default with `QRAFT_PROD_CLIENT_SECRET` override

- Harden token writes via 0600, symlink checks, logout generation guard

- Expand unit and E2E tests for token lifecycle and agent read path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Qraft IPC"] --> B["QraftService with tokenFilePath"]
  B --> C["syncTokenFile"]
  C --> D["workspace/.qraft/token.json"]
  B --> E["deleteTokenFile on logout"]
  B --> F["prod client_secret default"]
  G["Unit/E2E tests"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Export workspace path resolver for Qraft token file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ipc.ts</strong><dd><code>Inject workspace token file path into QraftService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-5507eb6c5c1ad3762cc5913543210b872adf029f2f98ebddeb72ce3dd0088f59">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QraftPage.tsx</strong><dd><code>Update client_secret placeholder for default value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-df6f3faee730d7190408e2a46578ea94c0215bdfb3aba09fe2c42093bc920f74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>service.ts</strong><dd><code>Persist tokens to file with logout and symlink protections</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-373c7a2a36fd357a77dca028fd31fd1bdc60e42c59c45e23392e6626d0a00674">+90/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Add production client_secret default and override helper</code>&nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-6741723697a09c9160fa8c299e9820f8959134f7241e6ffed2ccd1415e67e308">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>service.test.ts</strong><dd><code>Test token file lifecycle and edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-08d39ead05325dcd6b17e8eea84d5f3b6d5244ac753a576781b483cca2f8e480">+157/-13</a></td>

</tr>

<tr>
  <td><strong>qraft-login.spec.ts</strong><dd><code>Verify token file and agent read path in E2E</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-e6ac530d70356248cb5651eacf1ff07343e34779957831810597e4f8b5e7a18f">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>qraft-oauth2-login.md</strong><dd><code>Document token file channel implementation and production secret</code></dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/747/files#diff-4d367dba09018850dc76766d9ac85eab14ab49ebcfa885f64a001bd6cb2abd2e">+24/-23</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

