### PR TITLE
fix(web_search): fast 扇出走配置 provider 链 + 失败原因透出（#804）

### DIFF
--- a/miqi/agent/search_orchestrator.py
+++ b/miqi/agent/search_orchestrator.py
@@ -50,6 +50,49 @@ def _dedup_urls(urls: list[str], limit: int) -> list[str]:
     return out
 
 
+async def _ddgs_regional_search(query: str, n_queries: int, n: int) -> list[str]:
+    """ddgs 区域变体搜索（无 key 兜底，原 SearchOrchestrator._parallel_search 逻辑）。
+
+    每个区域查询有 15s 超时（#804/#803 审阅：ddgs 挂起会拖死整个工具调用——
+    search 没有 fetch 的 12s 超时保护）。
+    """
+    try:
+        from ddgs import DDGS
+    except ImportError:
+        return []
+
+    regions = [r for r, _ in _REGIONS[: max(1, n_queries)]]
+
+    def _one(region: str) -> list[dict[str, Any]]:
+        try:
+            return list(DDGS().text(query, region=region, max_results=n))
+        except Exception as e:  # ddgs rate-limit / network — degrade per-region
+            logger.warning("ddgs region=%s failed: %s", region, e)
+            return []
+
+    raw_lists = await asyncio.gather(
+        *(asyncio.wait_for(asyncio.to_thread(_one, r), timeout=15.0) for r in regions),
+        return_exceptions=True,
+    )
+
+    blocks: list[str] = []
+    seen: set[str] = set()
+    for region, raw in zip(regions, raw_lists):
+        if not isinstance(raw, list) or not raw:
+            continue
+        lines = [f"Results for: {query} (region: {region})"]
+        for item in raw:
+            href = item.get("href") or item.get("url", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+            lines.append(
+                f"- {item.get('title', '')}\n  {href}\n  {item.get('body') or item.get('description', '')}"
+            )
+        blocks.append("\n".join(lines))
+    return blocks
+
+
 class SearchOrchestrator:
     """Parallel breadth search: N queries + M fetches, one merged result."""
 
@@ -91,47 +134,16 @@ class SearchOrchestrator:
     async def _parallel_search(self, query: str, n_queries: int, n: int) -> list[str]:
         """Run up to n_queries ddgs queries concurrently (region variants).
 
-        A search tool may provide its own ``_parallel_search`` (tests, future
+        A search tool may provide its own ``_parallel_search`` (tests,
         providers) — prefer that over the built-in ddgs implementation.
+        WebSearchTool implements it to route through the configured provider
+        chain first (#804); the built-in ddgs fallback lives in
+        ``_ddgs_regional_search``.
         """
         impl = getattr(self._search, "_parallel_search", None)
         if callable(impl):
             return await impl(query, n_queries, n)
-
-        try:
-            from ddgs import DDGS
-        except ImportError:
-            return []
-
-        regions = [r for r, _ in _REGIONS[: max(1, n_queries)]]
-
-        def _one(region: str) -> list[dict[str, Any]]:
-            try:
-                return list(DDGS().text(query, region=region, max_results=n))
-            except Exception as e:  # ddgs rate-limit / network — degrade per-region
-                logger.warning("ddgs region=%s failed: %s", region, e)
-                return []
-
-        raw_lists = await asyncio.gather(
-            *(asyncio.to_thread(_one, r) for r in regions), return_exceptions=True
-        )
-
-        blocks: list[str] = []
-        seen: set[str] = set()
-        for region, raw in zip(regions, raw_lists):
-            if not isinstance(raw, list) or not raw:
-                continue
-            lines = [f"Results for: {query} (region: {region})"]
-            for item in raw:
-                href = item.get("href") or item.get("url", "")
-                if not href or href in seen:
-                    continue
-                seen.add(href)
-                lines.append(
-                    f"- {item.get('title', '')}\n  {href}\n  {item.get('body') or item.get('description', '')}"
-                )
-            blocks.append("\n".join(lines))
-        return blocks
+        return await _ddgs_regional_search(query, n_queries, n)
 
     async def _safe_fetch(self, url: str) -> str:
         """Fetch one page reusing WebFetchTool's extractor; errors → "" (skip).

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -148,24 +148,27 @@ class SearchResult:
     """Structured internal result — the tool layer formats it back to a
     string for the model (the model-facing contract stays unchanged)."""
 
-    __slots__ = ("success", "results", "error_type")
+    __slots__ = ("success", "results", "error_type", "provider")
 
     def __init__(
         self,
         success: bool,
         results: list[dict[str, str]] | None = None,
         error_type: str | None = None,
+        provider: str | None = None,
     ):
         self.success = success
         self.results = results or []
-        self.error_type = error_type  # RATE_LIMIT | NETWORK | SERVER_ERROR | AUTH_ERROR | NO_RESULT | None
+        # RATE_LIMIT | NETWORK | SERVER_ERROR | AUTH_ERROR | NO_KEY | NO_RESULT | None
+        self.error_type = error_type
+        self.provider = provider  # which provider produced this outcome (#804)
 
 
 # Error categories that should trigger fallback in auto mode.
 _FALLBACK_ERRORS = {"RATE_LIMIT", "NETWORK", "SERVER_ERROR"}
 # Errors that must NOT silently fall back (config problems) — log, but
 # degrade to the keyless provider once so the user still gets an answer.
-_AUTH_ERRORS = {"AUTH_ERROR"}
+_AUTH_ERRORS = {"AUTH_ERROR", "NO_KEY"}
 
 
 class SearchProvider:
@@ -250,7 +253,7 @@ class BraveProvider(SearchProvider):
 
     async def search(self, query: str, count: int) -> SearchResult:
         if not self.api_key:
-            return SearchResult(False, error_type="AUTH_ERROR")
+            return SearchResult(False, error_type="NO_KEY", provider="brave")
         try:
             async with httpx.AsyncClient() as client:
                 r = await client.get(
@@ -261,11 +264,11 @@ class BraveProvider(SearchProvider):
                     timeout=10.0,
                 )
                 if r.status_code == 429:
-                    return SearchResult(False, error_type="RATE_LIMIT")
+                    return SearchResult(False, error_type="RATE_LIMIT", provider="brave")
                 if r.status_code in (401, 403):
-                    return SearchResult(False, error_type="AUTH_ERROR")
+                    return SearchResult(False, error_type="AUTH_ERROR", provider="brave")
                 if r.status_code >= 500:
-                    return SearchResult(False, error_type="SERVER_ERROR")
+                    return SearchResult(False, error_type="SERVER_ERROR", provider="brave")
                 r.raise_for_status()
 
             items = r.json().get("web", {}).get("results", [])
@@ -275,14 +278,14 @@ class BraveProvider(SearchProvider):
                 for it in items[:count] if it.get("url")
             ]
             if not out:
-                return SearchResult(True, error_type="NO_RESULT")
-            return SearchResult(True, out)
+                return SearchResult(True, error_type="NO_RESULT", provider="brave")
+            return SearchResult(True, out, provider="brave")
         except httpx.TimeoutException:
-            return SearchResult(False, error_type="NETWORK")
+            return SearchResult(False, error_type="NETWORK", provider="brave")
         except httpx.HTTPStatusError:
-            return SearchResult(False, error_type="SERVER_ERROR")
+            return SearchResult(False, error_type="SERVER_ERROR", provider="brave")
         except Exception:
-            return SearchResult(False, error_type="NETWORK")
+            return SearchResult(False, error_type="NETWORK", provider="brave")
 
 
 class TavilyProvider(SearchProvider):
@@ -295,7 +298,7 @@ class TavilyProvider(SearchProvider):
 
     async def search(self, query: str, count: int) -> SearchResult:
         if not self.api_key:
-            return SearchResult(False, error_type="AUTH_ERROR")
+            return SearchResult(False, error_type="NO_KEY", provider="tavily")
         try:
             async with httpx.AsyncClient() as client:
                 r = await client.post(
@@ -305,11 +308,11 @@ class TavilyProvider(SearchProvider):
                     timeout=10.0,
                 )
                 if r.status_code == 429:
-                    return SearchResult(False, error_type="RATE_LIMIT")
+                    return SearchResult(False, error_type="RATE_LIMIT", provider="tavily")
                 if r.status_code in (401, 403):
-                    return SearchResult(False, error_type="AUTH_ERROR")
+                    return SearchResult(False, error_type="AUTH_ERROR", provider="tavily")
                 if r.status_code >= 500:
-                    return SearchResult(False, error_type="SERVER_ERROR")
+                    return SearchResult(False, error_type="SERVER_ERROR", provider="tavily")
                 r.raise_for_status()
 
             items = r.json().get("results", [])
@@ -319,14 +322,14 @@ class TavilyProvider(SearchProvider):
                 for it in items[:count] if it.get("url")
             ]
             if not out:
-                return SearchResult(True, error_type="NO_RESULT")
-            return SearchResult(True, out)
+                return SearchResult(True, error_type="NO_RESULT", provider="tavily")
+            return SearchResult(True, out, provider="tavily")
         except httpx.TimeoutException:
-            return SearchResult(False, error_type="NETWORK")
+            return SearchResult(False, error_type="NETWORK", provider="tavily")
         except httpx.HTTPStatusError:
-            return SearchResult(False, error_type="SERVER_ERROR")
+            return SearchResult(False, error_type="SERVER_ERROR", provider="tavily")
         except Exception:
-            return SearchResult(False, error_type="NETWORK")
+            return SearchResult(False, error_type="NETWORK", provider="tavily")
 
 
 class SearchProviderManager:
@@ -377,10 +380,15 @@ class SearchProviderManager:
     async def search(self, query: str, count: int) -> SearchResult:
         chain = self._chain()
         last_auth_warned = False
+        last_failure: SearchResult | None = None
         for provider in chain:
             result = await provider.search(query, count)
             if result.success:
                 return result
+            # Tag the failing provider for error surfacing (#804).
+            if not result.provider:
+                result.provider = provider.name
+            last_failure = result
             if result.error_type in _FALLBACK_ERRORS:
                 logging.getLogger(__name__).warning(
                     "web_search: %s failed (%s), trying next provider",
@@ -396,7 +404,47 @@ class SearchProviderManager:
                     last_auth_warned = True
                 continue  # degrade to the next (keyless) provider once
             return result  # NO_RESULT etc. — not a fallback condition
+        # Whole chain exhausted — surface the last real failure instead of a
+        # generic SERVER_ERROR so the model/user can act on it (#804).
+        if last_failure is not None:
+            return SearchResult(
+                False,
+                error_type=last_failure.error_type or "SERVER_ERROR",
+                provider=last_failure.provider,
+            )
         return SearchResult(False, error_type="SERVER_ERROR")
+
+
+# Model/user-facing reason mapping for failed searches (#804: surface the
+# actionable cause instead of an abstract error).
+_ERROR_REASONS: dict[str, str] = {
+    "NO_KEY": "未配置 {provider} API key，请在设置中填写",
+    "AUTH_ERROR": "{provider} API key 无效（401/403），请在设置中检查",
+    "RATE_LIMIT": "搜索服务限流（429），请稍后重试",
+    "NETWORK": "网络连接失败，请检查网络后重试",
+    "SERVER_ERROR": "搜索服务暂时不可用（服务端错误）",
+}
+_PROVIDER_LABELS: dict[str, str] = {
+    "tavily": "Tavily",
+    "brave": "Brave",
+    "ddgs": "DuckDuckGo",
+}
+
+
+def _failure_message(result: SearchResult) -> str:
+    """Human-readable, model-actionable failure message for web_search."""
+    label = _PROVIDER_LABELS.get(result.provider or "", result.provider or "")
+    template = _ERROR_REASONS.get(result.error_type or "")
+    if template is None:
+        reason = f"未知错误（{result.error_type or 'unknown'}）"
+    else:
+        reason = template.format(provider=label or "搜索")
+    provider_hint = f"（服务：{label}）" if label else ""
+    return (
+        f"Error: 网络搜索失败{provider_hint}。原因：{reason}。"
+        "请勿尝试用 web_fetch 抓取搜索引擎页面（会被拒绝且结果不可用）。"
+        "直接告知用户搜索暂不可用，或建议稍后重试。"
+    )
 
 
 class WebSearchTool(Tool):
@@ -448,14 +496,37 @@ class WebSearchTool(Tool):
 
         result = await self.manager.search(query, n)
         if not result.success:
-            return (
-                "Error: 网络搜索失败（所有可用搜索服务均不可用）。"
-                "请勿尝试用 web_fetch 抓取搜索引擎页面（会被拒绝且结果不可用）。"
-                "直接告知用户搜索暂不可用，或建议稍后重试。"
-            )
+            return _failure_message(result)
         if result.error_type == "NO_RESULT":
             return f"No results for: {query}"
         return _format_results(query, result.results)
+
+    async def _parallel_search(self, query: str, n_queries: int, n: int) -> list[str]:
+        """#804: fast 模式扇出搜索先走**配置的 provider 链**（Tavily→Brave→DDGS），
+        不再被 SearchOrchestrator 直接 ddgs 绕过——用户配的 key 在 fast 模式
+        同样生效（#748 的 fallback 链在默认 fast 路径下此前是死代码）。链失败
+        /空结果才回退 ddgs 区域变体（原 orchestrator 内置逻辑，含 15s 超时）；
+        两者都失败时透出配置链的最后失败原因，不让模型误读为\"无结果\"。
+        """
+        last_failure: SearchResult | None = None
+        try:
+            result = await self.manager.search(query, n)
+            if result.success and result.results:
+                return [_format_results(query, result.results)]
+            last_failure = result
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "web_search parallel: manager chain failed for %r — falling back to ddgs",
+                query[:60],
+            )
+        from miqi.agent.search_orchestrator import _ddgs_regional_search
+
+        blocks = await _ddgs_regional_search(query, n_queries, n)
+        if blocks:
+            return blocks
+        if last_failure is not None and not last_failure.success:
+            return [_failure_message(last_failure)]
+        return []
 
 
 class WebFetchTool(Tool):

--- a/tests/agent/tools/test_web.py
+++ b/tests/agent/tools/test_web.py
@@ -336,7 +336,7 @@ async def test_parallel_search_falls_back_to_regional_ddgs(monkeypatch):
 
     async def _fake_ddgs(query, n_queries, n):
         calls.append("ddgs")
-        return ["Results for: hello (region: 全球)\n- T\n  https://x.com\n  s"]
+        return ["Results for: hello (region: 全球)\n- T\n  https://example.com/x\n  s"]
 
     monkeypatch.setattr(
         "miqi.agent.search_orchestrator._ddgs_regional_search", _fake_ddgs
@@ -344,7 +344,7 @@ async def test_parallel_search_falls_back_to_regional_ddgs(monkeypatch):
     tool = WebSearchTool(provider="auto")
     blocks = await tool._parallel_search("hello", n_queries=2, n=5)
     assert calls == ["manager", "ddgs"]
-    assert blocks and "https://x.com" in blocks[0]
+    assert blocks and "https://example.com/x" in blocks[0]
 
 
 async def test_parallel_search_falls_back_on_empty_chain_result(monkeypatch):

--- a/tests/agent/tools/test_web.py
+++ b/tests/agent/tools/test_web.py
@@ -180,9 +180,10 @@ async def test_tavily_429_classified_rate_limit(monkeypatch):
     assert not result.success and result.error_type == "RATE_LIMIT"
 
 
-async def test_brave_missing_key_is_auth_error():
+async def test_brave_missing_key_is_no_key_error():
     result = await BraveProvider("").search("q", 5)
-    assert not result.success and result.error_type == "AUTH_ERROR"
+    assert not result.success and result.error_type == "NO_KEY"
+    assert result.provider == "brave"
 
 
 # ── tool-level string format (model contract) ────────────────────────────
@@ -202,15 +203,56 @@ async def test_execute_returns_string_format(monkeypatch):
     assert "1. T1" in out and "https://example.com/a" in out and "s1" in out
 
 
-async def test_execute_all_providers_down_returns_chinese_error(monkeypatch):
+async def test_execute_all_providers_down_exposes_reason(monkeypatch):
     async def _fake_search(self, query, count):
-        return SearchResult(False, error_type="SERVER_ERROR")
+        return SearchResult(False, error_type="NETWORK", provider="ddgs")
 
     monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
     tool = WebSearchTool(provider="auto")
     out = await tool.execute("hello")
     assert out.startswith("Error:")
-    assert "所有可用搜索服务均不可用" in out
+    assert "网络搜索失败" in out
+    assert "网络连接失败" in out  # actionable reason surfaced (#804)
+    assert "web_fetch" in out
+
+
+async def test_execute_no_key_exposes_setting_hint(monkeypatch):
+    async def _fake_search(self, query, count):
+        return SearchResult(False, error_type="NO_KEY", provider="tavily")
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+    tool = WebSearchTool(provider="auto")
+    out = await tool.execute("hello")
+    assert "未配置 Tavily API key，请在设置中填写" in out
+
+
+async def test_execute_auth_error_exposes_bad_key_hint(monkeypatch):
+    async def _fake_search(self, query, count):
+        return SearchResult(False, error_type="AUTH_ERROR", provider="brave")
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+    tool = WebSearchTool(provider="auto")
+    out = await tool.execute("hello")
+    assert "Brave API key 无效" in out
+
+
+async def test_manager_chain_exhausted_surfaces_last_failure(monkeypatch):
+    """Chain exhaustion must carry the last real failure, not a generic error."""
+
+    class _Tavily(TavilyProvider):
+        async def search(self, query, count):
+            return SearchResult(False, error_type="NETWORK")
+
+    class _Brave(BraveProvider):
+        async def search(self, query, count):
+            return SearchResult(False, error_type="RATE_LIMIT")
+
+    manager = SearchProviderManager("auto", tavily_api_key="t", brave_api_key="b")
+    manager._chain = lambda: [_Tavily("t"), _Brave("b")]
+    result = await manager.search("q", 5)
+    assert not result.success
+    assert result.error_type == "RATE_LIMIT"
+    assert result.provider == "brave"
 
 
 async def test_execute_no_result_message(monkeypatch):
@@ -251,3 +293,94 @@ def test_migrate_keeps_existing_brave_key():
     search = migrated["tools"]["web"]["search"]
     assert search["brave_api_key"] == "new"
     assert "api_key" not in search
+
+
+# ── fast 模式扇出搜索走配置链（#804）──────────────────────────────────
+
+
+async def test_parallel_search_uses_manager_chain_first(monkeypatch):
+    """fast 扇出：配置链（Tavily→Brave→DDGS）优先，成功就不碰 ddgs 区域兜底。"""
+    calls = []
+
+    async def _fake_search(self, query, count):
+        calls.append("manager")
+        return SearchResult(True, [
+            {"title": "T1", "url": "https://example.com/a", "snippet": "s1"},
+        ])
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+
+    async def _boom(query, n_queries, n):
+        raise AssertionError("ddgs fallback must not run when chain succeeds")
+
+    monkeypatch.setattr(
+        "miqi.agent.search_orchestrator._ddgs_regional_search", _boom
+    )
+    tool = WebSearchTool(provider="auto")
+    blocks = await tool._parallel_search("hello", n_queries=2, n=5)
+    assert calls == ["manager"]
+    assert len(blocks) == 1
+    assert blocks[0].startswith("Results for: hello")
+    assert "https://example.com/a" in blocks[0]
+
+
+async def test_parallel_search_falls_back_to_regional_ddgs(monkeypatch):
+    """fast 扇出：配置链失败/空结果 → 回退 ddgs 区域变体。"""
+    calls = []
+
+    async def _fake_search(self, query, count):
+        calls.append("manager")
+        return SearchResult(False, error_type="NETWORK", provider="ddgs")
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+
+    async def _fake_ddgs(query, n_queries, n):
+        calls.append("ddgs")
+        return ["Results for: hello (region: 全球)\n- T\n  https://x.com\n  s"]
+
+    monkeypatch.setattr(
+        "miqi.agent.search_orchestrator._ddgs_regional_search", _fake_ddgs
+    )
+    tool = WebSearchTool(provider="auto")
+    blocks = await tool._parallel_search("hello", n_queries=2, n=5)
+    assert calls == ["manager", "ddgs"]
+    assert blocks and "https://x.com" in blocks[0]
+
+
+async def test_parallel_search_falls_back_on_empty_chain_result(monkeypatch):
+    """fast 扇出：配置链成功但空结果 → 也回退 ddgs（否则空结果直接丢失）。"""
+
+    async def _fake_search(self, query, count):
+        return SearchResult(True, error_type="NO_RESULT")
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+
+    async def _fake_ddgs(query, n_queries, n):
+        return ["fallback block"]
+
+    monkeypatch.setattr(
+        "miqi.agent.search_orchestrator._ddgs_regional_search", _fake_ddgs
+    )
+    tool = WebSearchTool(provider="auto")
+    blocks = await tool._parallel_search("hello", n_queries=1, n=5)
+    assert blocks == ["fallback block"]
+
+
+async def test_parallel_search_all_down_exposes_reason(monkeypatch):
+    """fast 扇出：配置链 + ddgs 全失败 → 透出失败原因，不让模型误读为\"无结果\"。"""
+
+    async def _fake_search(self, query, count):
+        return SearchResult(False, error_type="NO_KEY", provider="tavily")
+
+    monkeypatch.setattr(SearchProviderManager, "search", _fake_search)
+
+    async def _empty_ddgs(query, n_queries, n):
+        return []
+
+    monkeypatch.setattr(
+        "miqi.agent.search_orchestrator._ddgs_regional_search", _empty_ddgs
+    )
+    tool = WebSearchTool(provider="auto")
+    blocks = await tool._parallel_search("hello", n_queries=2, n=5)
+    assert len(blocks) == 1
+    assert "未配置 Tavily API key，请在设置中填写" in blocks[0]


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #804：web_search 在默认 fast 模式下调用即报错——fast 扇出路径直接走 ddgs 区域搜索，**绕过了 #748 实现的 Tavily→Brave→DDGS 配置 fallback 链**（用户配的 Tavily/Brave key 完全不生效，ddgs 被墙/限流时整体失败）；同时补上失败原因透出（issue 期望的"未配置 Tavily API key，请在设置中填写"类可操作信息）。

## 背景/问题

- #748 已实现 provider 抽象 + auto fallback 链（Tavily→Brave→DDGS），但**只在非扇出路径生效**：默认 fast 模式下 `fanout_queries=2 > 1` 走 `SearchOrchestrator` 分支，`WebSearchTool` 没有实现 `_parallel_search` → orchestrator 用内置 ddgs 三区域直搜，配置链变成死代码
- ddgs 直搜无超时保护（挂起会拖死整个工具调用）
- 失败时只返回抽象错误（"所有可用搜索服务均不可用"），无法区分 key 问题/网络问题/provider 故障

## 变更内容

- **`miqi/agent/tools/web.py`**：
  - `WebSearchTool._parallel_search()`（新）——fast 扇出先走**配置的 provider 链**（Tavily→Brave→DDGS），链失败/空结果才回退 ddgs 区域变体；两者全失败时透出最后失败原因（不让模型误读为"无结果"）
  - `SearchResult` 加 `provider` 字段；无 key 与 key 无效分类（`NO_KEY` vs `AUTH_ERROR`）；provider 失败结果全部带 provider 名
  - `SearchProviderManager.search` 链耗尽时透出最后一个 provider 的真实失败（不再笼统 SERVER_ERROR）
  - 失败透出中文可操作原因：`未配置 Tavily API key，请在设置中填写` / `Tavily API key 无效（401/403）` / 限流 / 网络 / 服务端错误
- **`miqi/agent/search_orchestrator.py`**：ddgs 区域搜索抽成模块级 `_ddgs_regional_search()`，每区域查询加 15s 超时（防挂死拖死工具调用）
- **`tests/agent/tools/test_web.py`**：+7 测试（扇出走配置链优先 / 链失败回退 ddgs / 空结果回退 / 全失败透出原因 / 无 key 透出设置提示 / key 无效透出 / 链耗尽透出最后失败）

## 日志/验证证据

```
$ pytest tests/agent/tools/test_web.py tests/agent/test_agent_mode.py → 32 passed
$ pytest tests/agent tests/kun_runtime → 486 passed
$ pytest tests（全量）→ 待 CI 全量结果

真实网络验证（本机，issue 同款查询词）：
- 普通路径 execute("中国人工智能核心产业规模 2025") → 返回 2 条真实结果
- fast 扇出 execute(..., _search_strategy=FAST.search) → 返回 2 条真实结果
- auto + 无效 Tavily key → 日志警告 authentication failed → 降级 ddgs 成功返回结果
- 显式 tavily + 无效 key → "Error: 网络搜索失败（服务：Tavily）。原因：Tavily API key 无效（401/403），请在设置中检查。..."
- 显式 tavily + 无 key → "Error: 网络搜索失败（服务：Tavily）。原因：未配置 Tavily API key，请在设置中填写。..."
```

## 测试情况

- pytest：test_web.py + test_agent_mode.py 32 passed；tests/agent + tests/kun_runtime 486 passed
- 真实网络行为验证：5 场景全通过（见上）

Closes #804

## 截图

本 PR 为后端搜索链路修复，无 UI 变更。真实网络验证输出（issue 同款查询词，fast 扇出路径修复前后）：

```
=== fast 扇出 execute（修复后）===
Results for: 中国人工智能核心产业规模 2025
1. 中国信通院：2025年我国人工智能产业规模超1.2万亿元
   https://www.cnfin.com/hg-lb/detail/20260803/4450222_1.html
2. 2025年中国人工智能核心产业规模预计突破1.2万亿元
   https://www.chinanews.com.cn/cj/2026/01-21/10556406.shtml
```

失败透出（显式 tavily + 无 key）：
```
Error: 网络搜索失败（服务：Tavily）。原因：未配置 Tavily API key，请在设置中填写。...
```

