### PR TITLE
fix(desktop): Qraft token 通道重新合入 develop + auth.py 默认 home 候选路径

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -132,7 +132,7 @@ function resolveWorkspacePath(raw: string): string {
   return resolved;
 }
 
-function getWorkspacePath(): string {
+export function getWorkspacePath(): string {
   const config = readLocalConfig();
   const agents = (config['agents'] as Record<string, unknown> | undefined) ?? {};
   const defaults = (agents['defaults'] as Record<string, unknown> | undefined) ?? {};

--- a/apps/desktop/src/main/qraft/ipc.ts
+++ b/apps/desktop/src/main/qraft/ipc.ts
@@ -8,6 +8,7 @@
 
 import { electron } from '../../shared/electron';
 import { join } from 'path';
+import { getWorkspacePath } from '../ipc';
 import {
   IPC,
   IPC_EVENTS,
@@ -55,6 +56,15 @@ function getService(): QraftService {
     onStatusChanged: (status: QraftStatus) => {
       for (const win of BrowserWindow.getAllWindows()) {
         if (!win.isDestroyed()) win.webContents.send(IPC_EVENTS.QRAFT_STATUS_CHANGED, status);
+      }
+    },
+    // Skill/agent 读取 access_token 的通道：workspace 在沙箱中 bind-mount，
+    // 文件放 workspace 下即可被沙箱内 Skill 读取（见 docs qraft-oauth2-login.md 第 6 节）。
+    tokenFilePath: () => {
+      try {
+        return join(getWorkspacePath(), '.qraft', 'token.json');
+      } catch {
+        return null;
       }
     },
   });

--- a/apps/desktop/src/main/qraft/service.test.ts
+++ b/apps/desktop/src/main/qraft/service.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { QraftService, resolveConfig, defaultRedirectUri } from './service';
@@ -75,6 +83,7 @@ function makeService(clientStub: ClientStub): QraftService {
     store,
     log: noopLog,
     makeRedirectUri: () => 'http://localhost:38000/callback',
+    tokenFilePath: () => join(dir, 'qraft-token.json'),
     onStatusChanged: (status) => statusEvents.push(status),
   });
 }
@@ -95,11 +104,21 @@ describe('resolveConfig', () => {
     expect(config.clientSecret).toBe('miqi123456');
   });
 
-  it('生产环境默认 client_secret 为空、不自动生成 redirect_uri（需注册值）', () => {
+  it('生产环境默认 client_secret 使用硬编码默认值（测试阶段开箱即用）、不自动生成 redirect_uri', () => {
     const config = resolveConfig({ env: 'prod' }, null, () => 'http://localhost:1/callback');
     expect(config.baseUrl).toBe('https://forge.miqroera.com/api');
-    expect(config.clientSecret).toBe('');
+    expect(config.clientSecret).toBe('miqi123456');
     expect(config.redirectUri).toBe('');
+  });
+
+  it('QRAFT_PROD_CLIENT_SECRET 环境变量可覆盖生产默认值', () => {
+    process.env.QRAFT_PROD_CLIENT_SECRET = 'prod-override';
+    try {
+      const config = resolveConfig({ env: 'prod' }, null, () => 'http://localhost:1/callback');
+      expect(config.clientSecret).toBe('prod-override');
+    } finally {
+      delete process.env.QRAFT_PROD_CLIENT_SECRET;
+    }
   });
 
   it('用户覆盖优先于环境默认与上次存储', () => {
@@ -129,7 +148,7 @@ describe('resolveConfig', () => {
     });
     const config = resolveConfig({ env: 'prod' }, stored, () => 'http://localhost:9/callback');
     expect(config.baseUrl).toBe('https://forge.miqroera.com/api');
-    expect(config.clientSecret).toBe('');
+    expect(config.clientSecret).toBe('miqi123456'); // 生产默认值，非测试环境存储值
     expect(config.redirectUri).toBe('');
   });
 });
@@ -191,15 +210,6 @@ describe('QraftService.login', () => {
     const result = await service.login('18500000000', 'p');
     expect(result.ok).toBe(true);
     expect(result.account?.nickname).toBe('登录昵称');
-  });
-
-  it('client_secret 缺失（生产默认）报 INVALID_CONFIG，不发任何请求', async () => {
-    const stub = makeClientStub();
-    const service = makeService(stub);
-    const result = await service.login('18500000000', 'p', { env: 'prod' });
-    expect(result.ok).toBe(false);
-    expect(result.code).toBe('INVALID_CONFIG');
-    expect(stub.platformLogin).not.toHaveBeenCalled();
   });
 
   it('生产环境未填注册 redirect_uri 报 INVALID_CONFIG（不自动生成 loopback）', async () => {
@@ -389,5 +399,139 @@ describe('QraftService 手动刷新与退出', () => {
     expect(service.status().loggedIn).toBe(false);
     expect(store.current).toBeNull();
     expect(statusEvents.some((s) => (s as { loggedIn: boolean }).loggedIn === false)).toBe(true);
+  });
+});
+
+describe('QraftService token 文件通道（供 Skill/agent 读取 access_token）', () => {
+  const tokenPath = () => join(dir, 'qraft-token.json');
+
+  it('登录成功后写入 token 文件（仅 accessToken + expiresAt，无 refreshToken）', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = makeService(stub);
+
+    await service.login('18500000000', 'p');
+    expect(existsSync(tokenPath())).toBe(true);
+    const content = JSON.parse(readFileSync(tokenPath(), 'utf8'));
+    expect(content.accessToken).toBe('ACCESS-TOKEN');
+    expect(content.expiresAt).toBeGreaterThan(Date.now());
+    expect(content).not.toHaveProperty('refreshToken');
+  });
+
+  it('自动刷新成功后更新 token 文件中的 accessToken', async () => {
+    vi.useFakeTimers();
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '1', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '1', username: 'u', nickname: 'n' });
+    stub.refreshTokens.mockImplementation(async () =>
+      makeTokens({ accessToken: 'ACCESS-NEW', expiresAt: Date.now() + 7_199_000 })
+    );
+    const service = makeService(stub);
+    await service.login('18500000000', 'p');
+
+    await vi.advanceTimersByTimeAsync(7_199_000 - 15 * 60_000 + 100);
+    const content = JSON.parse(readFileSync(tokenPath(), 'utf8'));
+    expect(content.accessToken).toBe('ACCESS-NEW');
+  });
+
+  it('退出登录删除 token 文件', async () => {
+    const stub = makeClientStub();
+    store.save(makeStoredState());
+    const service = makeService(stub);
+    expect(existsSync(tokenPath())).toBe(true); // 构造时从磁盘恢复并同步
+
+    service.logout();
+    expect(existsSync(tokenPath())).toBe(false);
+  });
+
+  it('tokenFilePath 返回 null 时静默跳过（workspace 不可解析不报错）', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => null,
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    service.logout();
+  });
+});
+
+describe('QraftService 登出竞态与 token 文件防护', () => {
+  it('在途刷新完成于退出登录之后：丢弃结果，不写回 store 与 token 文件', async () => {
+    let resolveRefresh!: (t: QraftTokens) => void;
+    const refreshPromise = new Promise<QraftTokens>((r) => {
+      resolveRefresh = r;
+    });
+    const stub = makeClientStub();
+    stub.refreshTokens.mockReturnValue(refreshPromise);
+    store.save(makeStoredState());
+    const service = makeService(stub);
+    const tokenPath = join(dir, 'qraft-token.json');
+    expect(existsSync(tokenPath)).toBe(true); // 启动恢复时已同步
+
+    const pendingRefresh = service.refreshNow();
+    service.logout();
+    expect(existsSync(tokenPath)).toBe(false);
+
+    // 刷新在登出后才完成 —— 结果必须被代际校验丢弃
+    resolveRefresh(makeTokens({ accessToken: 'LATE-RESULT' }));
+    await pendingRefresh;
+    expect(store.current).toBeNull();
+    expect(existsSync(tokenPath)).toBe(false);
+    expect(service.status().loggedIn).toBe(false);
+  });
+
+  it('.qraft 路径被普通文件占用时跳过写入且不崩溃', async () => {
+    const blockedDir = join(dir, 'blocked-dir');
+    writeFileSync(blockedDir, 'not-a-dir', 'utf8');
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => join(blockedDir, 'token.json'),
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true); // 登录不受 token 文件失败影响
+    expect(store.current?.tokens.accessToken).toBe('ACCESS-TOKEN');
+  });
+
+  it.skipIf(process.platform === 'win32')('.qraft 为符号链接时拒绝写入目标位置', async () => {
+    const targetDir = join(dir, 'target-dir');
+    mkdirSync(targetDir, { recursive: true });
+    const linkDir = join(dir, 'qraft-link');
+    symlinkSync(targetDir, linkDir, 'dir');
+
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => join(linkDir, 'token.json'),
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    // 凭据绝不能写到 symlink 指向的目标目录
+    expect(existsSync(join(targetDir, 'token.json'))).toBe(false);
   });
 });

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -8,12 +8,15 @@
  * 由设置页引导用户重新登录。
  */
 
+import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
 import { CookieJar } from './cookie-jar';
 import { QraftClient, QraftError, type QraftLogger, type ResolvedQraftConfig } from './client';
 import { maskSecret } from './rsa';
 import { QraftStore } from './store';
 import {
   QRAFT_ENV_DEFAULTS,
+  prodEnvClientSecret,
   testEnvClientSecret,
   type QraftAccount,
   type QraftEnv,
@@ -38,6 +41,12 @@ export interface QraftServiceOptions {
   onStatusChanged?: (status: QraftStatus) => void;
   /** 生成 loopback 回调地址（随机端口），测试可注入固定值。 */
   makeRedirectUri?: () => string;
+  /**
+   * 供 Skill/agent 读取 access_token 的 token 文件路径解析器。
+   * 登录/刷新成功后写入 { accessToken, expiresAt }（0600），退出登录删除；
+   * 返回 null 表示不启用 token 文件（如 workspace 不可解析时）。
+   */
+  tokenFilePath?: () => string | null;
 }
 
 export function defaultRedirectUri(): string {
@@ -66,7 +75,7 @@ export function resolveConfig(
     clientSecret:
       opts.clientSecret ??
       storedMatches?.clientSecret ??
-      (env === 'test' ? testEnvClientSecret() : ''),
+      (env === 'test' ? testEnvClientSecret() : prodEnvClientSecret()),
     redirectUri:
       opts.redirectUri ??
       storedMatches?.redirectUri ??
@@ -106,13 +115,18 @@ export class QraftService {
   private refreshScheduledAt: number | null = null;
   private refreshError: QraftErrorCode | null = null;
   private requiresRelogin = false;
+  /** 登录代际：退出登录时递增，用于丢弃登出前发起的在途刷新结果，
+   *  防止"刷新完成于登出之后"把凭据写回磁盘/内存。 */
+  private authGeneration = 0;
 
   constructor(private readonly options: QraftServiceOptions) {
-    // 应用启动时恢复登录态并重建刷新调度。
+    // 应用启动时恢复登录态、重建刷新调度，并同步 token 文件
+    //（应用重启后文件可能已过期/被清理，按当前存储重写）。
     const stored = this.options.store.load();
     if (stored) {
       this.restoreJar(stored);
       this.scheduleRefresh(stored);
+      this.syncTokenFile(stored);
     }
   }
 
@@ -255,6 +269,7 @@ export class QraftService {
     this.refreshError = null;
     this.requiresRelogin = false;
     this.scheduleRefresh(state);
+    this.syncTokenFile(state);
     this.emitStatus();
   }
 
@@ -265,6 +280,60 @@ export class QraftService {
       code: 'INTERNAL',
       message: err instanceof Error ? err.message : String(err),
     };
+  }
+
+  // ── token 文件（供 Skill/agent 读取 access_token） ─────────────────────
+
+  /** 登录/刷新成功后写入 token 文件：仅含 accessToken + expiresAt（0600）。
+   *  防符号链接重定向：.qraft 目录必须是真实目录、token 文件必须是真实
+   *  常规文件，否则跳过写入并告警（workspace 对 agent 可写，恶意/意外
+   *  替换成 symlink 时不能把凭据写到重定向目标）。 */
+  private syncTokenFile(state: QraftStoredState): void {
+    const filePath = this.options.tokenFilePath?.();
+    if (!filePath) return;
+    try {
+      const dir = dirname(filePath);
+      mkdirSync(dir, { recursive: true });
+      const dirStat = lstatSync(dir);
+      if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+        throw new Error('.qraft 不是真实目录（可能被符号链接替换），跳过写入');
+      }
+      // mkdir 后目录若被替换为 symlink，lstat 会拿到链接本身 → 上面已拦截。
+      if (existsSync(filePath)) {
+        const fileStat = lstatSync(filePath);
+        if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+          throw new Error('token 文件路径被非常规文件/symlink 占用，跳过写入');
+        }
+      }
+      writeFileSync(
+        filePath,
+        JSON.stringify({
+          accessToken: state.tokens.accessToken,
+          expiresAt: state.tokens.expiresAt,
+        }),
+        { encoding: 'utf8', mode: 0o600 }
+      );
+      chmodSync(filePath, 0o600);
+    } catch (err) {
+      this.options.log(
+        'WARN',
+        `qraft: 同步 token 文件失败（${err instanceof Error ? err.message : err}）`
+      );
+    }
+  }
+
+  /** 退出登录时删除 token 文件，避免过期凭据残留。 */
+  private deleteTokenFile(): void {
+    const filePath = this.options.tokenFilePath?.();
+    if (!filePath) return;
+    try {
+      rmSync(filePath, { force: true });
+    } catch (err) {
+      this.options.log(
+        'WARN',
+        `qraft: 删除 token 文件失败（${err instanceof Error ? err.message : err}）`
+      );
+    }
   }
 
   status(): QraftStatus {
@@ -288,8 +357,12 @@ export class QraftService {
 
   logout(): void {
     this.cancelRefresh();
+    // 使登出前发起的在途刷新结果作废（runRefresh 代际校验丢弃）。
+    this.authGeneration += 1;
+    this.inFlightRefresh = null;
     this.jar.clear();
     this.options.store.clear();
+    this.deleteTokenFile();
     this.refreshError = null;
     this.requiresRelogin = false;
     this.options.log('INFO', 'qraft: 已退出登录（cookie 与 token 均已清除）');
@@ -354,12 +427,15 @@ export class QraftService {
   }
 
   private async tickRefresh(state: QraftStoredState): Promise<void> {
+    // 已退出登录（store 已清）时丢弃过期定时任务，不重试也不写回任何状态。
+    if (!this.options.store.current) return;
     try {
       await this.doRefresh(state);
       this.refreshError = null;
       this.requiresRelogin = false;
       this.emitStatus();
     } catch (err) {
+      if (!this.options.store.current) return; // 失败发生在登出前后：同样丢弃
       const code = err instanceof QraftError ? err.code : 'REFRESH_FAILED';
       this.options.log('ERROR', `qraft: 自动刷新失败（${code}），30 分钟后重试`);
       this.refreshError = code;
@@ -376,13 +452,16 @@ export class QraftService {
 
   private doRefresh(state: QraftStoredState): Promise<void> {
     if (this.inFlightRefresh) return this.inFlightRefresh;
-    this.inFlightRefresh = this.runRefresh(state).finally(() => {
-      this.inFlightRefresh = null;
+    const generation = this.authGeneration;
+    this.inFlightRefresh = this.runRefresh(state, generation).finally(() => {
+      // 只有代际未变（未退出登录）才清理；登出后新登录创建的刷新
+      // 不被旧请求的 finally 误清。
+      if (this.authGeneration === generation) this.inFlightRefresh = null;
     });
     return this.inFlightRefresh;
   }
 
-  private async runRefresh(state: QraftStoredState): Promise<void> {
+  private async runRefresh(state: QraftStoredState, generation: number): Promise<void> {
     const config: ResolvedQraftConfig = {
       baseUrl: state.baseUrl,
       clientId: state.clientId,
@@ -390,11 +469,17 @@ export class QraftService {
       redirectUri: state.redirectUri,
     };
     const tokens = await this.options.client.refreshTokens(config, state.tokens.refreshToken);
+    if (this.authGeneration !== generation) {
+      // 退出登录发生在刷新完成前：丢弃本次结果，不落盘、不写 token 文件。
+      this.options.log('WARN', 'qraft: 刷新完成前已退出登录，丢弃本次刷新结果');
+      return;
+    }
     // 实测 refresh_token 不轮换（返回同一个）；若服务端未来启用轮换，
     // 以响应中的新值为准，旧值在服务端已失效。
     const next: QraftStoredState = { ...state, tokens };
     this.options.store.save(next);
     this.scheduleRefresh(next);
+    this.syncTokenFile(next);
   }
 
   private emitStatus(): void {

--- a/apps/desktop/src/main/qraft/types.ts
+++ b/apps/desktop/src/main/qraft/types.ts
@@ -43,6 +43,15 @@ export function testEnvClientSecret(): string {
   return process.env.QRAFT_TEST_CLIENT_SECRET?.trim() || 'miqi123456';
 }
 
+/**
+ * 生产环境 client_secret。测试阶段同样提供硬编码默认值（开箱即用），
+ * 可经 QRAFT_PROD_CLIENT_SECRET 环境变量覆盖（转正式环境接入前应移除默认值）。
+ * 注意：生产环境仍必须填写在平台注册的 redirect_uri（见 service.validateConfig）。
+ */
+export function prodEnvClientSecret(): string {
+  return process.env.QRAFT_PROD_CLIENT_SECRET?.trim() || 'miqi123456';
+}
+
 /** 登录请求携带的可选覆盖项（设置页"高级设置"）。 */
 export interface QraftLoginOptions {
   env?: QraftEnv;

--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -393,7 +393,7 @@ export function QraftPage() {
                       type={showPassword ? 'text' : 'password'}
                       value={clientSecret}
                       onChange={(e) => setClientSecret(e.target.value)}
-                      placeholder="生产环境必填"
+                      placeholder="留空用默认值（测试阶段）"
                       className="font-mono text-xs"
                       data-testid="qraft-client-secret-input"
                     />

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -141,12 +141,37 @@ test.describe('Qraft 平台登录 E2E (issue #726)', () => {
     await expect(page.getByText('access_token 到期：')).toBeVisible();
     await expect(page.getByTestId('qraft-logout-btn')).toBeVisible();
 
+    // token 文件通道：登录态恢复时同步写入 workspace/.qraft/token.json
+    //（供 Skill/agent 读取，仅含 accessToken + expiresAt）
+    const tokenFile = join(fixture.miqiHome, 'workspace', '.qraft', 'token.json');
+    await expect
+      .poll(() => (existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8') : ''), {
+        timeout: 10_000,
+      })
+      .toContain('e2e-fake-access-token');
+    expect(JSON.parse(readFileSync(tokenFile, 'utf8'))).not.toHaveProperty('refreshToken');
+
+    // agent 视角：走 agent 文件工具同一条链路（files.read，workspace 相对路径）
+    // 读取 token 文件 —— 验证 MiQi agent（Python 后端）确实拿得到 access_token。
+    const agentRead = await page.evaluate(async () => {
+      try {
+        const r: { path?: string; content?: string; size?: number } =
+          await (window as any).miqi.files.read('.qraft/token.json');
+        return { ok: true, content: r?.content ?? '', size: r?.size ?? 0 };
+      } catch (e) {
+        return { ok: false, error: String(e) };
+      }
+    });
+    expect(agentRead.ok, `agent 读取 token 文件失败：${JSON.stringify(agentRead)}`).toBe(true);
+    expect(agentRead.content).toContain('e2e-fake-access-token');
+    expect(agentRead.content).toContain('expiresAt');
+
     await page.screenshot({
       path: 'test-results/qraft-e2e-logged-in.png',
       fullPage: true,
     });
 
-    // 退出登录：界面回到登录表单，磁盘文件被清空（凭据不残留）。
+    // 退出登录：界面回到登录表单，磁盘凭据清空（store 文件与 token 文件）
     // IPC 返回与磁盘写入存在竞态，轮询文件直到为空。
     await page.getByTestId('qraft-logout-btn').click();
     await expect(page.getByTestId('qraft-phone-input')).toBeVisible({ timeout: 15_000 });
@@ -156,5 +181,6 @@ test.describe('Qraft 平台登录 E2E (issue #726)', () => {
         timeout: 10_000,
       })
       .toBe('');
+    await expect.poll(() => existsSync(tokenFile), { timeout: 10_000 }).toBe(false);
   });
 });

--- a/docs/frontend/qraft-oauth2-login.md
+++ b/docs/frontend/qraft-oauth2-login.md
@@ -1,0 +1,148 @@
+# Qraft 平台 OAuth2 登录（内置）
+
+> 对应 Issue：[#726](https://github.com/14790897/MiQi/issues/726)（PR #728）
+> 实测依据：《Qraft OAuth2 接入实测文档》（2026-08-13 对 `https://test.forge.miqroera.com` 实测）
+
+MiQi Desktop 内置 Qraft 平台 OAuth2 登录：设置页完成登录后，MiQi 持有用户身份的
+access_token（安全存储 + 到期自动刷新），供后续以用户身份调用 Qraft 业务接口
+（如 #674 方案上传的 `dataUpload`）。
+
+## 1. 使用方式
+
+设置 → **Qraft 平台**：
+
+| 路径 | 操作 | 适用场景 |
+| ---- | ---- | -------- |
+| 浏览器登录（推荐） | 点「浏览器登录」→ 应用内打开 Qraft 授权页 → 用户自行登录并点击「同意」→ 自动完成授权回到 MiQi | 默认首选，无需在 MiQi 输入密码 |
+| 密码登录 | 填手机号 + 密码（RSA 加密后传输） | 无法弹窗/自动化场景 |
+
+登录后展示昵称、用户名、脱敏手机号、access_token 到期时间与计划自动刷新时间；
+「立即刷新」手动续期，「退出登录」清除 cookie 与 token。
+
+**高级设置**（接入配置，按环境预填）：API 基础地址、client_id、client_secret、
+redirect_uri。测试阶段 client_secret 有默认值（开箱即用）；生产环境必须填写在
+Qraft 平台注册的 redirect_uri。
+
+## 2. 代码位置
+
+全部在主进程实现（不依赖 Python bridge）：
+
+| 模块 | 职责 |
+| ---- | ---- |
+| `apps/desktop/src/main/qraft/client.ts` | OAuth2 协议客户端：平台登录（RSA）、authorize/doConfirm、code 换 token、refresh、userinfo；错误分类与重试 |
+| `apps/desktop/src/main/qraft/rsa.ts` | RSA 公钥从登录页 `era-index-*.js` bundle 动态提取（grep `BEGIN PUBLIC KEY`）；PKCS#1 v1.5 加密（与 JSEncrypt 一致）；脱敏工具 |
+| `apps/desktop/src/main/qraft/cookie-jar.ts` | 平台登录态 cookie（`Set-Cookie: Authorization=<uuid>`）解析与携带 |
+| `apps/desktop/src/main/qraft/store.ts` | 登录态经 Electron safeStorage 加密落盘（userData/qraft-auth.json，0600）；不可用时降级 Base64 并告警 |
+| `apps/desktop/src/main/qraft/service.ts` | 登录态编排：登录/登出/自动刷新调度（到期前 15 分钟刷新，失败 30 分钟重试并引导重登）；生产环境强制注册 redirect_uri |
+| `apps/desktop/src/main/qraft/ipc.ts` | IPC 处理 + 浏览器登录窗口（独立 partition、导航白名单、回调 code 拦截、登录态 cookie 轮询带回授权） |
+| `apps/desktop/src/renderer/features/settings/components/QraftPage.tsx` | 设置页 UI（表单/账号展示/错误指引） |
+
+IPC 通道：`qraft:login` / `qraft:browserLogin` / `qraft:status` / `qraft:refresh` /
+`qraft:logout` + 事件 `qraft:statusChanged`（自动刷新/过期时推送）。
+
+## 3. 登录流程
+
+### 3.1 密码登录（API 路径）
+
+```
+① 提取公钥   GET {origin}/login → 解析 era-index-*.js → BEGIN PUBLIC KEY
+② 平台登录   POST /api/portal/auth/login（密码 RSA PKCS#1 v1.5 加密 + Base64）
+             → Set-Cookie: Authorization=<uuid>（OAuth 依赖 cookie 而非 header）
+③ 发起授权   GET /api/oauth2/authorize（redirect_uri 必填、不传 state、
+             scope=openid,userinfo,oidc）
+④ 确认授权   POST /api/oauth2/doConfirm（授权页 accept=1 按钮修复前必须走此接口）
+⑤ 取授权码   再次 GET authorize → 302 Location 中的一次性 code
+⑥ 换 token   POST /api/oauth2/token（grant_type=authorization_code）
+⑦ 用户信息   GET /api/oauth2/userinfo（Bearer token；实测无 picture 字段）
+```
+
+### 3.2 浏览器登录
+
+```
+主进程打开独立 partition 窗口加载 authorize URL
+  → 未登录：302 到平台登录页，用户自行登录（实测平台 SPA 登录后停留首页，
+    主进程轮询 Authorization cookie，出现即主动 loadURL(authorize) 带回）
+  → 授权确认页：用户点击「同意」（Qraft 修复后可用）
+  → 302 → redirect_uri?code=xxx：will-redirect/did-navigate 拦截（仅当
+    origin+path 与注册 redirect_uri 完全一致才提取 code），关窗
+  → code 换 token + userinfo → 完成登录
+```
+
+安全约束：授权窗口 `will-navigate` 白名单（仅 Qraft origin），`window.open`
+一律拒绝；回调 code 拦截后立即销毁窗口，redirect_uri 不做真实 HTTP 服务。
+
+## 4. 与官方文档的实测差异（实现依据）
+
+| # | 项 | 实测行为 | 实现 |
+| - | - | - | - |
+| 1 | authorize 的 redirect_uri | 必填 | 恒传；生产环境强制注册值 |
+| 2 | 授权确认 | 页面 accept=1 按钮曾无效（已修复），doConfirm 接口有效 | 密码路径走 doConfirm；浏览器路径走页面同意 |
+| 3 | state 参数 | 传了报「多次请求的 state 不可重复」 | 恒不传 |
+| 4 | access_token 有效期 | expires_in=7199（约 2 小时，非官方 24 小时） | 到期前 15 分钟自动刷新 |
+| 5 | refresh_token | 不轮换（返回同一个） | 按响应存储，不依赖轮换语义 |
+| 6 | userinfo 响应 | 无 picture 字段 | 界面只展示 nickname/username/sub |
+| 7 | IP 白名单 | 未加白出口统一 nginx 403 | 分类提示「出口 IP 未加白，请联系 Qraft 管理员」 |
+| 8 | 网络抖动 | 随机超时（HTTP 000） | 自动重试 3 次指数退避 |
+
+## 5. 凭据与安全
+
+- **token/cookie**：Electron safeStorage 加密落盘（Windows DPAPI / macOS
+  Keychain）；安全存储不可用时降级 Base64 并写 WARN 日志；退出登录即清空。
+- **密码**：仅经 IPC 提交主进程，RSA 加密后传输；前端不落存储、不打日志。
+- **日志脱敏**：token/code 只记首尾片段（`maskSecret`）；手机号脱敏展示。
+- **client_secret**：测试阶段测试/生产环境均提供硬编码默认值（开箱即用），
+  可分别经 `QRAFT_TEST_CLIENT_SECRET` / `QRAFT_PROD_CLIENT_SECRET` 环境变量
+  覆盖；转正式接入前应移除默认值。生产环境 secret 也可在高级设置填写。
+- **授权窗口**：独立 `qraft-login` partition（无持久化），完成后清理，
+  不残留平台登录态。
+
+## 6. 给 Skill/Agent 提供 token（收敛通道设计）
+
+> 本节是 [#674](https://github.com/14790897/MiQi/issues/674) 凭据方案收敛目标的
+> 设计落地说明，供 Skill 侧 `auth.py` 实现时对齐。
+
+### 已实现：token 文件（方案 A）
+
+主进程在登录成功、自动/手动刷新成功后，将
+`{ "accessToken": "…", "expiresAt": <epoch 毫秒> }` 写入
+**`<workspace>/.qraft/token.json`**（0600 权限，仅含 access_token，不含
+refresh_token）；退出登录即删除；应用启动恢复登录态时同步重写。
+
+- 沙箱可达性：KUN 沙箱将自定义 workspace bind-mount 到
+  `/home/miqi/workspace`（bwrap.py），沙箱内 Skill 直接读
+  `/home/miqi/workspace/.qraft/token.json`；
+- 安全权衡：明文 2 小时 token + 0600 + 登出删除；workspace 本就是 agent
+  任意执行代码的信任域，风险可接受。方案 B（bridge 反向调用，不落盘）
+  需要改核心协议（当前只有主→Python 请求、Python→主事件，无反向 RPC），
+  作为长期目标暂不做。
+
+### auth.py 的读取策略（Skill 侧，待 #674 落地）
+
+1. 读取 token 文件 → 存在且 `expiresAt - now > 5min` → 直接使用；
+2. 已过期/不存在 → 若配置了凭据（env）→ 走自管登录兜底；
+3. 否则提示用户「请到 设置 → Qraft 平台 完成登录」，不阻断流程。
+
+### 实施顺序
+
+1. ~~Desktop 侧：token 文件写入/删除~~（已实现，随 #728 叠放 PR 交付）；
+2. Skill 侧（#674 后续）：`auth.py` 优先读 token 文件，自管凭据降级为兜底；
+3. 稳定后删除 Skill 自管凭据，auth.py 收敛为纯「取 token + 过期检测」。
+
+## 7. 测试
+
+| 层 | 命令 | 说明 |
+| -- | ---- | ---- |
+| 单测 | `cd apps/desktop && npx vitest run src/main/qraft` | mock 全流程/错误分类/重试/假时钟自动刷新/safeStorage 往返/脱敏 |
+| Smoke | `npx playwright test --config=playwright.config.ts --project=smoke issue-726-qraft.spec.ts` | 设置页 UI（mock bridge） |
+| Electron E2E（离线） | `npx playwright test tests/e2e/qraft-login.spec.ts --config=playwright.config.ts --project=electron` | 真实主进程：表单/错误分类/预置登录态与退出清盘；零网络依赖，CI 必跑 |
+| Electron E2E（真实环境） | `QRAFT_PHONE=… QRAFT_PASSWORD=… npx playwright test tests/e2e/qraft-browser-login.spec.ts --project=electron` | 打开真实 Qraft 页面完成登录全链路；CI 未配凭据自动跳过 |
+| live 集成 | `QRAFT_LIVE=1 QRAFT_PHONE=… QRAFT_PASSWORD=… npx vitest run src/main/qraft/live.integration.test.ts` | 平台登录→授权→token→userinfo→refresh 直连测试环境 |
+
+## 8. 已知限制与后续计划
+
+- token 文件通道（第 6 节方案 A）已实现；Skill 侧 `auth.py` 的读取与收敛
+  是 #674 的后续步骤；
+- 测试阶段 client_secret 为硬编码默认值（测试/生产环境），转正式接入前移除
+  （types.ts 已标注）；生产环境仍必须填写注册的 redirect_uri；
+- Qraft 授权页修复后，密码路径仍保留 doConfirm 流程（对已确认授权用户两者
+  等价；对未确认用户 doConfirm 依然可用，多一条兜底路径）。

--- a/miqi/skills/qraft-workflowspec-export/scripts/auth.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/auth.py
@@ -101,16 +101,31 @@ class AuthError(Exception):
 # ── token 文件（#747 通道） ────────────────────────────────────────────
 
 
+def _default_home_workspace() -> Path | None:
+    """经 miqi.paths 解析默认 home 的 workspace（遵守 MIQI_HOME 策略，
+    不直接构造 ~/.miqi 路径）。skill 脚本在 MiQi 环境内运行时可用；
+    独立运行时 ImportError 则跳过该候选。"""
+    try:
+        from miqi.paths import get_miqi_home
+
+        return get_miqi_home() / "workspace"
+    except ImportError:
+        return None
+
+
 def candidate_token_files() -> list[Path]:
     """按优先级返回可能存在的 token 文件位置（arg/env 由调用方先行处理）。
 
-    只探测 workspace 相对位置与 MIQI_HOME（不构造 ~/.miqi 路径，
-    MiQi 仓库策略要求路径经 MIQI_HOME 解析）。
+    覆盖三种运行形态：沙箱 cwd、MIQI_HOME 注入、默认 home 的 workspace
+    （桌面端 #747 默认写入位置，经 miqi.paths 解析）。
     """
     candidates: list[Path] = [Path.cwd() / ".qraft" / "token.json"]
     miqi_home = os.environ.get("MIQI_HOME", "").strip()
     if miqi_home:
         candidates.append(Path(miqi_home) / "workspace" / ".qraft" / "token.json")
+    default_ws = _default_home_workspace()
+    if default_ws:
+        candidates.append(default_ws / ".qraft" / "token.json")
     return candidates
 
 

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -428,3 +428,36 @@ class TestAuthCliNoToken:
         assert rc == 0
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload["accessToken"] == "TOKEN-ABC"
+
+
+class TestTokenFileCandidates:
+    def test_default_home_workspace_candidate(self, tmp_path, monkeypatch):
+        """MIQI_HOME 未设置、cwd 无 token 时，仍能经 miqi.paths 找到默认
+        home workspace 下的 token 文件（#747 桌面端默认写入位置）。"""
+        monkeypatch.delenv("MIQI_HOME", raising=False)
+        monkeypatch.delenv("QRAFT_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("QRAFT_PHONE", raising=False)
+        monkeypatch.delenv("QRAFT_TOKEN_FILE", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("miqi.paths.get_miqi_home", lambda: tmp_path)
+        (tmp_path / "workspace" / ".qraft").mkdir(parents=True)
+        (tmp_path / "workspace" / ".qraft" / "token.json").write_text(
+            json.dumps(
+                {"accessToken": "HOME-TOKEN", "expiresAt": int(time.time() * 1000) + 7_199_000}
+            ),
+            encoding="utf-8",
+        )
+        data = auth.resolve_token("https://test.forge.miqroera.com/api", None)
+        assert data["accessToken"] == "HOME-TOKEN"
+        assert "token_file:" in data["source"]
+
+    def test_candidates_respect_miqi_home_policy(self):
+        """仓库策略：生产代码不得构造 Path.home() / '.miqi'。"""
+        import miqi.skills  # noqa: F401
+
+        from pathlib import Path as _Path
+
+        src_file = _Path("miqi") / "skills" / "qraft-workflowspec-export" / "scripts" / "auth.py"
+        text = src_file.read_text(encoding="utf-8")
+        assert 'Path.home() / ".miqi"' not in text
+        assert '_Path.home() / ".miqi"' not in text


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

把 #747（Qraft token 文件通道 + 生产 client_secret 默认值）重新合入 develop，并修复 auth.py 检测不到桌面端登录态的候选路径缺失。

## 背景/问题

实测 bug：用户在设置页完成 Qraft 登录后，agent/Skill 仍报「系统中未找到 Qraft 登录态」。排查根因有两层：

1. **#747 从未进入 develop**：#747 是叠放 PR（base 指向 #728 分支），合并动作发生在已并入 develop 的旧分支上，develop 上的 qraft/service.ts 没有 `syncTokenFile`/`tokenFilePath`——桌面端登录后根本不写 token 文件；
2. **auth.py 候选路径缺失**：为过 MIQI_HOME 策略测试移除 `~/.miqi` 直接构造时，没有经 `miqi.paths` 补回默认 home workspace 候选，主机环境（MIQI_HOME 未设置）探测不到桌面端默认写入位置。

## 关联 issue

- #747（token 通道落地到 develop）
- #674（Skill 检测登录态）

## 变更内容

- cherry-pick #747 的 squash 提交（token 文件通道：登录/刷新写 `<workspace>/.qraft/token.json`、登出删除、启动恢复；生产 client_secret 硬编码默认值 + 环境变量覆盖；E2E 断言；文档第 6 节已实现说明）
- `miqi/skills/qraft-workflowspec-export/scripts/auth.py`：`candidate_token_files` 新增经 `miqi.paths.get_miqi_home()` 解析的默认 home workspace 候选（ImportError 时跳过）
- `tests/skills/test_qraft_workflowspec.py`：新增默认 home 候选命中 + MIQI_HOME 策略合规 2 例

## 日志/验证证据

```
$ uv run pytest tests/skills/test_qraft_workflowspec.py tests/test_miqi_home_consumers.py -q
37 passed

$ npx vitest run src/main/qraft
Test Files  5 passed | 1 skipped
     Tests  83 passed | 3 skipped

$ npm run typecheck
（通过）
```

## 测试情况

- 桌面端 qraft 83 例（含 token 文件生命周期/登出竞态/symlink 防护）+ 技能脚本 37 例 + typecheck 全过
- 合入后需在 develop 构建上验证：设置页登录 → `~/.miqi/workspace/.qraft/token.json` 出现 → auth.py 探测成功

## 截图

无需截图（无 UI 变更）

## 后续计划

- 合入后由用户实机复测登录 → token 文件 → Skill 检测全链路
- #749（token 文件宿主目录 + 沙箱只读挂载）仍为后续加固项


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Re-land Qraft token file channel into develop
  - Login/refresh writes, logout deletes, startup restores
  - Guards symlink, file-type, logout race

- Add production `client_secret` default with env override

- Fix `auth.py` default home workspace token candidate

- Expand unit and E2E token-channel tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Qraft IPC"] -->|"inject tokenFilePath"| B["QraftService"]
  B -->|"sync/write"| C["workspace/.qraft/token.json"]
  B -->|"delete on logout"| C
  D["resolveConfig"] -->|"prodEnvClientSecret"| E["production client_secret default"]
  F["auth.py candidate_token_files"] -->|"miqi.paths fallback"| G["default home workspace token"]
  H["Unit/E2E tests"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>service.ts</strong><dd><code>Implement token file sync and deletion hardening</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-373c7a2a36fd357a77dca028fd31fd1bdc60e42c59c45e23392e6626d0a00674">+90/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ipc.ts</strong><dd><code>Inject workspace token file path into service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-5507eb6c5c1ad3762cc5913543210b872adf029f2f98ebddeb72ce3dd0088f59">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export getWorkspacePath for Qraft reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Add production client_secret default helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-6741723697a09c9160fa8c299e9820f8959134f7241e6ffed2ccd1415e67e308">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>QraftPage.tsx</strong><dd><code>Update client_secret placeholder text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-df6f3faee730d7190408e2a46578ea94c0215bdfb3aba09fe2c42093bc920f74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qraft-oauth2-login.md</strong><dd><code>Document token channel implementation and prod default</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-4d367dba09018850dc76766d9ac85eab14ab49ebcfa885f64a001bd6cb2abd2e">+148/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>auth.py</strong><dd><code>Add default home workspace token candidate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-8a15eaa3f71e1292e5c92384bac39dc37acf1da4687ea0f11fb42bc833dcdb0a">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>service.test.ts</strong><dd><code>Cover token lifecycle and race/symlink protections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-08d39ead05325dcd6b17e8eea84d5f3b6d5244ac753a576781b483cca2f8e480">+157/-13</a></td>

</tr>

<tr>
  <td><strong>test_qraft_workflowspec.py</strong><dd><code>Test default home candidate and MIQI_HOME policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-44571c2184c6b0130a783a664eb2cb0daac248f69e7f6c5e7f55c1b7b120ac73">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qraft-login.spec.ts</strong><dd><code>Verify token file agent read path and deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/14790897/MiQi/pull/758/files#diff-e6ac530d70356248cb5651eacf1ff07343e34779957831810597e4f8b5e7a18f">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

