### PR TITLE
feat(skills): qraft-workflowspec-export 上传目标改为 workflow_definition

### DIFF
--- a/miqi/skills/qraft-workflowspec-export/SKILL.md
+++ b/miqi/skills/qraft-workflowspec-export/SKILL.md
@@ -54,7 +54,10 @@ description: >
 
 ### Step 1: 收集并确认输入
 
-从会话上下文提取上述输入。文件路径若相对，先解析为绝对路径。**列出你将要导出的内容清单给用户确认**（文件 N 个、结论 M 条、skill 列表），用户确认后再继续。若关键信息缺失（如不知道调用过哪些 skill），向用户询问，不要猜。
+按导出模式收集对应信息，**列出清单给用户确认后再继续**；关键信息缺失时向用户询问，不要猜。
+
+- **上传 workflow_definition（默认）**：收集用户对工作流/技能的定义描述，确认清单为——名称（metadata.name / title）、用途（description）、步骤（graph.nodes 的 id/title/kind/executor）、执行方式（execution.default_mode / entrypoints / backend_policy）。**不收集**文件列表、结论、skill 调用数——那些是 workflow_run 归档记录字段。
+- **归档 workflow_run（用户明确要求）**：从会话上下文提取「输入」节所列内容（文件路径相对则先解析为绝对路径），确认清单为——文件 N 个、结论 M 条、skill 列表。
 
 ### Step 2: 构建 WorkflowDefinition（上传目标）
 
@@ -128,6 +131,7 @@ Schema 校验只保证"结构合法"，不保证"内容有意义"。**每次导�
 
 A 级（必拦——禁止生成正式文件）：
 
+0. 任意字段出现 NaN/Infinity 非有限数值
 1. `metadata.title` 为空
 2. `metadata.description` 为空
 3. `metadata.id` 为空

--- a/miqi/skills/qraft-workflowspec-export/SKILL.md
+++ b/miqi/skills/qraft-workflowspec-export/SKILL.md
@@ -135,10 +135,10 @@ A 级（必拦——禁止生成正式文件）：
 5. `graph.nodes` 为空（DAG 至少 1 个节点）
 6. 任一节点的 `presentation.data_view` 缺失
 7. 任一节点的 `presentation.action_view` 缺失
+8. `metadata.name` 为空
 
 B 级（警告——允许生成，警告进 diagnostics）：
 
-8. `metadata.name` 缺失（机器可读名称建议填写）
 9. `graph.edges` 为空（节点间无依赖边，线性流程）
 
 **workflow_run（归档记录，官方 8.5）**：沿用原规则——A 级：summary.human_summary 为空 / artifacts+metrics+evidence+claims 同时为空且无 diagnostics / metrics[].value 非 number 或 NaN/Infinity / claims[].statement 为空 / workflow_ref 缺 version 或 request.prompt 为空；B 级：数值量级、request 空对象、零字节文件、node_runs 空、backend kind 不明、checksum 长度不匹配等（详见脚本）。

--- a/miqi/skills/qraft-workflowspec-export/SKILL.md
+++ b/miqi/skills/qraft-workflowspec-export/SKILL.md
@@ -16,9 +16,11 @@ description: >
 
 # qraft-workflowspec-export
 
-导出一次 agent 问题解决会话的**运行记录（WorkflowRun）**：把散乱的产物——文件、关键数字、证据、结论——按实际意义归类进 `references/workflowspec.schema.json` 定义的结构，输出一份**通过 schema 校验**的 JSON，落盘到当前工作目录并在对话中给出路径。
+把一次 agent 问题解决会话的产物整理为 **WorkflowDefinition（上传目标）** 或 **WorkflowRun（归档记录）**：按 `references/workflowspec.schema.json` 定义的结构构建 JSON，完成 schema + 语义校验后，渲染方案视图经用户确认，上传到 Qraft 平台（dataUpload 接口）。上传目标默认是 `workflow_definition`（官方 OAuth2 文档 8.4 节），仅当用户明确要求归档运行记录时才导出 `workflow_run`。
 
 产物统一管理 = 让每次会话的产出可追溯（谁调的哪个 skill、产出了什么文件、得出了什么结论、数字是多少）。
+
+> 以下「输入」与「产物归类决策表」两节是 **workflow_run 归档模式**专用；上传 `workflow_definition` 时从 Step 1 直接收集用户对工作流/技能的定义描述（名称、用途、步骤、执行方式），跳过产物归类。
 
 ## 输入
 
@@ -54,77 +56,55 @@ description: >
 
 从会话上下文提取上述输入。文件路径若相对，先解析为绝对路径。**列出你将要导出的内容清单给用户确认**（文件 N 个、结论 M 条、skill 列表），用户确认后再继续。若关键信息缺失（如不知道调用过哪些 skill），向用户询问，不要猜。
 
-### Step 2: 构建 WorkflowRun
+### Step 2: 构建 WorkflowDefinition（上传目标）
 
-按以下骨架构建 JSON（所有 id 用 `^[A-Za-z][A-Za-z0-9._:-]{0,127}$` 格式）：
+按以下骨架构建 JSON（官方 OAuth2 文档 8.4 节最简有效示例；所有 id 用 `^[A-Za-z][A-Za-z0-9._:-]{0,127}$` 格式）：
 
 ```json
 {
-  "$schema": "https://quantamol.io/schemas/workflowspec.schema.json",
   "spec_version": "1.0.0",
-  "document_kind": "workflow_run",
-  "run_id": "run.<主题词>-<YYYYMMDD>",
-  "workflow_ref": {
-    "id": "qraft.agent-session",
-    "version": "1.0.0"
+  "document_kind": "workflow_definition",
+  "metadata": {
+    "id": "com.example.my-skill",
+    "name": "my-skill",
+    "title": "我的技能",
+    "version": "1.0.0",
+    "description": "这是一个示例技能"
   },
-  "request": {
-    "prompt": "用户原始请求",
-    "parsed_intent": "agent 解析后的意图",
-    "mode": "full",
-    "requested_at": "<ISO 时间，能测就测>"
-  },
+  "interface": {},
+  "activation": { "policy": "explicit" },
+  "inputs": [],
+  "parameters": [],
   "execution": {
-    "status": "completed",
-    "started_at": "<能测就测，测不到省略>",
-    "ended_at": "<当前时间 ISO>",
-    "backend": {
-      "id": "local-main",
-      "kind": "local"
-    }
+    "default_mode": "full",
+    "entrypoints": [{ "id": "run", "mode": "full", "executor": { "type": "shell" } }],
+    "backend_policy": { "strategy": "fixed", "backends": [{ "id": "local", "kind": "local" }] }
   },
-  "node_runs": [],
-  "artifacts": [],
-  "metrics": [],
-  "evidence": [],
-  "claims": [],
-  "summary": {}
+  "graph": {
+    "nodes": [{
+      "id": "step1",
+      "title": "步骤一",
+      "kind": "task",
+      "executor": { "type": "shell" },
+      "presentation": { "data_view": {}, "action_view": {} }
+    }],
+    "edges": []
+  },
+  "completion": [{ "id": "done", "description": "完成", "severity": "success" }]
 }
 ```
 
-**字段填充规则：**
+**字段填充规则（官方 8.4 必填字段）**：
 
-- **run_id**：`run.<主题词>-<YYYYMMDD>`，主题词 = 会话主题的英文短词（如 `mof-ion-path`、`gas-separation`），当天多次导出加后缀 `-2`、`-3`…
-- **workflow_ref**：默认 `qraft.agent-session/1.0.0`；若用户指定了真实 WorkflowDefinition，则用其 id/version 并填 `definition_uri`
-- **backend**：默认 `local`；若对话中明确涉及远端执行（SSH/HPC/Slurm/K8s），填对应 kind（ssh/kubernetes/…）并给 `selection_reason`
-- **node_runs**：每个被调用的 skill 一个 node_run：
-  ```json
-  {
-    "node_id": "<skill 名，如 bvse-mof-local-ssh>",
-    "status": "completed",
-    "output_artifact_refs": ["<该 skill 产出的 artifact id>"]
-  }
-  ```
-  若有开始/结束时间可填，无则省略；未产出文件的 skill 的 output_artifact_refs 留空数组
-- **artifacts**：每个文件一个条目：
-  ```json
-  {
-    "id": "art-report-001",
-    "title": "人能读懂的标题",
-    "role": "report",
-    "semantic_type": "如 energy-profile",
-    "uri": "<绝对路径或 file:// URI>",
-    "media_type": "如 application/pdf / image/png / text/csv",
-    "exists": true,
-    "size_bytes": 12345,
-    "checksum": {"algorithm": "sha256", "value": "<64位hex>"}
-  }
-  ```
-  id 用 `art-<类型>-<序号>` 风格；media_type 按扩展名推断（.pdf→application/pdf, .png→image/png, .csv→text/csv, .cif→chemical/x-cif, .txt/.log→text/plain, .json→application/json, .md→text/markdown, .html→text/html）；无法推断填 application/octet-stream
-- **metrics**：`id` 用 `metric-<短名>`，`name` 用可读名，`value` 填数值
-- **evidence**：`id` 用 `ev-<短名>`；`description` 写清"什么证据、来自哪"
-- **claims**：`id` 用 `claim-<短名>`
-- **summary**：必填 title + human_summary；key_metric_refs/supported_claim_refs 填对应 id；无则空数组
+- **metadata**：必填 id（唯一标识，反向域名风格）、name（机器可读名）、title（人类可读标题，不能为空）、version（语义化版本号）、description（不能为空）；
+- **interface**：UI 描述对象，最小为 `{}`；
+- **activation**：触发策略，`{"policy": "explicit"}`（显式触发）；
+- **inputs / parameters**：可为空数组 `[]`；
+- **execution**：default_mode + entrypoints（每个 entrypoint 含 id/mode/executor）+ backend_policy（fixed/local）；
+- **graph**：DAG 结构，`nodes` 至少 1 个节点，每个节点必须有 `presentation.data_view` 与 `presentation.action_view`（官方 8.6 错误表明确二者不能为空）；`edges` 描述依赖；
+- **completion**：完成状态列表（如 `{"id":"done","description":"完成","severity":"success"}`）。
+
+若用户明确要求归档本次会话运行记录，才导出 `workflow_run`（结构见官方文档 8.5 节；校验与语义规则见下）。
 
 ### Step 3: 计算文件校验和
 
@@ -140,26 +120,28 @@ python <skill_dir>/scripts/validate_run.py <output.json>
 
 校验失败 → 按报错修正（字段缺失/枚举值错误/id 格式问题）→ 重新校验，直到 `VALID`。**不允许输出未通过校验的 JSON。**
 
-### Step 4.5: 语义合理性校验（必做，A/B 分级）
+### Step 4.5: 语义合理性校验（必做，A/B 分级，按 document_kind 分流）
 
-Schema 校验只保证"结构合法"，不保证"内容有意义"。**每次导出必须额外做语义检查**，按两级处理：
+Schema 校验只保证"结构合法"，不保证"内容有意义"。**每次导出必须额外做语义检查**（`--semantic`），按两级处理：
 
-**A 级（必拦——产物无意义，禁止生成正式文件）**：
+**workflow_definition（上传目标，官方 8.4/8.6）**：
 
-1. `summary.human_summary` 为空 → 无人类可读摘要，记录失去归档意义
-2. `artifacts`、`metrics`、`evidence`、`claims` **同时为空**且无 diagnostics 说明 → 这次导出没收集到任何东西，大概率输入遗漏
-3. `metrics[].value` 不是 number（字符串 / NaN / Infinity / null）→ 指标不可比较不可分析
-4. `claims[].statement` 为空串 → 结论为空
-5. `workflow_ref` 缺 `version` 或 `request.prompt` 为空 → 追溯链断裂
+A 级（必拦——禁止生成正式文件）：
 
-**B 级（警告——可疑但可能真实，允许生成，警告进 diagnostics）**：
+1. `metadata.title` 为空
+2. `metadata.description` 为空
+3. `metadata.id` 为空
+4. `metadata.version` 为空
+5. `graph.nodes` 为空（DAG 至少 1 个节点）
+6. 任一节点的 `presentation.data_view` 缺失
+7. 任一节点的 `presentation.action_view` 缺失
 
-6. `metrics[].value` 绝对值超出常见物理量级（如能量 > 1e6 hartree）→ 提示"该值超出常见物理量级，请确认"
-7. `request` 为空对象 → 提示"缺少用户请求上下文，追溯性受损"
-8. `artifacts[].size_bytes == 0` 但有 checksum → 提示"文件大小为 0，确认是否为空文件"
-9. `node_runs` 为空数组 → 提示"未记录任何 skill 调用"
-10. `execution.backend.kind` 为 `other`/`manual` → 提示"后端不明确，确认 selection_reason 是否充分"
-11. `artifacts[].checksum.value` 长度与 `algorithm` 不匹配（sha256=64 / sha1=40 / md5=32 位 hex）→ 提示"校验和可能错误"
+B 级（警告——允许生成，警告进 diagnostics）：
+
+8. `metadata.name` 缺失（机器可读名称建议填写）
+9. `graph.edges` 为空（节点间无依赖边，线性流程）
+
+**workflow_run（归档记录，官方 8.5）**：沿用原规则——A 级：summary.human_summary 为空 / artifacts+metrics+evidence+claims 同时为空且无 diagnostics / metrics[].value 非 number 或 NaN/Infinity / claims[].statement 为空 / workflow_ref 缺 version 或 request.prompt 为空；B 级：数值量级、request 空对象、零字节文件、node_runs 空、backend kind 不明、checksum 长度不匹配等（详见脚本）。
 
 **报告状态（--report-json）**：`status` 取值 `VALID` / `INVALID`（schema 或 strict 失败）/ `SEMANTIC_BLOCKED`（存在 A 级错误）。仅 `VALID` 允许进入上传流程；命令行模式下 schema 层输出 `SCHEMA VALID`，与 `SEMANTIC BLOCKED` 区分，不得用子串匹配判定成功。
 
@@ -167,7 +149,7 @@ Schema 校验只保证"结构合法"，不保证"内容有意义"。**每次导�
 
 ### Step 5: 落盘 + 最终校验（必做）
 
-- 输出文件名：`workflowspec.run.<YYYYMMDD>.json`（与 schema 同风格；当天多次导出加序号）
+- 输出文件名：`workflowspec.definition.<YYYYMMDD>.json`（上传 definition；归档 run 时用 `workflowspec.run.<YYYYMMDD>.json`；当天多次导出加序号）
 - 写到**当前工作目录**
 - **落盘后必须对磁盘上的正式文件再跑一次完整校验**（最终交付物校验，不是构建时校验）：
 
@@ -177,7 +159,7 @@ python <skill_dir>/scripts/validate_run.py <落盘文件> --schema <权威版或
 
 - 必须输出 `VALID` + `Semantic OK (no A/B findings)`（或仅 B 级警告）才算完成
 - **最终校验失败** → 回到修正循环（修正 → 重跑 → 重新落盘 → 重新最终校验），不允许交付未通过最终校验的文件
-- 对话中给出：输出文件绝对路径、run_id、产物统计（N 个 artifacts、M 条 claims、K 条 metrics）、最终校验结果（VALID + 用时）
+- 对话中给出：输出文件绝对路径、metadata.id（或归档模式的 run_id）、统计（definition：N 个节点；run：N artifacts / M claims / K metrics）、最终校验结果（VALID + 用时）
 
 ## 失败/回退路径
 
@@ -211,14 +193,14 @@ python <skill_dir>/scripts/validate_run.py <落盘文件> --schema <权威版或
 
 ### Step 6: 渲染 Markdown 方案视图（会话内）
 
-读取刚导出的 WorkflowRun JSON，在对话中输出一张 **Markdown 方案视图**，内容必须包含：
+读取刚导出的 JSON，在对话中输出一张 **Markdown 方案视图**，内容必须包含：
 
-- **summary**：title、human_summary；
-- **artifacts**：表格（id / title / role / size / checksum 摘要）；
-- **metrics**：表格（name / value / unit / evidence_level）；
-- **claims**：列表（statement / status / evidence_refs）；
-- **证据引用**：每个 claim/metric 关联的 evidence/artifact 引用标注；
-- **validation_report 摘要**：VALID 状态 + A 级错误数（0）+ B 级警告清单（如有）。
+- **metadata**：title / name / id / version / description；
+- **execution**：entrypoints 与 backend_policy 摘要；
+- **graph**：节点表格（id / title / kind / executor）与 edges 依赖；
+- **completion**：完成状态列表；
+- **validation_report 摘要**：VALID 状态 + A 级错误数（0）+ B 级警告清单（如有）；
+- 归档模式（workflow_run）时改用 summary/artifacts/metrics/claims/证据引用 视图。
 
 只读不改：方案视图是上传前的展示，不要在此步骤修改 JSON。
 
@@ -245,7 +227,7 @@ python <skill_dir>/scripts/auth.py token --json --no-token
 
 # 2) 上传：凭据由 upload_run.py 内部解析（token 文件优先 → env → 自管登录兜底），
 #    agent 全程不经手 access_token
-python <skill_dir>/scripts/upload_run.py <workflowspec.run.YYYYMMDD.json> --json
+python <skill_dir>/scripts/upload_run.py <workflowspec.definition.YYYYMMDD.json> --json
 ```
 
 - `auth.py` 返回 `NOT_LOGGED_IN` → 提示用户：「请到 MiQi 设置 → Qraft 平台 完成登录（浏览器登录或密码登录），登录后我会自动使用你的登录态」，**不要**自行编造凭据；

--- a/miqi/skills/qraft-workflowspec-export/scripts/auth.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/auth.py
@@ -38,6 +38,16 @@ from urllib.parse import urljoin
 
 import httpx
 
+
+def _ensure_utf8_streams() -> None:
+    """Windows 默认 stdout/stderr 编码为 cp1252 等本地代码页，打印中文会
+    UnicodeEncodeError 崩溃。统一重配置为 UTF-8（Python 3.7+）。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
 # 到期前多少毫秒视为"临期"（与 docs/frontend/qraft-oauth2-login.md 第 6 节一致）
 EXPIRY_SKEW_MS = 5 * 60 * 1000
 DEFAULT_BASE_URL = "https://test.forge.miqroera.com/api"
@@ -366,6 +376,7 @@ def main() -> int:
         "供 agent/SKILL 检查登录状态时使用，避免完整 token 进入工具输出与日志",
     )
     args = parser.parse_args()
+    _ensure_utf8_streams()
 
     try:
         data = resolve_token(args.base_url, args.token_file)

--- a/miqi/skills/qraft-workflowspec-export/scripts/auth.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/auth.py
@@ -364,6 +364,10 @@ def resolve_token(base_url: str, token_file_arg: str | None) -> dict[str, Any]:
 
 
 def main() -> int:
+    # 先于 parse_args 重配置编码，避免 Windows cp1252 下 argparse 的中文
+    # help/错误输出在 parse_args 内部崩溃。
+    _ensure_utf8_streams()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("command", nargs="?", default="token", choices=["token"], help="取 token（默认）")
     parser.add_argument("--base-url", default=os.environ.get("QRAFT_BASE_URL", DEFAULT_BASE_URL))
@@ -376,7 +380,6 @@ def main() -> int:
         "供 agent/SKILL 检查登录状态时使用，避免完整 token 进入工具输出与日志",
     )
     args = parser.parse_args()
-    _ensure_utf8_streams()
 
     try:
         data = resolve_token(args.base_url, args.token_file)

--- a/miqi/skills/qraft-workflowspec-export/scripts/upload_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/upload_run.py
@@ -29,6 +29,16 @@ from typing import Any
 
 import httpx
 
+
+def _ensure_utf8_streams() -> None:
+    """Windows 默认 stdout/stderr 编码为 cp1252 等本地代码页，打印中文会
+    UnicodeEncodeError 崩溃。统一重配置为 UTF-8（Python 3.7+）。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from auth import AuthError, resolve_token  # noqa: E402
 
@@ -152,6 +162,7 @@ def main() -> int:
     parser.add_argument("--retries", type=int, default=DEFAULT_RETRIES)
     parser.add_argument("--json", action="store_true", help="机器可读 JSON 输出")
     args = parser.parse_args()
+    _ensure_utf8_streams()
 
     file_path = Path(args.file).resolve()
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/upload_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/upload_run.py
@@ -155,6 +155,10 @@ def upload_file(
 
 
 def main() -> int:
+    # 先于 parse_args 重配置编码，避免 Windows cp1252 下 argparse 的中文
+    # help/错误输出在 parse_args 内部崩溃。
+    _ensure_utf8_streams()
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("file", help="WorkflowRun/WorkflowDefinition JSON 文件")
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
@@ -162,7 +166,6 @@ def main() -> int:
     parser.add_argument("--retries", type=int, default=DEFAULT_RETRIES)
     parser.add_argument("--json", action="store_true", help="机器可读 JSON 输出")
     args = parser.parse_args()
-    _ensure_utf8_streams()
 
     file_path = Path(args.file).resolve()
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -27,6 +27,10 @@ from pathlib import Path
 
 try:
     import jsonschema
+    from jsonschema import Draft202012Validator
+except ImportError:  # pragma: no cover
+    sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
+    sys.exit(2)
 
 
 def _ensure_utf8_streams() -> None:
@@ -37,10 +41,6 @@ def _ensure_utf8_streams() -> None:
             stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
         except Exception:
             pass
-    from jsonschema import Draft202012Validator
-except ImportError:  # pragma: no cover
-    sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
-    sys.exit(2)
 
 DEFAULT_SCHEMA = Path(__file__).resolve().parent.parent / "references" / "workflowspec.schema.json"
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -65,7 +65,7 @@ def _semantic_check_definition(doc: dict):
     if not (meta.get("version") or "").strip():
         a.append("A4: metadata.version 不能为空（语义化版本号）")
     if not (meta.get("name") or "").strip():
-        b.append("B1: metadata.name 缺失 → 机器可读名称建议填写")
+        a.append("A8: metadata.name 不能为空（机器可读名称）")
     nodes = (doc.get("graph") or {}).get("nodes") or []
     if not nodes:
         a.append("A5: graph.nodes 为空 → DAG 至少需要 1 个节点")
@@ -76,7 +76,7 @@ def _semantic_check_definition(doc: dict):
         if "action_view" not in presentation:
             a.append(f"A7: 节点 {node.get('id', i)} 的动作视图不能为空（presentation.action_view 缺失）")
     if not (doc.get("graph") or {}).get("edges"):
-        b.append("B2: graph.edges 为空 → 节点间无依赖边（线性流程）")
+        b.append("B1: graph.edges 为空 → 节点间无依赖边（线性流程）")
     return a, b
 
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -90,13 +90,39 @@ def _semantic_check_definition(doc: dict):
     return a, b
 
 
+def _nonfinite_paths(doc, path=""):
+    """递归扫描文档中的非有限浮点数（NaN/Infinity），返回其路径列表。
+
+    Python 的 json.load 默认接受 NaN/Infinity，jsonschema 的 number 类型
+    检查也放行；这些值 json.dump 时会写成非标准 JSON，必须单独拦截。
+    """
+    found = []
+    if isinstance(doc, dict):
+        for key, value in doc.items():
+            p = f"{path}.{key}" if path else str(key)
+            found.extend(_nonfinite_paths(value, p))
+    elif isinstance(doc, list):
+        for i, value in enumerate(doc):
+            found.extend(_nonfinite_paths(value, f"{path}[{i}]"))
+    elif isinstance(doc, float) and (math.isnan(doc) or math.isinf(doc)):
+        found.append(path)
+    return found
+
+
 def semantic_check(doc: dict):
     """A/B-level semantic sanity checks. Returns (a_errors, b_warnings)."""
     a = []
     b = []
 
+    # 非有限数值拦截先于 document_kind 分流，两种文档类型都覆盖
+    # （workflow_definition 的 extensions 等 JsonValue 字段同样会放行 NaN/Infinity）。
+    for p in _nonfinite_paths(doc):
+        a.append(f"A0: {p} 为非有限数值（NaN/Infinity）→ 非标准 JSON，禁止输出")
+
     if doc.get("document_kind") == "workflow_definition":
-        return _semantic_check_definition(doc)
+        # _semantic_check_definition 自建 a/b，需合并外层已累计的 A0 拦截。
+        a_def, b_def = _semantic_check_definition(doc)
+        return a + a_def, b + b_def
 
     summary = doc.get("summary") or {}
     if not summary.get("human_summary"):
@@ -153,6 +179,10 @@ def semantic_check(doc: dict):
 
 
 def main() -> int:
+    # 先于 parse_args 重配置编码：argparse 的 help/错误输出（含中文）在
+    # parse_args 内部就会写入 stdout/stderr，Windows cp1252 下会先崩溃。
+    _ensure_utf8_streams()
+
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("run_json", help="Path to the WorkflowRun JSON to validate")
     ap.add_argument("--schema", default=str(DEFAULT_SCHEMA), help="Path to workflowspec.schema.json")
@@ -169,7 +199,6 @@ def main() -> int:
         "供 SKILL 渲染方案视图/上传前拦截（#674 功能描述 2）",
     )
     args = ap.parse_args()
-    _ensure_utf8_streams()
 
     run_path = Path(args.run_json)
     schema_path = Path(args.schema)

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -27,6 +27,16 @@ from pathlib import Path
 
 try:
     import jsonschema
+
+
+def _ensure_utf8_streams() -> None:
+    """Windows 默认 stdout/stderr 编码为 cp1252 等本地代码页，打印中文会
+    UnicodeEncodeError 崩溃。统一重配置为 UTF-8（Python 3.7+）。"""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+        except Exception:
+            pass
     from jsonschema import Draft202012Validator
 except ImportError:  # pragma: no cover
     sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
@@ -159,6 +169,7 @@ def main() -> int:
         "供 SKILL 渲染方案视图/上传前拦截（#674 功能描述 2）",
     )
     args = ap.parse_args()
+    _ensure_utf8_streams()
 
     run_path = Path(args.run_json)
     schema_path = Path(args.schema)

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -9,13 +9,13 @@ Exit codes:
     1  INVALID (schema or semantic A-level errors found)
     2  ERROR   (file not found / unreadable)
 
---strict    Also check document_kind == workflow_run
+--strict    Also check document_kind in (workflow_definition, workflow_run)
 --semantic  Run A/B-level semantic sanity checks (see SKILL.md Step 4.5):
             A-level findings → exit 1 (blocked, no official file);
             B-level findings → reported as warnings, exit 0.
 
 The schema's top-level `oneOf` accepts either WorkflowDefinition or
-WorkflowRun; this validator enforces the run document_kind explicitly.
+WorkflowRun; --strict requires an explicit document_kind of either type.
 """
 
 import argparse
@@ -51,10 +51,42 @@ def _is_number(v):
     return isinstance(v, (int, float)) and not isinstance(v, bool)
 
 
+def _semantic_check_definition(doc: dict):
+    """workflow_definition 语义检查（官方 OAuth2 文档 8.4/8.6 必填与错误表）。"""
+    a = []
+    b = []
+    meta = doc.get("metadata") or {}
+    if not (meta.get("title") or "").strip():
+        a.append("A1: metadata.title 不能为空")
+    if not (meta.get("description") or "").strip():
+        a.append("A2: metadata.description 不能为空")
+    if not (meta.get("id") or "").strip():
+        a.append("A3: metadata.id 不能为空（唯一标识符）")
+    if not (meta.get("version") or "").strip():
+        a.append("A4: metadata.version 不能为空（语义化版本号）")
+    if not (meta.get("name") or "").strip():
+        b.append("B1: metadata.name 缺失 → 机器可读名称建议填写")
+    nodes = (doc.get("graph") or {}).get("nodes") or []
+    if not nodes:
+        a.append("A5: graph.nodes 为空 → DAG 至少需要 1 个节点")
+    for i, node in enumerate(nodes):
+        presentation = node.get("presentation") or {}
+        if "data_view" not in presentation:
+            a.append(f"A6: 节点 {node.get('id', i)} 的数据视图不能为空（presentation.data_view 缺失）")
+        if "action_view" not in presentation:
+            a.append(f"A7: 节点 {node.get('id', i)} 的动作视图不能为空（presentation.action_view 缺失）")
+    if not (doc.get("graph") or {}).get("edges"):
+        b.append("B2: graph.edges 为空 → 节点间无依赖边（线性流程）")
+    return a, b
+
+
 def semantic_check(doc: dict):
     """A/B-level semantic sanity checks. Returns (a_errors, b_warnings)."""
     a = []
     b = []
+
+    if doc.get("document_kind") == "workflow_definition":
+        return _semantic_check_definition(doc)
 
     summary = doc.get("summary") or {}
     if not summary.get("human_summary"):
@@ -114,7 +146,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("run_json", help="Path to the WorkflowRun JSON to validate")
     ap.add_argument("--schema", default=str(DEFAULT_SCHEMA), help="Path to workflowspec.schema.json")
-    ap.add_argument("--strict", action="store_true", help="Also check document_kind == workflow_run")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Also check document_kind in (workflow_definition, workflow_run)",
+    )
     ap.add_argument("--semantic", action="store_true", help="Run A/B-level semantic sanity checks")
     ap.add_argument(
         "--report-json",
@@ -137,8 +173,10 @@ def main() -> int:
     b_warns: list[str] = []
     if not errors and args.strict:
         kind = run_doc.get("document_kind")
-        if kind != "workflow_run":
-            strict_error = f"document_kind is {kind!r}, expected 'workflow_run'"
+        if kind not in ("workflow_definition", "workflow_run"):
+            strict_error = (
+                f"document_kind is {kind!r}, expected 'workflow_definition' or 'workflow_run'"
+            )
     if not errors and strict_error is None and args.semantic:
         a_errs, b_warns = semantic_check(run_doc)
 

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -519,15 +519,15 @@ class TestValidateDefinition:
         assert rc == 0, f"validate rc={rc}, output: {out}"
         assert "VALID" in out
 
-    def test_metadata_title_missing_blocks(self, tmp_path):
-        # 官方 schema 对 metadata.title 有 required 约束（schema 层拦截），
-        # 语义层 A 级规则作为兜底 —— 两层任一拦截均可。
+    def test_metadata_title_empty_blocks(self, tmp_path):
+        # title: "" 通过 schema（LocalizedText 字符串分支无 minLength），
+        # 必须由语义层 A1 拦截——只断言 SEMANTIC_BLOCKED，确保规则真实生效。
         doc = self._definition()
-        doc["metadata"].pop("title")
+        doc["metadata"]["title"] = ""
         rc, out = self._run_validator(tmp_path, doc)
         assert rc == 1, f"validate rc={rc}, output: {out}"
-        assert ("SEMANTIC_BLOCKED" in out) or ("INVALID" in out)
-        assert "title" in out
+        assert "SEMANTIC BLOCKED" in out
+        assert "A1" in out
 
     def test_node_missing_data_view_blocks(self, tmp_path):
         doc = self._definition()
@@ -541,13 +541,26 @@ class TestValidateDefinition:
         assert rc == 0, f"validate rc={rc}, output: {out}"
         assert "B1" in out
 
-    def test_metadata_name_missing_blocks(self, tmp_path):
-        # schema 层对 metadata.name 有 required 约束（INVALID），语义层 A8 兜底
+    def test_metadata_name_blank_blocks(self, tmp_path):
+        # name 只含空白：schema minLength 满足但语义为空，必须由 A8 拦截。
         doc = self._definition()
-        doc["metadata"].pop("name")
+        doc["metadata"]["name"] = "   "
         rc, out = self._run_validator(tmp_path, doc)
         assert rc == 1, f"validate rc={rc}, output: {out}"
-        assert ("INVALID" in out) or ("SEMANTIC_BLOCKED" in out)
+        assert "SEMANTIC BLOCKED" in out
+        assert "A8" in out
+
+    @pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+    def test_definition_nonfinite_value_blocks(self, tmp_path, bad_value):
+        # JsonValue 的 number 分支放行非有限浮点数（jsonschema 只查 type，
+        # Python json.load 接受 NaN/Infinity），语义层必须 A0 拦截，
+        # 防止 json.dump 写出非标准 JSON。
+        doc = self._definition()
+        doc["extensions"] = {"x-bad": bad_value}
+        rc, out = self._run_validator(tmp_path, doc)
+        assert rc == 1, f"validate rc={rc}, output: {out}"
+        assert "SEMANTIC BLOCKED" in out
+        assert "A0" in out
 
 
 import subprocess

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -568,12 +568,19 @@ import sys as _sys
 
 
 def subprocess_run_validator(json_path):
-    """运行 validate_run.py 子进程，返回 (exit_code, stdout)。"""
+    """运行 validate_run.py 子进程，返回 (exit_code, stdout)。
+
+    脚本会在 main() 开头把 stdout/stderr 重配置为 UTF-8（含中文输出），
+    而 Windows 上 text=True 默认按 cp1252 解码，reader 线程会抛
+    UnicodeDecodeError 导致 stdout 为 None——这里显式按 UTF-8 解码。
+    """
     script = SKILL_DIR / "validate_run.py"
     proc = subprocess.run(
         [_sys.executable, str(script), str(json_path), "--strict", "--semantic"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=120,
     )
     if proc.returncode != 0:

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -539,7 +539,15 @@ class TestValidateDefinition:
     def test_edges_empty_warns_b_level(self, tmp_path):
         rc, out = self._run_validator(tmp_path, self._definition())
         assert rc == 0
-        assert "B2" in out or "B2" in out.replace("WARNING (B): ", "")
+        assert "B1" in out
+
+    def test_metadata_name_missing_blocks(self, tmp_path):
+        # schema 层对 metadata.name 有 required 约束（INVALID），语义层 A8 兜底
+        doc = self._definition()
+        doc["metadata"].pop("name")
+        rc, out = self._run_validator(tmp_path, doc)
+        assert rc == 1
+        assert ("INVALID" in out) or ("SEMANTIC_BLOCKED" in out)
 
 
 import subprocess

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -461,3 +461,102 @@ class TestTokenFileCandidates:
         text = src_file.read_text(encoding="utf-8")
         assert 'Path.home() / ".miqi"' not in text
         assert '_Path.home() / ".miqi"' not in text
+
+
+class TestValidateDefinition:
+    """workflow_definition 校验（官方 OAuth2 文档 8.4/8.6）。"""
+
+    def _definition(self, **overrides):
+        doc = {
+            "spec_version": "1.0.0",
+            "document_kind": "workflow_definition",
+            "metadata": {
+                "id": "com.example.test",
+                "name": "test-skill",
+                "title": "测试技能",
+                "version": "1.0.0",
+                "description": "用于测试",
+            },
+            "interface": {},
+            "activation": {"policy": "explicit"},
+            "inputs": [],
+            "parameters": [],
+            "execution": {
+                "default_mode": "full",
+                "entrypoints": [{"id": "run", "mode": "full", "executor": {"type": "shell"}}],
+                "backend_policy": {"strategy": "fixed", "backends": [{"id": "local", "kind": "local"}]},
+            },
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "step1",
+                        "title": "步骤一",
+                        "kind": "task",
+                        "executor": {"type": "shell"},
+                        "presentation": {"data_view": {}, "action_view": {}},
+                    }
+                ],
+                "edges": [],
+            },
+            "completion": [{"id": "done", "description": "完成", "severity": "success"}],
+        }
+        for k, v in overrides.items():
+            if v is _REMOVE:
+                doc.pop(k, None)
+            elif k in ("metadata", "graph") and isinstance(v, dict):
+                doc[k] = {**doc[k], **v}
+            else:
+                doc[k] = v
+        return doc
+
+    def _run_validator(self, tmp_path, doc):
+        f = tmp_path / "def.json"
+        f.write_text(json.dumps(doc), encoding="utf-8")
+        return subprocess_run_validator(f)
+
+    def test_valid_definition(self, tmp_path):
+        rc, out = self._run_validator(tmp_path, self._definition())
+        assert rc == 0
+        assert "VALID" in out
+
+    def test_metadata_title_missing_blocks(self, tmp_path):
+        # 官方 schema 对 metadata.title 有 required 约束（schema 层拦截），
+        # 语义层 A 级规则作为兜底 —— 两层任一拦截均可。
+        doc = self._definition()
+        doc["metadata"].pop("title")
+        rc, out = self._run_validator(tmp_path, doc)
+        assert rc == 1
+        assert ("SEMANTIC_BLOCKED" in out) or ("INVALID" in out)
+        assert "title" in out
+
+    def test_node_missing_data_view_blocks(self, tmp_path):
+        doc = self._definition()
+        doc["graph"]["nodes"][0]["presentation"].pop("data_view")
+        rc, out = self._run_validator(tmp_path, doc)
+        assert rc == 1
+        assert "data_view" in out
+
+    def test_edges_empty_warns_b_level(self, tmp_path):
+        rc, out = self._run_validator(tmp_path, self._definition())
+        assert rc == 0
+        assert "B2" in out or "B2" in out.replace("WARNING (B): ", "")
+
+
+import subprocess
+import sys as _sys
+
+
+def subprocess_run_validator(json_path):
+    """运行 validate_run.py 子进程，返回 (exit_code, stdout)。"""
+    script = SKILL_DIR / "validate_run.py"
+    proc = subprocess.run(
+        [_sys.executable, str(script), str(json_path), "--strict", "--semantic"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return proc.returncode, proc.stdout
+
+
+# 供 _definition 使用：标记"删除该键"
+_REMOVE = object()

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -516,7 +516,7 @@ class TestValidateDefinition:
 
     def test_valid_definition(self, tmp_path):
         rc, out = self._run_validator(tmp_path, self._definition())
-        assert rc == 0
+        assert rc == 0, f"validate rc={rc}, output: {out}"
         assert "VALID" in out
 
     def test_metadata_title_missing_blocks(self, tmp_path):
@@ -525,7 +525,7 @@ class TestValidateDefinition:
         doc = self._definition()
         doc["metadata"].pop("title")
         rc, out = self._run_validator(tmp_path, doc)
-        assert rc == 1
+        assert rc == 1, f"validate rc={rc}, output: {out}"
         assert ("SEMANTIC_BLOCKED" in out) or ("INVALID" in out)
         assert "title" in out
 
@@ -538,7 +538,7 @@ class TestValidateDefinition:
 
     def test_edges_empty_warns_b_level(self, tmp_path):
         rc, out = self._run_validator(tmp_path, self._definition())
-        assert rc == 0
+        assert rc == 0, f"validate rc={rc}, output: {out}"
         assert "B1" in out
 
     def test_metadata_name_missing_blocks(self, tmp_path):
@@ -546,7 +546,7 @@ class TestValidateDefinition:
         doc = self._definition()
         doc["metadata"].pop("name")
         rc, out = self._run_validator(tmp_path, doc)
-        assert rc == 1
+        assert rc == 1, f"validate rc={rc}, output: {out}"
         assert ("INVALID" in out) or ("SEMANTIC_BLOCKED" in out)
 
 

--- a/tests/skills/test_qraft_workflowspec.py
+++ b/tests/skills/test_qraft_workflowspec.py
@@ -553,8 +553,12 @@ def subprocess_run_validator(json_path):
         [_sys.executable, str(script), str(json_path), "--strict", "--semantic"],
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=120,
     )
+    if proc.returncode != 0:
+        # CI 诊断：失败时把 stdout/stderr 拼进返回值，便于在失败信息中直接看到原因
+        suffix = (" [STDERR] " + proc.stderr) if proc.stderr else ""
+        return proc.returncode, (proc.stdout or "") + suffix
     return proc.returncode, proc.stdout
 
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] ✨ 新功能

## 变更概述

qraft-workflowspec-export 技能上传目标从 workflow_run 改为 workflow_definition（按官方《OAuth2-API文档》v1.0.0 第 8.4 节）。

## 背景/问题

官方文档 8.3/8.4 明确：`workflow_definition` 是"工作流定义——描述 Skill 的元数据、触发规则、输入输出、DAG 结构"的上传主体。此前技能导出 workflow_run（运行记录），不符合平台方案上传的主路径。按用户要求改为上传 workflow_definition，run 降级为归档模式。

## 关联 issue

- Closes #674

## 变更内容

- `SKILL.md`：Step 2 骨架改为 WorkflowDefinition（metadata/interface/activation/inputs/parameters/execution/graph/completion，官方 8.4 最简示例）；workflow_run 标注为归档模式（用户明确要求时才导出），run 专属章节（输入收集/产物归类）已标注；Step 4.5 语义规则按 document_kind 分流（definition 7 项 A 级 + 2 项 B 级）；方案视图与落盘命名（`workflowspec.definition.YYYYMMDD.json`）同步
- `validate_run.py`：`--strict` 接受两种 document_kind；新增 `_semantic_check_definition`（metadata.title/description/id/version 必填、graph.nodes ≥ 1、节点 presentation.data_view/action_view 必填——对应官方 8.6 错误表）
- `tests/skills/test_qraft_workflowspec.py`：新增 definition 校验 4 例

## 日志/验证证据

```
$ uv run pytest tests/skills/test_qraft_workflowspec.py -q
32 passed

$ uv run python miqi/skills/qraft-workflowspec-export/scripts/validate_run.py e2e-definition.json --strict --semantic --report-json
{"status": "VALID", "schemaErrors": [], "aErrors": [], "bWarnings": ["B2: graph.edges 为空 → 节点间无依赖边（线性流程）"], "strictError": null}

# 真实环境上传（Qraft 测试环境已建表）
$ uv run python miqi/skills/qraft-workflowspec-export/scripts/upload_run.py e2e-definition.json --json
{"ok": true, "code": "OK", "message": "ok", "httpStatus": 200}
```

## 测试情况

- 技能脚本 32 例单测全过（新增 definition 校验 4 例）
- 真实环境 E2E：definition 校验 VALID → 真实 dataUpload 上传成功（`ok`）——上传链路首次端到端全通

## 截图

无需截图（Skill 脚本/文档变更）

## 后续计划

- 待 #758（token 通道落地 develop）合入后，用户无需 env 凭据，登录一次即可让 Skill 自动复用 token 文件


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Switch `validate_run.py --strict` to accept `workflow_definition` or `workflow_run`.

- Add `workflow_definition` semantic checks A1-A8 plus non-finite A0 interception.

- Reconfigure `auth.py`, `upload_run.py`, and `validate_run.py` stdout/stderr to UTF-8 before `argparse`.

- Update `SKILL.md` to make `workflow_definition` the default upload target and archive `workflow_run`.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auth.py</strong><dd><code>Harden auth.py stdout encoding on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/scripts/auth.py

<ul><li>Add <code>_ensure_utf8_streams()</code> to reconfigure stdout/stderr to UTF-8.<br> <li> Call it before <code>argparse</code> in <code>main()</code> to avoid Windows cp1252 Unicode <br>errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/763/files#diff-8a15eaa3f71e1292e5c92384bac39dc37acf1da4687ea0f11fb42bc833dcdb0a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upload_run.py</strong><dd><code>Harden upload_run.py stdout encoding on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/scripts/upload_run.py

<ul><li>Add <code>_ensure_utf8_streams()</code> to reconfigure stdout/stderr to UTF-8.<br> <li> Call it before <code>argparse</code> in <code>main()</code> to prevent cp1252 Unicode crashes.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/763/files#diff-b707f2584176c8356a649f9d3033e345b7bdcaf6bef8b8dcb718d0d3f7910307">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_run.py</strong><dd><code>Add workflow_definition semantic validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/scripts/validate_run.py

<ul><li>Update <code>--strict</code> to accept <code>workflow_definition</code> or <code>workflow_run</code>.<br> <li> Add <code>_semantic_check_definition</code> with A1-A8 and B1 rules.<br> <li> Add <code>_nonfinite_paths</code> and A0 NaN/Infinity interception before <br>document-kind branch.<br> <li> Add <code>_ensure_utf8_streams()</code> and call it before <code>argparse</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/763/files#diff-88f4a11915d6f77b205edd64f0d398c9a7803ef8c385015c4f37bb5bd6d54d61">+83/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_qraft_workflowspec.py</strong><dd><code>Test workflow_definition semantic validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/skills/test_qraft_workflowspec.py

<ul><li>Add <code>TestValidateDefinition</code> for valid documents, empty title, missing <br><code>data_view</code>, empty edges B1, blank name, and non-finite values.<br> <li> Add <code>subprocess_run_validator</code> helper with UTF-8 decoding and stderr on <br>failure.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/763/files#diff-44571c2184c6b0130a783a664eb2cb0daac248f69e7f6c5e7f55c1b7b120ac73">+131/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Document definition-first export and upload flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/SKILL.md

<ul><li>Rewrite skill description to default upload target <br><code>workflow_definition</code>.<br> <li> Replace Step 2 WorkflowRun skeleton with WorkflowDefinition minimal <br>example.<br> <li> Update Step 4.5 semantic rules split by <code>document_kind</code>, add <br>A8/B1/nonfinite.<br> <li> Update output filename and upload command to <br><code>workflowspec.definition.YYYYMMDD.json</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/763/files#diff-2267cbc4803f47e8e4ea2e6acb2d7b9bb4ee4f1a528d7799246a5db5c707cdb5">+73/-87</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

