### PR TITLE
fix(desktop): 重启恢复加固——lastSession 丢失时回退到最近活跃会话

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -55,6 +55,15 @@ function AppShell() {
       return 'desktop:default';
     }
   });
+  // lastSession 丢失（清缓存/清应用数据）时：先落到默认会话，bridge 就绪后
+  // 回退到"最近有活动的会话"再覆盖，避免用户重启后回到一个空默认会话。
+  const [pendingRestore, setPendingRestore] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem('miqi:lastSession');
+    } catch {
+      return true;
+    }
+  });
   const [sessionRefreshKey, setSessionRefreshKey] = useState(0);
   const [renameVersion, setRenameVersion] = useState(0);
   const [runtimeReadyKey, setRuntimeReadyKey] = useState(0);
@@ -91,14 +100,41 @@ function AppShell() {
     sessionKeyRef.current = sessionKey;
   }, [sessionKey]);
 
-  // Persist last active session so the app restores it on next launch
+  // Persist last active session so the app restores it on next launch.
+  // 回退探测期间不写 lastSession（初始默认值不代表用户真实会话）。
   useEffect(() => {
+    if (pendingRestore) return;
     try {
       localStorage.setItem('miqi:lastSession', sessionKey);
     } catch {
       /* localStorage unavailable */
     }
-  }, [sessionKey]);
+  }, [sessionKey, pendingRestore]);
+
+  // lastSession 丢失时的回退：bridge 就绪后取最近更新的会话覆盖默认值。
+  useEffect(() => {
+    if (!pendingRestore || status.state !== 'running') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await window.miqi.sessions.list();
+        const sessions = (r?.sessions ?? []) as Array<{ key?: string; updated_at?: string | number }>;
+        const recent = sessions
+          .filter((s) => s?.key && s.key !== 'desktop:default')
+          .sort((a, b) => Number(b.updated_at ?? 0) - Number(a.updated_at ?? 0))[0];
+        if (!cancelled && recent?.key) {
+          setSessionKey(recent.key);
+        }
+      } catch {
+        /* 列表不可用时保持默认会话 */
+      } finally {
+        if (!cancelled) setPendingRestore(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingRestore, status.state]);
 
   // When the bridge becomes ready, trigger a session history reload in ChatConsole
   useEffect(() => {


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

重启恢复加固：`miqi:lastSession` 丢失时，回退到「最近有活动的会话」而不是写死的 desktop:default。

## 背景/问题

重启后回到哪个会话完全依赖 localStorage 的 `miqi:lastSession`。清缓存/清应用数据（或开发模式 userData 隔离）后该值丢失，应用落回写死的 `desktop:default`——用户之前会话的文件按会话目录隔离存储，全部不可见，表现为"重启后找不到之前的文件"。

## 关联 issue

- （本会话实测暴露的问题，无对应 issue 编号）

## 变更内容

- `apps/desktop/src/renderer/App.tsx`：
  - lastSession 缺失时置 `pendingRestore` 标记；
  - bridge 就绪后调用 `sessions.list`，取 `updated_at` 最新且非默认的会话覆盖初始值；
  - 回退探测期间不写 `miqi:lastSession`（避免把默认值误记为用户真实会话）；
  - 列表不可用/无会话时保持默认并结束探测。

## 日志/验证证据

```
$ npm run typecheck
（通过）

$ npx vitest run
Test Files  20 passed | 1 skipped (21)
     Tests  265 passed | 3 skipped (268)
```

## 测试情况

- 全量 265 单测 + typecheck 通过
- 实机验证路径：清掉 localStorage 的 miqi:lastSession 后重启 → 应自动回到最近活跃会话（文件视图随之恢复）

## 截图

无需截图（启动逻辑变更，无 UI 视觉变化）

## 后续计划

- 若需跨会话文件浏览（旧会话文件入口），另立需求


___

### **PR Type**
Bug fix


___

### **Description**
- Handle missing `miqi:lastSession` with fallback to recent session.

- Track `pendingRestore` until bridge status becomes running.

- Call `sessions.list()` and choose latest updated non-default session.

- Avoid persisting default session while fallback is pending.


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Read localStorage lastSession"] -- "missing" --> B["Set pendingRestore"]
  B -- "status running" --> C["Call sessions.list"]
  C -- "latest updated_at, non-default" --> D["Set sessionKey"]
  D -- "finish" --> E["Clear pendingRestore"]
  E -- "allow persist" --> F["Write miqi:lastSession"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Fallback to recent active session after lastSession loss</code>&nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/App.tsx

<ul><li>Add <code>pendingRestore</code> state initialized from missing <code>miqi:lastSession</code>.<br> <li> Guard persistence effect to skip writing <code>miqi:lastSession</code> during <br>fallback.<br> <li> Add effect that waits for running bridge, fetches sessions, and picks <br>latest updated non-default session.<br> <li> Clear <code>pendingRestore</code> in finally and on cancellation.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/760/files#diff-4b03b04efb7537be2e18ba0418bc81886c910207148cec6f9e92c88208fc58dd">+38/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

