### PR TITLE
fix(safety): fast 模式只跳过信息型工具确认 — EXEC/WRITE/PAYMENT 永不绕过

### DIFF
--- a/miqi/agent/search_orchestrator.py
+++ b/miqi/agent/search_orchestrator.py
@@ -37,7 +37,7 @@ def _normalize_url(url: str) -> str:
 
 
 def _dedup_urls(urls: list[str], limit: int) -> list[str]:
-    """Domain-level dedup: keep at most one URL per domain, then fill."""
+    """Domain-level dedup: keep at most one URL per domain, stop at limit."""
     seen_domains: set[str] = set()
     out: list[str] = []
     for u in urls:
@@ -113,9 +113,9 @@ class SearchOrchestrator:
                 return []
 
         raw_lists = await asyncio.gather(
-            *(asyncio.to_thread(_one, r) for r in regions), return_exceptions=True
+            *(asyncio.wait_for(asyncio.to_thread(_one, r), timeout=15.0) for r in regions),
+            return_exceptions=True,
         )
-
         blocks: list[str] = []
         seen: set[str] = set()
         for region, raw in zip(regions, raw_lists):

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -457,6 +457,55 @@ class WebSearchTool(Tool):
             return f"No results for: {query}"
         return _format_results(query, result.results)
 
+    async def _parallel_search(self, query: str, n_queries: int, n: int) -> list[str]:
+        """#741 审阅 #4: fan-out 搜索走**配置的 provider 链**（Tavily→Brave→DDGS），
+        不再由 SearchOrchestrator 直接 ddgs 绕过配置——用户配的 Tavily/Brave
+        key 在 fast 模式同样生效；链失败/空结果时回退 ddgs 区域变体
+        （原 orchestrator 内置逻辑）。"""
+        # 主路径：配置链
+        try:
+            result = await self.manager.search(query, n)
+            if result.success and result.results:
+                return [_format_results(query, result.results)]
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "web_search parallel: manager chain failed for %r — falling back to ddgs",
+                query[:60],
+            )
+        # 回退：ddgs 区域变体（与 orchestrator 原实现一致）
+        try:
+            from ddgs import DDGS
+        except ImportError:
+            return []
+        regions = [r for r, _ in _REGIONS[: max(1, n_queries)]]
+
+        def _one(region: str) -> list[dict[str, Any]]:
+            try:
+                return list(DDGS().text(query, region=region, max_results=n))
+            except Exception:
+                return []
+
+        raw_lists = await asyncio.gather(
+            *(asyncio.wait_for(asyncio.to_thread(_one, r), timeout=15.0) for r in regions),
+            return_exceptions=True,
+        )
+        blocks: list[str] = []
+        seen: set[str] = set()
+        for region, raw in zip(regions, raw_lists):
+            if not isinstance(raw, list) or not raw:
+                continue
+            lines = [f"Results for: {query} (region: {region})"]
+            for item in raw:
+                href = item.get("href") or item.get("url", "")
+                if not href or href in seen:
+                    continue
+                seen.add(href)
+                lines.append(
+                    f"- {item.get('title', '')}\n  {href}\n  {item.get('body') or item.get('description', '')}"
+                )
+            blocks.append("\n".join(lines))
+        return blocks
+
 
 class WebFetchTool(Tool):
     """Fetch and extract content from a URL using Readability."""

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -525,31 +525,32 @@ class WebFetchTool(Tool):
         try:
             # 手动跟随重定向，每跳都验证目标 URL（CodeRabbit #741：公共 URL
             # 可重定向到内网/元数据地址，自动 follow_redirects 会绕过 _validate_url）。
+            # #748 审阅: client 提到循环外复用——每跳新建最多 5 次连接开销。
             current = url
-            for _ in range(MAX_REDIRECTS + 1):
-                async with httpx.AsyncClient(
-                    follow_redirects=False, timeout=30.0
-                ) as client:
+            async with httpx.AsyncClient(
+                follow_redirects=False, timeout=30.0
+            ) as client:
+                for _ in range(MAX_REDIRECTS + 1):
                     r = await client.get(current, headers={"User-Agent": USER_AGENT})
-                if r.status_code in (301, 302, 303, 307, 308):
-                    location = r.headers.get("location")
-                    if not location:
-                        break
-                    next_url = str(httpx.URL(current).join(location))
-                    is_valid, error_msg = _validate_url(next_url)
-                    if not is_valid:
-                        return json.dumps(
-                            {"error": f"Redirect target rejected: {error_msg}", "url": next_url},
-                            ensure_ascii=False,
-                        )
-                    current = next_url
-                    continue
-                r.raise_for_status()
-                break
-            else:
-                return json.dumps(
-                    {"error": "Too many redirects", "url": url}, ensure_ascii=False
-                )
+                    if r.status_code in (301, 302, 303, 307, 308):
+                        location = r.headers.get("location")
+                        if not location:
+                            break
+                        next_url = str(httpx.URL(current).join(location))
+                        is_valid, error_msg = _validate_url(next_url)
+                        if not is_valid:
+                            return json.dumps(
+                                {"error": f"Redirect target rejected: {error_msg}", "url": next_url},
+                                ensure_ascii=False,
+                            )
+                        current = next_url
+                        continue
+                    r.raise_for_status()
+                    break
+                else:
+                    return json.dumps(
+                        {"error": "Too many redirects", "url": url}, ensure_ascii=False
+                    )
 
             ctype = r.headers.get("content-type", "")
 

--- a/miqi/execution/sandbox_policy.py
+++ b/miqi/execution/sandbox_policy.py
@@ -308,7 +308,11 @@ class SandboxPolicyEngine:
 
         Rules:
           - Read-only tools (NO_SANDBOX_TOOLS) always get NONE.
-          - Exec NEVER falls back to NONE — fail closed.
+          - Exec: the BASE path (#793) already returns NONE when no sandbox
+            is available (direct host execution, network as configured);
+            this fallback only runs when the escalation chain is exhausted
+            and still fails closed — an exec that lost even its base type
+            must not silently run unrestricted.
           - File mutation tools NEVER fall back to NONE — fail closed.
             allow_fallback_to_none does not affect file mutation tools.
           - Other tools fall back to NONE only if allow_fallback_to_none
@@ -319,12 +323,10 @@ class SandboxPolicyEngine:
 
         if tool_name == "exec":
             raise SandboxDeniedError(
-                "No sandbox available for exec — "
-                "NONE fallback is disabled for exec because it would "
-                "run arbitrary commands directly on the host without "
-                "any isolation. Configure bwrap_available=True or "
-                "set network_allowed=True on the permission profile "
-                "to allow RESTRICTED execution."
+                "No sandbox available for exec — the base sandbox type "
+                "fell back to NONE but the escalation chain is exhausted. "
+                "Configure bwrap_available=True on the host or install "
+                "a supported sandbox to isolate command execution."
             )
 
         if tool_name in self.FILE_MUTATION_TOOLS:

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -224,7 +224,9 @@ class MiQiToolHost:
         from miqi.execution.collab_policy import (
             AutonomyMode,
             CollabVerdict,
+            RiskLevel,
             evaluate as collab_evaluate,
+            risk_of,
         )
 
         if tool_name != ASK_USER_CONFIRM_TOOL:
@@ -255,10 +257,21 @@ class MiQiToolHost:
             if (
                 collab_verdict == CollabVerdict.CONFIRM
                 and context.await_user_input is not None
-                # Reasoning mode (issue #680): fast = 信息型操作直接执行，
-                # 不弹确认卡（用户：极速模式完全不可能快）。权限型仍由
-                # ExecutionPolicy/approval 门控制。
-                and context.mode != "fast"
+                and context.mode == "fast"
+                # #741/#680 审阅 P1: fast 只跳过**信息型**（READ）工具的确认
+                # 卡——用户：极速模式快。EXEC/WRITE/EXTERNAL/PAYMENT/UNKNOWN
+                # 永不因 fast 跳过（collab 矩阵里 AUTONOMOUS+PAYMENT 明确
+                # "never bypassable"）；否则 approval_policy=never 时支付/
+                # 执行/写入零确认直接执行。confirm_policy 配置不再死置。
+                and risk_of(tool_name) is RiskLevel.READ
+            ):
+                logger.info(
+                    "fast mode: skipping confirm card for info-only tool {}",
+                    tool_name,
+                )
+            elif (
+                collab_verdict == CollabVerdict.CONFIRM
+                and context.await_user_input is not None
             ):
                 gate_result = await context.await_user_input({
                     "threadId": context.thread_id,

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -1289,7 +1289,7 @@ async def test_exec_escalation_exhausted_raises_not_none():
     # BWRAP→LANDLOCK→RESTRICTED = 3 items. Attempt 3 is exhausted.
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(FakeCtx(), attempt=3)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -1319,7 +1319,7 @@ async def test_allow_fallback_to_none_true_does_not_let_exec_become_none():
 
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(FakeCtx(), attempt=1)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -1415,9 +1415,11 @@ async def test_sandbox_denied_error_for_exec_is_clear():
         await engine.select(FakeCtx(), attempt=1)
 
     msg = str(exc_info.value)
-    assert "NONE fallback is disabled for exec" in msg
+    # 审阅 #2: 文案与 #793 语义同步——base 路径 exec 无沙箱已允许 NONE，
+    # 此错误只在 escalation 耗尽时出现（fail closed）。
+    assert "base sandbox type" in msg
+    assert "escalation chain is exhausted" in msg
     assert "bwrap_available=True" in msg
-    assert "network_allowed=True" in msg
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/execution/test_sandbox_policy.py
+++ b/tests/execution/test_sandbox_policy.py
@@ -103,7 +103,7 @@ async def test_escalation_on_retry_bwrap_available():
     # Attempt 3 → beyond chain → exec NEVER falls to NONE → raises
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=3)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -117,7 +117,7 @@ async def test_escalation_past_chain_raises_for_exec():
     ctx = FakeContext("exec", {"command": "npm test"})
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=4)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -130,7 +130,7 @@ async def test_allow_fallback_to_none_false_for_exec():
     ctx = FakeContext("exec", {"command": "npm test"})
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=4)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -189,7 +189,7 @@ async def test_exec_with_landlock_no_fallback_to_none():
     # Attempt 1 → beyond chain → MUST raise for exec
     with pytest.raises(SandboxDeniedError) as exc_info:
         await engine.select(ctx, attempt=1)
-    assert "NONE fallback is disabled for exec" in str(exc_info.value)
+    assert "escalation chain is exhausted" in str(exc_info.value)
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
- [x] 修复

## 变更概述

响应三轮外部审阅的安全与一致性修复（4 项）：fast 模式确认卡只跳过信息型工具（EXEC/WRITE/PAYMENT 永不绕过）；fast 扇出搜索走配置的 provider 链（不再直接 ddgs）；沙箱策略文案与 #793 语义同步；重定向抓取 client 复用。

## 背景/问题

外部审阅发现：
1. tool_host.py 原逻辑 mode != "fast" 一刀切跳过确认卡——fast 模式下 EXEC/WRITE/EXTERNAL/PAYMENT 零确认直接执行（collab 矩阵 AUTONOMOUS+PAYMENT 明确 never bypassable；approval_policy=never 时无兜底）
2. SearchOrchestrator 因 WebSearchTool 无 _parallel_search 直接 ddgs——绕过 Tavily/Brave 配置链（配 key 不生效；ddgs 被墙静默 No results）
3. sandbox_policy _resolve_fallback 文案与 #793 base 路径语义矛盾（误导用户）
4. web.py 重定向循环每跳新建 AsyncClient（最多 5 次连接开销）

## 变更内容

- kun_runtime/tool_host.py：fast 只跳过 risk_of==READ 的信息型工具确认；EXEC/WRITE/EXTERNAL/PAYMENT/UNKNOWN 永不因 fast 跳过
- agent/tools/web.py：WebSearchTool 实现 _parallel_search（manager provider 链优先 + ddgs 回退）；ddgs 调用加 15s 超时；重定向 client 提到循环外复用
- agent/search_orchestrator.py：ddgs 加 15s 超时；_dedup_urls 注释修正
- execution/sandbox_policy.py：_resolve_fallback docstring/错误文案与 #793 语义同步
- tests/execution/test_exec_tool_sandbox_selection.py：3 处旧文案断言同步

## 日志/验证证据
```
py_compile: OK（4 文件）
pytest tests/execution/: 412 passed（含 approval/sandbox/exec 集成）
pytest tests/agent/tools/: 136 passed（含搜索/抓取）
pytest tests/execution/test_exec_tool_sandbox_selection.py + tests/agent/tools/: 203 passed
```

## 测试情况

- tests/execution 全量 412 passed（P1 修复无回归）
- tests/agent/tools 136 passed（#4 搜索修复无回归）
- 行为验证：fast + READ 跳过确认（极速保留）；fast + exec/payment 仍确认卡；fast 扇出搜索优先走配置链

## 截图

（无 UI 改动）
