### PR TITLE
fix(qraft): validate_run.py 语法修复——develop 全 PR test job 失败根因

### DIFF
--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 try:
     import jsonschema
-
+    from jsonschema import Draft202012Validator
 
 except ImportError:  # pragma: no cover
     sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
@@ -42,7 +42,8 @@ def _ensure_utf8_streams() -> None:
             stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
         except Exception:
             pass
-    from jsonschema import Draft202012Validator
+
+
 DEFAULT_SCHEMA = Path(__file__).resolve().parent.parent / "references" / "workflowspec.schema.json"
 
 

--- a/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
+++ b/miqi/skills/qraft-workflowspec-export/scripts/validate_run.py
@@ -29,6 +29,11 @@ try:
     import jsonschema
 
 
+except ImportError:  # pragma: no cover
+    sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
+    sys.exit(2)
+
+
 def _ensure_utf8_streams() -> None:
     """Windows 默认 stdout/stderr 编码为 cp1252 等本地代码页，打印中文会
     UnicodeEncodeError 崩溃。统一重配置为 UTF-8（Python 3.7+）。"""
@@ -38,10 +43,6 @@ def _ensure_utf8_streams() -> None:
         except Exception:
             pass
     from jsonschema import Draft202012Validator
-except ImportError:  # pragma: no cover
-    sys.stderr.write("ERROR: jsonschema package not installed. Run: pip install jsonschema\n")
-    sys.exit(2)
-
 DEFAULT_SCHEMA = Path(__file__).resolve().parent.parent / "references" / "workflowspec.schema.json"
 
 


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 `miqi/skills/qraft-workflowspec-export/scripts/validate_run.py` 的语法错误——`_ensure_utf8_streams` 函数被插入 `try: import jsonschema` 块中间，导致所有依赖该文件的测试/工具 SyntaxError。

## 背景/问题

2026-08-20 起，**所有 PR 的 test (ubuntu/windows) job 失败**（含 #752 等）：`validate_run.py line 32 SyntaxError: expected 'except' or 'finally' block`。根因：文件编辑时 `_ensure_utf8_streams()` 函数定义被插到 `try: import jsonschema` 与 `except ImportError` 之间，破坏 try/except 结构；且 `from jsonschema import Draft202012Validator` 残留在函数末尾（模块级使用处 NameError）。

## 变更内容

- `validate_run.py`：
  - `from jsonschema import Draft202012Validator` 移回 `try` 块（与 `import jsonschema` 一起）
  - `_ensure_utf8_streams()` 移到 `except` 块之后（独立函数）
  - 函数与 `DEFAULT_SCHEMA` 之间补空行

## 日志/验证证据

```
修复前：python -c "import validate_run" → SyntaxError line 32
        pytest tests/skills/test_qraft_workflowspec.py → 5 failed (NameError: Draft202012Validator)

修复后：
$ python -c "import ast; ast.parse(open(...))" → 语法 OK
$ pytest tests/skills/test_qraft_workflowspec.py → 33 passed
```

## 测试情况

- `tests/skills/test_qraft_workflowspec.py`：33 passed（修复前 5 failed）
- 语法校验：ast.parse 通过

## 截图

无需截图。


___

### **PR Type**
Other


___

### **Description**
- Adds a blank line between `jsonschema` imports and `except ImportError`

- Adds a blank line after `_ensure_utf8_streams` before `DEFAULT_SCHEMA`

- Formatting-only change; no runtime behavior affected


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_run.py</strong><dd><code>Add blank lines for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/skills/qraft-workflowspec-export/scripts/validate_run.py

<ul><li>Insert blank line after <code>from jsonschema import Draft202012Validator</code> <br>before <code>except ImportError</code><br> <li> Insert blank line after <code>_ensure_utf8_streams</code> function body before <br><code>DEFAULT_SCHEMA</code></ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/768/files#diff-88f4a11915d6f77b205edd64f0d398c9a7803ef8c385015c4f37bb5bd6d54d61">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

