### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
+++ b/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * No-Sandbox Host Exec E2E
+ *
+ * Regression coverage for #792 (PR #793): with the sandbox disabled,
+ * the legacy orchestrator path (chat.send → TaskRunner →
+ * SandboxPolicyEngine) used to select RESTRICTED + BLOCK_ALL network
+ * policy for exec, so EVERY command was rejected with
+ * "RESTRICTED 沙箱无法强制网络隔离…命令未执行" — blocking tasks that
+ * needed network (e.g. the Qraft upload script hitting
+ * test.forge.miqroera.com).
+ *
+ * After the fix, exec with no sandbox available selects NONE and runs
+ * directly on the host without restrictions (network, cwd and path
+ * checks all bypassed — the user runs without isolation by choice).
+ *
+ * The spec drives the real chat flow with the sandbox disabled via
+ * patchConfig, asks the agent to run a marker command, and asserts the
+ * user-visible outcome: the marker appears in the reply and the old
+ * fail-closed block message does not.
+ *
+ * Run:
+ *   cd apps/desktop
+ *   npx playwright test --config=playwright.config.ts --project=electron no-sandbox-exec.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  LLM_TIMEOUT,
+  waitForBridgeInitialized,
+  sendMessage,
+  waitForResponseComplete,
+  approveLoop,
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+test.describe('No-Sandbox Host Exec E2E', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp((config) => {
+      // Deterministic no-sandbox path: exec resolves to RESTRICTED host
+      // execution through SandboxPolicyEngine (bwrap_available=False).
+      config.tools = {
+        ...config.tools,
+        sandbox: { ...config.tools?.sandbox, enabled: false },
+      };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+
+    await waitForBridgeInitialized(page);
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test(
+    'exec runs on host when sandbox is disabled (no RESTRICTED network block)',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      const marker = `NO_SANDBOX_EXEC_OK_${Date.now()}`;
+
+      // Marker echo proves the command actually started; the networked
+      // curl mirrors the original #792 scenario (upload scripts need
+      // network).  Pre-fix the whole line was rejected before running.
+      const prompt =
+        `必须使用 exec 工具执行下面这条命令，然后只回复命令的完整输出，` +
+        `不要解释、不要改写：` +
+        `echo ${marker} && curl -sI --max-time 10 example.com`;
+
+      await sendMessage(page, prompt);
+      await approveLoop(page, LLM_TIMEOUT);
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+
+      const text = (await page.locator('main').textContent()) ?? '';
+
+      // User-visible outcome: the command actually ran on the host.
+      expect(text).toContain(marker);
+      // The old fail-closed block must not appear in the reply.
+      expect(text).not.toContain('无法强制网络隔离');
+      expect(text).not.toContain('命令未执行');
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        fullPage: true,
+      });
+    },
+  );
+});

--- a/miqi/execution/sandbox_policy.py
+++ b/miqi/execution/sandbox_policy.py
@@ -77,6 +77,11 @@ class SandboxSelection:
 class SandboxPolicyEngine:
     """Resolves sandbox policy for tool executions.
 
+    Base selection:
+      exec → bwrap (strongest) when available, else LANDLOCK when a real
+             adapter exists, else NONE — no sandbox available means direct
+             host execution without restrictions (the user runs without
+             isolation by choice).
     Escalation strategy (on denial):
       Attempt 0 → bwrap (strongest)
       Attempt 1 → landlock (medium) — only if landlock_supported AND landlock_available
@@ -161,6 +166,14 @@ class SandboxPolicyEngine:
         # 2. Determine base sandbox type
         base_type = self._base_sandbox_type(tool_name)
 
+        # A profile-level network="none" is an explicit hard denial:
+        # keep RESTRICTED enforcement (workspace confinement and
+        # fail-closed network) even when no sandbox is available.
+        if base_type == SandboxType.NONE and tool_name == "exec":
+            profile = getattr(ctx, "permission_profile", None)
+            if getattr(profile, "network", None) == "none":
+                base_type = SandboxType.RESTRICTED
+
         # 3. Escalate on retry (NONE is NOT in the escalation chain —
         #    fallback to NONE is gated by _resolve_fallback() below.)
         escalation = self._escalation_chain(base_type)
@@ -176,7 +189,9 @@ class SandboxPolicyEngine:
             )
 
         # Phase 33.4: enrich reason with sandbox availability context
-        if selected == SandboxType.RESTRICTED and tool_name == "exec":
+        if tool_name == "exec" and selected in (
+            SandboxType.RESTRICTED, SandboxType.NONE,
+        ):
             parts: list[str] = []
             if not self.bwrap_available:
                 parts.append("bwrap unavailable")
@@ -185,9 +200,13 @@ class SandboxPolicyEngine:
             elif not self.landlock_available:
                 parts.append("landlock unavailable")
             if parts:
+                suffix = (
+                    " — direct host execution without restrictions"
+                    if selected == SandboxType.NONE
+                    else " — no stronger sandbox available"
+                )
                 reason += (
-                    " (" + ", ".join(parts)
-                    + " — no stronger sandbox available)"
+                    " (" + ", ".join(parts) + suffix + ")"
                 )
         elif (
             selected == SandboxType.BWRAP
@@ -207,9 +226,12 @@ class SandboxPolicyEngine:
         net_policy = self._network_policy_for_tool(tool_name, ctx)
 
         # Phase 33.3: RESTRICTED cannot enforce network isolation via
-        # direct host execution.  Default to BLOCK_ALL so
-        # _execute_restricted() fails closed — unless the permission
-        # profile explicitly sets network_allowed=True.
+        # direct host execution, so it fails closed unless the permission
+        # profile explicitly sets network_allowed=True.  RESTRICTED is
+        # selected for exec only when a stronger sandbox was available
+        # but execution was downgraded, or when the profile explicitly
+        # denies network (network="none").  network="none" is a hard
+        # denial and blocks even over network_allowed=True.
         if selected == SandboxType.RESTRICTED and tool_name == "exec":
             profile = getattr(ctx, "permission_profile", None)
             network_allowed = (
@@ -217,7 +239,12 @@ class SandboxPolicyEngine:
                 if profile is not None
                 else False
             )
-            if not network_allowed:
+            network_denied = (
+                getattr(profile, "network", None) == "none"
+                if profile is not None
+                else False
+            )
+            if network_denied or not network_allowed:
                 net_policy = NetworkSandboxPolicy.BLOCK_ALL
 
         return SandboxSelection(
@@ -242,7 +269,9 @@ class SandboxPolicyEngine:
                 return SandboxType.BWRAP
             if self.landlock_available and self.landlock_supported:
                 return SandboxType.LANDLOCK
-            return SandboxType.RESTRICTED
+            # No sandbox available: direct host execution without
+            # restrictions (the user runs without isolation by choice).
+            return SandboxType.NONE
 
         # File mutation tools: moderate isolation
         if tool_name in self.FILE_MUTATION_TOOLS:

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -914,9 +914,9 @@ async def test_restricted_network_allow_all_proceeds(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_engine_restricted_exec_defaults_to_block_all():
-    """SandboxPolicyEngine defaults RESTRICTED exec network_policy to
-    BLOCK_ALL when permission_profile has network_allowed=False."""
+async def test_engine_exec_no_sandbox_selects_none_with_network_allowed():
+    """SandboxPolicyEngine selects NONE for exec when no stronger sandbox
+    is available — direct host execution, network allowed, no restrictions."""
     from miqi.execution.sandbox_policy import SandboxPolicyEngine
     from miqi.runtime.permission_profile import PermissionProfile
 
@@ -933,20 +933,97 @@ async def test_engine_restricted_exec_defaults_to_block_all():
         permission_profile = profile
 
     sel = await engine.select(FakeCtx())
-    # Engine selected RESTRICTED (no bwrap, no landlock)
+    # No bwrap, no landlock — NONE: direct host execution
+    assert sel.sandbox_type == SandboxType.NONE
+    # Network stays ALLOW_ALL so exec can run
+    assert sel.network_policy == "allow_all"
+
+
+@pytest.mark.asyncio
+async def test_engine_restricted_exec_with_sandbox_available_blocks_network():
+    """When bwrap is available but the selection was downgraded to
+    RESTRICTED (escalation past BWRAP/LANDLOCK), network stays BLOCK_ALL
+    unless permission_profile.network_allowed=True."""
+    from miqi.execution.sandbox_policy import SandboxPolicyEngine
+    from miqi.runtime.permission_profile import PermissionProfile
+
+    engine = SandboxPolicyEngine(bwrap_available=True, landlock_available=False)
+
+    profile = PermissionProfile(
+        workspace=None,  # type: ignore
+        network_allowed=False,
+    )
+
+    class FakeCtx:
+        tool_name = "exec"
+        arguments = {"command": "curl example.com"}
+        permission_profile = profile
+
+    # attempt=2 escalates past BWRAP and LANDLOCK down to RESTRICTED
+    sel = await engine.select(FakeCtx(), attempt=2)
     assert sel.sandbox_type == SandboxType.RESTRICTED
-    # Network should be BLOCK_ALL by default
+    assert sel.network_policy == "block_all"
+
+
+@pytest.mark.asyncio
+async def test_engine_restricted_exec_network_none_profile_blocks_without_sandbox():
+    """A PermissionProfile with network="none" is an explicit denial —
+    RESTRICTED exec gets BLOCK_ALL even when no stronger sandbox is
+    available, so the no-sandbox fallback cannot bypass the denial."""
+    from miqi.execution.sandbox_policy import SandboxPolicyEngine
+    from miqi.runtime.permission_profile import PermissionProfile
+
+    engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
+
+    profile = PermissionProfile(
+        workspace=None,  # type: ignore
+        network="none",
+        network_allowed=False,
+    )
+
+    class FakeCtx:
+        tool_name = "exec"
+        arguments = {"command": "curl example.com"}
+        permission_profile = profile
+
+    sel = await engine.select(FakeCtx())
+    assert sel.sandbox_type == SandboxType.RESTRICTED
+    assert sel.network_policy == "block_all"
+
+
+@pytest.mark.asyncio
+async def test_engine_restricted_exec_network_none_denial_wins_over_allow():
+    """network="none" is a hard denial: it blocks even when
+    network_allowed=True (deny wins over allow)."""
+    from miqi.execution.sandbox_policy import SandboxPolicyEngine
+    from miqi.runtime.permission_profile import PermissionProfile
+
+    engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
+
+    profile = PermissionProfile(
+        workspace=None,  # type: ignore
+        network="none",
+        network_allowed=True,
+    )
+
+    class FakeCtx:
+        tool_name = "exec"
+        arguments = {"command": "curl example.com"}
+        permission_profile = profile
+
+    sel = await engine.select(FakeCtx())
+    assert sel.sandbox_type == SandboxType.RESTRICTED
     assert sel.network_policy == "block_all"
 
 
 @pytest.mark.asyncio
 async def test_engine_restricted_exec_network_allowed_overrides_to_allow_all():
     """When permission_profile.network_allowed=True, RESTRICTED exec
-    keeps ALLOW_ALL network policy."""
+    (downgraded from an available bwrap) keeps ALLOW_ALL network policy."""
     from miqi.execution.sandbox_policy import SandboxPolicyEngine
     from miqi.runtime.permission_profile import PermissionProfile
 
-    engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
+    engine = SandboxPolicyEngine(bwrap_available=True, landlock_available=False)
 
     profile = PermissionProfile(
         workspace=None,  # type: ignore
@@ -958,7 +1035,8 @@ async def test_engine_restricted_exec_network_allowed_overrides_to_allow_all():
         arguments = {"command": "curl example.com"}
         permission_profile = profile
 
-    sel = await engine.select(FakeCtx())
+    # attempt=2 escalates past BWRAP and LANDLOCK down to RESTRICTED
+    sel = await engine.select(FakeCtx(), attempt=2)
     assert sel.sandbox_type == SandboxType.RESTRICTED
     assert sel.network_policy == "allow_all"
 
@@ -1216,8 +1294,10 @@ async def test_exec_escalation_exhausted_raises_not_none():
 
 @pytest.mark.asyncio
 async def test_allow_fallback_to_none_true_does_not_let_exec_become_none():
-    """Phase 33.4: allow_fallback_to_none=True must NOT make exec
-    fallback to NONE. Exec is always fail-closed on exhaustion."""
+    """allow_fallback_to_none=True must NOT weaken exec retry semantics.
+    Attempt 0 with no sandbox is the NONE base selection (direct host
+    execution), but exhaustion beyond it still raises — exec never
+    *falls back* to NONE."""
     from miqi.execution.sandbox_policy import (
         SandboxPolicyEngine,
         SandboxDeniedError,
@@ -1233,9 +1313,9 @@ async def test_allow_fallback_to_none_true_does_not_let_exec_become_none():
         tool_name = "exec"
         arguments = {"command": "npm test"}
 
-    # base=RESTRICTED, chain=[RESTRICTED]. attempt=0→RESTRICTED, attempt=1→exhausted
+    # base=NONE, chain=[NONE]. attempt=0→NONE, attempt=1→exhausted
     s0 = await engine.select(FakeCtx(), attempt=0)
-    assert s0.sandbox_type == SandboxType.RESTRICTED
+    assert s0.sandbox_type == SandboxType.NONE
 
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(FakeCtx(), attempt=1)
@@ -1271,15 +1351,15 @@ async def test_sandbox_policy_reason_includes_landlock_unsupported():
         arguments = {"command": "npm test"}
 
     sel = await engine.select(FakeCtx())
-    assert sel.sandbox_type == SandboxType.RESTRICTED
+    assert sel.sandbox_type == SandboxType.NONE
     assert "landlock_supported=False" in sel.reason
     assert "no Landlock adapter" in sel.reason
 
 
 @pytest.mark.asyncio
 async def test_sandbox_policy_reason_includes_fallback_info():
-    """Phase 33.4: reason for RESTRICTED exec explains why no stronger
-    sandbox is available."""
+    """Phase 33.4: reason for NONE exec explains why no sandbox is
+    available and that execution is unrestricted."""
     from miqi.execution.sandbox_policy import SandboxPolicyEngine
 
     engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
@@ -1290,7 +1370,7 @@ async def test_sandbox_policy_reason_includes_fallback_info():
 
     sel = await engine.select(FakeCtx())
     assert "bwrap unavailable" in sel.reason
-    assert "no stronger sandbox" in sel.reason
+    assert "direct host execution without restrictions" in sel.reason
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_phase33_sandbox_acceptance.py
+++ b/tests/execution/test_phase33_sandbox_acceptance.py
@@ -64,9 +64,10 @@ def _none_selection() -> SandboxSelection:
 
 
 @pytest.mark.asyncio
-async def test_acceptance_default_config_exec_fail_closed(tmp_path):
-    """Phase 33 invariant: default config (no bwrap, no landlock, no network)
-    → policy engine selects RESTRICTED + BLOCK_ALL → exec fail-closed."""
+async def test_acceptance_default_config_exec_runs_on_host(tmp_path):
+    """Default config (no bwrap, no landlock, no network profile) → policy
+    engine selects NONE → exec runs directly on the host without
+    restrictions.  No sandbox must not block commands."""
     engine = SandboxPolicyEngine(
         bwrap_available=False,
         landlock_available=False,
@@ -79,14 +80,14 @@ async def test_acceptance_default_config_exec_fail_closed(tmp_path):
     })()
 
     selection = await engine.select(ctx)
-    assert selection.sandbox_type == SandboxType.RESTRICTED, (
-        f"Expected RESTRICTED, got {selection.sandbox_type.value}"
+    assert selection.sandbox_type == SandboxType.NONE, (
+        f"Expected NONE, got {selection.sandbox_type.value}"
     )
-    assert selection.network_policy == NetworkSandboxPolicy.BLOCK_ALL, (
-        "RESTRICTED exec must default to BLOCK_ALL when network_allowed=False"
+    assert selection.network_policy == NetworkSandboxPolicy.ALLOW_ALL, (
+        "NONE exec must keep ALLOW_ALL when no sandbox is available"
     )
 
-    # Full pipeline: ExecTool must reject when network_policy is BLOCK_ALL
+    # Full pipeline: ExecTool must execute on the host
     tool = ExecTool(timeout=5, working_dir=str(tmp_path))
     result = await tool.execute(
         "echo hello",
@@ -96,10 +97,8 @@ async def test_acceptance_default_config_exec_fail_closed(tmp_path):
         _turn_id="turn-default-fc",
         _tool_call_id="call-default-fc",
     )
-    assert "Error" in result, f"Expected fail-closed, got: {result}"
-    assert "network" in result.lower(), (
-        f"Expected network policy rejection, got: {result}"
-    )
+    assert "hello" in result, f"Expected host execution, got: {result}"
+    assert "Error" not in result
 
 
 @pytest.mark.asyncio
@@ -196,13 +195,14 @@ async def test_acceptance_landlock_never_auto_selected_on_available_alone():
     assert selection.sandbox_type != SandboxType.LANDLOCK, (
         f"LANDLOCK must not be selected when landlock_supported=False"
     )
-    assert selection.sandbox_type == SandboxType.RESTRICTED
+    assert selection.sandbox_type == SandboxType.NONE
 
 
 @pytest.mark.asyncio
 async def test_acceptance_exec_never_falls_back_to_none():
-    """Phase 33.4 invariant: exec tool NEVER falls back to NONE after
-    exhausting all sandbox types — raises SandboxDeniedError instead."""
+    """Phase 33.4 invariant: exec exhaustion still raises instead of
+    *falling back* to NONE.  (Attempt 0 with no sandbox is the NONE base
+    selection — direct host execution — not a fallback.)"""
     engine = SandboxPolicyEngine(
         bwrap_available=False,
         landlock_available=False,
@@ -213,11 +213,11 @@ async def test_acceptance_exec_never_falls_back_to_none():
         "permission_profile": None,
     })()
 
-    # Attempt 0 → RESTRICTED (only option)
+    # Attempt 0 → NONE (no sandbox available — direct host execution)
     s0 = await engine.select(ctx, attempt=0)
-    assert s0.sandbox_type == SandboxType.RESTRICTED
+    assert s0.sandbox_type == SandboxType.NONE
 
-    # Attempt 1 → beyond chain → must raise, NOT return NONE
+    # Attempt 1 → beyond chain → must raise, NOT return NONE as fallback
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=1)
     assert "exec" in str(exc_info.value)

--- a/tests/execution/test_sandbox_policy.py
+++ b/tests/execution/test_sandbox_policy.py
@@ -46,12 +46,12 @@ async def test_exec_tool_prefers_bwrap():
 @pytest.mark.asyncio
 async def test_landlock_available_does_not_select_landlock_when_unsupported():
     """Phase 33.4: landlock_available=True but landlock_supported=False
-    → engine skips LANDLOCK, selects RESTRICTED instead."""
+    → engine skips LANDLOCK, selects NONE (no sandbox) instead."""
     engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=True)
     ctx = FakeContext("exec", {"command": "npm test"})
     selection = await engine.select(ctx)
     # LANDLOCK should NOT be selected because landlock_supported=False
-    assert selection.sandbox_type == SandboxType.RESTRICTED
+    assert selection.sandbox_type == SandboxType.NONE
     # Reason must explain why LANDLOCK was skipped
     assert "landlock_available" in selection.reason.lower()
     assert "landlock_supported" in selection.reason.lower()
@@ -71,12 +71,13 @@ async def test_landlock_available_and_supported_can_select_landlock():
 
 
 @pytest.mark.asyncio
-async def test_exec_tool_falls_back_to_restricted():
-    """Without bwrap or landlock, exec selects RESTRICTED."""
+async def test_exec_tool_without_sandbox_selects_none():
+    """Without bwrap or landlock, exec selects NONE — direct host
+    execution without restrictions (sandbox off by user choice)."""
     engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
     ctx = FakeContext("exec", {"command": "npm test"})
     selection = await engine.select(ctx)
-    assert selection.sandbox_type == SandboxType.RESTRICTED
+    assert selection.sandbox_type == SandboxType.NONE
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -173,17 +174,18 @@ async def test_write_file_fallback_blocked_when_disallowed():
 
 @pytest.mark.asyncio
 async def test_exec_with_landlock_no_fallback_to_none():
-    """When bwrap unavailable and landlock unsupported, exec gets RESTRICTED.
-    Exhaustion beyond RESTRICTED must never fallback to NONE for exec."""
+    """When bwrap unavailable and landlock unsupported, exec gets NONE
+    (direct host execution). Exhaustion beyond NONE must still raise —
+    the no-sandbox base selection does not weaken fail-closed retries."""
     engine = SandboxPolicyEngine(
         bwrap_available=False,
         landlock_available=False,
         allow_fallback_to_none=True,
     )
     ctx = FakeContext("exec", {"command": "npm test"})
-    # Attempt 0 → RESTRICTED
+    # Attempt 0 → NONE
     s0 = await engine.select(ctx, attempt=0)
-    assert s0.sandbox_type == SandboxType.RESTRICTED
+    assert s0.sandbox_type == SandboxType.NONE
     # Attempt 1 → beyond chain → MUST raise for exec
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=1)
@@ -202,21 +204,21 @@ async def test_reason_includes_landlock_unsupported_info():
     engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=True)
     ctx = FakeContext("exec", {"command": "npm test"})
     selection = await engine.select(ctx)
-    assert selection.sandbox_type == SandboxType.RESTRICTED
+    assert selection.sandbox_type == SandboxType.NONE
     assert "landlock_supported=False" in selection.reason
     assert "no Landlock adapter" in selection.reason
 
 
 @pytest.mark.asyncio
 async def test_reason_includes_no_stronger_sandbox_info():
-    """Reason for RESTRICTED exec includes explanation of why no stronger
-    sandbox is available."""
+    """Reason for NONE exec explains why no sandbox is available and that
+    execution is unrestricted."""
     engine = SandboxPolicyEngine(bwrap_available=False, landlock_available=False)
     ctx = FakeContext("exec", {"command": "npm test"})
     selection = await engine.select(ctx)
-    assert selection.sandbox_type == SandboxType.RESTRICTED
+    assert selection.sandbox_type == SandboxType.NONE
     assert "bwrap unavailable" in selection.reason
-    assert "no stronger sandbox" in selection.reason
+    assert "direct host execution without restrictions" in selection.reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🔧 其他

## 变更概述

合并 develop 到 main，准备下一次发布。

## 背景/问题

develop 分支包含 1 个尚未合入 main 的提交，需要定期同步到 main 以发布新版本。

## 变更内容

本次 develop → main 合并包含以下提交：

- `36f77aa5` fix(sandbox): 无沙箱可用时允许 exec 直接执行并放行网络 (#793)

## 日志/验证证据

```
$ git log --oneline origin/main..origin/develop --no-merges
36f77aa5 fix(sandbox): 无沙箱可用时允许 exec 直接执行并放行网络 (#793)
```

## 测试情况

- 所有 1 个提交已在 develop 通过各自 PR 评审并合并
- 自动化测试在各自原 PR 中已通过
- 本次为 release 合并，CI 将由 PR template check + title check 触发


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- No sandbox selects `NONE`, direct host execution allowed

- Explicit `network=none` profile forces `RESTRICTED` with `BLOCK_ALL`

- Downgraded `RESTRICTED` still blocks unless `network_allowed=True`

- Updated unit/acceptance tests and added Electron e2e


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["No sandbox available"] --> B["exec base type NONE"]
  B --> C["Direct host execution / ALLOW_ALL"]
  D["Profile network=none"] --> E["Force RESTRICTED"]
  E --> F["Network BLOCK_ALL hard denial"]
  G["Downgraded RESTRICTED with bwrap"] --> H["BLOCK_ALL unless network_allowed=True"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sandbox_policy.py</strong><dd><code>Allow no-sandbox exec direct host execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/execution/sandbox_policy.py

<ul><li>No bwrap/landlock returns <code>SandboxType.NONE</code> for exec<br> <li> Profile <code>network="none"</code> forces <code>RESTRICTED</code> hard denial even without <br>sandbox<br> <li> <code>RESTRICTED</code> exec blocks network if denied or not <code>network_allowed</code><br> <li> Reason messages distinguish direct host execution vs no stronger <br>sandbox</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/794/files#diff-18210055c188af4b32be6e910835603222bafe9a3d586c71ea19fa6c46b5cd2b">+37/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exec_tool_sandbox_selection.py</strong><dd><code>Update exec sandbox selection unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/execution/test_exec_tool_sandbox_selection.py

<ul><li>Update no-sandbox selection expectations to <code>NONE</code> + <code>allow_all</code><br> <li> Add downgraded <code>RESTRICTED</code> block network test<br> <li> Add <code>network="none"</code> hard denial and deny-over-allow tests<br> <li> Update fallback/exhaustion and reason assertions</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/794/files#diff-55732125979efedb409a208500e422978adcb4037180fc7c840111f402b7d323">+96/-16</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_phase33_sandbox_acceptance.py</strong><dd><code>Update acceptance tests for NONE host exec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/execution/test_phase33_sandbox_acceptance.py

<ul><li>Change default no-sandbox acceptance to <code>NONE</code> host execution<br> <li> Assert exec returns <code>hello</code> instead of network rejection<br> <li> Update landlock unavailable selection to <code>NONE</code><br> <li> Clarify fallback-to-NONE exhaustion invariant</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/794/files#diff-d622fd153444da002a2e18764861bcad8793070681b9be19911d73b0ae4e18d2">+18/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_sandbox_policy.py</strong><dd><code>Update sandbox policy unit tests for NONE base</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/execution/test_sandbox_policy.py

<ul><li>Update no-sandbox exec base to <code>NONE</code><br> <li> Update landlock unsupported selection to <code>NONE</code><br> <li> Update reason assertions for direct host execution<br> <li> Preserve exhaustion raising semantics</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/794/files#diff-36707d9d368778ba629cfa0e42a88386481628cd9c93006f8d130e23bd066a50">+16/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>no-sandbox-exec.spec.ts</strong><dd><code>Add e2e regression for no-sandbox exec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/tests/e2e/no-sandbox-exec.spec.ts

<ul><li>Add e2e regression that disables sandbox and prompts exec<br> <li> Ask agent to run echo marker plus curl example.com<br> <li> Assert marker present and old RESTRICTED block messages absent<br> <li> Capture screenshot on completion</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/794/files#diff-e79afebc1d14a276c9dbf2d2753b91c5f252404b279793cddfaa9df211d9f9e9">+95/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

