### PR TITLE
fix(desktop): 确认卡选项统一 testid，e2e 自动确认覆盖自定义选项

### DIFF
--- a/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx
@@ -239,6 +239,7 @@ export function ConfirmCard({
               return (
                 <button
                   key={c.id}
+                  data-testid="confirm-card-choice"
                   onClick={() => onResolve(c.id, c.label, remember)}
                   className="text-[12.5px] font-medium px-2.5 py-1.5 cursor-pointer transition-all rounded-lg"
                   style={{ background: 'none', border: 'none', color: 'var(--text-faint)', fontFamily: 'inherit' }}
@@ -253,6 +254,7 @@ export function ConfirmCard({
               return (
                 <button
                   key={c.id}
+                  data-testid="confirm-card-choice"
                   onClick={() => onResolve(c.id, c.label, remember)}
                   className="text-[12.5px] font-medium rounded-lg px-3.5 py-1.5 cursor-pointer transition-all"
                   style={{ border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-muted)', fontFamily: 'inherit' }}

--- a/apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts
+++ b/apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts
@@ -143,13 +143,33 @@ test.describe('MOF-5 Qraft Upload E2E', () => {
           console.log('[test] Auto-confirmed card: (primary choice)');
           idleDeadline = Date.now() + IDLE_DEADLINE;
         } else {
-          for (const name of ['确认上传', '确认执行', '确认', '继续执行']) {
-            const btn = page.getByRole('button', { name, exact: false });
-            if (await btn.isVisible({ timeout: 300 }).catch(() => false)) {
-              await btn.click();
-              console.log(`[test] Auto-confirmed card: ${name}`);
+          // Cards whose options are all custom (e.g. upload-conflict:
+          // "作为新版本上传") have no accent primary — click the first
+          // non-cancel choice to keep the flow moving.
+          const choices = page.locator('[data-testid="confirm-card-choice"]');
+          const count = await choices.count();
+          let clicked = false;
+          for (let i = 0; i < count; i++) {
+            const c = choices.nth(i);
+            const label = (await c.textContent()) ?? '';
+            if (/取消/.test(label)) continue;
+            if (await c.isVisible({ timeout: 300 }).catch(() => false)) {
+              await c.click();
+              console.log(`[test] Auto-confirmed card: (choice ${label.trim().slice(0, 20)})`);
               idleDeadline = Date.now() + IDLE_DEADLINE;
+              clicked = true;
               break;
+            }
+          }
+          if (!clicked) {
+            for (const name of ['确认上传', '确认执行', '确认', '继续执行']) {
+              const btn = page.getByRole('button', { name, exact: false });
+              if (await btn.isVisible({ timeout: 300 }).catch(() => false)) {
+                await btn.click();
+                console.log(`[test] Auto-confirmed card: ${name}`);
+                idleDeadline = Date.now() + IDLE_DEADLINE;
+                break;
+              }
             }
           }
         }

--- a/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
+++ b/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
@@ -146,10 +146,26 @@ test.describe('No-Sandbox Host Exec E2E', () => {
           await primary.first().click();
           idleDeadline = Date.now() + IDLE_DEADLINE;
         } else {
-          const confirmBtn = page.getByRole('button', { name: '确认执行' });
-          if (await confirmBtn.isVisible({ timeout: 400 }).catch(() => false)) {
-            await confirmBtn.click();
-            idleDeadline = Date.now() + IDLE_DEADLINE;
+          const choices = page.locator('[data-testid="confirm-card-choice"]');
+          const count = await choices.count();
+          let clicked = false;
+          for (let i = 0; i < count; i++) {
+            const c = choices.nth(i);
+            const label = (await c.textContent()) ?? '';
+            if (/取消/.test(label)) continue;
+            if (await c.isVisible({ timeout: 400 }).catch(() => false)) {
+              await c.click();
+              idleDeadline = Date.now() + IDLE_DEADLINE;
+              clicked = true;
+              break;
+            }
+          }
+          if (!clicked) {
+            const confirmBtn = page.getByRole('button', { name: '确认执行' });
+            if (await confirmBtn.isVisible({ timeout: 400 }).catch(() => false)) {
+              await confirmBtn.click();
+              idleDeadline = Date.now() + IDLE_DEADLINE;
+            }
           }
         }
         text = (await page.locator('main').textContent()) ?? '';


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

确认卡（ask_user_confirm_card）所有选项按钮统一加稳定 testid；e2e 自动确认在无 accent 主选项时点击第一个非「取消」选项，上传冲突卡不再超时挂起。

## 背景/问题

AI 弹的确认卡选择项为自定义标签时（上传冲突卡「方案已存在，如何处理？」的选项是「作为新版本上传」等），自动确认按标签匹配不到任何按钮（无「确认」字样、无 accent 主选项）→ 卡片 120 秒超时被后端当取消 → 任务挂起（见 #823）。

## 关联 issue

- Closes #823

## 变更内容

- `apps/desktop/src/renderer/features/chat/components/ConfirmCard.tsx`：cancel/adjust/主三种选项按钮分别加 `confirm-card-choice` / `confirm-card-primary` testid（主选项保留原 testid 不变）
- `apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts`：主选项优先；否则遍历选项按钮，点击第一个非「取消」选项（如「作为新版本上传」），再回退到标签匹配
- `apps/desktop/tests/e2e/no-sandbox-exec.spec.ts`：同样补充非主选项点击逻辑

## 日志/验证证据

```
$ npx playwright test --config=playwright.config.ts --project=electron no-sandbox-exec.spec.ts
1 passed (1.3m)

$ npx playwright test --config=playwright.config.ts --project=electron mof5-qraft-upload.spec.ts
1 passed (52.3s)   ← 修复前：冲突卡 120s 超时 → 任务挂起 → 测试上限失败
```

## 测试情况

- 两个 e2e 本地实测通过（快速回归 + 完整验收，含真实上传冲突场景）
- 仅涉及测试定位逻辑与 UI testid 属性，无业务逻辑变更

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)
