### PR TITLE
fix(agent): exec 环境描述随沙箱状态动态生成，消除 WSL 路径误导

### DIFF
--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -82,14 +82,12 @@ class ExecTool(Tool):
 
     @property
     def description(self) -> str:
+        from miqi.sandbox.manager import describe_exec_environment
+
         return (
-            "Execute a shell command in the WSL sandbox and return its output. "
-            "Use with caution. 沙箱工作目录说明：exec 在沙箱中运行，"
-            "`/home/miqi/workspace` 与文件工具（read_file/write_file/list_dir）的工作目录"
-            "在【默认工作区】下是两个不同目录（沙箱内为独立目录，看不到文件工具写入的文件）；"
-            "在【自定义工作区】下是同一目录（bind-mount）。"
-            "要在 exec 中访问文件工具写入的文件，请用主机路径（如 /mnt/c/...），"
-            "或改用文件工具。"
+            "Execute a shell command and return its output. "
+            "Use with caution. "
+            + describe_exec_environment(self._sandbox_manager)
         )
 
     @property

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -61,6 +61,30 @@ class LiveAgent:
     completion_emitted: bool = False
 
 
+def build_session_context(
+    workspace: Path,
+    session_id: str,
+    sandbox_manager: Any = None,
+) -> str:
+    """Per-turn session context injected into the agent system prompt.
+
+    Describes the working directory and the ACTUAL exec environment
+    (sandbox active or direct host execution) so the AI issues paths and
+    shell syntax that match reality instead of a hard-coded sandbox story.
+    """
+    from miqi.sandbox.manager import describe_exec_environment
+
+    exec_env = describe_exec_environment(sandbox_manager)
+    return (
+        f"\n\n## 工作目录\n"
+        f"你当前的工作目录是: {workspace}\n"
+        f"文件工具（read_file / write_file / list_dir）在这个目录下进行。\n"
+        f"注意：{exec_env}\n"
+        f"当用户问你工作目录时，请直接回答 {workspace}，不要说 /home/miqi/workspace。\n"
+        f"MIQI_SESSION_KEY={session_id}"
+    )
+
+
 class AgentControl:
     """Control plane for multi-agent operations.
 
@@ -84,6 +108,7 @@ class AgentControl:
         store: AgentGraphStore | None = None,
         completion_callback: Callable[[dict], Awaitable[None]] | None = None,
         max_concurrent: int = 3,
+        sandbox_manager: Any = None,  # live sandbox state for prompt context
     ):
         self.session_id = session_id
         self.registry = registry
@@ -96,6 +121,7 @@ class AgentControl:
         self._hooks = hooks
         self._store = store
         self._completion_callback = completion_callback
+        self._sandbox_manager = sandbox_manager
         # Issue #246: cap concurrently-running subagents (default 3, the
         # legacy SubagentManager limit).  Terminal agents (completed/error/
         # aborted) do not count; killed agents are removed from the registry.
@@ -486,17 +512,10 @@ class AgentControl:
             if agent.state.current != AgentStatus.THINKING:
                 agent.state.transition(AgentStatus.THINKING)
             # Inject session workspace info so the AI knows where its files live
-            _sess_key = "".join(
-                c if c.isalnum() or c in "_-" else "_"
-                for c in self.session_id.split(":", 1)[-1]
-            )
-            _session_context = (
-                f"\n\n## 工作目录\n"
-                f"你当前的工作目录是: {self.workspace}\n"
-                f"文件工具（read_file / write_file / list_dir）在这个目录下进行。\n"
-                f"注意：exec 在沙箱中运行——默认工作区下沙箱 /home/miqi/workspace 与文件工具目录不同（沙箱为独立目录），自定义工作区下二者相同；exec 中访问文件请用主机路径（/mnt/c/...）。\n"
-                f"当用户问你工作目录时，请直接回答 {self.workspace}，不要说 /home/miqi/workspace。\n"
-                f"MIQI_SESSION_KEY={self.session_id}"
+            _session_context = build_session_context(
+                workspace=self.workspace,
+                session_id=self.session_id,
+                sandbox_manager=self._sandbox_manager,
             )
             agent.messages = [
                 {"role": "system", "content": agent.metadata.system_prompt + _session_context},

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -84,6 +84,9 @@ class RuntimeServices:
     hooks: HookRuntime | None = None
     # Phase 52: shared agent graph persistence
     agent_graph_store: Any | None = None
+    # Live sandbox manager reference (enabled/_initialized reflect current
+    # state) — used by prompt builders for an accurate exec environment story.
+    sandbox_manager: Any | None = None
 
     @classmethod
     def from_config(
@@ -202,6 +205,7 @@ class RuntimeServices:
             hooks=hook_runtime,
             store=agent_graph_store,
             completion_callback=agent_completion_callback,
+            sandbox_manager=sandbox_manager,
         )
 
         # Wire SpawnTool into AgentControl
@@ -329,6 +333,7 @@ class RuntimeServices:
             ledger_runtime=ledger_runtime,
             replay_runtime=replay_runtime,
             hooks=hook_runtime,
+            sandbox_manager=sandbox_manager,
         )
 
         agent_jobs = AgentJobRuntime(services=services, store=agent_graph_store)

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -593,14 +593,22 @@ class TaskRunner:
         # (/home/miqi/workspace), which hides the user's chosen project
         # directory. State it explicitly so the AI reports the real
         # workspace (mirrors agent_control's subagent prompt).
+        # The exec environment sentence reflects the LIVE sandbox state —
+        # with the sandbox off, exec runs directly on the host and the AI
+        # must not be told the WSL /mnt/c story.
         _ws = self.services.workspace
         if _ws is not None:
+            from miqi.sandbox.manager import describe_exec_environment
+
+            _exec_env = describe_exec_environment(
+                getattr(self.services, "sandbox_manager", None)
+            )
             effective_system_prompt = (
                 effective_system_prompt
                 + f"\n\n## 工作目录\n"
                 f"你当前的工作目录是: {_ws}\n"
                 f"文件工具（read_file / write_file / list_dir）在这个目录下进行。\n"
-                f"注意：exec 在沙箱中运行——默认工作区下沙箱 /home/miqi/workspace 与文件工具目录不同（沙箱为独立目录），自定义工作区下二者相同；exec 中访问文件请用主机路径（/mnt/c/...）。\n"
+                f"注意：{_exec_env}\n"
                 f"当用户问你工作目录时，请直接回答 {_ws}，不要说 /home/miqi/workspace。\n"
             )
 

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -44,6 +44,51 @@ from loguru import logger
 from miqi.sandbox.bwrap import BwrapSandbox, BwrapSandboxError, _create_subprocess_exec, _is_windows
 
 
+def sandbox_is_active(sandbox_manager: Any) -> bool:
+    """Whether the WSL/bwrap sandbox is enabled AND initialized right now.
+
+    Mirrors the ``bwrap_available`` computation in RuntimeServices, but
+    reads the LIVE manager attributes — the policy engine's snapshot at
+    build time can be stale after a toggle change mid-session.
+    """
+    return bool(
+        sandbox_manager is not None
+        and sandbox_manager != "disabled"
+        and getattr(sandbox_manager, "enabled", False)
+        and getattr(sandbox_manager, "_initialized", False)
+    )
+
+
+def describe_exec_environment(sandbox_manager: Any) -> str:
+    """Human-readable description of where/how exec commands run, for AI prompts.
+
+    Used by the exec tool description and the per-turn session context so
+    the AI is told the ACTUAL environment instead of a hard-coded sandbox
+    story: with the sandbox active exec runs inside WSL with /home/miqi
+    paths; without it exec runs directly on the host (Windows cmd on
+    Windows) and shares the file tools' directory.
+    """
+    if sandbox_is_active(sandbox_manager):
+        return (
+            "exec 在 WSL 沙箱中运行——默认工作区下沙箱 /home/miqi/workspace "
+            "与文件工具目录不同（沙箱为独立目录，看不到文件工具写入的文件），"
+            "自定义工作区下二者相同；exec 中访问文件请用主机路径（如 /mnt/c/...），"
+            "或改用文件工具。"
+        )
+    if os.name == "nt":
+        return (
+            "exec 直接在 Windows cmd 中运行（当前未启用沙箱），"
+            "与文件工具使用同一工作目录，请使用 Windows 路径（如 C:\\Users\\...）。"
+            "cmd 语法注意：用 && 连接多条命令（不支持 ; 分隔），"
+            "ls/find/grep/sed 不可用（用 dir / where / findstr），"
+            "或使用 powershell -Command \"...\"。"
+        )
+    return (
+        "exec 直接在本机 shell（bash）中运行（当前未启用沙箱），"
+        "与文件工具使用同一工作目录，使用标准 Linux/macOS 命令与路径。"
+    )
+
+
 class SandboxManager:
     """Manages per-session bwrap sandboxes.
 

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -1,0 +1,103 @@
+"""Tests for exec environment description helpers.
+
+The exec tool description and the per-turn session context used to
+hard-code "exec 在沙箱中运行 / /home/miqi / /mnt/c" regardless of the
+actual runtime state.  With the sandbox disabled, exec runs directly on
+the host (Windows cmd on Windows), so the AI was told a false story and
+kept issuing WSL paths / bash syntax that failed — see the MOF-5
+re-upload thrashing (bridge log 2026-08-24: /mnt/c paths and
+--break-system-packages run through Windows cmd, sandbox=none).
+"""
+
+import pytest
+
+from miqi.sandbox.manager import describe_exec_environment, sandbox_is_active
+
+
+class FakeSandboxManager:
+    def __init__(self, enabled: bool = False, initialized: bool = False):
+        self.enabled = enabled
+        self._initialized = initialized
+
+
+@pytest.mark.parametrize(
+    "manager,expected",
+    [
+        (None, False),
+        ("disabled", False),
+        (FakeSandboxManager(enabled=False, initialized=True), False),
+        (FakeSandboxManager(enabled=True, initialized=False), False),
+        (FakeSandboxManager(enabled=True, initialized=True), True),
+    ],
+)
+def test_sandbox_is_active(manager, expected):
+    assert sandbox_is_active(manager) is expected
+
+
+def test_describe_exec_environment_sandbox_active():
+    manager = FakeSandboxManager(enabled=True, initialized=True)
+    text = describe_exec_environment(manager)
+    assert "WSL" in text
+    assert "/home/miqi/workspace" in text
+
+
+def test_describe_exec_environment_no_sandbox_windows(monkeypatch):
+    monkeypatch.setattr("miqi.sandbox.manager.os.name", "nt")
+    text = describe_exec_environment(None)
+    assert "Windows" in text
+    assert "cmd" in text
+    assert "&&" in text
+    assert "/mnt/c" not in text
+    assert "/home/miqi" not in text
+
+
+def test_describe_exec_environment_no_sandbox_posix(monkeypatch):
+    monkeypatch.setattr("miqi.sandbox.manager.os.name", "posix")
+    text = describe_exec_environment(None)
+    assert "bash" in text
+    assert "/mnt/c" not in text
+    assert "/home/miqi" not in text
+
+
+def test_exec_tool_description_reflects_sandbox_state(monkeypatch):
+    from miqi.agent.tools.shell import ExecTool
+
+    tool_active = ExecTool(
+        working_dir=".",
+        sandbox_manager=FakeSandboxManager(enabled=True, initialized=True),
+    )
+    assert "WSL" in tool_active.description
+    assert "/home/miqi/workspace" in tool_active.description
+
+    monkeypatch.setattr("miqi.sandbox.manager.os.name", "nt")
+    tool_off = ExecTool(working_dir=".")
+    assert "Windows" in tool_off.description
+    assert "cmd" in tool_off.description
+    assert "/mnt/c" not in tool_off.description
+    assert "/home/miqi" not in tool_off.description
+
+
+def test_session_context_reflects_sandbox_state(monkeypatch, tmp_path):
+    from miqi.runtime.agent_control import build_session_context
+
+    monkeypatch.setattr("miqi.sandbox.manager.os.name", "nt")
+    ctx = build_session_context(
+        workspace=tmp_path,
+        session_id="miqi-desktop:desktop:test",
+        sandbox_manager=None,
+    )
+    assert "Windows" in ctx
+    assert "cmd" in ctx
+    assert str(tmp_path) in ctx
+    assert "/mnt/c" not in ctx
+    # the legacy "不要说 /home/miqi/workspace" disclaimer may remain,
+    # but the WSL sandbox environment story must not be injected
+    assert "WSL" not in ctx
+
+    ctx_active = build_session_context(
+        workspace=tmp_path,
+        session_id="miqi-desktop:desktop:test",
+        sandbox_manager=FakeSandboxManager(enabled=True, initialized=True),
+    )
+    assert "/home/miqi/workspace" in ctx_active
+    assert "WSL" in ctx_active


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

exec 工具描述与每轮注入的会话上下文改为随沙箱实时状态动态生成：沙箱关闭时明确告知 AI「exec 在 Windows cmd 直连、使用 Windows 路径与 cmd 语法」，不再硬编码 WSL 沙箱描述。

## 背景/问题

沙箱关闭后 exec 实际直接在本机执行（#793 起无沙箱选 NONE），但三处提示词仍硬编码「exec 在沙箱中运行 / /home/miqi / /mnt/c」：exec 工具描述（shell.py）、每轮会话上下文（agent_control.py）、任务提示注入（task_runner.py）。AI 按错误环境持续发出 WSL 路径与 bash 语法命令——`bash -lc "pip install --break-system-packages ..."`、`/mnt/c/...` 路径、`;` 分号链（Windows cmd 不支持）——全部失败，最终 find 全盘搜索卡死 154 秒，任务被中断（见 #795）。

## 关联 issue

- Closes #795

## 变更内容

- `miqi/sandbox/manager.py`：新增 `sandbox_is_active()`（读取管理器实时 enabled/_initialized 状态，非启动快照）与 `describe_exec_environment()`（三态文案：WSL 沙箱激活 / Windows cmd 直连 / POSIX 本机 shell）
- `miqi/agent/tools/shell.py`：exec 工具描述改为调用该助手（每轮取工具定义时实时生成）
- `miqi/runtime/agent_control.py`：抽出可测试的 `build_session_context()`，注入的「工作目录」上下文按实时沙箱状态描述 exec 环境
- `miqi/runtime/services.py`：RuntimeServices 保存 sandbox_manager 引用并传给 AgentControl
- `miqi/runtime/task_runner.py`：任务提示注入改用同一助手
- `tests/sandbox/test_exec_environment_description.py`：新增 10 个单测（激活/禁用/None/disabled 状态矩阵 + Windows/POSIX 平台分支 + 工具描述与会话上下文断言）

## 日志/验证证据

```
$ uv run pytest tests/sandbox/test_exec_environment_description.py -q
10 passed in 0.11s

$ uv run pytest tests/sandbox tests/execution tests/runtime tests/agent/tools -q
1887 passed, 3 skipped in 402.42s
```

修复前（bridge 日志 2026-08-24，沙箱关闭状态下 AI 仍按 WSL 环境行事）：

```
Tool execute: name=exec args={'command': 'bash -lc "pip install --break-system-packages -q httpx 2>&1 | tail -1; S=/mnt/c/Users/Intership003/.miqi/workspace/skills/qraft-workflowspec-export; ...'} sandbox=none
Direct command failed exit=2 duration=875ms
ERROR Direct command timed out after 154717ms: bash -c "echo '=== 全盘搜索 upload_run.py ==='; find /mnt/c/Users/Intership003 -maxdepth 8 ..."
```

修复后生成的描述（Windows 无沙箱）：

```
exec 直接在 Windows cmd 中运行（当前未启用沙箱），与文件工具使用同一工作目录，请使用 Windows 路径（如 C:\Users\...）。cmd 语法注意：用 && 连接多条命令（不支持 ; 分隔），ls/find/grep/sed 不可用（用 dir / where / findstr），或使用 powershell -Command "..."。
```

## 测试情况

- 新增 10 个单测全过；tests/sandbox + tests/execution + tests/runtime + tests/agent/tools 合计 1887 通过（3 跳过）
- 子代理路径无需改：subagent 的 ExecTool 本就未注入 sandbox_manager，动态描述自动落到「无沙箱」分支，与其直连主机执行的实际行为一致

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `sandbox_is_active()` and `describe_exec_environment()` helpers.

- Replace hard-coded WSL sandbox text in exec description.

- Inject live exec environment into session context and task prompt.

- Add tests for active, Windows cmd, and POSIX states.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  M["miqi/sandbox/manager.py: sandbox_is_active / describe_exec_environment"] --> S["miqi/agent/tools/shell.py: dynamic exec tool description"]
  M --> A["miqi/runtime/agent_control.py: build_session_context"]
  M --> T["miqi/runtime/task_runner.py: prompt injection"]
  S --> P["Live exec environment in AI prompts"]
  A --> P
  T --> P
  P --> R["Avoid WSL paths when sandbox disabled"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manager.py</strong><dd><code>Add live exec environment description helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/sandbox/manager.py

<ul><li>Add <code>sandbox_is_active(sandbox_manager)</code> checking enabled and <br><code>_initialized</code> state.<br> <li> Add <code>describe_exec_environment(sandbox_manager)</code> for three-state exec <br>descriptions.<br> <li> Windows no-sandbox branch recommends Windows paths, <code>&&</code>, <code>dir</code>, <code>where</code>, <br><code>findstr</code>.<br> <li> POSIX no-sandbox branch recommends standard bash/Linux/macOS commands.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-4ba4fb086c91c1958f0af2a0228609261cb4fdb078919a1f345c018bf3691361">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shell.py</strong><dd><code>Dynamic exec tool description from sandbox state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/agent/tools/shell.py

<ul><li>Replace hard-coded WSL sandbox exec description with <br><code>describe_exec_environment(self._sandbox_manager)</code>.<br> <li> Exec tool description now reflects actual sandbox state at tool <br>definition time.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-3cc5757485ddb3df794186684ead9e7294ad0648552d9d298091abdafc38ca92">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent_control.py</strong><dd><code>Inject live exec environment into agent session context</code>&nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/agent_control.py

<ul><li>Add <code>build_session_context()</code> to construct per-turn session context.<br> <li> <code>AgentControl.__init__</code> accepts and stores <code>sandbox_manager</code>.<br> <li> Session context uses <code>describe_exec_environment</code> instead of hard-coded <br>WSL text.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-865b6d18de4fe68ca3d7689effb0cdcfb6f504f8c47f3ff201ffde3e8de97c61">+30/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_runner.py</strong><dd><code>Dynamic exec environment in task prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/task_runner.py

<ul><li>Import and call <code>describe_exec_environment</code> for prompt injection.<br> <li> Read live sandbox_manager via <code>getattr(self.services, </code><br><code>"sandbox_manager", None)</code>.<br> <li> Replace hard-coded WSL sandbox text with dynamic exec environment <br>description.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-a663f5ea49ead69f2c25a2ede0c74445b85e90195ff1b2c11d6cbac5d58e3c05">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Wire sandbox_manager through runtime services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/runtime/services.py

<ul><li>Add <code>sandbox_manager</code> field to <code>RuntimeServices</code>.<br> <li> Pass <code>sandbox_manager</code> to <code>AgentControl</code> and downstream runtime services.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-3f67e147cf7f5f862ddf78772f3a728ac8fbf3637b5950375ff997084db27dbc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exec_environment_description.py</strong><dd><code>Unit tests for exec environment descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sandbox/test_exec_environment_description.py

<ul><li>Add <code>FakeSandboxManager</code> and parametrized <code>sandbox_is_active</code> tests.<br> <li> Test active WSL, no-sandbox Windows, and no-sandbox POSIX <br>descriptions.<br> <li> Test <code>ExecTool.description</code> and <code>build_session_context</code> reflect sandbox <br>state.<br> <li> Ensure no WSL <code>/mnt/c</code> or <code>/home/miqi</code> hints when sandbox disabled.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/796/files#diff-f9ae1e5e18bb7fd98f87e999714999a13ad7718267b5dbee8a8fffe3d329f5ef">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

