### PR TITLE
fix(agent): exec 工具说明沙箱/文件工具双目录关系（#221 提示侧补全）

### DIFF
--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -82,7 +82,15 @@ class ExecTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Execute a shell command and return its output. Use with caution."
+        return (
+            "Execute a shell command in the WSL sandbox and return its output. "
+            "Use with caution. 沙箱工作目录说明：exec 在沙箱中运行，"
+            "`/home/miqi/workspace` 与文件工具（read_file/write_file/list_dir）的工作目录"
+            "在【默认工作区】下是两个不同目录（沙箱内为独立目录，看不到文件工具写入的文件）；"
+            "在【自定义工作区】下是同一目录（bind-mount）。"
+            "要在 exec 中访问文件工具写入的文件，请用主机路径（如 /mnt/c/...），"
+            "或改用文件工具。"
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -493,7 +493,8 @@ class AgentControl:
             _session_context = (
                 f"\n\n## 工作目录\n"
                 f"你当前的工作目录是: {self.workspace}\n"
-                f"所有文件操作（read_file / write_file / list_dir / exec）都在这个目录下进行。\n"
+                f"文件工具（read_file / write_file / list_dir）在这个目录下进行。\n"
+                f"注意：exec 在沙箱中运行——默认工作区下沙箱 /home/miqi/workspace 与文件工具目录不同（沙箱为独立目录），自定义工作区下二者相同；exec 中访问文件请用主机路径（/mnt/c/...）。\n"
                 f"当用户问你工作目录时，请直接回答 {self.workspace}，不要说 /home/miqi/workspace。\n"
                 f"MIQI_SESSION_KEY={self.session_id}"
             )

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -599,7 +599,8 @@ class TaskRunner:
                 effective_system_prompt
                 + f"\n\n## 工作目录\n"
                 f"你当前的工作目录是: {_ws}\n"
-                f"所有文件操作（read_file / write_file / list_dir / exec）都在这个目录下进行。\n"
+                f"文件工具（read_file / write_file / list_dir）在这个目录下进行。\n"
+                f"注意：exec 在沙箱中运行——默认工作区下沙箱 /home/miqi/workspace 与文件工具目录不同（沙箱为独立目录），自定义工作区下二者相同；exec 中访问文件请用主机路径（/mnt/c/...）。\n"
                 f"当用户问你工作目录时，请直接回答 {_ws}，不要说 /home/miqi/workspace。\n"
             )
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

exec 工具描述与工作区提示词明确说明"沙箱 /home/miqi/workspace 与文件工具工作目录"的关系，消除 agent 在默认工作区下的路径困惑。

## 背景/问题

应用内真实 LLM 运行实测：agent 反复困惑于 exec 沙箱的 `/home/miqi/workspace` 与文件工具（read_file/write_file/list_dir）工作目录不一致——默认工作区下二者是两个不同目录（沙箱为 per-sandbox 独立目录，bwrap.py 的 Issue #221 隔离设计），自定义工作区下才是同一目录（bind-mount），但工具描述与提示词从未说明这一点，导致每轮会话 agent 都要靠试探重新摸清。

## 关联 issue

- #221（隔离设计的提示侧补全）

## 变更内容

- `miqi/agent/tools/shell.py`：ExecTool.description 补充——默认工作区下沙箱目录与文件工具目录不同、自定义工作区下相同（bind-mount）、exec 中访问文件请用主机路径（/mnt/c/...）或改用文件工具
- `miqi/runtime/agent_control.py` / `miqi/runtime/task_runner.py`：会话上下文提示词修正「所有文件操作（含 exec）都在这个目录下进行」的误导表述，区分文件工具与 exec 的目录关系

## 日志/验证证据

```
$ uv run pytest tests/kun_runtime tests/agent -q
424 passed

$ uv run python -c "import ast; ..."
syntax ok
```

## 测试情况

- tests/kun_runtime + tests/agent 全量 424 例通过（无工具描述快照锁定）
- 三个文件语法校验通过

## 截图

无需截图（提示词/工具描述文案变更，无 UI 变更）

## 后续计划

- 若默认工作区也想让 exec 与文件工具同目录，需权衡 #221 隔离设计，另议
- 相关：#749（token 文件沙箱只读挂载，与该双目录问题同源）


___

### **PR Type**
Bug fix


___

### **Description**
- Update `ExecTool.description` in `miqi/agent/tools/shell.py` to clarify exec sandbox `/home/miqi/workspace` differs from file tool working directory under default workspace and matches under custom workspace bind-mount.

- Revise session context prompts in `miqi/runtime/agent_control.py` and `miqi/runtime/task_runner.py` to remove the inaccurate claim that all file operations occur in one directory and add exec host-path guidance `/mnt/c/...`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["shell.py ExecTool.description"] -- "clarifies sandbox vs file tool dirs" --> B["agent workspace prompts"]
    C["agent_control.py session context"] -- "removes misleading all-ops-same-dir" --> B
    D["task_runner.py effective prompt"] -- "mirrors exec sandbox distinction" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell.py</strong><dd><code>Clarify exec tool sandbox and file tool directory relationship</code></dd></summary>
<hr>

miqi/agent/tools/shell.py

<ul><li>Extend <code>ExecTool.description</code> from single sentence to include WSL <br>sandbox context.<br> <li> Explain default workspace has separate sandbox <code>/home/miqi/workspace</code> vs <br>file tool directory.<br> <li> Explain custom workspace uses bind-mount making directories same.<br> <li> Advise using host path <code>/mnt/c/...</code> or file tools when accessing files <br>from exec.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/755/files#diff-3cc5757485ddb3df794186684ead9e7294ad0648552d9d298091abdafc38ca92">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_control.py</strong><dd><code>Correct main agent session workspace prompt for exec sandbox</code></dd></summary>
<hr>

miqi/runtime/agent_control.py

<ul><li>Replace prompt line claiming all file operations including exec occur <br>in workspace.<br> <li> Add statement that file tools run in workspace and exec runs in <br>sandbox with different default directory.<br> <li> Include host path guidance <code>/mnt/c/...</code> and retain workspace answer <br>instruction.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/755/files#diff-865b6d18de4fe68ca3d7689effb0cdcfb6f504f8c47f3ff201ffde3e8de97c61">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_runner.py</strong><dd><code>Align task runner prompt with exec sandbox directory distinction</code></dd></summary>
<hr>

miqi/runtime/task_runner.py

<ul><li>Mirror agent_control prompt fix in task runner effective system <br>prompt.<br> <li> Remove misleading all-operations-in-one-directory claim.<br> <li> Add exec sandbox distinction and host path guidance.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/755/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

