### PR TITLE
fix(#814): 建线程竞争 except 收窄为 IntegrityError + 桌面模式行为实机验证

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -981,7 +981,7 @@ class BridgeRuntimeLoop:
                             # is fine — we update metadata next anyway.
                             await thread_runtime.create_thread(title="New thread", thread_id=thread_id)
                         except sqlite3.IntegrityError:
-                            # 并发 threads.start 已建同 id 线程——竞争正常，忽略
+                            # 并发 threads.start 已建同 id 线程 - 竞争正常, 忽略
                             pass
                     await thread_runtime.update_metadata(thread_id, {"mode": mode_param})
             except Exception as exc:

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 import sys
 import threading
 import time
@@ -979,7 +980,8 @@ class BridgeRuntimeLoop:
                             # threads.start may win the INSERT race; IntegrityError
                             # is fine — we update metadata next anyway.
                             await thread_runtime.create_thread(title="New thread", thread_id=thread_id)
-                        except Exception:
+                        except sqlite3.IntegrityError:
+                            # 并发 threads.start 已建同 id 线程——竞争正常，忽略
                             pass
                     await thread_runtime.update_metadata(thread_id, {"mode": mode_param})
             except Exception as exc:


### PR DESCRIPTION
## 类型

- [x] 🐛 修复

## 变更概述

#680 跟进收尾：桌面模式行为实机验证 + 建线程竞争异常收窄。

## 背景/问题

#680（#783）合并后遗留：
1. 桌面 fast/think 行为差异只靠单测证明，缺实机验证
2. bridge 建线程竞争的 `except Exception: pass` 过宽（磁盘错误也会被静默）

## 关联 issue

Closes #814

## 变更内容

- `miqi/bridge/loop.py`：建线程竞争容错 `except Exception` → `except sqlite3.IntegrityError`（并发 threads.start 竞争正常忽略；磁盘错误不再静默，由外层 warning 暴露）

## 日志/验证证据

```
桌面实机 A/B（同一问题"写一篇200字左右的关于父亲的作文"）：
fast  = 11.4s / 309 字（30s 预算内短答）
think = 45s+ / 398 字（仍在生成，无预算限制）
→ 桌面链路模式行为差异确认生效（#814 验证项 1）
```

## 测试情况

- `pytest tests/bridge/test_mode_new_thread.py` → 2 passed（回归）
- 实机 A/B 1 passed（真实 Electron + 真实 LLM）

## 截图

无（无 UI 变更）

## 后续计划

- `_last_asst` 预算终止重复显示：实机未复现（A/B 中 fast 11.4s 正常完成未触发预算终止），低优先级，后续实机观察
