### PR TITLE
feat(exec): 支持 per-call timeout 参数，长任务不再被默认超时截断（#810）

### DIFF
--- a/miqi/agent/subagent.py
+++ b/miqi/agent/subagent.py
@@ -153,6 +153,7 @@ class SubagentManager:
             tools.register(ExecTool(
                 working_dir=str(self.workspace),
                 timeout=self.exec_config.timeout,
+                max_timeout=getattr(self.exec_config, "max_timeout", 600),
                 restrict_to_workspace=self.restrict_to_workspace,
                 env_passthrough=list(self.exec_config.env_passthrough),
             ))

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -213,6 +213,7 @@ class ExecTool(Tool):
     def __init__(
         self,
         timeout: int = 60,
+        max_timeout: int = 600,
         working_dir: str | None = None,
         deny_patterns: list[str] | None = None,
         allow_patterns: list[str] | None = None,
@@ -222,6 +223,11 @@ class ExecTool(Tool):
         sandbox_manager=None,
     ):
         self.timeout = timeout
+        # Issue #810: hard ceiling for the per-call ``timeout`` argument the
+        # model may pass.  The configured ``timeout`` remains the anti-runaway
+        # default when no argument is given; the ceiling keeps a runaway
+        # long-running command from pinning the turn indefinitely.
+        self.max_timeout = max_timeout
         self.working_dir = working_dir
         self.env_passthrough: frozenset[str] = frozenset(env_passthrough or [])
         self.deny_patterns = deny_patterns or [
@@ -260,6 +266,16 @@ class ExecTool(Tool):
         return "exec"
 
     @property
+    def execution_timeout(self) -> float | None:
+        # Issue #810: the tool enforces its own timeout internally (default +
+        # per-call cap), so the registry-level ``asyncio.wait_for`` safety net
+        # (ToolRegistry.execute, the KUN tool-host path) must sit ABOVE the
+        # tool's ceiling instead of pre-empting long-running commands with a
+        # generic registry error.  The buffer covers the kill-and-drain
+        # cleanup after the internal timeout fires.
+        return float(self.max_timeout + 30)
+
+    @property
     def description(self) -> str:
         from miqi.sandbox.manager import describe_exec_environment
 
@@ -279,12 +295,42 @@ class ExecTool(Tool):
                     "type": "string",
                     "description": "Optional working directory for the command",
                 },
+                "timeout": {
+                    "type": "integer",
+                    "description": (
+                        f"Optional timeout in seconds for this command "
+                        f"(default {self.timeout}s). Long tasks such as pip "
+                        f"installs, chart rendering, or batch link checks "
+                        f"need larger values — pass e.g. 120 or 300. "
+                        f"Values are clamped to the allowed range "
+                        f"[1, {self.max_timeout}]; beyond the ceiling the "
+                        f"run is still capped to prevent a runaway command "
+                        f"from pinning the turn indefinitely."
+                    ),
+                    "minimum": 1,
+                    "maximum": self.max_timeout,
+                },
             },
             "required": ["command"],
         }
 
     async def execute(self, command: str, working_dir: str | None = None, **kwargs: Any) -> str:
         cwd = working_dir or self.working_dir or os.getcwd()
+
+        # Issue #810: per-call timeout requested by the model (seconds).
+        # Clamped to [1, self.max_timeout]; None → the configured default
+        # (self.timeout) applies downstream.  The clamp is a backstop — the
+        # JSON schema already declares minimum/maximum and validation
+        # rejects out-of-range values before this method runs.
+        _requested_timeout = kwargs.pop("timeout", None)
+        call_timeout_ms: int | None = None
+        if _requested_timeout is not None:
+            try:
+                clamped = min(max(int(_requested_timeout), 1), self.max_timeout)
+            except (TypeError, ValueError):
+                clamped = None
+            if clamped is not None:
+                call_timeout_ms = clamped * 1000
 
         # Phase 21: extract runtime-injected event emitter and metadata
         event_emitter = kwargs.pop("_event_emitter", None)
@@ -417,6 +463,9 @@ class ExecTool(Tool):
                 thread_id=thread_id,
                 # Session key for per-session sandbox isolation
                 session_key=_session_key,
+                # Issue #810: per-call timeout override (None → default).
+                # Overrides the orchestrator's selection.timeout_ms too.
+                timeout_ms=call_timeout_ms,
             )
 
             # Phase 31: if ToolOrchestrator injected a SandboxSelection,
@@ -665,10 +714,7 @@ class ExecTool(Tool):
         if timed_out:
             logger.error("Sandbox command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
-                output=(
-                    f"Error: 命令在 "
-                    f"{effective_timeout:.0f} 秒后超时"
-                ),
+                output=self._timeout_message(effective_timeout, duration_ms),
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
             )
@@ -702,6 +748,17 @@ class ExecTool(Tool):
 
         return _ExecResult(
             output=result, exit_code=exit_code, duration_ms=duration_ms,
+        )
+
+    def _timeout_message(self, effective_timeout: float, duration_ms: int) -> str:
+        """Issue #810: timeout output naming the configured limit, the
+        actual elapsed time, and a retry hint pointing at the per-call
+        ``timeout`` argument (capped at ``max_timeout``)."""
+        return (
+            f"Error: 命令在 {effective_timeout:.0f} 秒后超时"
+            f"（实际已执行 {duration_ms / 1000:.1f} 秒）。\n"
+            f"若为长任务（pip 安装、图表渲染、批量链接检测等），请重试并在 exec 的 "
+            f"timeout 参数中指定更大时限（1–{self.max_timeout} 秒）。"
         )
 
     def _resolve_sandbox_cwd(self, cwd: str) -> str:
@@ -762,6 +819,7 @@ class ExecTool(Tool):
     async def _execute_with_sandbox_selection(
         self, selection: Any, command: str, cwd: str,
         *,
+        timeout_ms: int | None = None,
         event_emitter=None,
         turn_id: str = "",
         tool_call_id: str = "",
@@ -778,6 +836,11 @@ class ExecTool(Tool):
         ``ToolOrchestrator._execute_in_sandbox()``.  ExecTool MUST NOT
         second-guess it or silently fall back to a weaker execution mode.
 
+        Issue #810: *timeout_ms* is the model-requested per-call override
+        (already clamped in :meth:`execute`); when set it takes precedence
+        over ``selection.timeout_ms`` — the selection's value is the
+        policy default, not a safety bound the model may not raise.
+
         Rules (Phase 31):
         - NONE       → direct host execution (orchestrator explicitly allowed it).
         - BWRAP      → must use bwrap sandbox.  Unavailable → fall back to host with warning.
@@ -786,7 +849,7 @@ class ExecTool(Tool):
         """
         st = selection.sandbox_type
         common = dict(
-            timeout_ms=selection.timeout_ms,
+            timeout_ms=timeout_ms if timeout_ms is not None else selection.timeout_ms,
             env_passthrough=list(selection.env_passthrough),
             event_emitter=event_emitter,
             turn_id=turn_id,
@@ -925,10 +988,13 @@ class ExecTool(Tool):
             )
 
         # 5. Proceed with direct host execution — timeout and
-        #    env_passthrough from SandboxSelection.
+        #    env_passthrough from SandboxSelection.  Issue #810: the
+        #    model-requested per-call timeout (already resolved into the
+        #    ``timeout_ms`` kwarg by _execute_with_sandbox_selection) wins
+        #    over the selection default when present.
         return await self._execute_direct(
             command, cwd,
-            timeout_ms=sandbox_selection.timeout_ms,
+            timeout_ms=timeout_ms if timeout_ms is not None else sandbox_selection.timeout_ms,
             env_passthrough=list(sandbox_selection.env_passthrough),
             event_emitter=event_emitter,
             turn_id=turn_id,
@@ -1330,10 +1396,7 @@ class ExecTool(Tool):
         if timed_out:
             logger.error("Direct command timed out after {}ms: {}", duration_ms, cmd_summary)
             return _ExecResult(
-                output=(
-                    f"Error: 命令在 "
-                    f"{effective_timeout:.0f} 秒后超时"
-                ),
+                output=self._timeout_message(effective_timeout, duration_ms),
                 exit_code=exit_code, duration_ms=duration_ms,
                 timed_out=True,
             )

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -469,6 +469,17 @@ class ExecToolConfig(Base):
     """Shell exec tool configuration."""
 
     timeout: int = 60
+    max_timeout: int = Field(
+        default=600,
+        description=(
+            "Hard cap (seconds) for the per-call ``timeout`` argument the model may pass "
+            "to the exec tool (#810).  Long tasks (pip installs, chart rendering, batch "
+            "link checks) previously died at the fixed 30-60 s default; the model can now "
+            "request up to this ceiling per call.  Keep it bounded so a runaway command "
+            "cannot pin the turn indefinitely — 600 s (10 min) covers texlive-scale "
+            "installs short of the routed system-install budget (1200 s, #759)."
+        ),
+    )
     env_passthrough: list[str] = Field(
         default_factory=list,
         description=(

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -281,6 +281,8 @@ def create_runtime_tool_registry(
         ExecTool(
             working_dir=str(_work_dir or workspace),
             timeout=getattr(exec_cfg, "timeout", 60) if exec_cfg is not None else 60,
+            # Issue #810: per-call timeout ceiling from config
+            max_timeout=getattr(exec_cfg, "max_timeout", 600) if exec_cfg is not None else 600,
             restrict_to_workspace=restrict_to_workspace,
             env_passthrough=list(getattr(exec_cfg, "env_passthrough", [])) if exec_cfg is not None else [],
             approval_callback=approval_callback,

--- a/tests/execution/test_exec_timeout_param.py
+++ b/tests/execution/test_exec_timeout_param.py
@@ -1,0 +1,199 @@
+"""Tests for exec per-call timeout parameter (issue #810).
+
+Issue #810: the exec tool previously enforced a fixed default timeout
+(30-60 s) for every command — long tasks (pip installs, chart rendering,
+batch link checks) died mid-run.  The fix adds a model-supplied
+``timeout`` argument (seconds, clamped to [1, max_timeout]) that
+overrides both the configured default and the orchestrator's
+SandboxSelection.timeout_ms, plus a timeout message that names the
+configured limit, the actual elapsed time, and a retry hint.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.agent.tools.shell import ExecTool
+
+
+# ── Schema / construction ──────────────────────────────────────────────
+
+
+def test_schema_exposes_timeout_param_with_cap():
+    """The exec schema must declare the ``timeout`` argument with
+    minimum 1 and maximum == max_timeout."""
+    tool = ExecTool(timeout=60, max_timeout=300)
+    props = tool.parameters["properties"]
+    assert "timeout" in props
+    assert props["timeout"]["type"] == "integer"
+    assert props["timeout"]["minimum"] == 1
+    assert props["timeout"]["maximum"] == 300
+    assert str(60) in props["timeout"]["description"]  # names the default
+
+
+def test_execution_timeout_sits_above_cap():
+    """The registry-level safety net (ToolRegistry.execute's
+    asyncio.wait_for) must sit ABOVE max_timeout so long per-call
+    timeouts are not pre-empted by a generic registry error."""
+    tool = ExecTool(max_timeout=600)
+    assert tool.execution_timeout == 630
+
+
+def test_validation_rejects_out_of_range_timeout():
+    """Schema validation rejects timeout values outside [1, max_timeout]."""
+    tool = ExecTool(timeout=60, max_timeout=120)
+    assert tool.validate_params({"command": "ls", "timeout": 0})
+    assert tool.validate_params({"command": "ls", "timeout": 121})
+    assert not tool.validate_params({"command": "ls", "timeout": 1})
+    assert not tool.validate_params({"command": "ls", "timeout": 120})
+    assert not tool.validate_params({"command": "ls"})
+
+
+# ── Per-call timeout behaviour (real subprocesses) ─────────────────────
+
+
+@pytest.mark.subprocess
+@pytest.mark.asyncio
+async def test_per_call_timeout_overrides_default(require_subprocess, tmp_path):
+    """A model-supplied timeout shorter than the configured default must
+    actually apply, and the timeout message must carry elapsed time,
+    the retry hint, and the cap."""
+    tool = ExecTool(timeout=60, max_timeout=600, working_dir=str(tmp_path))
+
+    output = await tool.execute(
+        "python -c \"import time; time.sleep(30)\"",
+        timeout=1,
+    )
+
+    assert "超时" in output
+    assert "实际已执行" in output
+    assert "timeout 参数" in output
+    assert "1–600 秒" in output
+
+
+@pytest.mark.subprocess
+@pytest.mark.asyncio
+async def test_per_call_timeout_extends_selection(require_subprocess, tmp_path):
+    """A model-supplied timeout longer than the SandboxSelection's
+    timeout_ms must win over the selection (issue #810 — the selection
+    carries the policy default, not a ceiling)."""
+    from miqi.execution.sandbox_policy import SandboxSelection, SandboxType
+    from miqi.protocol.permissions import (
+        FileSystemSandboxPolicy,
+        NetworkSandboxPolicy,
+    )
+
+    tool = ExecTool(timeout=60, max_timeout=600, working_dir=str(tmp_path))
+    sel = SandboxSelection(
+        sandbox_type=SandboxType.NONE,
+        filesystem_policy=FileSystemSandboxPolicy(),
+        network_policy=NetworkSandboxPolicy.ALLOW_ALL,
+        timeout_ms=50,  # selection would kill this command in 50ms
+        env_passthrough=[],
+        reason="test",
+    )
+
+    output = await tool.execute(
+        "python -c \"import time; time.sleep(0.5); print('done-long')\"",
+        timeout=30,
+        _sandbox=sel,
+    )
+
+    assert "done-long" in output
+    assert "超时" not in output
+
+
+@pytest.mark.subprocess
+@pytest.mark.asyncio
+async def test_per_call_timeout_shortens_selection(require_subprocess, tmp_path):
+    """Conversely, a model-supplied timeout shorter than the selection's
+    must also win — the per-call value is authoritative both ways."""
+    from miqi.execution.sandbox_policy import SandboxSelection, SandboxType
+    from miqi.protocol.permissions import (
+        FileSystemSandboxPolicy,
+        NetworkSandboxPolicy,
+    )
+
+    tool = ExecTool(timeout=60, max_timeout=600, working_dir=str(tmp_path))
+    sel = SandboxSelection(
+        sandbox_type=SandboxType.NONE,
+        filesystem_policy=FileSystemSandboxPolicy(),
+        network_policy=NetworkSandboxPolicy.ALLOW_ALL,
+        timeout_ms=30_000,
+        env_passthrough=[],
+        reason="test",
+    )
+
+    output = await tool.execute(
+        "python -c \"import time; time.sleep(30)\"",
+        timeout=1,
+        _sandbox=sel,
+    )
+
+    assert "超时" in output
+
+
+@pytest.mark.subprocess
+@pytest.mark.asyncio
+async def test_per_call_timeout_clamped_to_max(require_subprocess, tmp_path):
+    """Values above max_timeout are clamped (backstop — validation already
+    rejects them), and the timeout message shows the effective cap."""
+    tool = ExecTool(timeout=60, max_timeout=2, working_dir=str(tmp_path))
+
+    output = await tool.execute(
+        "python -c \"import time; time.sleep(30)\"",
+        timeout=999,
+    )
+
+    assert "超时" in output
+    assert "命令在 2 秒后超时" in output  # clamped, not 999
+    assert "1–2 秒" in output
+
+
+@pytest.mark.subprocess
+@pytest.mark.asyncio
+async def test_per_call_timeout_flows_into_sandbox_path(require_subprocess, tmp_path):
+    """The per-call timeout must also govern the bwrap sandbox path
+    (KUN runtime has no orchestrator-injected selection — timeout_ms=None
+    reaches _execute_in_sandbox as the per-call override)."""
+    # Sleep-forever process: only the timeout can end it.
+    process = await asyncio.create_subprocess_exec(
+        "python", "-c", "import time; time.sleep(3600)",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    handle = MagicMock()
+    handle.stdout = process.stdout
+    handle.stderr = process.stderr
+    handle.returncode = None
+    handle.wait = AsyncMock(side_effect=process.wait)
+    handle.kill = AsyncMock(side_effect=process.kill)
+    handle.cleanup = AsyncMock()
+
+    sandbox = MagicMock()
+    sandbox.is_running = True
+    sandbox.get_sandbox_env = MagicMock(return_value={})
+    sandbox.run_command_streaming = AsyncMock(return_value=handle)
+    mgr = MagicMock()
+    mgr.active_sandbox = sandbox
+
+    tool = ExecTool(
+        timeout=60, max_timeout=600,
+        working_dir=str(tmp_path), sandbox_manager=mgr,
+    )
+
+    try:
+        output = await tool.execute(
+            "sleep 999",
+            timeout=1,
+            _sandbox=None,  # KUN path: no selection injected
+        )
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+
+    assert "超时" in output
+    assert "实际已执行" in output
+    handle.kill.assert_awaited()


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

exec 工具新增按次 `timeout` 参数（钳制在 1–`tools.exec.max_timeout` 秒内），长任务不再被固定默认超时截断；超时错误消息标注配置时限、实际执行时长与重试提示。

## 背景/问题

#810：`exec` 工具此前对所有命令统一使用固定默认超时（用户配置 30s / 默认 60s），长任务被硬截断。2026-08-24 generate-analysis-report 运行实测：

- `pip install matplotlib numpy` 两次超时（30s 截断），重试后才成功
- `check_pdf_links.py`（并发 HTTP 验证 PDF 链接）受限制只能降并发参数凑时间（`--parallel 4 --timeout 5`）
- 技能里"exec 30s 硬限制"已成设计约束，所有长操作都要绕

同类根因另见 #759（安装类操作被超时/权限双重阻断）。#709 已让 LLM 侧尊重调用方超时，但 exec 侧一直未覆盖。

## 关联 issue

- Closes #810 exec 工具 30s 硬超时——长任务被截断，建议可配置超时或异步长任务通道

## 变更内容

- `miqi/agent/tools/shell.py`：
  - exec 参数 schema 新增 `timeout`（integer，minimum 1、maximum `max_timeout`），模型可按次为长任务请求更长时限；不传时仍用配置的 `timeout` 兜底防失控
  - `execute()` 解析并钳制 per-call timeout（钳制是兜底——schema 校验已先拒绝越界值），下传到沙箱/直连/旧 orchestrator 三条执行路径
  - `_execute_with_sandbox_selection`：per-call timeout 优先于 `SandboxSelection.timeout_ms`（selection 只是策略默认值，不是模型不可提升的安全上限）
  - 超时消息升级为 `_timeout_message()`：配置时限 + 实际已执行时长 + "重试并在 exec 的 timeout 参数中指定更大时限（1–N 秒）"提示
  - `execution_timeout` 属性置于 `max_timeout + 30s`，避免 KUN 路径下 `ToolRegistry.execute` 的 `wait_for` 安全网抢在工具自身超时前用通用错误截杀长命令
- `miqi/config/schema.py`：`ExecToolConfig` 新增 `max_timeout`（默认 600s，10 分钟——覆盖 pip 安装/链接批量检测，低于系统安装路由 #759 的 1200s 预算）
- `miqi/runtime/tool_registry_factory.py`、`miqi/agent/subagent.py`：构造 ExecTool 时透传 `max_timeout`
- `tests/execution/test_exec_timeout_param.py`：新增 8 个测试（schema 声明、execution_timeout 高度、校验拒绝越界、per-call 压过默认、per-call 双向覆盖 selection、钳制到 max、沙箱路径透传、消息内容）

## 日志/验证证据

```
$ uv run --frozen pytest tests/execution/test_exec_timeout_param.py -v
tests/execution/test_exec_timeout_param.py::test_schema_exposes_timeout_param_with_cap PASSED
tests/execution/test_exec_timeout_param.py::test_execution_timeout_sits_above_cap PASSED
tests/execution/test_exec_timeout_param.py::test_validation_rejects_out_of_range_timeout PASSED
tests/execution/test_exec_timeout_param.py::test_per_call_timeout_overrides_default PASSED
tests/execution/test_exec_timeout_param.py::test_per_call_timeout_extends_selection PASSED
tests/execution/test_exec_timeout_param.py::test_per_call_timeout_shortens_selection PASSED
tests/execution/test_exec_timeout_param.py::test_per_call_timeout_clamped_to_max PASSED
tests/execution/test_exec_timeout_param.py::test_per_call_timeout_flows_into_sandbox_path PASSED
============================== 8 passed in 6.80s ==============================
```

超时消息实测效果（默认 60s、max 600s，per-call `timeout=1`）：

```
Error: 命令在 1 秒后超时（实际已执行 1.0 秒）。
若为长任务（pip 安装、图表渲染、批量链接检测等），请重试并在 exec 的 timeout 参数中指定更大时限（1–600 秒）。
```

## 测试情况

- 新增 `tests/execution/test_exec_timeout_param.py`：8 passed
- 回归：`tests/execution/`（含 test_exec_events、test_exec_tool_sandbox_selection、test_phase33 等）、`tests/runtime/`、`tests/kun_runtime/`、`tests/agent/`、`tests/sandbox/test_system_install_routing.py` 等共 **1725 passed, 1 skipped**

## 截图

无需截图（无 UI 变更；配置项 `tools.exec.max_timeout` 走 config.json，桌面设置面板暂未提供 exec timeout 输入框）
