### PR TITLE
fix(tools): infer graph_type from file name for old graph artifacts

### DIFF
--- a/miqi/agent/tools/graph_render.py
+++ b/miqi/agent/tools/graph_render.py
@@ -152,7 +152,27 @@ def parse_graph_json(raw: str, source_name: str = "graph") -> dict[str, Any]:
         warnings.append(f"schema_version={version!r}，仅保证 1.0 兼容")
 
     graph_type = data.get("graph_type")
-    if graph_type not in ("step-nodes", "data-nodes"):
+    if graph_type is None:
+        # Old-artifact compatibility: skill scripts added graph_type at
+        # different times, so JSON generated before that is missing the
+        # field.  Infer it from the file name instead of hard-failing —
+        # the tool still rejects files it cannot classify.  An explicit
+        # but invalid value is NOT inferred (data error, not old format).
+        inferred = None
+        if "step-graph" in source_name:
+            inferred = "step-nodes"
+        elif "data-graph" in source_name:
+            inferred = "data-nodes"
+        if inferred is not None:
+            warnings.append(
+                f"{source_name} 缺少 graph_type，已按文件名推断为 {inferred!r}"
+            )
+            graph_type = inferred
+        else:
+            raise GraphDataError(
+                f"{source_name} 缺少 graph_type，且文件名无法推断（仅支持 step-nodes / data-nodes）"
+            )
+    elif graph_type not in ("step-nodes", "data-nodes"):
         raise GraphDataError(
             f"{source_name} graph_type={graph_type!r}，仅支持 step-nodes / data-nodes"
         )

--- a/tests/agent/tools/test_graph_render.py
+++ b/tests/agent/tools/test_graph_render.py
@@ -176,6 +176,22 @@ class TestParseGraphJson:
         with pytest.raises(GraphDataError, match="仅支持 step-nodes / data-nodes"):
             parse_graph_json(json.dumps(d))
 
+    def test_missing_graph_type_inferred_from_filename(self):
+        """Old artifacts (missing graph_type) are inferred from the file
+        name instead of rejected — skill scripts added the field at
+        different times, leaving pre-sync JSON without it (#808)."""
+        d = {k: v for k, v in STEP_GRAPH.items() if k != "graph_type"}
+        g = parse_graph_json(json.dumps(d), source_name="step-graph.json")
+        assert g["graph_type"] == "step-nodes"
+        assert any("按文件名推断" in w for w in g["warnings"])
+
+    def test_unknown_graph_type_no_inference_from_unrelated_name(self):
+        """A file whose name does not identify the graph type still fails
+        when graph_type is missing or invalid (contract not relaxed)."""
+        d = dict(STEP_GRAPH, graph_type="flowchart")
+        with pytest.raises(GraphDataError, match="仅支持 step-nodes / data-nodes"):
+            parse_graph_json(json.dumps(d), source_name="custom.json")
+
     def test_missing_nodes(self):
         d = dict(STEP_GRAPH, nodes=[])
         with pytest.raises(GraphDataError, match="nodes 缺失或为空"):


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

graph_render 对缺 `graph_type` 字段的旧产物按文件名自动推断，不再硬拒绝（#808 关闭后的兼容性改进）。

## 背景/问题

各 skill 的 export_graph_data.py 在不同时间（8-18 ~ 8-24）才加入 `graph_type` 输出，导致**脚本同步前生成的 JSON 缺该字段**（旧产物）。graph_render 对这些文件直接报错，agent 只能手工编辑 JSON 补字段才能渲染（#808 实测）。

`graph_type` 可以从文件名推断（`step-graph.json` → step-nodes，`data-graph.json` → data-nodes），工具没必要为一个可推断的字段拒绝整个文件。

## 变更内容

- `miqi/agent/tools/graph_render.py`: `parse_graph_json` 中 `graph_type` **缺失**（None）时按 `source_name` 文件名推断并告警；**显式但非法**的值仍报错（数据错误非旧格式，契约不放松）（+15/-1 行）
- `tests/agent/tools/test_graph_render.py`: 新增 2 个用例（文件名推断成功 / 无关文件名仍报错）（+22 行）

## 日志/验证证据

```
改前（真实旧产物）：
step-graph.json graph_type=None，仅支持 step-nodes / data-nodes → 渲染失败，需手工补字段

改后（真实 mof 产物模拟旧格式验证）：
step-graph.json 缺少 graph_type，已按文件名推断为 'step-nodes' → 渲染成功
data-graph.json 缺少 graph_type，已按文件名推断为 'data-nodes' → 渲染成功
非法值（graph_type='flowchart'）仍报错：仅支持 step-nodes / data-nodes ✓

pytest tests/agent/tools/test_graph_render.py → 33 passed（31 现有 + 2 新增）
```

## 测试情况

- [x] `test_graph_render.py`: 33 passed，无回归
- [x] 真实产物验证：mof 任务 step-graph.json / data-graph.json 模拟旧格式（删 graph_type）→ 推断成功
- [x] 契约不放松：显式非法值 + 无关文件名仍报错

## 截图

无需截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
