### PR TITLE
feat(skills): auth.py 恢复 client_secret 硬编码默认值（测试阶段开箱即用）

### DIFF
--- a/miqi/skills/qraft-workflowspec-export/SKILL.md
+++ b/miqi/skills/qraft-workflowspec-export/SKILL.md
@@ -265,7 +265,7 @@ python <skill_dir>/scripts/upload_run.py <workflowspec.run.YYYYMMDD.json> --json
 ## 凭据管理约定（#674 功能描述 3）
 
 - **主路径**：读取 MiQi Desktop 登录态生成的 token 文件 `<workspace>/.qraft/token.json`（沙箱内 `/home/miqi/workspace/.qraft/token.json`），存在且未临期（`expiresAt - now > 5min`）直接使用——用户在 设置 → Qraft 平台 登录后无需任何额外配置；
-- **兜底**：环境变量 `QRAFT_ACCESS_TOKEN`（直接可用）；`QRAFT_PHONE` + `QRAFT_PASSWORD` + `QRAFT_CLIENT_SECRET`（走自管 RSA 登录，测试阶段；client_secret 必须显式配置，脚本内不硬编码）；
+- **兜底**：环境变量 `QRAFT_ACCESS_TOKEN`（直接可用）；`QRAFT_PHONE` + `QRAFT_PASSWORD`（走自管 RSA 登录，测试阶段；client_secret 有硬编码默认值，可用 `QRAFT_CLIENT_SECRET` 覆盖，转正式接入前移除默认值）；
 - **安全**：SKILL.md 与脚本不硬编码任何真实凭据；token/密码/手机号在界面与日志中一律脱敏；
 - 读取策略与安全权衡详见 `docs/frontend/qraft-oauth2-login.md` 第 6 节。
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/auth.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/auth.py
@@ -266,13 +266,9 @@ def _try_json(resp: httpx.Response) -> dict[str, Any]:
 def exchange_token(
     client: httpx.Client, base_url: str, code: str, redirect_uri: str
 ) -> dict[str, Any]:
-    # client_secret 不落仓库/技能包：要求显式配置，缺失即分类报错（#674 脱敏要求）。
-    client_secret = os.environ.get("QRAFT_CLIENT_SECRET", "").strip()
-    if not client_secret:
-        raise AuthError(
-            "CLIENT_SECRET_MISSING",
-            "缺少 QRAFT_CLIENT_SECRET 环境变量，无法换取 token（凭据不硬编码在脚本内）",
-        )
+    # 测试阶段开箱即用：硬编码默认值，QRAFT_CLIENT_SECRET 环境变量可覆盖
+    #（转正式环境接入前移除默认值，改回显式要求）。
+    client_secret = os.environ.get("QRAFT_CLIENT_SECRET", "miqi123456").strip()
     resp = retry_http(
         lambda: client.post(
             f"{base_url}/oauth2/token",

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -327,13 +327,52 @@ class TestUploadFile:
 
 
 class TestClientSecretAndRetryExhaustion:
-    def test_exchange_token_requires_env_secret(self, monkeypatch):
+    def test_exchange_token_uses_hardcoded_default_secret(self, monkeypatch):
         monkeypatch.delenv("QRAFT_CLIENT_SECRET", raising=False)
-        client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(500)))
-        with pytest.raises(auth.AuthError) as exc_info:
-            auth.exchange_token(client, "https://test.forge.miqroera.com/api", "code-1", "http://localhost:1/cb")
-        assert exc_info.value.code == "CLIENT_SECRET_MISSING"
-        assert "QRAFT_CLIENT_SECRET" in exc_info.value.message
+        seen: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            form = dict(kv.split("=", 1) for kv in request.content.decode("utf-8").split("&"))
+            seen.append(form)
+            return httpx.Response(200, json={"code": 200, "access_token": "T-1", "expires_in": "7199"})
+
+        orig_client = httpx.Client
+
+        def fake_client(**kwargs):
+            return orig_client(transport=httpx.MockTransport(handler))
+
+        monkeypatch.setattr(auth.httpx, "Client", fake_client)
+        data = auth.exchange_token(
+            fake_client(),
+            "https://test.forge.miqroera.com/api",
+            "code-1",
+            "http://localhost:1/cb",
+        )
+        assert data["accessToken"] == "T-1"
+        assert seen[0]["client_secret"] == "miqi123456"
+
+    def test_exchange_token_env_secret_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("QRAFT_CLIENT_SECRET", "env-secret")
+        seen: list[dict] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            form = dict(kv.split("=", 1) for kv in request.content.decode("utf-8").split("&"))
+            seen.append(form)
+            return httpx.Response(200, json={"code": 200, "access_token": "T-2", "expires_in": "7199"})
+
+        orig_client = httpx.Client
+
+        def fake_client(**kwargs):
+            return orig_client(transport=httpx.MockTransport(handler))
+
+        monkeypatch.setattr(auth.httpx, "Client", fake_client)
+        auth.exchange_token(
+            fake_client(),
+            "https://test.forge.miqroera.com/api",
+            "code-2",
+            "http://localhost:1/cb",
+        )
+        assert seen[0]["client_secret"] == "env-secret"
 
     def test_auth_retry_exhausted_raises_classified_error(self, monkeypatch):
         def boom():


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

Skill 脚本 auth.py 恢复 client_secret 硬编码默认值（测试阶段开箱即用，QRAFT_CLIENT_SECRET 环境变量可覆盖）。

## 背景/问题

CodeRabbit 评审曾要求移除 auth.py 硬编码的 client_secret（凭据不入库），改为显式要求 QRAFT_CLIENT_SECRET 环境变量。但用户实际使用时会直接报「client_secret 未配置」，测试阶段体验差。按维护者决策：测试阶段默认要配置——恢复硬编码默认值。

## 关联 issue

- #674

## 变更内容

- `miqi/skills/qraft-workflowspec-export/scripts/auth.py`：exchange_token 的 client_secret 恢复硬编码默认值 `miqi123456`，`QRAFT_CLIENT_SECRET` 可覆盖；注释标注「转正式环境接入前移除默认值」
- `SKILL.md`：兜底凭据说明同步（client_secret 有默认值，可覆盖）
- `tests/skills/test_qraft_workflowspec.py`：CLIENT_SECRET_MISSING 用例替换为「默认值生效」+「环境变量覆盖」两例

## 日志/验证证据

```
$ uv run pytest tests/skills/test_qraft_workflowspec.py -q
26 passed
```

## 测试情况

- 技能脚本 26 例单测全过（含新增默认值/覆盖两例）

## 截图

无需截图（脚本逻辑变更，无 UI 变更）

## 后续计划

- 转正式环境接入前移除默认值（代码注释已标注）


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restore hardcoded `QRAFT_CLIENT_SECRET` default `miqi123456` in `exchange_token`

- Allow `QRAFT_CLIENT_SECRET` environment variable to override default

- Update tests to verify default and override behavior

- Sync `SKILL.md` credential fallback documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["exchange_token in auth.py"] -- "default secret miqi123456" --> B["OAuth2 token request"]
  C["QRAFT_CLIENT_SECRET env"] -- "overrides" --> A
  A -- "tests" --> D["test_qraft_workflowspec.py"]
  A -- "docs" --> E["SKILL.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.py</strong><dd><code>Restore hardcoded client_secret default in token exchange</code></dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/scripts/auth.py

<ul><li>Replace explicit missing secret error with hardcoded default <br><code>miqi123456</code><br> <li> Allow <code>QRAFT_CLIENT_SECRET</code> environment variable to override default<br> <li> Add comment noting removal before production</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/757/files#diff-8a15eaa3f71e1292e5c92384bac39dc37acf1da4687ea0f11fb42bc833dcdb0a">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_qraft_workflowspec.py</strong><dd><code>Update auth tests for client_secret default behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/skills/test_qraft_workflowspec.py

<ul><li>Replace missing-secret test with default-secret <code>miqi123456</code> test<br> <li> Add test that env var <code>env-secret</code> overrides default<br> <li> Verify request <code>client_secret</code> field in both cases</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/757/files#diff-44571c2184c6b0130a783a664eb2cb0daac248f69e7f6c5e7f55c1b7b120ac73">+45/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Sync SKILL.md fallback credential guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/SKILL.md

<ul><li>Update fallback credential documentation to mention hardcoded default<br> <li> Note <code>QRAFT_CLIENT_SECRET</code> can override<br> <li> Note default removal before production</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/757/files#diff-2267cbc4803f47e8e4ea2e6acb2d7b9bb4ee4f1a528d7799246a5db5c707cdb5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

