### PR TITLE
feat(runtime): execution snapshots — 中断 turn 快照落盘 + 中断卡 UI（#740）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -312,6 +312,7 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
         mode: input.mode,
         attachments: input.attachments,
         workspace: input.workspace,
+        resume_turn_id: (input as any).resume_turn_id ?? undefined,
       },
       (type: string, data: unknown) => {
         if (type === 'progress') {
@@ -346,6 +347,18 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
     return bridge.send('chat.abort', {
       session_key: input.session_key,
       thread_id: input.thread_id,
+    });
+  });
+
+  // #740: discard an interrupted turn's execution snapshot (重新开始)
+  ipcMain.handle(IPC.CHAT_DISCARD_RESUME, async (_event, payload: unknown) => {
+    const input = (payload ?? {}) as {
+      resume_turn_id?: string;
+      session_key?: string;
+    };
+    return bridge.send('chat.discard_resume', {
+      resume_turn_id: input.resume_turn_id,
+      session_key: input.session_key,
     });
   });
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -121,7 +121,8 @@ const api = {
       threadId?: string,
       mode?: string,
       attachments?: Array<{ name: string; data_base64?: string; mime_type?: string }>,
-      workspace?: string
+      workspace?: string,
+      resumeTurnId?: string
     ): Promise<unknown> =>
       ipcRenderer.invoke(IPC.CHAT_SEND, {
         content,
@@ -130,9 +131,15 @@ const api = {
         mode,
         attachments,
         workspace,
+        resume_turn_id: resumeTurnId,
       }),
     abort: (sessionKey?: string, threadId?: string): Promise<unknown> =>
       ipcRenderer.invoke(IPC.CHAT_ABORT, { session_key: sessionKey, thread_id: threadId }),
+    discardResume: (resumeTurnId: string, sessionKey?: string): Promise<unknown> =>
+      ipcRenderer.invoke(IPC.CHAT_DISCARD_RESUME, {
+        resume_turn_id: resumeTurnId,
+        session_key: sessionKey,
+      }),
     onProgress: (callback: (data: ChatProgress) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: ChatProgress) => callback(data);
       ipcRenderer.on(IPC_EVENTS.CHAT_PROGRESS, handler);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3,6 +3,7 @@ import { AgentAvatar, UserAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { SandboxHtmlFrame } from './components/SandboxHtmlFrame';
 import { ThinkBlock } from './components/ThinkBlock';
+import { InterruptedTurnCard } from './components/InterruptedTurnCard';
 import { DiffView } from './components/DiffView';
 import { renderContent } from './components/renderContent';
 import { TrackedFileCard } from './components/TrackedFileCard';
@@ -235,6 +236,18 @@ interface Message {
   isLiveReasoning?: boolean;
   /** Seconds elapsed from send to final for the "用时 X 秒" label. */
   reasoningElapsedS?: number;
+  /** #740: this assistant bubble is a half-generated reply recovered from an
+   *  execution snapshot after an interrupted turn (process exit / abort).
+   *  interruptedMeta carries the snapshot payload for the resume card. */
+  interrupted?: boolean;
+  interruptedMeta?: {
+    turnId: string;
+    status: string;
+    assistantContent: string;
+    reasoningContent: string;
+    updatedAt: number;
+    tokenEstimate?: number;
+  };
   timestamp: number;
 }
 
@@ -2633,6 +2646,30 @@ export function ChatConsole({
             setStreaming(false);
           }
         }
+        // #740: append interrupted-turn snapshots — half-generated replies
+        // the user saw before an interruption (process exit / abort) — as
+        // resumable assistant bubbles with the 中断卡 + 继续执行/重新开始 actions.
+        const _interruptedTurns = (detail as any)?.interrupted_turns ?? [];
+        if (Array.isArray(_interruptedTurns) && _interruptedTurns.length > 0) {
+          for (const _it of _interruptedTurns) {
+            const _halfContent = String(_it.assistant_content ?? '');
+            merged.push({
+              role: 'assistant',
+              content: _halfContent,
+              reasoning: String(_it.reasoning_content ?? '') || undefined,
+              interrupted: true,
+              interruptedMeta: {
+                turnId: String(_it.turn_id ?? ''),
+                status: String(_it.status ?? 'interrupted'),
+                assistantContent: _halfContent,
+                reasoningContent: String(_it.reasoning_content ?? ''),
+                updatedAt: Number(_it.updated_at ?? 0) * 1000,
+                tokenEstimate: _halfContent ? Math.round(_halfContent.length / 4) : 0,
+              },
+              timestamp: Number(_it.updated_at ?? Date.now() / 1000) * 1000,
+            });
+          }
+        }
         setMessages(merged);
         // Snapshot is now reconciled into `merged` — clear it so a later
         // load() (loadTrigger refresh) doesn't re-append stale transient
@@ -3002,6 +3039,20 @@ export function ChatConsole({
    *  false once it streamed, was cancelled, or was superseded by a newer send. */
   const isCurrentPendingSend = (key: string, id: number) =>
     pendingSendIdsRef.current.get(key) === id;
+
+  // #740: 中断 turn 的「继续执行 / 重新开始」。
+  // Phase 2 接入真实 resume 后端（chat.send + resume_turn_id）；当前先提供
+  // 明确的占位行为，保证中断卡按钮可交互、不静默失效。
+  const handleResumeTurn = useCallback((msg: Message) => {
+    console.info('[resume] 继续执行 turn=', msg.interruptedMeta?.turnId ?? '(unknown)');
+    // TODO(#740 Phase 2): 调用 window.miqi.chat.send(..., { resumeTurnId })，
+    // 由后端以 snapshot 半截内容为上下文续答，并在成功后删除该快照。
+  }, []);
+
+  const handleRestartTurn = useCallback((msg: Message) => {
+    console.info('[resume] 重新开始 turn=', msg.interruptedMeta?.turnId ?? '(unknown)');
+    // TODO(#740 Phase 2): 删除该 turn 的 execution snapshot，让用户重发新消息。
+  }, []);
 
   const handleSend = useCallback(async () => {
     // 发送即清除调整提示——占位词只属于"点了调整方案之后"的输入场景
@@ -5247,6 +5298,16 @@ export function ChatConsole({
                         sources={sourcesByMsg.get(group.msg) ?? []}
                         toolStepIndex={toolStepByMsg.get(group.msg)}
                         isLast={i === chatGroups.length - 1}
+                        onResume={
+                          group.msg.interrupted
+                            ? () => handleResumeTurn(group.msg)
+                            : undefined
+                        }
+                        onRestart={
+                          group.msg.interrupted
+                            ? () => handleRestartTurn(group.msg)
+                            : undefined
+                        }
                         searchResults={
                           group.msg.toolCallId
                             ? searchResultsByCallId[group.msg.toolCallId]
@@ -6318,6 +6379,9 @@ interface MessageBubbleProps {
   isLastToolRow?: boolean;
   /** web_search result text for this row (click-to-expand cards). */
   searchResults?: string;
+  /** #740: resume/restart an interrupted turn (half-generated reply). */
+  onResume?: () => void;
+  onRestart?: () => void;
 }
 
 const MessageBubble = memo(function MessageBubble({
@@ -6342,6 +6406,8 @@ const MessageBubble = memo(function MessageBubble({
   turnIndex,
   copyIdx,
   sending,
+  onResume,
+  onRestart,
 }: MessageBubbleProps) {
   const [expanded, setExpanded] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -6406,6 +6472,23 @@ const MessageBubble = memo(function MessageBubble({
       setDislikeSending(false);
     }
   };
+
+  if (msg.interrupted) {
+    return (
+      <InterruptedTurnCard
+        meta={
+          msg.interruptedMeta ?? {
+            turnId: '',
+            status: 'interrupted',
+          }
+        }
+        reasoning={msg.reasoning}
+        content={String(msg.content ?? '')}
+        onResume={onResume}
+        onRestart={onRestart}
+      />
+    );
+  }
 
   if (msg.role === 'progress') {
     // Thinking blocks live in the timeline as their own quiet block, both

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3024,6 +3024,10 @@ export function ChatConsole({
   /** Payload for programmatic sends (e.g. regenerate) — bypasses input state */
   const retryPayloadRef = useRef<{ text: string; attachments: Attachment[]; retry?: boolean } | null>(null);
   const handleSendRef = useRef<() => void>(() => {});
+  /** #740: pending resume-turn id — set by 继续执行, consumed by handleSend
+   *  so the resume request flows through the full send pipeline (listeners,
+   *  streaming render) instead of a bare chat.send call. */
+  const resumeTurnIdRef = useRef<string | null>(null);
   /** Per-session send id of the send currently in its pre-stream pending phase
    *  (issue #364).  A session is "pending" while its optimistic bubble waits on
    *  the non-blocking provider check / thread init.  The double-Enter guard
@@ -3041,30 +3045,16 @@ export function ChatConsole({
     pendingSendIdsRef.current.get(key) === id;
 
   // #740: 中断 turn 的「继续执行 / 重新开始」。
-  // 继续执行 → chat.send(resumeTurnId)：后端以快照半截内容为上下文续答
-  // （replan），新回复走正常流式渲染；重新开始 → 删除该快照并移除卡片。
-  const handleResumeTurn = useCallback(
-    async (msg: Message) => {
-      const meta = msg.interruptedMeta;
-      if (!meta?.turnId) return;
-      // 移除中断卡——resume 的新回复由流式事件接管渲染
-      setMessages((prev) => prev.filter((m) => m !== msg));
-      try {
-        await window.miqi.chat.send(
-          '',
-          sessionKey,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          meta.turnId
-        );
-      } catch (e) {
-        console.error('[resume] failed', e);
-      }
-    },
-    [sessionKey]
-  );
+  // 继续执行 → 经 handleSend 主流程发 resume 请求（复用流式监听/渲染），
+  // 后端以快照半截内容为上下文续答（replan）；重新开始 → 删除快照并移除卡片。
+  const handleResumeTurn = useCallback((msg: Message) => {
+    const meta = msg.interruptedMeta;
+    if (!meta?.turnId) return;
+    resumeTurnIdRef.current = meta.turnId;
+    // 移除中断卡——resume 的新回复由流式事件接管渲染
+    setMessages((prev) => prev.filter((m) => m !== msg));
+    handleSendRef.current();
+  }, []);
 
   const handleRestartTurn = useCallback(
     async (msg: Message) => {
@@ -3083,10 +3073,13 @@ export function ChatConsole({
   const handleSend = useCallback(async () => {
     // 发送即清除调整提示——占位词只属于"点了调整方案之后"的输入场景
     setAdjustHint(false);
+    // #740: resume consumes the pending resume-turn id (set by 继续执行).
+    const _resumeId = resumeTurnIdRef.current;
+    resumeTurnIdRef.current = null;
     const payload = retryPayloadRef.current;
     const text = (payload?.text ?? input).trim();
     const atts = payload?.attachments ?? attachments;
-    if (!text && atts.length === 0) {
+    if (!text && atts.length === 0 && !_resumeId) {
       retryPayloadRef.current = null;
       return;
     }
@@ -3154,7 +3147,9 @@ export function ChatConsole({
     pendingSendIdsRef.current.set(sendSessionKey, thisSendId);
     setSendingFor(sendSessionKey, userMsg.timestamp);
     setStreaming(true);
-    setMessages((prev) => [...prev, userMsg]);
+    // #740: resume has no user bubble (the interrupted card was removed and
+    // the streamed reply takes over rendering) — skip the optimistic push.
+    if (!_resumeId) setMessages((prev) => [...prev, userMsg]);
     userScrolledUp.current = false;
     setInput('');
     // Reset textarea height after sending
@@ -4198,7 +4193,8 @@ export function ChatConsole({
         threadId ?? undefined,
         executionPolicy,
         chatAttachments.length > 0 ? chatAttachments : undefined,
-        workspace ?? undefined
+        workspace ?? undefined,
+        _resumeId ?? undefined
       );
 
       // Mark as done after a tick — server parsing is synchronous, already complete

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3041,18 +3041,44 @@ export function ChatConsole({
     pendingSendIdsRef.current.get(key) === id;
 
   // #740: 中断 turn 的「继续执行 / 重新开始」。
-  // Phase 2 接入真实 resume 后端（chat.send + resume_turn_id）；当前先提供
-  // 明确的占位行为，保证中断卡按钮可交互、不静默失效。
-  const handleResumeTurn = useCallback((msg: Message) => {
-    console.info('[resume] 继续执行 turn=', msg.interruptedMeta?.turnId ?? '(unknown)');
-    // TODO(#740 Phase 2): 调用 window.miqi.chat.send(..., { resumeTurnId })，
-    // 由后端以 snapshot 半截内容为上下文续答，并在成功后删除该快照。
-  }, []);
+  // 继续执行 → chat.send(resumeTurnId)：后端以快照半截内容为上下文续答
+  // （replan），新回复走正常流式渲染；重新开始 → 删除该快照并移除卡片。
+  const handleResumeTurn = useCallback(
+    async (msg: Message) => {
+      const meta = msg.interruptedMeta;
+      if (!meta?.turnId) return;
+      // 移除中断卡——resume 的新回复由流式事件接管渲染
+      setMessages((prev) => prev.filter((m) => m !== msg));
+      try {
+        await window.miqi.chat.send(
+          '',
+          sessionKey,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          meta.turnId
+        );
+      } catch (e) {
+        console.error('[resume] failed', e);
+      }
+    },
+    [sessionKey]
+  );
 
-  const handleRestartTurn = useCallback((msg: Message) => {
-    console.info('[resume] 重新开始 turn=', msg.interruptedMeta?.turnId ?? '(unknown)');
-    // TODO(#740 Phase 2): 删除该 turn 的 execution snapshot，让用户重发新消息。
-  }, []);
+  const handleRestartTurn = useCallback(
+    async (msg: Message) => {
+      const meta = msg.interruptedMeta;
+      if (!meta?.turnId) return;
+      try {
+        await window.miqi.chat.discardResume(meta.turnId, sessionKey);
+        setMessages((prev) => prev.filter((m) => m !== msg));
+      } catch (e) {
+        console.error('[resume] discard failed', e);
+      }
+    },
+    [sessionKey]
+  );
 
   const handleSend = useCallback(async () => {
     // 发送即清除调整提示——占位词只属于"点了调整方案之后"的输入场景

--- a/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
@@ -27,6 +27,9 @@ export function InterruptedTurnCard({
 }) {
   const [busy, setBusy] = useState(false);
   const [confirmingRestart, setConfirmingRestart] = useState(false);
+  // Note: snapshots are persisted only as running/interrupted/completed —
+  // there is no 'aborted' state, so the card always renders the interrupted
+  // (recoverable) presentation.
 
   const handleResume = () => {
     if (busy) return;
@@ -47,8 +50,6 @@ export function InterruptedTurnCard({
     }
   };
 
-  const paused = meta.status === 'aborted';
-
   return (
     <div className="my-1 flex min-w-0">
       <div className="w-4 flex flex-col items-center self-stretch" aria-hidden>
@@ -65,7 +66,7 @@ export function InterruptedTurnCard({
           style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface)' }}
         >
           <div className="flex items-center gap-2 text-[13.5px] font-bold" style={{ color: 'var(--text)' }}>
-            <span>⚠️ {paused ? '任务已停止' : '任务被中断'}</span>
+            <span>⚠️ 任务被中断</span>
             <span
               className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-semibold"
               style={{ background: 'rgba(180,83,9,.12)', color: '#b45309' }}
@@ -74,7 +75,7 @@ export function InterruptedTurnCard({
                 className="inline-block h-[6px] w-[6px] rounded-full"
                 style={{ background: '#b45309' }}
               />
-              {paused ? '已暂停' : '未完成'}
+              未完成
             </span>
           </div>
           {meta.tokenEstimate ? (

--- a/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import { ThinkBlock } from './ThinkBlock';
+
+/**
+ * #740: 中断的 turn 恢复卡片。
+ *
+ * 渲染一个被打断的 turn 的半截状态：进度摘要（中断卡）+ 已生成的
+ * 思考块 + 半截回答，以及「继续执行 / 重新开始」两个动作。
+ * 样式遵循 ChatConsole 消息气泡语言（白底 14px 圆角、accent 主按钮）。
+ */
+export function InterruptedTurnCard({
+  meta,
+  reasoning,
+  content,
+  onResume,
+  onRestart,
+}: {
+  meta: {
+    turnId: string;
+    status: string;
+    tokenEstimate?: number;
+  };
+  reasoning?: string;
+  content: string;
+  onResume?: () => void;
+  onRestart?: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [confirmingRestart, setConfirmingRestart] = useState(false);
+
+  const handleResume = () => {
+    if (busy) return;
+    setBusy(true);
+    onResume?.();
+    // 恢复请求已发出——流式事件会接管渲染；若回调未触发（无后端），
+    // 短延迟后复位按钮以免永久卡在"继续中"。
+    setTimeout(() => setBusy(false), 1500);
+  };
+
+  const handleRestart = () => {
+    if (confirmingRestart) {
+      onRestart?.();
+      setConfirmingRestart(false);
+    } else {
+      setConfirmingRestart(true);
+      setTimeout(() => setConfirmingRestart(false), 2500);
+    }
+  };
+
+  const paused = meta.status === 'aborted';
+
+  return (
+    <div className="my-1 flex min-w-0">
+      <div className="w-4 flex flex-col items-center self-stretch" aria-hidden>
+        <span className="text-[13px] leading-[1.2]">⚠️</span>
+        <span
+          className="mt-[3px] w-[2px] flex-1 min-h-2 rounded-full"
+          style={{ background: 'var(--border-subtle)' }}
+        />
+      </div>
+      <div className="min-w-0 flex-1 pl-2">
+        {/* 中断卡：进度摘要 */}
+        <div
+          className="mb-2 max-w-[600px] rounded-xl border p-3.5"
+          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface)' }}
+        >
+          <div className="flex items-center gap-2 text-[13.5px] font-bold" style={{ color: 'var(--text)' }}>
+            <span>⚠️ {paused ? '任务已停止' : '任务被中断'}</span>
+            <span
+              className="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-semibold"
+              style={{ background: 'rgba(180,83,9,.12)', color: '#b45309' }}
+            >
+              <span
+                className="inline-block h-[6px] w-[6px] rounded-full"
+                style={{ background: '#b45309' }}
+              />
+              {paused ? '已暂停' : '未完成'}
+            </span>
+          </div>
+          {meta.tokenEstimate ? (
+            <div className="mt-1.5 text-[11.5px]" style={{ color: 'var(--text-faint)' }}>
+              已生成约 {meta.tokenEstimate} tokens
+            </div>
+          ) : null}
+          <div className="mt-2 flex gap-2">
+            <button
+              className="btn-resume inline-flex items-center gap-1.5 rounded-lg px-3.5 py-1.5 text-[12.5px] font-semibold text-white disabled:opacity-55"
+              style={{ background: 'var(--accent)' }}
+              onClick={handleResume}
+              disabled={busy}
+            >
+              {busy ? (
+                <>
+                  <span
+                    className="inline-block h-[11px] w-[11px] rounded-full border-2 border-white/40 border-t-white"
+                    style={{ animation: 'turn-spin .8s linear infinite' }}
+                  />
+                  继续中…
+                </>
+              ) : (
+                <>▶ 继续执行</>
+              )}
+            </button>
+            <button
+              className="inline-flex items-center rounded-lg border px-3.5 py-1.5 text-[12.5px] font-semibold"
+              style={{
+                background: 'var(--surface-muted)',
+                color: 'var(--text-muted)',
+                borderColor: 'var(--border-subtle)',
+              }}
+              onClick={handleRestart}
+            >
+              {confirmingRestart ? '确认重新开始？再点一次' : '重新开始'}
+            </button>
+          </div>
+        </div>
+
+        {/* 已生成的思考块（可展开） */}
+        {reasoning ? (
+          <ThinkBlock
+            reasoning={reasoning}
+            defaultOpen={false}
+            elapsedSeconds={1}
+          />
+        ) : null}
+
+        {/* 半截回答 */}
+        {content ? (
+          <div
+            className="text-[13.5px] leading-relaxed whitespace-pre-wrap break-words"
+            style={{ color: 'var(--text)' }}
+          >
+            {content}
+            <span
+              className="ml-0.5 inline-block h-[14px] w-[2px] animate-pulse rounded-sm align-[-2px]"
+              style={{ background: 'var(--accent)' }}
+            />
+          </div>
+        ) : (
+          <div className="text-[13px]" style={{ color: 'var(--text-faint)' }}>
+            回答尚未开始生成。
+          </div>
+        )}
+      </div>
+      <style>{`@keyframes turn-spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -16,6 +16,7 @@ export const IPC = {
   // Chat
   CHAT_SEND: 'chat:send',
   CHAT_ABORT: 'chat:abort',
+  CHAT_DISCARD_RESUME: 'chat:discard-resume',
 
   // Threads (Codex-style, Phase 36+)
   THREAD_START: 'thread:start',
@@ -202,11 +203,12 @@ export const IPC_EVENTS = {
 // ---------------------------------------------------------------------------
 
 export const ChatSendInput = z.object({
-  content: z.string().min(1),
+  content: z.string().optional(),
   session_key: z.string().optional(),
   thread_id: z.string().optional(),
   mode: z.enum(['plan', 'manual', 'edit', 'auto']).optional(),
   workspace: z.string().optional(),
+  resume_turn_id: z.string().optional(),
   attachments: z
     .array(
       z.object({

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -303,6 +303,11 @@ class BridgeRuntimeLoop:
         # Register Phase 27.3: chat.send through AppServer
         self._app_server.register_method("chat.send", self._chat_send_handler)
 
+        # Register #740: discard an interrupted turn's execution snapshot
+        self._app_server.register_method(
+            "chat.discard_resume", self._chat_discard_resume_handler,
+        )
+
         # Register Phase 27.4: agent.spawn/kill through AppServer
         self._app_server.register_method("agent.spawn", self._agent_spawn_handler)
         self._app_server.register_method("agent.kill", self._agent_kill_handler)
@@ -702,10 +707,13 @@ class BridgeRuntimeLoop:
         from miqi.protocol.commands import UserMessage
 
         content = params.get("content")
-        if not content:
+        resume_turn_id = params.get("resume_turn_id")
+        if not content and not resume_turn_id:
             from miqi.runtime.app_server import AppServerError
 
-            raise AppServerError("content is required", code="INVALID_PARAMS")
+            raise AppServerError(
+                "content (or resume_turn_id) is required", code="INVALID_PARAMS"
+            )
 
         session_key = params.get("session_key", "desktop:default")
         thread_id = params.get("thread_id", session_key)
@@ -940,9 +948,10 @@ class BridgeRuntimeLoop:
 
         # Submit the user message
         await runtime.submit(UserMessage(
-            content=content,
+            content=content or "",
             thread_id=thread_id,
             mode=mode,
+            resume_turn_id=resume_turn_id,
         ))
 
         # Subscribe client to session events so emit_event delivers to the sink.
@@ -979,6 +988,58 @@ class BridgeRuntimeLoop:
             client_id, runtime_id, thread_id,
         )
         return {"result": {"accepted": True}}
+
+    async def _chat_discard_resume_handler(
+        self, request_id: str, params: dict, client_id: str,
+        session_id: str | None, registry: Any,
+    ) -> dict:
+        """#740: discard an interrupted turn's execution snapshot (重新开始).
+
+        Active sessions delete via the live HistoryRuntime connection; inactive
+        ones (after restart) fall back to a throwaway HistoryRuntime over the
+        workspace db. Never raises for a missing snapshot.
+        """
+        from miqi.runtime.app_server import AppServerError
+
+        resume_turn_id = params.get("resume_turn_id")
+        if not resume_turn_id:
+            raise AppServerError("resume_turn_id is required", code="INVALID_PARAMS")
+
+        session_key = params.get("session_key", "desktop:default")
+        runtime_id = session_id or f"{client_id}:{session_key}"
+        runtime = await registry.get_session(client_id, runtime_id)
+        deleted = False
+
+        if runtime is not None:
+            hr = getattr(runtime.services, "history_runtime", None)
+            if hr is not None:
+                await hr.delete_snapshot(resume_turn_id)
+                deleted = True
+
+        if not deleted and self._bridge_state is not None:
+            try:
+                from pathlib import Path as _Path
+
+                from miqi.runtime.history_runtime import HistoryRuntime
+                from miqi.session.manager import SessionManager
+
+                config = self._bridge_state.load_config()
+                sm = SessionManager(config.workspace_path)
+                sess = sm.get_or_create(session_key, client_id=client_id)
+                ws = sess.metadata.get("workspace") or config.workspace_path
+                db_path = _Path(ws) / ".miqi-runtime" / "runtime.db"
+                if db_path.exists():
+                    hr = HistoryRuntime(db_path, session_id=runtime_id)
+                    await hr.initialize()
+                    try:
+                        await hr.delete_snapshot(resume_turn_id)
+                        deleted = True
+                    finally:
+                        await hr.close()
+            except Exception as exc:
+                logger.warning("discard_resume fallback failed: {}", exc)
+
+        return {"result": {"deleted": deleted}}
 
     async def _drain_chat_events(
         self,

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -706,7 +706,7 @@ class BridgeRuntimeLoop:
         """
         from miqi.protocol.commands import UserMessage
 
-        content = params.get("content")
+        content = params.get("content") or ""
         resume_turn_id = params.get("resume_turn_id")
         if not content and not resume_turn_id:
             from miqi.runtime.app_server import AppServerError

--- a/miqi/protocol/commands.py
+++ b/miqi/protocol/commands.py
@@ -21,6 +21,9 @@ class UserMessage:
     input_items: list[dict[str, Any]] = field(default_factory=list)
     client_user_message_id: str | None = None
     settings_overrides: dict[str, Any] = field(default_factory=dict)
+    # #740: resume an interrupted turn — the new turn continues from the
+    # snapshot's half-generated content instead of starting fresh.
+    resume_turn_id: str | None = None
 
 
 @dataclass

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -428,18 +428,21 @@ class HistoryRuntime:
             return None
         return self._snapshot_row_to_dict(row)
 
-    async def get_interrupted_snapshots(self, thread_id: str) -> list[dict[str, Any]]:
-        """Return recoverable snapshots for a thread (running/interrupted).
+    async def get_interrupted_snapshots(self) -> list[dict[str, Any]]:
+        """Return recoverable snapshots for this runtime's session.
 
+        Queried by session_id (not thread_id) — threads use UUID-style ids
+        ("thread-…") while the load path historically derived "sid:default";
+        session_id matches on both sides (#740).
         Used by the session-load path to render "任务被中断" cards with the
         half-generated content the user saw before the interruption.
         """
         db = self._conn
         async with db.execute(
             """SELECT * FROM execution_snapshots
-               WHERE thread_id = ? AND status IN ('running', 'interrupted')
+               WHERE session_id = ? AND status IN ('running', 'interrupted')
                ORDER BY updated_at DESC""",
-            (thread_id,),
+            (self.session_id,),
         ) as cursor:
             rows = await cursor.fetchall()
         return [self._snapshot_row_to_dict(r) for r in rows]

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -417,11 +417,11 @@ class HistoryRuntime:
         await db.commit()
 
     async def get_snapshot(self, turn_id: str) -> dict[str, Any] | None:
-        """Return the snapshot for a turn, or None."""
+        """Return the snapshot for a turn (scoped to this session), or None."""
         db = self._conn
         async with db.execute(
-            "SELECT * FROM execution_snapshots WHERE turn_id = ?",
-            (turn_id,),
+            "SELECT * FROM execution_snapshots WHERE turn_id = ? AND session_id = ?",
+            (turn_id, self.session_id),
         ) as cursor:
             row = await cursor.fetchone()
         if row is None:
@@ -448,11 +448,11 @@ class HistoryRuntime:
         return [self._snapshot_row_to_dict(r) for r in rows]
 
     async def delete_snapshot(self, turn_id: str) -> None:
-        """Remove a turn's snapshot (turn completed normally)."""
+        """Remove a turn's snapshot (scoped to this session)."""
         db = self._conn
         await db.execute(
-            "DELETE FROM execution_snapshots WHERE turn_id = ?",
-            (turn_id,),
+            "DELETE FROM execution_snapshots WHERE turn_id = ? AND session_id = ?",
+            (turn_id, self.session_id),
         )
         await db.commit()
 

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -129,6 +129,23 @@ class HistoryRuntime:
                 created_at REAL NOT NULL
             )
         """)
+        # #740: execution snapshots — in-flight turn state persisted so an
+        # interrupted turn (process exit / abort) can be resumed later.
+        # Deleted when the turn completes normally (content is then persisted
+        # as real messages); kept when interrupted (status=running/interrupted).
+        await self._db.execute("""
+            CREATE TABLE IF NOT EXISTS execution_snapshots (
+                turn_id TEXT PRIMARY KEY,
+                thread_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'running',
+                assistant_content TEXT NOT NULL DEFAULT '',
+                reasoning_content TEXT NOT NULL DEFAULT '',
+                tool_state_json TEXT NOT NULL DEFAULT '[]',
+                version INTEGER NOT NULL DEFAULT 1,
+                updated_at REAL NOT NULL
+            )
+        """)
         await self._db.commit()
 
     async def close(self) -> None:
@@ -358,6 +375,106 @@ class HistoryRuntime:
             ))
             copied += 1
         return copied
+
+    # ── #740: execution snapshots (in-flight turn state) ───────────────
+
+    async def upsert_snapshot(
+        self,
+        turn_id: str,
+        thread_id: str,
+        *,
+        status: str = "running",
+        assistant_content: str = "",
+        reasoning_content: str = "",
+        tool_state: list[dict] | None = None,
+        version: int = 1,
+    ) -> None:
+        """Persist (or update) an in-flight turn's execution snapshot.
+
+        Called by the turn loop on a throttle (time/bytes threshold), on
+        interruption, and on completion (before the snapshot is deleted).
+        """
+        db = self._conn
+        await db.execute(
+            """INSERT INTO execution_snapshots
+               (turn_id, thread_id, session_id, status, assistant_content,
+                reasoning_content, tool_state_json, version, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(turn_id) DO UPDATE SET
+                 status = excluded.status,
+                 assistant_content = excluded.assistant_content,
+                 reasoning_content = excluded.reasoning_content,
+                 tool_state_json = excluded.tool_state_json,
+                 version = excluded.version,
+                 updated_at = excluded.updated_at""",
+            (
+                turn_id, thread_id, self.session_id, status,
+                assistant_content, reasoning_content,
+                json.dumps(tool_state or [], ensure_ascii=False),
+                version, time.time(),
+            ),
+        )
+        await db.commit()
+
+    async def get_snapshot(self, turn_id: str) -> dict[str, Any] | None:
+        """Return the snapshot for a turn, or None."""
+        db = self._conn
+        async with db.execute(
+            "SELECT * FROM execution_snapshots WHERE turn_id = ?",
+            (turn_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return self._snapshot_row_to_dict(row)
+
+    async def get_interrupted_snapshots(self, thread_id: str) -> list[dict[str, Any]]:
+        """Return recoverable snapshots for a thread (running/interrupted).
+
+        Used by the session-load path to render "任务被中断" cards with the
+        half-generated content the user saw before the interruption.
+        """
+        db = self._conn
+        async with db.execute(
+            """SELECT * FROM execution_snapshots
+               WHERE thread_id = ? AND status IN ('running', 'interrupted')
+               ORDER BY updated_at DESC""",
+            (thread_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [self._snapshot_row_to_dict(r) for r in rows]
+
+    async def delete_snapshot(self, turn_id: str) -> None:
+        """Remove a turn's snapshot (turn completed normally)."""
+        db = self._conn
+        await db.execute(
+            "DELETE FROM execution_snapshots WHERE turn_id = ?",
+            (turn_id,),
+        )
+        await db.commit()
+
+    async def clear_snapshots(self, thread_id: str) -> int:
+        """Remove all snapshots for a thread (session deleted/archived)."""
+        db = self._conn
+        async with db.execute(
+            "DELETE FROM execution_snapshots WHERE thread_id = ?",
+            (thread_id,),
+        ) as cursor:
+            await db.commit()
+            return int(cursor.rowcount or 0)
+
+    @staticmethod
+    def _snapshot_row_to_dict(row: Any) -> dict[str, Any]:
+        return {
+            "turn_id": row["turn_id"],
+            "thread_id": row["thread_id"],
+            "status": row["status"],
+            "assistant_content": row["assistant_content"],
+            "reasoning_content": row["reasoning_content"],
+            "tool_state": json.loads(row["tool_state_json"] or "[]"),
+            "version": row["version"],
+            "updated_at": row["updated_at"],
+        }
 
     # ── Phase 19: compaction persistence ───────────────────────────────
 

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -295,6 +295,8 @@ class RuntimeServices:
 
         history_runtime = HistoryRuntime(runtime_db, session_id=session_id)
         thread_runtime = ThreadRuntime(runtime_db, session_id=session_id)
+        # #740: wire history runtime into TurnRunner for execution snapshots
+        turn_runner._history = history_runtime
 
         session_state = SessionState(
             session_id=session_id,

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -123,6 +123,39 @@ async def sessions_list_handler(
 # ── sessions.get ───────────────────────────────────────────────────────────
 
 
+async def _load_interrupted_turns(
+    *,
+    history_runtime: Any | None = None,
+    workspace: Path | None = None,
+    sid: str,
+) -> list[dict[str, Any]]:
+    """#740: return recoverable execution snapshots for the session's thread.
+
+    Active sessions use the live HistoryRuntime connection; inactive ones
+    (after restart) construct a throwaway HistoryRuntime over the same db.
+    Never raises — a snapshot-lookup failure degrades to an empty list.
+    """
+    try:
+        thread_id = f"{sid}:default"
+        if history_runtime is not None:
+            return await history_runtime.get_interrupted_snapshots(thread_id)
+        if workspace is not None:
+            from miqi.runtime.history_runtime import HistoryRuntime
+
+            db_path = workspace / ".miqi-runtime" / "runtime.db"
+            if not db_path.exists():
+                return []
+            hr = HistoryRuntime(db_path, session_id=sid)
+            await hr.initialize()
+            try:
+                return await hr.get_interrupted_snapshots(thread_id)
+            finally:
+                await hr.close()
+    except Exception as exc:
+        logger.warning("interrupted-turn lookup failed for %s: %s", sid, exc)
+    return []
+
+
 async def sessions_get_handler(
     request_id: str,
     params: dict[str, Any],
@@ -191,6 +224,10 @@ async def sessions_get_handler(
                 "updated_at": updated_at,
                 "metadata": metadata,
                 "workspace": ws_result,
+                "interrupted_turns": await _load_interrupted_turns(
+                    history_runtime=getattr(runtime.services, "history_runtime", None),
+                    sid=sid,
+                ),
             },
         }
 
@@ -204,6 +241,10 @@ async def sessions_get_handler(
             "status": "inactive",
             "ownership": ownership,
             "workspace": ws_result,
+            "interrupted_turns": await _load_interrupted_turns(
+                workspace=ws or (Path(ws_result) if ws_result else None),
+                sid=sid,
+            ),
         },
     }
 

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -123,6 +123,19 @@ async def sessions_list_handler(
 # ── sessions.get ───────────────────────────────────────────────────────────
 
 
+async def _default_workspace_path() -> Path | None:
+    """Fallback workspace root when a session carries no explicit workspace."""
+    try:
+        import miqi.bridge.server as bridge_module
+
+        state = getattr(bridge_module, "_state", None)
+        if state is None:
+            return None
+        return Path(state.load_config().workspace_path)
+    except Exception:
+        return None
+
+
 async def _load_interrupted_turns(
     *,
     history_runtime: Any | None = None,
@@ -136,19 +149,19 @@ async def _load_interrupted_turns(
     Never raises — a snapshot-lookup failure degrades to an empty list.
     """
     try:
-        thread_id = f"{sid}:default"
         if history_runtime is not None:
-            return await history_runtime.get_interrupted_snapshots(thread_id)
-        if workspace is not None:
+            return await history_runtime.get_interrupted_snapshots()
+        ws = workspace or await _default_workspace_path()
+        if ws is not None:
             from miqi.runtime.history_runtime import HistoryRuntime
 
-            db_path = workspace / ".miqi-runtime" / "runtime.db"
+            db_path = ws / ".miqi-runtime" / "runtime.db"
             if not db_path.exists():
                 return []
             hr = HistoryRuntime(db_path, session_id=sid)
             await hr.initialize()
             try:
-                return await hr.get_interrupted_snapshots(thread_id)
+                return await hr.get_interrupted_snapshots()
             finally:
                 await hr.close()
     except Exception as exc:

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -708,6 +708,19 @@ class TaskRunner:
                 resume_snapshot = await history_runtime.get_snapshot(resume_turn_id)
             except Exception as exc:
                 logger.warning("resume: snapshot lookup failed for {}: {}", resume_turn_id, exc)
+            # Scope/state validation: only resume a snapshot that belongs to
+            # THIS thread and is in a recoverable state — otherwise a request
+            # could inject another thread's partial response into this turn.
+            if resume_snapshot and (
+                resume_snapshot.get("thread_id") != thread_id
+                or resume_snapshot.get("status") not in ("running", "interrupted")
+            ):
+                logger.warning(
+                    "resume: snapshot {} rejected (thread={} status={})",
+                    resume_turn_id, resume_snapshot.get("thread_id"), resume_snapshot.get("status"),
+                )
+                resume_snapshot = None
+                resume_turn_id = None
             if resume_snapshot and (
                 resume_snapshot.get("assistant_content") or resume_snapshot.get("reasoning_content")
             ):

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -697,6 +697,35 @@ class TaskRunner:
                 + slash_content
             )
 
+        # ── #740: resume context — continue an interrupted turn ──────
+        # Replan (not replay): feed the snapshot's half-generated content to
+        # the model as context and instruct it to continue from where it
+        # stopped, rather than restoring raw messages.
+        resume_turn_id = getattr(msg, "resume_turn_id", None)
+        resume_snapshot: dict[str, Any] | None = None
+        if resume_turn_id and history_runtime is not None:
+            try:
+                resume_snapshot = await history_runtime.get_snapshot(resume_turn_id)
+            except Exception as exc:
+                logger.warning("resume: snapshot lookup failed for {}: {}", resume_turn_id, exc)
+            if resume_snapshot and (
+                resume_snapshot.get("assistant_content") or resume_snapshot.get("reasoning_content")
+            ):
+                _half = resume_snapshot["assistant_content"][-2000:]
+                _half_think = resume_snapshot["reasoning_content"][-800:]
+                effective_system_prompt += (
+                    "\n\n## 任务恢复（Resume）\n"
+                    "你正在继续一个被中断的任务。以下是你上次已生成的内容，"
+                    "请从上次中断处继续完成，不要重复已生成的部分。\n\n"
+                    f"已生成回答（末尾部分）:\n{_half or '（尚未生成正文）'}\n\n"
+                    + (f"上次思考过程（末尾部分）:\n{_half_think}\n\n" if _half_think else "")
+                    + "请继续完成该任务。"
+                )
+                logger.info("resume: turn {} injected snapshot context", resume_turn_id)
+            else:
+                logger.warning("resume: no usable snapshot for {}", resume_turn_id)
+                resume_turn_id = None
+
         # ── End Execution Policy ─────────────────────────────────────
 
         # Phase 13: attach permission profile for orchestrator
@@ -769,36 +798,39 @@ class TaskRunner:
             ))
 
             # Persist the user message
-            payload_fields: dict[str, Any] = {}
-            if msg.input_items:
-                payload_fields["input_items"] = msg.input_items
-            if msg.client_user_message_id:
-                payload_fields["client_user_message_id"] = msg.client_user_message_id
-            # Issue #402: write JSONL FIRST so sessions.get (which reads
-            # JSONL) sees the message even if a crash occurs before the
-            # SQLite write completes.  The JSONL store is the legacy
-            # single-source-of-truth for session overview; SQLite is
-            # thread-scoped and recoverable from JSONL if needed.
-            await self._save_to_session_manager(
-                role="user", content=msg.content)
-            if history_runtime is not None:
-                await history_runtime.append_message(
-                    thread_id=thread_id,
-                    turn_id=turn_id,
-                    role="user",
-                    content=msg.content,
-                    payload={"message_fields": payload_fields},
-                )
-            # Phase 24: record user message in ledger
-            if ledger is not None:
-                await ledger.append_item(
-                    thread_id=thread_id,
-                    turn_id=turn_id,
-                    item_type="message",
-                    role="user",
-                    content=msg.content,
-                    payload={"message_fields": payload_fields},
-                )
+            # #740: resume turns carry no real user input (content is a
+            # placeholder) — skip persisting it so history stays clean.
+            if not resume_turn_id:
+                payload_fields: dict[str, Any] = {}
+                if msg.input_items:
+                    payload_fields["input_items"] = msg.input_items
+                if msg.client_user_message_id:
+                    payload_fields["client_user_message_id"] = msg.client_user_message_id
+                # Issue #402: write JSONL FIRST so sessions.get (which reads
+                # JSONL) sees the message even if a crash occurs before the
+                # SQLite write completes.  The JSONL store is the legacy
+                # single-source-of-truth for session overview; SQLite is
+                # thread-scoped and recoverable from JSONL if needed.
+                await self._save_to_session_manager(
+                    role="user", content=msg.content)
+                if history_runtime is not None:
+                    await history_runtime.append_message(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        role="user",
+                        content=msg.content,
+                        payload={"message_fields": payload_fields},
+                    )
+                # Phase 24: record user message in ledger
+                if ledger is not None:
+                    await ledger.append_item(
+                        thread_id=thread_id,
+                        turn_id=turn_id,
+                        item_type="message",
+                        role="user",
+                        content=msg.content,
+                        payload={"message_fields": payload_fields},
+                    )
 
             # Check for abort before starting turn
             if cancel_evt.is_set():
@@ -888,6 +920,10 @@ class TaskRunner:
                     tools_used=result.tools_used,
                     token_usage=result.token_usage,
                 )
+            # #740: resume succeeded — the old interrupted turn's snapshot is
+            # no longer needed (its content is now part of this turn's reply).
+            if resume_turn_id and history_runtime is not None:
+                await history_runtime.delete_snapshot(resume_turn_id)
             # Phase 24: complete turn in ledger
             if ledger is not None:
                 await ledger.append_item(

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -76,6 +76,7 @@ class TurnRunner:
         max_iterations: int,
         capability_resolver: Any | None = None,
         ledger_runtime: Any | None = None,
+        history_runtime: Any | None = None,
         hooks: HookRuntime | None = None,
     ):
         self._provider = provider
@@ -85,7 +86,43 @@ class TurnRunner:
         self._max_iterations = max_iterations
         self._capability_resolver = capability_resolver
         self._ledger = ledger_runtime
+        self._history = history_runtime
         self._hooks = hooks
+        # #740: in-flight snapshot buffer (per-turn, reset in run()).
+        self._snap_content: list[str] = []
+        self._snap_reasoning: list[str] = []
+        self._snap_last_flush = 0.0
+        self._snap_flushed_len = 0
+
+    # ── #740: execution snapshot (in-flight turn state) ────────────────
+
+    def _snapshot_due(self) -> bool:
+        """Throttle: flush at least once per second or per 4KB of new output."""
+        if self._history is None:
+            return False
+        total = sum(len(p) for p in self._snap_content) + sum(
+            len(p) for p in self._snap_reasoning
+        )
+        return (
+            time.perf_counter() - self._snap_last_flush >= 1.0
+            or total - self._snap_flushed_len >= 4096
+        )
+
+    async def _snapshot_flush(self, turn: Any, *, status: str) -> None:
+        """Persist the accumulated content/reasoning as an execution snapshot."""
+        if self._history is None:
+            return
+        content = "".join(self._snap_content)
+        reasoning = "".join(self._snap_reasoning)
+        await self._history.upsert_snapshot(
+            turn.turn_id,
+            turn.thread_id,
+            status=status,
+            assistant_content=content,
+            reasoning_content=reasoning,
+        )
+        self._snap_last_flush = time.perf_counter()
+        self._snap_flushed_len = len(content) + len(reasoning)
 
     async def run(
         self,
@@ -124,8 +161,14 @@ class TurnRunner:
             lifecycle_ctx.hook_point = HookPoint.TURN_START
             await self._hooks.run(HookPoint.TURN_START, lifecycle_ctx)
 
+        # #740: reset per-turn snapshot buffer; flush on throttle, on
+        # interruption (keep snapshot for resume), and on completion (delete).
+        self._snap_content = []
+        self._snap_reasoning = []
+        self._snap_last_flush = time.perf_counter()
+        self._snap_flushed_len = 0
         try:
-            return await self._run_impl(
+            result = await self._run_impl(
                 turn=turn,
                 user_content=user_content,
                 system_prompt=system_prompt,
@@ -135,6 +178,14 @@ class TurnRunner:
                 steer_queue=steer_queue,
                 max_iterations=max_iterations,
             )
+        except BaseException:
+            await self._snapshot_flush(turn, status="interrupted")
+            raise
+        else:
+            await self._snapshot_flush(turn, status="completed")
+            if self._history is not None:
+                await self._history.delete_snapshot(turn.turn_id)
+            return result
         finally:
             if self._hooks is not None:
                 end_ctx = LifecycleHookContext(
@@ -232,6 +283,9 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     content_parts.append(stream_event.delta)
+                    self._snap_content.append(stream_event.delta)
+                    if self._snapshot_due():
+                        await self._snapshot_flush(turn, status="running")
                     from miqi.protocol.events import AgentMessageDeltaEvent
                     await self._events.emit(AgentMessageDeltaEvent(
                         turn_id=turn.turn_id,
@@ -254,6 +308,9 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     reasoning_parts.append(stream_event.delta)
+                    self._snap_reasoning.append(stream_event.delta)
+                    if self._snapshot_due():
+                        await self._snapshot_flush(turn, status="running")
                     from miqi.protocol.events import AgentReasoningEvent
                     logger.info(
                         "turn_runner: got reasoning_delta len={} for turn={}",

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -59,6 +59,48 @@ class TurnResult:
     reasoning: str | None = None
 
 
+class _SnapshotBuffer:
+    """#740: per-turn execution-snapshot buffer with throttled flush state.
+
+    Created fresh inside every ``run()`` call so a reused TurnRunner can never
+    leak or corrupt snapshot state across concurrent/sequential turns.
+    """
+
+    def __init__(self) -> None:
+        self.content: list[str] = []
+        self.reasoning: list[str] = []
+        self.last_flush = time.perf_counter()
+        self.flushed_len = 0
+
+    def due(self, history: Any) -> bool:
+        """Throttle: flush at least once per second or per 4KB of new output."""
+        if history is None:
+            return False
+        total = sum(len(p) for p in self.content) + sum(
+            len(p) for p in self.reasoning
+        )
+        return (
+            time.perf_counter() - self.last_flush >= 1.0
+            or total - self.flushed_len >= 4096
+        )
+
+    async def flush(self, history: Any, turn: Any, *, status: str) -> None:
+        """Persist the accumulated content/reasoning as an execution snapshot."""
+        if history is None:
+            return
+        content = "".join(self.content)
+        reasoning = "".join(self.reasoning)
+        await history.upsert_snapshot(
+            turn.turn_id,
+            turn.thread_id,
+            status=status,
+            assistant_content=content,
+            reasoning_content=reasoning,
+        )
+        self.last_flush = time.perf_counter()
+        self.flushed_len = len(content) + len(reasoning)
+
+
 class TurnRunner:
     """Runs a single model+tool turn.
 
@@ -88,41 +130,6 @@ class TurnRunner:
         self._ledger = ledger_runtime
         self._history = history_runtime
         self._hooks = hooks
-        # #740: in-flight snapshot buffer (per-turn, reset in run()).
-        self._snap_content: list[str] = []
-        self._snap_reasoning: list[str] = []
-        self._snap_last_flush = 0.0
-        self._snap_flushed_len = 0
-
-    # ── #740: execution snapshot (in-flight turn state) ────────────────
-
-    def _snapshot_due(self) -> bool:
-        """Throttle: flush at least once per second or per 4KB of new output."""
-        if self._history is None:
-            return False
-        total = sum(len(p) for p in self._snap_content) + sum(
-            len(p) for p in self._snap_reasoning
-        )
-        return (
-            time.perf_counter() - self._snap_last_flush >= 1.0
-            or total - self._snap_flushed_len >= 4096
-        )
-
-    async def _snapshot_flush(self, turn: Any, *, status: str) -> None:
-        """Persist the accumulated content/reasoning as an execution snapshot."""
-        if self._history is None:
-            return
-        content = "".join(self._snap_content)
-        reasoning = "".join(self._snap_reasoning)
-        await self._history.upsert_snapshot(
-            turn.turn_id,
-            turn.thread_id,
-            status=status,
-            assistant_content=content,
-            reasoning_content=reasoning,
-        )
-        self._snap_last_flush = time.perf_counter()
-        self._snap_flushed_len = len(content) + len(reasoning)
 
     async def run(
         self,
@@ -161,12 +168,9 @@ class TurnRunner:
             lifecycle_ctx.hook_point = HookPoint.TURN_START
             await self._hooks.run(HookPoint.TURN_START, lifecycle_ctx)
 
-        # #740: reset per-turn snapshot buffer; flush on throttle, on
-        # interruption (keep snapshot for resume), and on completion (delete).
-        self._snap_content = []
-        self._snap_reasoning = []
-        self._snap_last_flush = time.perf_counter()
-        self._snap_flushed_len = 0
+        # #740: per-turn snapshot buffer — flush on throttle, on interruption
+        # (keep snapshot for resume), and on completion (delete).
+        _snap = _SnapshotBuffer()
         try:
             result = await self._run_impl(
                 turn=turn,
@@ -177,12 +181,13 @@ class TurnRunner:
                 cancel_event=cancel_event,
                 steer_queue=steer_queue,
                 max_iterations=max_iterations,
+                snapshot_buffer=_snap,
             )
         except BaseException:
-            await self._snapshot_flush(turn, status="interrupted")
+            await _snap.flush(self._history, turn, status="interrupted")
             raise
         else:
-            await self._snapshot_flush(turn, status="completed")
+            await _snap.flush(self._history, turn, status="completed")
             if self._history is not None:
                 await self._history.delete_snapshot(turn.turn_id)
             return result
@@ -209,6 +214,7 @@ class TurnRunner:
         cancel_event: Any | None = None,
         steer_queue: Any | None = None,
         max_iterations: int | None = None,
+        snapshot_buffer: _SnapshotBuffer | None = None,
     ) -> TurnResult:
         """Core turn loop implementation."""
         # #729: first-token observability — log latency from turn start to the
@@ -283,9 +289,10 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     content_parts.append(stream_event.delta)
-                    self._snap_content.append(stream_event.delta)
-                    if self._snapshot_due():
-                        await self._snapshot_flush(turn, status="running")
+                    if snapshot_buffer is not None:
+                        snapshot_buffer.content.append(stream_event.delta)
+                        if snapshot_buffer.due(self._history):
+                            await snapshot_buffer.flush(self._history, turn, status="running")
                     from miqi.protocol.events import AgentMessageDeltaEvent
                     await self._events.emit(AgentMessageDeltaEvent(
                         turn_id=turn.turn_id,
@@ -308,9 +315,10 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     reasoning_parts.append(stream_event.delta)
-                    self._snap_reasoning.append(stream_event.delta)
-                    if self._snapshot_due():
-                        await self._snapshot_flush(turn, status="running")
+                    if snapshot_buffer is not None:
+                        snapshot_buffer.reasoning.append(stream_event.delta)
+                        if snapshot_buffer.due(self._history):
+                            await snapshot_buffer.flush(self._history, turn, status="running")
                     from miqi.protocol.events import AgentReasoningEvent
                     logger.info(
                         "turn_runner: got reasoning_delta len={} for turn={}",

--- a/tests/bridge/test_phase35_control_plane_audit.py
+++ b/tests/bridge/test_phase35_control_plane_audit.py
@@ -320,8 +320,8 @@ def test_phase35_runtime_bridge_state_imports_audit():
     )
 
     total_imports = sum(imports.values())
-    assert total_imports == 15, (
-        f"Expected 15 total bridge.server imports in runtime/, "
+    assert total_imports == 16, (
+        f"Expected 16 total bridge.server imports in runtime/, "
         f"got {total_imports}. Update this test if the count changed."
     )
 

--- a/tests/bridge/test_phase72_thread_contract_audit.py
+++ b/tests/bridge/test_phase72_thread_contract_audit.py
@@ -55,6 +55,6 @@ async def test_plan72_primary_thread_contract_counts():
         legacy = [item for item in catalog["methods"] if item["stability"] == "legacy"]
 
         assert len(typed) >= 83
-        assert len(legacy) <= 77  # +1 legacy: sessions.rename, +1 legacy: sessions.list_recent_workspaces
+        assert len(legacy) <= 78  # +1 legacy: chat.discard_resume (#740)
     finally:
         await loop.app_server.stop()

--- a/tests/fixtures/protocol/app_protocol_snapshot.v1.json
+++ b/tests/fixtures/protocol/app_protocol_snapshot.v1.json
@@ -211,6 +211,21 @@
         "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
         "emits": [],
         "eventSchemas": {},
+        "method": "chat.discard_resume",
+        "paramsSchema": {
+          "type": "object"
+        },
+        "resultSchema": {
+          "type": "object"
+        },
+        "scope": "session",
+        "stability": "legacy"
+      },
+      {
+        "deprecatedBy": null,
+        "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
+        "emits": [],
+        "eventSchemas": {},
         "method": "chat.send",
         "paramsSchema": {
           "type": "object"
@@ -5552,8 +5567,8 @@
     "source": "miqi.runtime.export_app_protocol_ts.render_typescript_contract"
   },
   "methodCounts": {
-    "legacy": 77,
-    "total": 161,
+    "legacy": 78,
+    "total": 162,
     "typed": 84
   },
   "schemaVersion": 1


### PR DESCRIPTION
### **User description**
## 类型

- [x] ✨ 新功能
- [ ] 🐛 Bug 修复
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

执行快照（Execution Snapshot）：AI turn 进行中被打断（退出应用/点停止/崩溃）后，半截状态持久化到本地库；重启回来时显示「任务被中断」卡片 + 半截回答 + 思考块，并提供「继续执行 / 重新开始」按钮（#740 Phase 0 + Phase 1）。

## 背景/问题

#740（可恢复 Agent Run）第一阶段。现状：turn 中断（进程退出/abort）时，进行中已生成的内容**不落盘**（abort 路径只记"已中止"），重启后半截回答丢失、无法继续。本 PR 实现：

- 后端：turn 进行中增量落盘（reasoning/content delta，双阈值 flush ≥1s 或 ≥4KB）；中断时快照保留（status=interrupted），正常完成时删除
- 前端：会话加载时识别未完成 turn，渲染中断卡 + 半截内容 + 继续执行/重新开始按钮

## 关联 issue

- Closes #740（Phase 0+1：快照落盘 + 中断显示；续答后端 Phase 2 与工具感知 Phase 3 后续跟进）

## 变更内容

**后端（Phase 0）**
- `miqi/runtime/history_runtime.py`：新增 `execution_snapshots` 表（turn_id/thread_id/session_id/status/assistant_content/reasoning_content/tool_state_json/version/updated_at）+ 方法 `upsert_snapshot` / `get_snapshot` / `get_interrupted_snapshots` / `delete_snapshot` / `clear_snapshots`
- `miqi/runtime/turn_runner.py`：双阈值 flush（1s / 4KB 新输出）持久化 content/reasoning；turn 正常完成 → final flush + 删除快照；异常/取消（CancelledError）→ flush(status=interrupted) 保留供恢复
- `miqi/runtime/services.py`：TurnRunner 接入 history_runtime
- `miqi/runtime/session_handlers.py`：`sessions.get` 返回 `interrupted_turns`（active 会话用 live HistoryRuntime 连接；inactive 重启后用临时 HistoryRuntime 读同一 db；任何失败降级空列表，不阻塞会话加载）

**前端（Phase 1）**
- 新增 `InterruptedTurnCard.tsx`：中断卡（⚠️ 任务被中断/已停止 + 已生成 tokens + 「继续执行 / 重新开始」按钮，按钮交互含继续中 spinner、重新开始二次确认）+ 已生成思考块（ThinkBlock，可展开）+ 半截回答 + 光标标记；样式沿用 ChatConsole 消息气泡语言（白底 14px 圆角、accent 主按钮）
- `ChatConsole.tsx`：`load()` 把 `interrupted_turns` 转换为可恢复 assistant 消息（`interrupted` + `interruptedMeta` 字段）；MessageBubble 优先分派给中断卡；`onResume`/`onRestart` 回调占位（Phase 2 接真实 resume 后端）

## 日志/验证证据

```
tsc --noEmit → 0 errors
pytest → 74 passed (turn_runner / history_runtime / session_handlers / task_runner 集成)
```

快照生命周期（设计语义）：
- turn 开始 → status=running，增量 flush
- turn 正常完成 → final flush(completed) → 删除快照（内容已落盘为真实消息）
- turn 被停止/崩溃 → flush(interrupted) → 快照保留 → 重启后 sessions.get 返回 → 前端渲染中断卡

## 测试情况

```
pytest tests/runtime/test_turn_runner.py tests/runtime/test_turn_error_propagation.py \
       tests/runtime/test_history_runtime.py tests/runtime/test_session_handlers.py \
       tests/runtime/test_task_runner_history_integration.py \
       tests/runtime/test_task_runner_ledger_integration.py -q
74 passed in 22.88s
```

```
cd apps/desktop && npx tsc --noEmit
exit 0（无类型错误）
```

（待补：前端 E2E + 实机 kill→重启→恢复验证，draft 阶段进行中）

## 截图

见 #740 讨论中的 HTML 原型（v3，用户确认）：中断卡 + 思考块 + 半截回答 + 继续执行/重新开始按钮布局。

## 后续计划

- Phase 2：续答后端（chat.send + resume_turn_id，以快照半截内容为上下文 replan 而非 replay；孤儿 tool_calls 处理；幂等锁）
- Phase 3：工具感知恢复（tool_state 状态机：pending/running/completed/unknown）
- 按钮动作接线：onResume/onRestart 从占位改为真实后端调用


___

### **PR Type**
Enhancement


___

### **Description**
- Persist in-flight turn snapshots with throttled flush

- Expose interrupted turns via `sessions.get` API

- Resume turns with snapshot-injected context, skip duplicate history

- Add interrupted card with continue and restart actions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TurnRunner streaming deltas"] -- "throttled flush" --> B["execution_snapshots table"]
  B -- "interrupted status" --> C["session_handlers load"]
  C -- "interrupted_turns" --> D["ChatConsole InterruptedTurnCard"]
  D -- "resume_turn_id" --> E["task_runner resume context"]
  D -- "discard_resume" --> B
  E -- "delete snapshot on completion" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>loop.py`</strong><dd><code>Add discard_resume handler and resume_turn_id validation</code>&nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>commands.py`</strong><dd><code>Add resume_turn_id field to UserMessage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>history_runtime.py`</strong><dd><code>Add execution_snapshots table and snapshot CRUD methods</code>&nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>services.py`</strong><dd><code>Wire history runtime into TurnRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>session_handlers.py`</strong><dd><code>Return interrupted_turns in sessions.get response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>task_runner.py`</strong><dd><code>Build resume context and clean snapshot after completion</code>&nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>turn_runner.py`</strong><dd><code>Add throttled snapshot flushing during streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>index.ts`</strong><dd><code>Add IPC handler for discard resume and resume send</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>index.ts`</strong><dd><code>Expose resumeTurnId and discardResume in preload API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx`</strong><dd><code>Render interrupted turns and handle resume/restart actions</code></dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>InterruptedTurnCard.tsx`</strong><dd><code>Add interrupted turn card with resume and restart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>ipc.ts`</strong><dd><code>Add CHAT_DISCARD_RESUME constant and optional content schema</code></dd></td>
  <td><a href=""></a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_phase35_control_plane_audit.py`</strong><dd><code>Update bridge.server import count assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>test_phase72_thread_contract_audit.py`</strong><dd><code>Adjust legacy method count for discard_resume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td><strong>app_protocol_snapshot.v1.json`</strong><dd><code>Update protocol snapshot counts and method entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href=""></a></td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-8884758a148ac81f6980064c69650ae427e276cf7752f4481578bd12abbc4258">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-fecf2d7e27201df1f0e00156c44faaa274e5dd37dfb485582ce3b2271ce5558c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChatConsole.tsx</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+108/-3</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>InterruptedTurnCard.tsx</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-e657fd70477da86b4310f69a6e6388a5b5cff48295f5d2b3fb078fce2e4450b0">+149/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ipc.ts</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-81ac7bad817ed82c59690622ef10a178997322633c6e2cd137a7f933a5072727">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loop.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+65/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>commands.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-e6d1afb72e93c832567d72e840c796a938457faba56a280e9ab9d3814c3b099d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>history_runtime.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-da2ec0f091912a5173cdc6d54f397a19f51a911ef1510bd88cbc90147435568b">+120/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>services.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-3f67e147cf7f5f862ddf78772f3a728ac8fbf3637b5950375ff997084db27dbc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>session_handlers.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-8521ca715b3fa343900b3be160f6dad8ba5e95bb2c3fb356daa2449261b015c4">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>task_runner.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+79/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>turn_runner.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-4627bd8e77d69d5a0d5be03c29bd0c3402cd0988e6d538cad1b99f4be0a60696">+66/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase35_control_plane_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-247945c7b237a2c148d8afced6a2c6a4739afd5cdf049596866a388513f55d83">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_phase72_thread_contract_audit.py</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-da6da0639dbf2d8041f89dba158f37a7aec27de1abc363b3b55ceb7f22cf8721">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_protocol_snapshot.v1.json</strong></td>
  <td><a href="https://github.com/14790897/MiQi/pull/766/files#diff-64f26c341ba8a85b08764290f8268986f4ee73e8976e506e879add3d5c3e5a41">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

