### PR TITLE
fix(desktop): 回合静默期心跳事件，消除看门狗 60s 误报（#798）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3689,6 +3689,15 @@ export function ChatConsole({
         return;
       }
       lastEventAt = Date.now();
+      // #798: retract a previously-shown watchdog warning once events
+      // resume — a recovered backend must not leave a stale error behind.
+      if (warnMsgId !== null) {
+        const retracted = warnMsgId;
+        warnMsgId = null;
+        setMessages((prev) =>
+          prev.filter((m) => !(m.role === 'error' && m.timestamp === retracted)),
+        );
+      }
       // The backend has started streaming — the send was accepted.  Clear the
       // pending spinner on the optimistic user bubble (issue #364).
       setSendingFor(_owner, null);

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -22,6 +22,13 @@ from loguru import logger
 
 CHAT_DRAIN_IDLE_TIMEOUT_SECONDS = 600
 
+# #798: the frontend watchdog reports "后端 60s 无响应" after 60s without
+# progress events, but a turn may legitimately stay silent for minutes
+# (model thinking, long exec with no stdout).  The drain emits a heartbeat
+# progress event this often so the frontend sees liveness; heartbeats carry
+# only {stream: "heartbeat"} and the renderer skips displaying them.
+CHAT_HEARTBEAT_INTERVAL_SECONDS = 10
+
 
 # A drain task that outlives this is considered stale (stuck on WSL sandbox
 # creation, which ignores asyncio cancellation) — the turn lock is force-
@@ -1111,6 +1118,8 @@ class BridgeRuntimeLoop:
             })
             return True
 
+        heartbeat_task: asyncio.Task | None = None
+
         try:
             from dataclasses import asdict, is_dataclass
 
@@ -1127,6 +1136,20 @@ class BridgeRuntimeLoop:
             from miqi.agent.user_input_resolver import set_thread_session
 
             set_thread_session(thread_id, session_key)
+
+            # #798: heartbeat so the frontend watchdog sees backend
+            # liveness during long silent stretches (model thinking,
+            # exec with no stdout).  The drain's own idle timeout is
+            # 600s; the frontend fires at 60s without this.
+            async def _heartbeat() -> None:
+                try:
+                    while True:
+                        await asyncio.sleep(CHAT_HEARTBEAT_INTERVAL_SECONDS)
+                        await _emit("progress", {"stream": "heartbeat"})
+                except asyncio.CancelledError:
+                    pass
+
+            heartbeat_task = asyncio.create_task(_heartbeat())
 
             from miqi.protocol.events import (
                 AgentMessageDeltaEvent,
@@ -1309,6 +1332,9 @@ class BridgeRuntimeLoop:
                 "message": f"Bridge 事件循环错误：{raw}",
             })
         finally:
+            # Stop the heartbeat — the turn is done (or the drain died).
+            if heartbeat_task is not None:
+                heartbeat_task.cancel()
             # Unwire THIS session's user-input emitter and thread mapping so
             # a finished turn's emitter can't linger and capture cards for a
             # later turn. Keyed per session — concurrent sessions keep their

--- a/tests/bridge/test_chat_drain_heartbeat.py
+++ b/tests/bridge/test_chat_drain_heartbeat.py
@@ -1,0 +1,103 @@
+"""Tests for the chat drain heartbeat (#798).
+
+The frontend watchdog treats 60s without progress events as a dead
+backend, but turns legitimately stay silent for minutes (model thinking,
+long exec without stdout) while the drain's own idle timeout is 600s.
+The drain must emit a heartbeat progress event every
+CHAT_HEARTBEAT_INTERVAL_SECONDS so the frontend sees liveness, and stop
+heartbeating once the turn finishes.
+"""
+
+import asyncio
+
+import pytest
+
+from miqi.bridge import loop as loop_mod
+from miqi.bridge.loop import BridgeRuntimeLoop
+from miqi.protocol.events import TurnCompleteEvent, TurnStartedEvent
+
+
+class _FakeAppServer:
+    def __init__(self):
+        self.emitted: list[tuple[str, dict, str]] = []
+
+    async def emit_event(self, session_id, event_type, data, request_id=None):
+        self.emitted.append(
+            (event_type, dict(data) if isinstance(data, dict) else data, session_id)
+        )
+
+
+class _FakeRuntime:
+    """Yields the given events; sleeps *first_delay* before the first one."""
+
+    def __init__(self, events, first_delay: float = 0.0):
+        self._events = list(events)
+        self._delay = first_delay
+
+    async def next_event(self, timeout=None):
+        if self._delay > 0:
+            await asyncio.sleep(self._delay)
+            self._delay = 0.0
+        return self._events.pop(0) if self._events else None
+
+
+def _drain_kwargs():
+    return dict(
+        request_id="req1",
+        runtime=None,  # set per test
+        thread_id="sess",
+        session_id="c:sess",
+        client_id="c",
+        session_key="sess",
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_emits_heartbeat_while_turn_is_silent(monkeypatch):
+    monkeypatch.setattr(loop_mod, "CHAT_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    loop = BridgeRuntimeLoop(send_func=lambda msg: None)
+    app = _FakeAppServer()
+    loop._app_server = app
+
+    runtime = _FakeRuntime(
+        [
+            TurnStartedEvent(turn_id="t1", agent_name="a", thread_id="sess"),
+            TurnCompleteEvent(turn_id="t1", thread_id="sess", outcome="success"),
+        ],
+        first_delay=0.15,
+    )
+    kwargs = _drain_kwargs()
+    kwargs["runtime"] = runtime
+    await loop._drain_chat_events(**kwargs)
+
+    heartbeats = [
+        data
+        for (etype, data, _sess) in app.emitted
+        if etype == "progress" and data.get("stream") == "heartbeat"
+    ]
+    assert heartbeats, "drain must emit heartbeat progress events while the turn is silent"
+    assert all(d.get("session_key") == "sess" for d in heartbeats)
+
+
+@pytest.mark.asyncio
+async def test_drain_heartbeat_stops_after_turn_completes(monkeypatch):
+    monkeypatch.setattr(loop_mod, "CHAT_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    loop = BridgeRuntimeLoop(send_func=lambda msg: None)
+    app = _FakeAppServer()
+    loop._app_server = app
+
+    runtime = _FakeRuntime(
+        [TurnCompleteEvent(turn_id="t1", thread_id="sess", outcome="success")],
+        first_delay=0.1,
+    )
+    kwargs = _drain_kwargs()
+    kwargs["runtime"] = runtime
+    await loop._drain_chat_events(**kwargs)
+
+    emitted_after_drain = len(app.emitted)
+    await asyncio.sleep(0.2)
+    assert len(app.emitted) == emitted_after_drain, (
+        "heartbeat must stop once the drain finishes"
+    )


### PR DESCRIPTION
### **User description**
## 类型

- [x] 🐛 Bug 修复

## 变更概述

回合静默运行期间 bridge 每 10 秒发一次心跳进度事件，前端看门狗不再把「长思考/无输出长 exec」误报为「后端 60s 无响应」；事件恢复后已显示的误报气泡自动撤回。

## 背景/问题

后端 drain 的静默超时是 600 秒，前端看门狗却在 60 秒无 progress 事件时追加「⚠️ 后端 60s 无响应」错误气泡（且只追加不撤回）。长模型推理（deepseek 深度思考可达数分钟）与无 stdout 的长 exec 必然触发误报，用户据此中止了实际正常的任务（MOF-5 上传验证中断现场，见 #798）。

## 关联 issue

- Closes #798

## 变更内容

- `miqi/bridge/loop.py`：`_drain_chat_events` 内新增心跳任务——每 `CHAT_HEARTBEAT_INTERVAL_SECONDS`（10s）发一个 `{stream: "heartbeat"}` 进度事件（带 session_key，顺带刷新 drain 活跃时间戳）；回合结束（drain finally）取消。真正的后端挂起时心跳停止，看门狗仍会照常报警——只在「活着但安静」时不误报
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：onProgress 收到事件时若已有看门狗警告气泡则撤回（后端恢复后不残留假错误）；心跳事件本身被渲染层跳过（stream-only 事件不渲染，仅刷新 lastEventAt）
- `tests/bridge/test_chat_drain_heartbeat.py`：2 个单测——静默期发出心跳、回合结束后停止

## 日志/验证证据

```
$ uv run pytest tests/bridge/test_chat_drain_heartbeat.py tests/bridge/test_bridge_loop.py -q
19 passed in 1.75s

$ npm run build -- --logLevel warn
exit=0
```

## 测试情况

- 新增 drain 心跳单测 2 个通过；bridge 现有 17 个测试无回归
- 前端构建（TS 校验）通过
- 行为验证路径：心跳间隔 10s << 看门狗阈值 60s，且心跳与真实事件走同一 _emit 通道（session_key 注入、订阅分发一致）

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add backend heartbeat every 10s during silent turns.

- Retract stale watchdog warning when events resume.

- Add unit tests for heartbeat emit/stop.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bridge _drain_chat_events"] -- "creates heartbeat task" --> B["_emit progress {stream: heartbeat}"]
  B -- "every 10s" --> C["Frontend onProgress"]
  C -- "refreshes lastEventAt" --> D["Watchdog no false alarm"]
  C -- "retracts warnMsgId if set" --> E["Remove stale warning bubble"]
  F["turn finally"] -- "cancels heartbeat" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loop.py</strong><dd><code>Add drain heartbeat during active chat turns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

miqi/bridge/loop.py

<ul><li>Add <code>CHAT_HEARTBEAT_INTERVAL_SECONDS = 10</code> constant.<br> <li> Create heartbeat asyncio task in <code>_drain_chat_events</code> that emits <br><code>progress</code> events with <code>stream: "heartbeat"</code> every interval.<br> <li> Include session key on emitted heartbeat events.<br> <li> Cancel heartbeat task in <code>finally</code> when drain ends.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/802/files#diff-d7466c5406c4be3d4763dc0906dd88a416a3b9c05274a8add16a7b6970800bf2">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChatConsole.tsx</strong><dd><code>Retract watchdog warning when events resume</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/desktop/src/renderer/features/chat/ChatConsole.tsx

<ul><li>When a current-session progress event arrives, clear <code>warnMsgId</code> and <br>remove the matching error message.<br> <li> Prevent stale watchdog warning bubble from remaining after backend <br>recovery.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/802/files#diff-bf0b5d655e32236185f78ebf5181f0672807b9aa4f1255927b0d6da397494986">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chat_drain_heartbeat.py</strong><dd><code>Add heartbeat unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/bridge/test_chat_drain_heartbeat.py

<ul><li>Add test that silent turns emit heartbeat progress events with <br><code>session_key</code>.<br> <li> Add test that heartbeat stops after turn completes.</ul>


</details>


  </td>
  <td><a href="https://github.com/14790897/MiQi/pull/802/files#diff-324acb2fb59ef9ebd158de0a811951c924b18f187c981c493caabfeb1dde1ea3">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

