### PR TITLE
feat(e2e): 截图自动上传并贴到 PR 评论

### DIFF
--- a/apps/desktop/tests/e2e/helpers/pr-image-post.ts
+++ b/apps/desktop/tests/e2e/helpers/pr-image-post.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E screenshot → PR comment helper.
+ *
+ * Uploads a screenshot to the repo's fixed `_gh-imgup` prerelease (release
+ * assets API — official, token-only) and posts it as a markdown image into
+ * the pull request's comments, so acceptance runs surface their evidence
+ * directly in the PR.
+ *
+ * All API calls use Node's fetch (no shell quoting traps).  Enabled by
+ * default on CI; local runs opt in with MIQI_E2E_POST_IMG=1 on a
+ * checked-out PR branch (PR number resolved via `gh pr view`).
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+const REPO = process.env.MIQI_IMG_REPO ?? '14790897/MiQi';
+const RELEASE_TAG = '_gh-imgup';
+
+function token(): string | null {
+  return (
+    process.env.GH_TOKEN ??
+    process.env.GITHUB_TOKEN ??
+    (() => {
+      try {
+        return execSync('gh auth token', {
+          encoding: 'utf8',
+          windowsHide: true,
+        }).trim();
+      } catch {
+        return null;
+      }
+    })()
+  );
+}
+
+async function api(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const tok = token();
+  if (!tok) throw new Error('no GitHub token available');
+  const res = await fetch(`https://api.github.com/${path}`, {
+    ...init,
+    headers: {
+      Authorization: `token ${tok}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API ${init.method ?? 'GET'} ${path} → ${res.status}: ${await res.text()}`,
+    );
+  }
+  return res;
+}
+
+function prNumber(): number | null {
+  const fromEnv = process.env.GITHUB_EVENT_NUMBER;
+  if (fromEnv) {
+    const n = Number(fromEnv);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  try {
+    const out = execSync('gh pr view --json number --jq .number', {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    const n = Number(out.trim());
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function imagePostingEnabled(): boolean {
+  if (process.env.MIQI_E2E_POST_IMG === '1') return true;
+  if (process.env.MIQI_E2E_POST_IMG === '0') return false;
+  return !!process.env.CI;
+}
+
+async function ensureImageRelease(): Promise<number> {
+  const existing = await api(`repos/${REPO}/releases/tags/${RELEASE_TAG}`, {
+    method: 'GET',
+  }).catch(() => null);
+  if (existing) {
+    return (await existing.json()).id as number;
+  }
+  const created = await api(`repos/${REPO}/releases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      tag_name: RELEASE_TAG,
+      name: RELEASE_TAG,
+      prerelease: true,
+      body: 'Image assets - do not delete',
+    }),
+  });
+  return (await created.json()).id as number;
+}
+
+async function uploadImage(imagePath: string): Promise<string> {
+  const releaseId = await ensureImageRelease();
+  const meta = await api(`repos/${REPO}/releases/${releaseId}`);
+  const uploadUrlTemplate = (await meta.json()).upload_url as string;
+  const uploadUrl = uploadUrlTemplate.replace('{?name,label}', '');
+  const stem = basename(imagePath).replace(/\.[^.]+$/, '');
+  const ext = basename(imagePath).split('.').pop() ?? 'png';
+  const hash = execSync(`sha256sum "${imagePath}" | cut -c1-8`, {
+    encoding: 'utf8',
+    windowsHide: true,
+  }).trim();
+  const name = `${stem}-${hash}.${ext}`;
+  const buf = readFileSync(imagePath);
+  const up = await fetch(`${uploadUrl}?name=${name}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token()}`,
+      'Content-Type': 'application/octet-stream',
+    },
+    body: new Uint8Array(buf),
+  });
+  if (up.status === 422) {
+    // Identical content → identical name → asset already exists.
+    // Reuse the existing asset instead of failing.
+    const assets = await api(
+      `repos/${REPO}/releases/${releaseId}/assets?per_page=100`,
+    );
+    const list = (await assets.json()) as Array<{
+      name: string;
+      browser_download_url: string;
+    }>;
+    const found = list.find((a) => a.name === name);
+    if (found) return found.browser_download_url;
+    throw new Error(`asset name conflict for ${name} and reuse failed`);
+  }
+  if (!up.ok) {
+    throw new Error(`asset upload → ${up.status}: ${await up.text()}`);
+  }
+  const asset = (await up.json()) as { browser_download_url: string };
+  return asset.browser_download_url;
+}
+
+/** Upload an image and post it into the PR comments. No-op without a PR. */
+export async function postScreenshotToPr(
+  imagePath: string,
+  caption: string,
+): Promise<void> {
+  if (!imagePostingEnabled()) return;
+  const n = prNumber();
+  if (n === null) return;
+  if (!existsSync(imagePath)) return;
+
+  const url = await uploadImage(imagePath);
+  const body = `${caption}\n\n![](${url})`;
+  await api(`repos/${REPO}/issues/${n}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+}
+
+/** Internal helpers exposed for the upload script path. */
+export const _internal = { join, dirname };

--- a/apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts
+++ b/apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts
@@ -35,6 +35,7 @@ import { _electron as electron, test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { postScreenshotToPr } from './helpers/pr-image-post';
 import {
   LLM_TIMEOUT,
   sendMessage,
@@ -100,6 +101,16 @@ test.describe('MOF-5 Qraft Upload E2E', () => {
 
   test.afterAll(async () => {
     await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test.afterEach(async () => {
+    // Surface evidence into the PR: success screenshots are posted by the
+    // test body; failures post the auto-captured failure screenshot here.
+    if (test.info().status === 'passed') return;
+    const fail = join(test.info().outputDir, 'test-failed-1.png');
+    if (existsSync(fail)) {
+      await postScreenshotToPr(fail, `❌ E2E 失败：${test.info().title}`);
+    }
   });
 
   test(
@@ -193,6 +204,11 @@ test.describe('MOF-5 Qraft Upload E2E', () => {
         path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
         fullPage: true,
       });
+
+      await postScreenshotToPr(
+        `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        '✅ E2E 验收通过：MOF-5 报告生成 + qraft-workflowspec-export 上传',
+      );
     },
   );
 });

--- a/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
+++ b/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts
@@ -30,6 +30,8 @@ import { _electron as electron, test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { postScreenshotToPr } from './helpers/pr-image-post';
 import {
   LLM_TIMEOUT,
   waitForBridgeInitialized,
@@ -63,6 +65,14 @@ test.describe('No-Sandbox Host Exec E2E', () => {
 
   test.afterAll(async () => {
     await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test.afterEach(async () => {
+    if (test.info().status === 'passed') return;
+    const fail = join(test.info().outputDir, 'test-failed-1.png');
+    if (existsSync(fail)) {
+      await postScreenshotToPr(fail, `❌ E2E 失败：${test.info().title}`);
+    }
   });
 
   test(
@@ -196,6 +206,11 @@ test.describe('No-Sandbox Host Exec E2E', () => {
         path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
         fullPage: true,
       });
+
+      await postScreenshotToPr(
+        `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        '✅ E2E 通过：无沙箱 exec 链路（Git Bash/cmd 回退）',
+      );
     },
   );
 });


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

e2e 验收跑完自动把截图上传到固定预发布并作为 markdown 图片评论到当前 PR。

## 背景/问题

验收测试的通过/失败证据目前只能本地查看。用 release assets 官方 API + 固定 `_gh-imgup` 预发布复用（实测匿名可访问、Releases 列表只多一条），跑完自动贴图。

## 关联 issue

- Closes #825

## 变更内容

- 新增 `tests/e2e/helpers/pr-image-post.ts`：纯 Node fetch 调 GitHub API；固定 prerelease 复用创建；内容 hash 去重（相同内容 422 时复用已有资产）
- 通过贴成功截图、失败贴 test-failed-1.png
- CI 默认开启，本地 `MIQI_E2E_POST_IMG=1` 开启；无 PR 上下文静默跳过
- 接入 no-sandbox-exec 与 mof5-qraft-upload 两个验收 spec

## 日志/验证证据

```
本地实测：MIQI_E2E_POST_IMG=1 跑 no-sandbox-exec，PR 评论数 3→4，新增评论正文为规范 markdown 图片（匿名访问 HTTP 200）。
```

## 测试情况

- no-sandbox-exec 本地实跑通过（1.5m）并成功贴图
- mof5 验收 spec 同样接入（未实跑，共享同一 helper）

## 截图

无需截图（功能本身就是贴图）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
