### PR TITLE
fix(documents): 工具参数 schema anyOf 补 type — 修 deepseek API 400（发送即失败）

### DIFF
--- a/miqi/documents/docx_tool.py
+++ b/miqi/documents/docx_tool.py
@@ -373,9 +373,9 @@ class DocxReadTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 
@@ -545,9 +545,9 @@ class CreateDocxTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 
@@ -700,9 +700,9 @@ class EditDocxTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 

--- a/miqi/documents/pdf_create_tool.py
+++ b/miqi/documents/pdf_create_tool.py
@@ -654,9 +654,9 @@ class CreatePdfTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 

--- a/miqi/documents/pptx_tool.py
+++ b/miqi/documents/pptx_tool.py
@@ -109,9 +109,9 @@ class PptxReadTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 
@@ -202,9 +202,9 @@ class CreatePptxTool(Tool):
                 },
             },
             "anyOf": [
-                {"required": ["filename"]},
-                {"required": ["file_path"]},
-                {"required": ["path"]},
+                {"type": "object", "required": ["filename"]},
+                {"type": "object", "required": ["file_path"]},
+                {"type": "object", "required": ["path"]},
             ],
         }
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

工具参数 schema 的 anyOf 项补 type: object，修复 deepseek API 400 导致发送即失败。

## 背景/问题

E2E 实测发现：chat.send 发送后立即失败——前端一直「正在思考…」无任何输出、无中断卡。
根因：docx/pdf/pptx 工具的 parameters schema 里 anyOf 项只有 {"required": [...]} 没有 type——deepseek API 的 moonshot 风格 JSON schema 校验拒绝（"when using anyOf, type should be defined in anyOf items"）→ 400 → turn 失败 → 无回复。

## 变更内容

- miqi/documents/docx_tool.py / pdf_create_tool.py / pptx_tool.py：所有 anyOf 项补 "type": "object"（18 个 required 项）

## 日志/验证证据

```
修复前（dev 日志）：
openai.BadRequestError: Error code: 400 - Invalid request: tools.function.parameters is not a valid moonshot flavored json schema, details: <At path 'root': when using anyOf, type should be defined in anyOf items instead of the parent schema>

修复后（E2E 实机）：
停止按钮 → 中断卡 → 续答 全过（发送不再失败）
```

## 测试情况

- py_compile OK
- tests/documents 41 passed
- E2E 实机全过（生成/停止/中断卡/续答）

## 截图

无需截图（后端 schema 修复，无 UI 变更）

## 后续计划

无