### PR TITLE
feat: 右侧资产面板路径不可达时明确报错并给出建议（#790）

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -52,6 +52,7 @@ import type {
   WslInstallAndProvisionResult,
 } from '../../shared/ipc';
 import { registerQraftIpcHandlers } from '../qraft/ipc';
+import type { FilesCheckItem } from '../../shared/ipc';
 
 const { ipcMain, dialog, shell } = electron;
 
@@ -1936,6 +1937,21 @@ for m in ("pydantic", "httpx", "loguru"):
     } catch (e: any) {
       return { opened: false, path: tmpPath, error: e?.message ?? String(e) };
     }
+  });
+
+  // -- #790: 资产面板路径可达性批量校验（渲染资产卡片时按需调用） -------------
+  // 判定逻辑在 bridge files.check_many —— 复用 files.read 的权威路径解析
+  // （沙箱前缀/越界/会话作用域，见 miqi/runtime/file_handlers.py）；不可达
+  // 日志由 bridge 侧记录（可观测性）。
+  ipcMain.handle(IPC.FILES_CHECK, async (_event, payload: unknown) => {
+    const p = payload as { items?: unknown; session_key?: unknown };
+    const items: FilesCheckItem[] = Array.isArray(p?.items)
+      ? (p.items as FilesCheckItem[]).filter((it) => !!it && typeof it.path === 'string' && it.path)
+      : [];
+    return bridge.sendSafe('files.check_many', {
+      items,
+      session_key: typeof p?.session_key === 'string' ? p.session_key : undefined,
+    });
   });
 
   // -- Reveal file in system file manager (Explorer / Finder) ------------

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -48,6 +48,8 @@ import type {
   FilesRevertResult,
   FilesOpenExternalResult,
   FilesOpenContainingFolderResult,
+  FilesCheckItem,
+  FilesCheckResult,
   DocumentsParseResult,
   TrackedFileInfo,
   ChatProgress,
@@ -399,6 +401,10 @@ const api = {
       ipcRenderer.invoke(IPC.FILES_OPEN_EXTERNAL, { path }),
     openContainingFolder: (path: string): Promise<FilesOpenContainingFolderResult> =>
       ipcRenderer.invoke(IPC.FILES_OPEN_CONTAINING_FOLDER, { path }),
+    /** #790: 批量校验资产路径可达性（渲染资产卡片时按需调用，bridge 判定）。
+     *  sessionKey 用于会话隔离解析（#731），与 files.read 一致。 */
+    checkMany: (items: FilesCheckItem[], sessionKey?: string): Promise<FilesCheckResult> =>
+      ipcRenderer.invoke(IPC.FILES_CHECK, { items, session_key: sessionKey }),
     /** #740: open AI-generated HTML in the system browser (temp file + auto-cleanup). */
     openInBrowser: (html: string): Promise<{ opened: boolean; path: string; error?: string }> =>
       ipcRenderer.invoke(IPC.HTML_OPEN_IN_BROWSER, { html }),

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -65,6 +65,7 @@ import {
   Scissors,
   ClipboardPaste,
   Star,
+  AlertTriangle,
 } from 'lucide-react';
 import type {
   ChatProgress,
@@ -72,6 +73,8 @@ import type {
   ChatError,
   ChatAborted,
   ChatSubagentResult,
+  FileCheckStatus,
+  FilesCheckItem,
 } from '../../../shared/ipc';
 import { extractProgressMessage, type ProgressPayload } from './progressUtils';
 import { sanitizeUiMessage } from '../../lib/sanitizeUiMessage';
@@ -824,6 +827,148 @@ function normalizeSandboxPath(p: string): string {
   if (p === '/home/miqi/workspace') return '.';
   if (p.startsWith('/home/miqi/workspace/')) return p.slice('/home/miqi/workspace/'.length);
   return p;
+}
+
+/* ─── #790: 资产路径可达性校验 ────────────────────────────────────────── */
+const ASSET_CHECK_DEBOUNCE_MS = 300;
+const ASSET_CHECK_CACHE_TTL_MS = 30_000;
+/** 周期清扫间隔——比 TTL 短，外部删除/镜像晚到最长 ~TTL+间隔 内被捕获。 */
+const ASSET_CHECK_SWEEP_INTERVAL_MS = 10_000;
+const ASSET_CHECK_RETRY_INTERVAL_MS = 5_000;
+const ASSET_CHECK_RETRY_WINDOW_MS = 60_000;
+/** 判定"近期写入"的时间窗——窗内 not_found 视为沙箱镜像未回写（#474）。 */
+const ASSET_CHECK_RECENT_WRITE_MS = 120_000;
+
+/** 渲染资产卡片时按需校验路径可达性（issue #790）。
+ *  - files 变化后 debounce 批量 checkMany（单次 IPC 往返，主进程判定）
+ *  - 结果缓存 TTL 内不重复打磁盘；周期清扫重查过期项（外部删除/镜像晚到可被捕获）
+ *  - 近期写入的 write/edit 文件 not_found → 定时重试，镜像完成自动转 ok
+ */
+function useFileStatuses(
+  files: TrackedFile[],
+  sessionKeyRef: { current: string | null }
+): { statusByPath: Map<string, FileCheckStatus> } {
+  const [statusByPath, setStatusByPath] = useState<Map<string, FileCheckStatus>>(
+    () => new Map()
+  );
+  const cacheRef = useRef<Map<string, { status: FileCheckStatus; checkedAt: number }>>(
+    new Map()
+  );
+  const retryTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const filesRef = useRef(files);
+  filesRef.current = files;
+
+  const applyResults = useCallback(
+    (results: Record<string, FileCheckStatus>, checkedAt: number) => {
+      const cache = cacheRef.current;
+      for (const [p, st] of Object.entries(results)) cache.set(p, { status: st, checkedAt });
+      setStatusByPath(new Map([...cache].map(([k, v]) => [k, v.status])));
+    },
+    []
+  );
+
+  const scheduleRetry = useCallback(
+    (path: string, op?: TrackedFile['op'], truncated?: boolean) => {
+      if (retryTimersRef.current.has(path)) return; // 已有重试链，避免并发
+      const startedAt = Date.now();
+      const tick = () => {
+        const f = filesRef.current.find((x) => x.path === path);
+        const stillRelevant =
+          !!f &&
+          (f.op === 'write' || f.op === 'edit') &&
+          Date.now() - f.lastSeen <= ASSET_CHECK_RECENT_WRITE_MS;
+        if (!stillRelevant || Date.now() - startedAt > ASSET_CHECK_RETRY_WINDOW_MS) {
+          retryTimersRef.current.delete(path);
+          return;
+        }
+        window.miqi.files
+          .checkMany([{ path, truncated: f?.truncated ?? truncated, op: f?.op ?? op }], sessionKeyRef.current ?? undefined)
+          .then((res) => {
+            const st = res.results[path];
+            if (!st) return;
+            applyResults({ [path]: st }, Date.now());
+            if (st === 'ok' || Date.now() - startedAt > ASSET_CHECK_RETRY_WINDOW_MS) {
+              retryTimersRef.current.delete(path);
+              return;
+            }
+            const t = setTimeout(tick, ASSET_CHECK_RETRY_INTERVAL_MS);
+            retryTimersRef.current.set(path, t);
+          })
+          .catch(() => {
+            const t = setTimeout(tick, ASSET_CHECK_RETRY_INTERVAL_MS);
+            retryTimersRef.current.set(path, t);
+          });
+      };
+      const t = setTimeout(tick, ASSET_CHECK_RETRY_INTERVAL_MS);
+      retryTimersRef.current.set(path, t);
+    },
+    [applyResults]
+  );
+
+  const checkPaths = useCallback(
+    (items: FilesCheckItem[]) => {
+      if (items.length === 0) return;
+      window.miqi.files
+        .checkMany(items, sessionKeyRef.current ?? undefined)
+        .then((res) => {
+          applyResults(res.results, Date.now());
+          // 近期写入但不可达 → 可能仍在沙箱镜像中，安排重试（#474）
+          for (const item of items) {
+            if (res.results[item.path] !== 'not_found') continue;
+            if (item.op !== 'write' && item.op !== 'edit') continue;
+            scheduleRetry(item.path, item.op, item.truncated);
+          }
+        })
+        .catch(() => {
+          /* 校验失败不阻塞面板渲染（保持 unknown，卡片按可达处理） */
+        });
+    },
+    [applyResults, scheduleRetry]
+  );
+
+  // files 变化 → debounce 批量检查未缓存/已过期项
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const now = Date.now();
+      const cache = cacheRef.current;
+      const toCheck: FilesCheckItem[] = [];
+      for (const f of files) {
+        const hit = cache.get(f.path);
+        if (hit && hit.checkedAt + ASSET_CHECK_CACHE_TTL_MS > now) continue;
+        toCheck.push({ path: f.path, truncated: f.truncated, op: f.op });
+      }
+      checkPaths(toCheck);
+    }, ASSET_CHECK_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [files, checkPaths]);
+
+  // 周期清扫：TTL 过期项重查（外部删除 / 镜像晚到会被捕获）；truncated 永不变，跳过
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const cache = cacheRef.current;
+      const stale: FilesCheckItem[] = [];
+      for (const f of filesRef.current) {
+        const hit = cache.get(f.path);
+        if (!hit || hit.checkedAt + ASSET_CHECK_CACHE_TTL_MS > now) continue;
+        if (hit.status === 'truncated') continue;
+        stale.push({ path: f.path, truncated: f.truncated, op: f.op });
+      }
+      checkPaths(stale);
+    }, ASSET_CHECK_SWEEP_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [checkPaths]);
+
+  // 卸载时清理重试定时器
+  useEffect(() => {
+    const timers = retryTimersRef.current;
+    return () => {
+      for (const t of timers.values()) clearTimeout(t);
+      timers.clear();
+    };
+  }, []);
+
+  return { statusByPath };
 }
 
 const DEFAULT_SESSION = 'desktop:default';
@@ -4959,6 +5104,26 @@ export function ChatConsole({
     () => classifyTrackedFiles(trackedFiles),
     [trackedFiles]
   );
+  // #790: 资产路径可达性校验（渲染时按需、批量、缓存 + 镜像重试）
+  const { statusByPath } = useFileStatuses(trackedFiles, currentSessionRef);
+  const unreachableFiles = useMemo(
+    () =>
+      resultFiles
+        .concat(processFiles)
+        .filter((f) => statusByPath.has(f.path) && statusByPath.get(f.path) !== 'ok'),
+    [resultFiles, processFiles, statusByPath]
+  );
+  // 汇总条点击 → 定位到第一个异常卡片并短暂高亮
+  const [flashPath, setFlashPath] = useState<string | null>(null);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const focusAsset = useCallback((path: string) => {
+    document
+      .querySelector(`[data-asset-path="${CSS.escape(path)}"]`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setFlashPath(path);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = setTimeout(() => setFlashPath(null), 1800);
+  }, []);
   // 「修改建议」区只关心本次会话 write/edit 过的文件；按分类拆成两组
   // （用户反馈 2026-08-13：合并前结果/过程混排，合并（op→read）后才分类）。
   const writeEditFiles = useMemo(
@@ -5849,18 +6014,54 @@ export function ChatConsole({
               </div>
             ) : (
               <>
+                {/* #790: 批量异常汇总条 —— 点击定位到第一个不可达卡片 */}
+                {unreachableFiles.length > 0 && (
+                  <div
+                    className="mx-3 mb-1 flex items-center gap-1.5 rounded-md px-2 py-1.5 text-size-2xs cursor-pointer transition-colors hover:brightness-110"
+                    data-testid="asset-unreachable-bar"
+                    onClick={() => focusAsset(unreachableFiles[0].path)}
+                    title="点击定位到第一个异常卡片"
+                    style={{
+                      border: '1px solid color-mix(in srgb, var(--danger) 40%, transparent)',
+                      background: 'color-mix(in srgb, var(--danger) 8%, var(--surface))',
+                      color: 'var(--danger)',
+                    }}
+                  >
+                    <AlertTriangle size={11} className="shrink-0" />
+                    <span className="font-semibold shrink-0">
+                      {unreachableFiles.length} 个资产路径不可达
+                    </span>
+                  </div>
+                )}
                 {/* issue #607: 结果资产（默认展开、星标强调） + 过程资产（默认折叠） */}
                 {resultFiles.length > 0 && (
                   <AssetSection label="结果文件" testKey="result" count={resultFiles.length} defaultOpen accent>
                     {resultFiles.map((f) => (
-                      <TrackedFileCard
+                      <div
                         key={f.path}
-                        file={f}
-                        isResult
-                        onPreview={() => handlePreview(f.path)}
-                        onDiff={() => handleShowDiff(f.path)}
-                        onReveal={() => window.miqi.files.openContainingFolder(normalizePath(f.path))}
-                      />
+                        data-asset-path={f.path}
+                        className="rounded-lg transition-shadow"
+                        style={flashPath === f.path ? { boxShadow: '0 0 0 2px var(--accent)' } : undefined}
+                      >
+                        <TrackedFileCard
+                          file={f}
+                          isResult
+                          status={statusByPath.get(f.path)}
+                          onPreview={() => handlePreview(f.path)}
+                          onDiff={() => handleShowDiff(f.path)}
+                          onReveal={async () => {
+                            // #790: 不再 fire-and-forget —— 失败时给出明确原因
+                            const res = await window.miqi.files.openContainingFolder(normalizePath(f.path));
+                            if (!res.revealed) {
+                              setPreviewFile({
+                                path: f.path,
+                                content: `无法定位文件：${res.error ?? '未知原因'}\n\n原始路径：${f.path}`,
+                              });
+                            }
+                          }}
+                          onCopyPath={(p) => window.miqi.clipboard.writeText(p)}
+                        />
+                      </div>
                     ))}
                   </AssetSection>
                 )}
@@ -5873,12 +6074,20 @@ export function ChatConsole({
                     defaultOpen={resultFiles.length === 0}
                   >
                     {processFiles.map((f) => (
-                      <TrackedFileCard
+                      <div
                         key={f.path}
-                        file={f}
-                        onPreview={() => handlePreview(f.path)}
-                        onDiff={() => handleShowDiff(f.path)}
-                      />
+                        data-asset-path={f.path}
+                        className="rounded-lg transition-shadow"
+                        style={flashPath === f.path ? { boxShadow: '0 0 0 2px var(--accent)' } : undefined}
+                      >
+                        <TrackedFileCard
+                          file={f}
+                          status={statusByPath.get(f.path)}
+                          onPreview={() => handlePreview(f.path)}
+                          onDiff={() => handleShowDiff(f.path)}
+                          onCopyPath={(p) => window.miqi.clipboard.writeText(p)}
+                        />
+                      </div>
                     ))}
                   </AssetSection>
                 )}

--- a/apps/desktop/src/renderer/features/chat/components/TrackedFileCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/TrackedFileCard.tsx
@@ -1,4 +1,6 @@
-import { BookOpen, X, Pencil, FileText, Eye, GitCompare, Star, FolderOpen } from 'lucide-react';
+import { useState } from 'react';
+import { BookOpen, X, Pencil, FileText, Eye, GitCompare, Star, FolderOpen, Copy, Check, AlertTriangle } from 'lucide-react';
+import type { FileCheckStatus } from '../../../../shared/ipc';
 
 export interface TrackedFile {
   path: string;
@@ -8,22 +10,52 @@ export interface TrackedFile {
   truncated?: boolean;
 }
 
-export const OFFICE_FILE_RE_LEGACY = /\.(docx|xlsx|pptx|ppt)$/i;
+export const OFFICE_FILE_RE_LEGACY = /\\.(docx|xlsx|pptx|ppt)$/i;
+
+/** #790: 资产路径不可达的错误态文案（错误类型 / 原因 / 建议）。 */
+function assetErrorInfo(
+  file: TrackedFile,
+  status?: FileCheckStatus
+): { label: string; hint: string; color: string } | null {
+  if (!status || status === 'ok') return null;
+  switch (status) {
+    case 'truncated':
+      return { label: '路径截断', hint: '路径在进度消息中被截断，无法定位或打开', color: 'var(--warning)' };
+    case 'outside':
+      return { label: '路径越界', hint: '路径不在工作区内，请检查沙箱/路径映射', color: 'var(--warning)' };
+    case 'permission':
+      return { label: '权限不足', hint: '文件存在但无读取权限，请检查文件权限', color: 'var(--warning)' };
+    case 'not_found': {
+      // 近期写入的 write/edit 文件不可达 → 大概率是沙箱镜像未回写完成（#474）
+      const recentWrite =
+        (file.op === 'write' || file.op === 'edit') && Date.now() - file.lastSeen < 120_000;
+      return recentWrite
+        ? { label: '文件不存在', hint: '刚写入的文件可能仍在沙箱镜像中，等待同步…', color: 'var(--danger)' }
+        : { label: '文件不存在', hint: '文件可能已被删除，可重新生成产物', color: 'var(--danger)' };
+    }
+  }
+}
 
 export function TrackedFileCard({
   file,
   isResult,
+  status,
   onPreview,
   onDiff,
   onReveal,
+  onCopyPath,
 }: {
   file: TrackedFile;
   /** issue #607: result assets get accent border/background + Star + 结果 badge. */
   isResult?: boolean;
+  /** #790: 可达性校验结果（未校验时为 undefined → 按可达处理）。 */
+  status?: FileCheckStatus;
   onPreview: () => void;
   onDiff?: () => void;
   /** issue #607: 定位 → reveal the file in the OS file manager (results only). */
   onReveal?: () => void;
+  /** #790: 复制原始路径（经主进程 clipboard，file:// 下 navigator.clipboard 不可用）。 */
+  onCopyPath?: (path: string) => void;
 }) {
   const opColor: Record<TrackedFile['op'], string> = {
     read: 'var(--info)',
@@ -38,8 +70,21 @@ export function TrackedFileCard({
     edit: '编辑',
     delete: '删除',
   };
-  const displayPath = file.path.replace(/\\/g, '/');
+  const displayPath = file.path.replace(/\\\\/g, '/');
   const isOfficeFile = OFFICE_FILE_RE_LEGACY.test(file.path);
+
+  const [copied, setCopied] = useState(false);
+  const assetError = assetErrorInfo(file, status) ?? (file.truncated
+    ? { label: '路径截断', hint: '路径在进度消息中被截断', color: 'var(--warning)' }
+    : null);
+  const unavailable = !!assetError;
+
+  const copyPath = () => {
+    if (!onCopyPath) return;
+    onCopyPath(file.path);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   return (
     <div
@@ -96,33 +141,78 @@ export function TrackedFileCard({
           </div>
         </div>
       </div>
-      {file.truncated ? (
-        <div className="w-full flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs"
-             style={{ border: '1px solid var(--border-subtle)', color: 'var(--text-faint)', background: 'var(--surface-muted)' }}
-             title="路径在进度消息中被截断">
-          <span className="text-size-2xs">路径不完整</span>
+      {assetError ? (
+        /* #790: 路径不可达错误态 —— 类型 / 原因与建议 / 原始路径（可复制） */
+        <div
+          className="w-full rounded-md px-2 py-1.5 flex flex-col gap-1"
+          data-testid="file-error-block"
+          style={{
+            border: `1px solid color-mix(in srgb, ${assetError.color} 45%, transparent)`,
+            background: `color-mix(in srgb, ${assetError.color} 8%, var(--surface))`,
+          }}
+        >
+          <div className="flex items-center gap-1.5 min-w-0">
+            <AlertTriangle size={11} className="shrink-0" style={{ color: assetError.color }} />
+            <span className="text-size-2xs font-semibold shrink-0" data-testid="file-error-label" style={{ color: assetError.color }}>
+              {assetError.label}
+            </span>
+            <span className="text-size-2xs truncate" style={{ color: 'var(--text-faint)' }}>
+              {assetError.hint}
+            </span>
+            <button
+              type="button"
+              onClick={copyPath}
+              disabled={!onCopyPath}
+              title="复制原始路径"
+              data-testid="file-copy-path-btn"
+              className="ml-auto shrink-0 p-0.5 rounded transition-colors"
+              style={{ color: copied ? 'var(--accent)' : 'var(--text-faint)' }}
+            >
+              {copied ? <Check size={11} /> : <Copy size={11} />}
+            </button>
+          </div>
+          <div
+            className="truncate font-mono text-[10px]"
+            title={file.path}
+            data-testid="file-error-path"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            {file.path}
+          </div>
         </div>
       ) : (
         <div className="flex gap-1.5">
           {onReveal && isResult && (
-            <button onClick={onReveal}
-                    className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors"
-                    style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
-                    title="在文件管理器中定位" data-testid="file-reveal-btn">
+            <button
+              onClick={onReveal}
+              disabled={unavailable}
+              className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors disabled:opacity-40"
+              style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+              title="在文件管理器中定位"
+              data-testid="file-reveal-btn"
+            >
               <FolderOpen size={10} />定位
             </button>
           )}
           {onDiff && (file.op === 'write' || file.op === 'edit') && (
-            <button onClick={onDiff} disabled={isOfficeFile}
-                    className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors"
-                    style={{ border: '1px solid var(--border)', color: isOfficeFile ? 'var(--text-faint)' : 'var(--warning)', opacity: isOfficeFile ? 0.55 : 1 }}
-                    title="二进制 Office 文件不支持差异对比">
+            <button
+              onClick={onDiff}
+              disabled={unavailable || isOfficeFile}
+              className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors disabled:opacity-40"
+              style={{ border: '1px solid var(--border)', color: isOfficeFile ? 'var(--text-faint)' : 'var(--warning)', opacity: isOfficeFile ? 0.55 : 1 }}
+              title="二进制 Office 文件不支持差异对比"
+            >
               <GitCompare size={10} />差异
             </button>
           )}
-          <button onClick={onPreview} className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors"
-                  style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
-                  title="预览文件" data-testid="file-preview-btn">
+          <button
+            onClick={onPreview}
+            disabled={unavailable}
+            className="flex-1 flex items-center justify-center gap-1 py-1 rounded-md text-size-2xs transition-colors disabled:opacity-40"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+            title="预览文件"
+            data-testid="file-preview-btn"
+          >
             <Eye size={10} />预览
           </button>
         </div>

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -97,6 +97,7 @@ export const IPC = {
   FILES_ACCEPT: 'files:accept',
   FILES_OPEN_EXTERNAL: 'files:openExternal',
   FILES_OPEN_CONTAINING_FOLDER: 'files:openContainingFolder',
+  FILES_CHECK: 'files:check', // #790: 资产面板路径可达性批量校验
   HTML_OPEN_IN_BROWSER: 'html:openInBrowser',
   DOWNLOADS_DOWNLOAD: 'downloads:download', // #667: 直接下载（论文 PDF 等）
   DOCUMENTS_PARSE: 'documents:parse',
@@ -826,6 +827,26 @@ export interface FilesOpenContainingFolderResult {
   revealed: boolean;
   path: string;
   error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// #790: 资产面板路径可达性校验（渲染时按需调用，主进程判定）
+// ---------------------------------------------------------------------------
+
+export type FileCheckStatus = 'ok' | 'not_found' | 'outside' | 'permission' | 'truncated';
+
+export interface FilesCheckItem {
+  path: string;
+  /** 路径在进度消息中被截断（不可解析，直接判 truncated，不碰磁盘）。 */
+  truncated?: boolean;
+  /** 最近一次操作类型（主进程日志/镜像重试参考）。 */
+  op?: 'read' | 'write' | 'edit' | 'delete';
+}
+
+export interface FilesCheckResult {
+  results: Record<string, FileCheckStatus>;
+  /** 非 ok 条目的解析后路径/错误说明。 */
+  details?: Record<string, { resolvedPath?: string; error?: string }>;
 }
 
 export interface DocumentsParseResult {

--- a/apps/desktop/tests/e2e/task-assets.spec.ts
+++ b/apps/desktop/tests/e2e/task-assets.spec.ts
@@ -6,6 +6,8 @@
 
 import { _electron as electron, test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
+import { readdir, rm } from 'fs/promises';
+import { join } from 'path';
 import {
   LLM_TIMEOUT,
   waitForInputReady,
@@ -70,6 +72,21 @@ async function clickPreviewButton(page: Page, card: ReturnType<Page['locator']>)
       await page.waitForTimeout(500);
     }
   }
+}
+
+/** #790: 在 workspace 下递归查找文件（会话隔离后文件在 sessions/<key>/files/）。 */
+async function findFileRecursive(dir: string, name: string): Promise<string | null> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const found = await findFileRecursive(p, name);
+      if (found) return found;
+    } else if (entry.name === name) {
+      return p;
+    }
+  }
+  return null;
 }
 
 // ─── Test Suite ───────────────────────────────────────────────────
@@ -286,5 +303,62 @@ test.describe('Task Assets Panel E2E', () => {
       console.log('[test] ✅ Docx test complete');
     },
   );
+
+  // ═══════════════════════════════════════════════════════════════
+  //  Test 4 (#790): 文件被删除后卡片出现明确错误态 + 按钮降级 + 汇总条
+  // ═══════════════════════════════════════════════════════════════
+
+  test('deleted tracked file → error block, disabled actions, summary bar', async () => {
+    test.setTimeout(LLM_TIMEOUT * 2);
+    await page.evaluate(async () => {
+      for (let i = 0; i < 30; i++) {
+        try {
+          const s = await (window as any).miqi.runtime.status();
+          if (s?.state === 'running' && s?.initialized) return;
+        } catch { /* */ }
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    });
+
+    const filename = `e2e_gone_${Date.now()}.txt`;
+    const content = `E2E gone-file test ${Date.now()}`;
+
+    await sendMessage(
+      page,
+      `Use write_file to create ${filename} with content="${content}"`,
+    );
+    await waitForResponseComplete(page, 240_000);
+
+    // 先确认卡片正常出现（可达态）
+    const fileCard = await waitForFileInPanel(page, filename);
+
+    // 在宿主磁盘上删除真实文件（会话隔离：sessions/<key>/files/ 下）
+    const fileAbs = await findFileRecursive(join(miqiHome, 'workspace'), filename);
+    expect(fileAbs).toBeTruthy();
+    await rm(fileAbs!, { force: true });
+    console.log(`[test] 🗑 Deleted on host: ${fileAbs}`);
+
+    // 校验由周期清扫（TTL 30s + sweep 10s）触发的重查 —— 最长等 70s
+    const errorBlock = fileCard.getByTestId('file-error-block');
+    await expect(errorBlock).toBeVisible({ timeout: 70_000 });
+    console.log('[test] ✅ Error block visible');
+
+    // 错误类型 = 文件不存在
+    await expect(fileCard.getByTestId('file-error-label')).toHaveText('文件不存在');
+    // 原始路径展示 + 可复制按钮
+    await expect(fileCard.getByTestId('file-error-path')).toContainText(filename);
+    await expect(fileCard.getByTestId('file-copy-path-btn')).toBeVisible();
+
+    // 点击降级：不可达时按钮区被错误块取代（定位/预览/差异不可再点，杜绝无响应）
+    await expect(fileCard.getByTestId('file-preview-btn')).not.toBeVisible();
+
+    // 批量异常汇总条
+    const bar = page.getByTestId('asset-unreachable-bar');
+    await expect(bar).toBeVisible({ timeout: 10_000 });
+    await expect(bar).toContainText('1 个资产路径不可达');
+    console.log('[test] ✅ Summary bar shows 1 unreachable');
+
+    await page.screenshot({ path: 'test-results/asset-unreachable.png' });
+  });
 
 });

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -461,6 +461,7 @@ class BridgeRuntimeLoop:
         # Register Phase 30: files.* handlers (client-scoped ownership)
         from miqi.runtime.file_handlers import (
             files_accept_handler,
+            files_check_many_handler,
             files_delete_handler,
             files_diff_handler,
             files_read_handler,
@@ -475,6 +476,7 @@ class BridgeRuntimeLoop:
         self._app_server.register_method("files.diff", files_diff_handler)
         self._app_server.register_method("files.revert", files_revert_handler)
         self._app_server.register_method("files.accept", files_accept_handler)
+        self._app_server.register_method("files.check_many", files_check_many_handler, spec=protocol_specs.FILES_CHECK_MANY)
 
         # Register documents.* handlers
         from miqi.documents.documents_parse_handler import (

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -860,19 +860,23 @@ class AgentControl:
     def _format_tool_hint(name: str, args: dict) -> str:
         """Format a tool call as a concise display hint.
 
-        Path-like and command args show the target value (truncated at 50
-        chars); every other arg shows only the parameter name. Values like
-        paper titles, URLs, or queries are long strings that would leak
-        into the hint instead of a concise call summary (issue #532).
+        Path-like args show the FULL target value — the asset panel depends
+        on complete paths (issue #790; a truncated path is permanently
+        unreachable). command stays capped at 50 chars; every other arg
+        shows only the parameter name so paper titles / URLs / queries
+        don't leak into the hint (issue #532).
         """
         if not args:
             return name
-        for key in ("path", "file_path", "filename", "outPath", "command"):
+        for key in ("path", "file_path", "filename", "outPath"):
             val = args.get(key)
             if isinstance(val, str) and val:
-                if len(val) > 50:
-                    return f'{name}("{val[:50]}…")'
                 return f'{name}("{val}")'
+        val = args.get("command")
+        if isinstance(val, str) and val:
+            if len(val) > 50:
+                return f'{name}("{val[:50]}…")'
+            return f'{name}("{val}")'
         key = next(iter(args), "")
         return f"{name}({key}=…)" if key else name
 

--- a/miqi/runtime/file_handlers.py
+++ b/miqi/runtime/file_handlers.py
@@ -25,6 +25,7 @@ Key semantics:
 from __future__ import annotations
 
 import difflib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -1057,3 +1058,92 @@ async def files_accept_handler(
 
     logger.info("[files:accept] ok path={}", file_path)
     return {"result": {"accepted": True, "path": file_path}}
+
+
+# ── files.check_many (issue #790) ──────────────────────────────────────────
+
+def _check_one_path_status(
+    item: dict[str, Any],
+    client_id: str,
+    session_key: str | None,
+) -> tuple[str, dict[str, Any]]:
+    """#790: 判定单条资产路径可达性。
+
+    复用 ``_validate_file_path`` 的权威解析（沙箱前缀剥离 / 宿主绝对路径 /
+    越界保护 / 会话作用域），保证与 files.read 等读操作看到同一套路径语义。
+
+    Returns (status, detail): ok / not_found / outside / permission / truncated。
+    """
+    path = item.get("path")
+    if not isinstance(path, str) or not path:
+        return "", {}
+    if item.get("truncated"):
+        # 路径在进度消息中被截断，无法解析——不碰磁盘
+        return "truncated", {"error": "path truncated in progress message"}
+
+    try:
+        resolved = _validate_file_path(path, client_id, session_key)
+    except (AppServerError, ValueError) as exc:
+        return "outside", {"error": str(exc)}
+
+    try:
+        if resolved.exists():
+            if os.access(resolved, os.R_OK):
+                return "ok", {}
+            return "permission", {
+                "resolvedPath": str(resolved),
+                "error": "exists but not readable",
+            }
+    except OSError:
+        pass
+
+    # 宿主不可见——可能在 WSL 沙箱工作区副本里（#474 镜像未回写宿主）。
+    # 记入 detail 供日志/排查，仍按 not_found 处理（前端对近期写入条目
+    # 会给出"等待沙箱镜像完成"的建议并定时重查）。
+    try:
+        sandbox_result = _find_in_sandbox_workspaces(path, resolved, session_key)
+    except Exception:
+        sandbox_result = None
+    if sandbox_result is not None:
+        return "not_found", {
+            "resolvedPath": str(sandbox_result[0]),
+            "error": "found in sandbox workspace (not yet mirrored to host)",
+        }
+    return "not_found", {"resolvedPath": str(resolved)}
+
+
+async def files_check_many_handler(
+    request_id: str,
+    params: dict[str, Any],
+    client_id: str,
+    session_id: str | None,
+    registry: Any,
+) -> dict[str, Any]:
+    """#790: 批量校验资产路径可达性（渲染资产卡片时按需调用）。
+
+    返回 {results: {path: status}, details: {path: {resolvedPath?, error?}}}。
+    可观测性：存在不可达条目时记录一条 WARN 日志（文件、原因），便于排查
+    WSL 镜像与路径映射问题。
+    """
+    items = params.get("items") or []
+    session_key = params.get("session_key")
+    results: dict[str, str] = {}
+    details: dict[str, dict[str, Any]] = {}
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        if not isinstance(path, str) or not path:
+            continue
+        status, detail = _check_one_path_status(item, client_id, session_key)
+        results[path] = status
+        if detail:
+            details[path] = detail
+
+    unreachable = [p for p, s in results.items() if s != "ok"]
+    if unreachable:
+        logger.warning(
+            "[files:check_many] req={} unreachable={} session_key={} client={}",
+            request_id, unreachable, session_key, client_id,
+        )
+    return {"result": {"results": results, "details": details}}

--- a/miqi/runtime/files_request_models.py
+++ b/miqi/runtime/files_request_models.py
@@ -1,0 +1,28 @@
+"""Typed request params for files.* App Server methods (Phase 30 files handlers)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Params(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class FilesCheckItemModel(_Params):
+    """Single asset-panel path check item (issue #790)."""
+
+    path: str
+    truncated: bool = False
+    op: str | None = None
+
+
+class FilesCheckManyParams(_Params):
+    """files.check_many — 资产面板路径可达性批量校验（#790）。
+
+    session_key 可选：提供时按会话作用域解析（#731 会话隔离），
+    否则按 workspace 作用域解析。
+    """
+
+    items: list[FilesCheckItemModel] = Field(default_factory=list)
+    session_key: str | None = None

--- a/miqi/runtime/protocol_specs.py
+++ b/miqi/runtime/protocol_specs.py
@@ -54,6 +54,7 @@ from miqi.runtime.session_request_models import (
     SESSION_METHOD_PARAM_MODELS,
     SessionKeyParams,
 )
+from miqi.runtime.files_request_models import FilesCheckManyParams
 from miqi.runtime.session_response_models import SESSION_METHOD_RESULT_MODELS
 from miqi.runtime.thread_request_models import (
     THREAD_METHOD_PARAM_MODELS,
@@ -370,6 +371,15 @@ SESSIONS_RENAME = model_spec(
     SESSION_METHOD_PARAM_MODELS["sessions.rename"],
     scope=MethodScope.SESSION,
     result_model=SESSION_METHOD_RESULT_MODELS["sessions.rename"],
+)
+
+# ── files (Phase 30 handlers, #790) ────────────────────────────────────────
+
+FILES_CHECK_MANY = model_spec(
+    "files.check_many",
+    FilesCheckManyParams,
+    scope=MethodScope.SESSION,
+    description="资产面板路径可达性批量校验（渲染资产卡片时按需调用）",
 )
 
 # ── thread (Codex-style) ──────────────────────────────────────────────────

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -848,19 +848,23 @@ class TurnRunner:
     def _format_tool_hint(name: str, args: dict) -> str:
         """Format a tool call as a concise display hint.
 
-        Path-like and command args show the target value (truncated at 50
-        chars); every other arg shows only the parameter name. Values like
-        paper titles, URLs, or queries are long strings that would leak
-        into the hint instead of a concise call summary (issue #532).
+        Path-like args show the FULL target value — the asset panel depends
+        on complete paths (issue #790; a truncated path is permanently
+        unreachable). command stays capped at 50 chars; every other arg
+        shows only the parameter name so paper titles / URLs / queries
+        don't leak into the hint (issue #532).
         """
         if not args:
             return name
-        for key in ("path", "file_path", "filename", "outPath", "command"):
+        for key in ("path", "file_path", "filename", "outPath"):
             val = args.get(key)
             if isinstance(val, str) and val:
-                if len(val) > 50:
-                    return f'{name}("{val[:50]}…")'
                 return f'{name}("{val}")'
+        val = args.get("command")
+        if isinstance(val, str) and val:
+            if len(val) > 50:
+                return f'{name}("{val[:50]}…")'
+            return f'{name}("{val}")'
         key = next(iter(args), "")
         return f"{name}({key}=…)" if key else name
 

--- a/tests/fixtures/protocol/app_protocol_snapshot.v1.json
+++ b/tests/fixtures/protocol/app_protocol_snapshot.v1.json
@@ -1139,6 +1139,77 @@
       },
       {
         "deprecatedBy": null,
+        "description": "资产面板路径可达性批量校验（渲染资产卡片时按需调用）",
+        "emits": [],
+        "eventSchemas": {},
+        "method": "files.check_many",
+        "paramsSchema": {
+          "$defs": {
+            "FilesCheckItemModel": {
+              "additionalProperties": true,
+              "description": "Single asset-panel path check item (issue #790).",
+              "properties": {
+                "op": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "title": "Op"
+                },
+                "path": {
+                  "title": "Path",
+                  "type": "string"
+                },
+                "truncated": {
+                  "default": false,
+                  "title": "Truncated",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "title": "FilesCheckItemModel",
+              "type": "object"
+            }
+          },
+          "additionalProperties": true,
+          "description": "files.check_many — 资产面板路径可达性批量校验（#790）。\n\nsession_key 可选：提供时按会话作用域解析（#731 会话隔离），\n否则按 workspace 作用域解析。",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/FilesCheckItemModel"
+              },
+              "type": "array"
+            },
+            "session_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "type": "object"
+        },
+        "resultSchema": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "scope": "session",
+        "stability": "stable"
+      },
+      {
+        "deprecatedBy": null,
         "description": "Legacy untyped method; migrate to an explicit spec in a later plan.",
         "emits": [],
         "eventSchemas": {},
@@ -5568,8 +5639,8 @@
   },
   "methodCounts": {
     "legacy": 78,
-    "total": 162,
-    "typed": 84
+    "total": 163,
+    "typed": 85
   },
   "schemaVersion": 1
 }

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -495,3 +495,118 @@ async def test_files_read_image_jpg_mime(fake_config, fake_provider, tmp_path):
     r = result["result"]
     assert r["is_binary"] is True
     assert r["mime_type"] == "image/jpeg"
+
+
+# ── files.check_many (issue #790) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_files_check_many_classifies_statuses(fake_config, fake_provider, tmp_path):
+    """files.check_many classifies ok / not_found / truncated / outside."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_check_many_handler
+
+    sm, ws = _setup_session("check-many", "client-1")
+    _ensure_session_file(ws, "check-many", "ok.txt", "x")
+
+    registry = ClientSessionRegistry()
+    result = await files_check_many_handler(
+        "req-check",
+        {
+            "items": [
+                {"path": "ok.txt", "op": "write"},
+                {"path": "missing.txt", "op": "write"},
+                {"path": "truncated-long-name.txt", "truncated": True},
+            ],
+            "session_key": "check-many",
+        },
+        "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["results"]["ok.txt"] == "ok"
+    assert r["results"]["missing.txt"] == "not_found"
+    assert r["results"]["truncated-long-name.txt"] == "truncated"
+    # details 只为非 ok 条目提供（解析后路径 / 错误说明）
+    assert "resolvedPath" in r["details"]["missing.txt"]
+    assert "ok.txt" not in r["details"]
+
+    # 越界：workspace 分支（无 session_key）下的 .. 逃逸 → outside
+    # （会话分支里 .. 会被 .resolve() 圈在 workspace 内，属 not_found 语义）
+    escape = await files_check_many_handler(
+        "req-check-esc",
+        {"items": [{"path": "../escape.txt"}]},
+        "client-1", None, registry,
+    )
+    assert escape["result"]["results"]["../escape.txt"] == "outside"
+
+
+@pytest.mark.asyncio
+async def test_files_check_many_session_scoped_bare_name(fake_config, fake_provider, tmp_path):
+    """Bare name resolves against sessions/<key>/files/ with session_key (ok),
+    and against workspace root without it (not_found)."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_check_many_handler
+
+    sm, ws = _setup_session("check-many-sess", "client-1")
+    _ensure_session_file(ws, "check-many-sess", "asset.md", "hello")
+
+    registry = ClientSessionRegistry()
+    with_key = await files_check_many_handler(
+        "req-1",
+        {"items": [{"path": "asset.md"}], "session_key": "check-many-sess"},
+        "client-1", None, registry,
+    )
+    assert with_key["result"]["results"]["asset.md"] == "ok"
+
+    without_key = await files_check_many_handler(
+        "req-2",
+        {"items": [{"path": "asset.md"}]},
+        "client-1", None, registry,
+    )
+    assert without_key["result"]["results"]["asset.md"] == "not_found"
+
+    # workspace 根文件不带 session_key → ok
+    (ws / "root.md").write_text("r", encoding="utf-8")
+    root_check = await files_check_many_handler(
+        "req-2b",
+        {"items": [{"path": "root.md"}]},
+        "client-1", None, registry,
+    )
+    assert root_check["result"]["results"]["root.md"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_files_check_many_cross_client_session_never_leaks(fake_config, fake_provider, tmp_path):
+    """Other client's session file must not be reported as ok (ownership
+    rejection surfaces as outside — no existence leakage)."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_check_many_handler
+
+    sm, ws = _setup_session("check-many-owner", "client-1")
+    _ensure_session_file(ws, "check-many-owner", "secret.txt", "s")
+
+    registry = ClientSessionRegistry()
+    result = await files_check_many_handler(
+        "req-3",
+        {"items": [{"path": "secret.txt"}], "session_key": "check-many-owner"},
+        "client-2", None, registry,
+    )
+    assert result["result"]["results"]["secret.txt"] == "outside"
+
+
+@pytest.mark.asyncio
+async def test_files_check_many_skips_invalid_items(fake_config, fake_provider, tmp_path):
+    """Non-dict / empty-path items are skipped without failing the batch."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_check_many_handler
+
+    sm, ws = _setup_session("check-many-skip", "client-1")
+    registry = ClientSessionRegistry()
+    result = await files_check_many_handler(
+        "req-4",
+        {"items": [None, {"path": ""}, "junk", {"path": "x.txt"}]},
+        "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["results"]["x.txt"] == "not_found"
+    assert len(r["results"]) == 1

--- a/tests/runtime/test_turn_runner.py
+++ b/tests/runtime/test_turn_runner.py
@@ -739,11 +739,17 @@ async def test_turn_runner_consumes_steer_queue_before_completing_final_response
         ("write_file", {"path": "/tmp/asset.txt"}, 'write_file("/tmp/asset.txt")'),
         ("write_file", {"file_path": "/tmp/x"}, 'write_file("/tmp/x")'),
         ("exec", {"command": "npm test"}, 'exec("npm test")'),
-        # Long values are truncated, not dumped in full.
+        # #790: path 类参数不截断——资产面板依赖完整路径（截断即永久不可达）。
         (
             "write_file",
             {"path": "/very/long/path/" + "a" * 60},
-            f'write_file("/very/long/path/{"a" * 34}…")',
+            f'write_file("/very/long/path/{"a" * 60}")',
+        ),
+        # command 仍保持 50 字符截断（#532 防泄漏）。
+        (
+            "exec",
+            {"command": "echo " + "x" * 60},
+            f'exec("echo {"x" * 45}…")',
         ),
         # Non-path args show only the parameter name — values like paper
         # titles or URLs are long strings that would leak into the hint.


### PR DESCRIPTION
- [x] 功能实现
- [ ] Bug 修复
- [ ] 重构 / 性能优化
- [ ] 文档 / 测试

## 变更概述

右侧任务资产面板对不可达路径（文件已删除、沙箱未镜像回宿主、路径截断/越界）明确报错并给出原因与建议，不再静默展示失效信息。关闭 #790。

## 背景/问题

TrackedFileCard 无任何存在性校验与错误态：路径不可达时卡片静默显示，点击"定位/预览/差异"无反馈（定位是 fire-and-forget，主进程返回的 `revealed:false` 被丢弃）。且后端 `_format_tool_hint` 把 >50 字符路径截断，人为制造永久不可达的残缺路径。

## 变更内容

**提交 1 — feat(runtime): files.check_many 资产路径可达性批量校验**
- 新 bridge 方法 `files.check_many`（+ protocol spec，type 化）：返回 `ok / not_found / outside / permission / truncated`
- 复用 `_validate_file_path` 权威解析：沙箱前缀剥离、越界保护、#731 会话作用域，与 files.read 同一套路径语义
- 不可达条目 WARN 日志（可观测性）；沙箱工作区副本命中记 `not yet mirrored to host`（#474）
- protocol 快照重生成（additive，无 breaking）

**提交 2 — feat(desktop): 错误态 / 按钮降级 / 汇总条**
- 新 IPC `files:check`（preload `files.checkMany(items, sessionKey?)`），委托 bridge 判定
- `useFileStatuses` hook：debounce 批量校验 + 缓存 TTL + 周期清扫重查 + 近期 write/edit 的 not_found 定时重试（镜像完成自动转 ok）
- TrackedFileCard 错误态：类型徽标（文件不存在/路径越界/权限不足/路径截断）+ 原因与建议 + 原始路径可复制；不可达时按钮区被错误块取代，杜绝无响应
- 定位按钮 await 结果，失败时弹出原因（不再静默）
- 面板顶部汇总条："N 个资产路径不可达"，点击定位并高亮首个异常卡片

**提交 3 — fix(runtime): tool hint 路径类参数不再截断**
- `path/file_path/filename/outPath` 取消 50 字符截断（资产面板依赖完整路径）；`command` 保持截断（#532 防泄漏不受影响）

## 日志/验证证据

```
# pytest（相关模块 + 全量）
tests/runtime/test_file_handlers.py          26 passed
tests/runtime/test_turn_runner.py            26 passed
tests/bridge/                                232 passed
tests/runtime/test_phase68_protocol_snapshot  5 passed
全量 pytest tests/                            3044 passed, 2 failed（均为 EXPECTED WSL 沙箱用例）

# desktop
vitest run                                   266 passed | 3 skipped
npm run typecheck                            node + web 双通过
npm run build                                ✓ built in 3.24s

# e2e（真实 Electron + bridge + LLM）
task-assets.spec.ts Test 4「deleted tracked file → error block,
disabled actions, summary bar」 1 passed (1.4m)
— 删除真实会话隔离文件后：错误块出现、按钮区被错误块取代、
  汇总条显示「1 个资产路径不可达」
```

## 测试情况

- pytest：`files.check_many` 分类（ok/not_found/truncated/outside）、会话作用域解析、跨客户端不泄漏存在性、无效条目跳过；`_format_tool_hint` 长路径不截断 + command 仍截断
- vitest：全量 266 通过（含既有 chatConsole/taskAssetClassification 等）
- e2e：Test 4 全链路（创建→磁盘删除→错误态/降级/汇总条），真实 LLM 会话

## 截图

e2e 失败截图未留；错误态 UI 可在本地运行 `task-assets.spec.ts` Test 4 复现（test-results/asset-unreachable.png）。

Closes #790
