### PR TITLE
fix(agent): 提示词不披露机器相关绝对路径，技能脚本目录由工具返回

### DIFF
--- a/miqi/agent/tools/skill_manage.py
+++ b/miqi/agent/tools/skill_manage.py
@@ -117,6 +117,22 @@ class SkillManageTool(Tool):
         content = self._skills.load_skill(name)
         if content is None:
             return f"Error: 未找到技能 '{name}'"
+        # Append the runtime-resolved scripts directory so the agent can run
+        # the skill's scripts without relying on any hard-coded path — the
+        # skill lives in different places per machine (builtin install dir,
+        # workspace copy), so only the tool can answer reliably.
+        script_dir = ""
+        for s in self._skills.list_skills(filter_unavailable=False):
+            if s["name"] == name:
+                from pathlib import Path
+
+                script_dir = str(Path(s["path"]).parent)
+                break
+        if script_dir:
+            content = (
+                content.rstrip()
+                + f"\n\n---\n本技能的脚本目录（运行技能脚本时使用）：{script_dir}\n"
+            )
         return content
 
     def _do_create(self, name: str, content: str) -> str:

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -161,40 +161,30 @@ def windows_path_to_mnt(path: str | Path) -> str:
 
 
 def _skills_dirs_note(workspace: str | Path | None, style: str) -> str:
-    """One sentence disclosing the REAL skills directories for the AI.
+    """One sentence telling the AI how to locate skills.
 
-    The injected <skills> summary only shows relative locations
-    (qraft-workflowspec-export/SKILL.md) — the AI does not know where
-    the builtin root lives and resorts to slow full-disk finds.  Give it
-    the actual directories in the exec environment's path style
-    (msys = /c/..., mnt = /mnt/c/..., native = as-is).
+    The prompt must NOT disclose machine-specific absolute paths for the
+    builtin skills — the app may live anywhere (dev checkout, installed
+    package, extracted archive).  skill_manage(action='view') resolves the
+    runtime location itself and appends the scripts directory, so point the
+    AI there; the workspace skills dir is the only config-derived path worth
+    mentioning (and it is per-user runtime data, not a hard-coded path).
     """
-    try:
-        from miqi.agent.skills import BUILTIN_SKILLS_DIR
-
-        builtin = str(BUILTIN_SKILLS_DIR)
-    except Exception:
-        builtin = ""
     ws_skills = str(Path(workspace) / "skills") if workspace is not None else ""
 
     if style == "msys":
-        builtin = windows_path_to_msys(builtin) if builtin else ""
         ws_skills = windows_path_to_msys(ws_skills) if ws_skills else ""
     elif style == "mnt":
-        builtin = windows_path_to_mnt(builtin) if builtin else ""
         ws_skills = windows_path_to_mnt(ws_skills) if ws_skills else ""
 
     parts = []
-    if builtin:
-        parts.append(f"内置 {builtin}")
     if ws_skills:
-        parts.append(f"工作区 {ws_skills}")
-    if not parts:
-        return ""
-    return (
-        "技能目录：" + "、".join(parts) + "。"
-        "直接用这些路径查找/读取技能（SKILL.md 与脚本），无需全盘搜索。"
+        parts.append(f"工作区技能目录 {ws_skills}")
+    parts.append(
+        "技能内容与内置技能的脚本目录请用 skill_manage(action='view', name=<技能名>) 获取"
+        "（返回内容末尾附脚本目录路径），无需搜索或猜测绝对路径"
     )
+    return "技能定位：" + "、".join(parts) + "。"
 
 
 def _python_note(style: str) -> str:

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -33,6 +33,7 @@ import asyncio
 import json
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -196,6 +197,28 @@ def _skills_dirs_note(workspace: str | Path | None, style: str) -> str:
     )
 
 
+def _python_note(style: str) -> str:
+    """One sentence disclosing the bridge's REAL python interpreter.
+
+    The AI otherwise resolves `python` via PATH and can hit the
+    WindowsApps store stub (hangs ~forever) or a stale interpreter —
+    give it the full path in the exec environment's path style
+    (msys = /c/..., mnt = /mnt/c/..., native = as-is).
+    """
+    exe = str(getattr(sys, "executable", ""))
+    if not exe:
+        return ""
+    if style == "msys":
+        exe = windows_path_to_msys(exe)
+    elif style == "mnt":
+        exe = windows_path_to_mnt(exe)
+    return (
+        f"推荐 Python 解释器：{exe}。"
+        "运行 python 脚本请直接用这个完整路径，避免 PATH 上其他 "
+        "python 启动卡顿（如商店占位程序）。"
+    )
+
+
 def describe_exec_environment(
     sandbox_manager: Any,
     workspace: str | Path | None = None,
@@ -214,7 +237,7 @@ def describe_exec_environment(
             "与文件工具目录不同（沙箱为独立目录，看不到文件工具写入的文件），"
             "自定义工作区下二者相同；exec 中访问文件请用主机路径（如 /mnt/c/...），"
             "或改用文件工具。"
-            + _skills_dirs_note(workspace, "mnt")
+            + _skills_dirs_note(workspace, "mnt") + _python_note("mnt")
         )
     if os.name == "nt":
         if find_git_bash() is not None:
@@ -230,7 +253,7 @@ def describe_exec_environment(
                 "（ls/find/grep/sed 等），用 && 或 ; 连接多条命令；"
                 f"Windows 路径在 Git Bash 中映射为 /c/... 形式（如 C:\\Users\\x 对应 /c/Users/x）。{mapping}"
                 "文件工具（read_file/write_file/list_dir）仍使用 Windows 路径。"
-                + _skills_dirs_note(workspace, "msys")
+                + _skills_dirs_note(workspace, "msys") + _python_note("msys")
             )
         return (
             "exec 直接在 Windows cmd 中运行（当前未启用沙箱），"
@@ -238,7 +261,7 @@ def describe_exec_environment(
             "cmd 语法注意：用 && 连接多条命令（不支持 ; 分隔），"
             "ls/find/grep/sed 不可用（用 dir / where / findstr），"
             "或使用 powershell -Command \"...\"。"
-            + _skills_dirs_note(workspace, "native")
+            + _skills_dirs_note(workspace, "native") + _python_note("native")
         )
     return (
         "exec 直接在本机 shell（bash）中运行（当前未启用沙箱），"

--- a/tests/agent/tools/test_skill_manage.py
+++ b/tests/agent/tools/test_skill_manage.py
@@ -1,0 +1,33 @@
+"""Tests for the skill_manage tool's skill-location disclosure.
+
+skill_manage(view) must append the runtime-resolved scripts directory to
+the SKILL.md content so the agent can run the skill's scripts without
+relying on hard-coded machine paths in the system prompt.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.skill_manage import SkillManageTool
+
+
+@pytest.mark.asyncio
+async def test_view_appends_scripts_dir(tmp_path):
+    skill_dir = tmp_path / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Demo\n\nDo the thing.\n", encoding="utf-8")
+
+    tool = SkillManageTool(workspace=tmp_path)
+    result = await tool.execute(action="view", name="demo-skill")
+
+    assert "# Demo" in result
+    assert "本技能的脚本目录" in result
+    assert str(skill_dir).replace("\\", "/") in result.replace("\\", "/")
+
+
+@pytest.mark.asyncio
+async def test_view_missing_skill_errors(tmp_path):
+    tool = SkillManageTool(workspace=tmp_path)
+    result = await tool.execute(action="view", name="nope")
+    assert "未找到技能" in result

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -253,6 +253,27 @@ def test_describe_exec_environment_skills_dirs_cmd_fallback(monkeypatch):
     assert "miqi\\skills" in text or "miqi/skills" in text
 
 
+def test_describe_exec_environment_discloses_python_interpreter(monkeypatch):
+    """The description must disclose the bridge's real python interpreter
+    (with the Git Bash path form) — the AI otherwise resolves `python` to
+    the WindowsApps store stub or a hung interpreter."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.find_git_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+
+    class _FakeSys:
+        executable = r"C:\git-program\venv\Scripts\python.exe"
+
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.sys", _FakeSys(), raising=False,
+    )
+    text = describe_exec_environment(None, workspace=r"C:\Users\demo\ws")
+    assert "python" in text
+    assert "/c/git-program/venv/Scripts/python.exe" in text
+
+
 def test_describe_exec_environment_skills_dirs_sandbox_wsl():
     manager = FakeSandboxManager(enabled=True, initialized=True)
     text = describe_exec_environment(manager, workspace=r"C:\Users\demo\ws")

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -229,28 +229,31 @@ def test_describe_exec_environment_no_sandbox_posix(monkeypatch):
 
 
 def test_describe_exec_environment_skills_dirs_git_bash(monkeypatch):
-    """The description must disclose the REAL skills directories so the
-    AI reads SKILL.md/scripts directly instead of full-disk finds."""
+    """The description must point the AI to skill_manage for skill
+    locations instead of hard-coding machine-specific builtin paths."""
     monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
     monkeypatch.setattr(
         "miqi.sandbox.manager.find_git_bash",
         lambda: r"C:\Program Files\Git\bin\bash.exe",
     )
     text = describe_exec_environment(None, workspace=r"C:\Users\demo\ws")
-    assert "技能目录" in text
+    assert "技能定位" in text
     assert "/c/Users/demo/ws/skills" in text
-    assert "miqi/skills" in text
+    assert "skill_manage" in text
+    # machine-specific builtin paths must NOT leak into the prompt
+    assert "miqi/skills" not in text
 
 
 def test_describe_exec_environment_skills_dirs_cmd_fallback(monkeypatch):
     monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
     monkeypatch.setattr("miqi.sandbox.manager.find_git_bash", lambda: None)
     text = describe_exec_environment(None, workspace=r"C:\Users\demo\ws")
-    assert "技能目录" in text
+    assert "技能定位" in text
+    assert "skill_manage" in text
     # Separator-agnostic: the workspace path is joined on the host
     # platform (backslash on Windows, mixed on POSIX test runs).
     assert "demo" in text and "ws" in text and "skills" in text
-    assert "miqi\\skills" in text or "miqi/skills" in text
+    assert "miqi/skills" not in text
 
 
 def test_describe_exec_environment_discloses_python_interpreter(monkeypatch):
@@ -277,9 +280,10 @@ def test_describe_exec_environment_discloses_python_interpreter(monkeypatch):
 def test_describe_exec_environment_skills_dirs_sandbox_wsl():
     manager = FakeSandboxManager(enabled=True, initialized=True)
     text = describe_exec_environment(manager, workspace=r"C:\Users\demo\ws")
-    assert "技能目录" in text
+    assert "技能定位" in text
     assert "/mnt/c/Users/demo/ws/skills" in text
-    assert "miqi/skills" in text
+    assert "skill_manage" in text
+    assert "miqi/skills" not in text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

提示词不再披露机器相关的绝对路径：技能内容与脚本目录改由 `skill_manage(action='view')` 运行时解析并附在返回末尾；同时披露真实 Python 解释器完整路径（`sys.executable`，按安装位置解析），避免 AI 命中商店占位程序或卡死解释器。

## 背景/问题

每轮注入的环境描述把内置技能目录按应用实际位置拼进提示词（开发工作区/安装目录/打包临时目录各不相同），打包发布后会暴露本机路径且每次启动可能变化（见 #816）。同时 `skill_manage(view)` 只返回 SKILL.md 正文、不含脚本目录，AI 无法脱离提示词路径运行技能脚本；`python` 按 PATH 解析还可能命中 WindowsApps 商店占位程序（启动挂起）或残留的卡死解释器。

## 关联 issue

- Closes #816

## 变更内容

- `miqi/sandbox/manager.py`：新增 `_python_note()`——按平台风格（Git Bash /c/、WSL /mnt/c/、原生）披露 `sys.executable`；`_skills_dirs_note()` 改为指引式（工作区技能目录 + 用 skill_manage 获取内容与脚本位置），不再拼接内置技能绝对路径
- `miqi/agent/tools/skill_manage.py`：`view` 返回内容末尾附上运行时解析的脚本目录（机器无关）
- `tests/sandbox/test_exec_environment_description.py`：更新 3 个断言（内置绝对路径不得出现在提示词）+ 新增 python 披露测试
- `tests/agent/tools/test_skill_manage.py`：新增 2 个测试（view 附脚本目录 / 技能缺失报错）

## 日志/验证证据

```
$ uv run pytest tests/sandbox/test_exec_environment_description.py tests/agent/tools/test_skill_manage.py -q
40 passed in 0.55s
```

修复后提示词尾部示例（不再含内置技能绝对路径）：

```
技能定位：工作区技能目录 /c/Users/.../.miqi/workspace/skills、
技能内容与内置技能的脚本目录请用 skill_manage(action='view', name=<技能名>)
获取（返回内容末尾附脚本目录路径），无需搜索或猜测绝对路径。
推荐 Python 解释器：<sys.executable 的运行时路径>。
```

## 测试情况

- 相关 40 个单测全过（sandbox 环境描述 38 + skill_manage 2）
- 变更仅涉及提示词构建与 skill_manage 返回格式（正文后追加），不改变既有调用方解析逻辑

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)
