### PR TITLE
fix(sandbox): 沙箱内环境描述改推 python3,不再推荐无法启动的 Windows venv Python (#822)

### DIFF
--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -189,22 +189,55 @@ def _skills_dirs_note(workspace: str | Path | None, style: str) -> str:
 def _python_note(style: str) -> str:
     """One sentence disclosing the bridge's REAL python interpreter.
 
-    The AI otherwise resolves `python` via PATH and can hit the
-    WindowsApps store stub (hangs ~forever) or a stale interpreter —
-    give it the full path in the exec environment's path style
-    (msys = /c/..., mnt = /mnt/c/..., native = as-is).
+    Host-exec paths only — inside the sandbox the host interpreter cannot
+    run (no WSL interop), see _sandbox_python_note instead.  The AI
+    otherwise resolves `python` via PATH and can hit the WindowsApps
+    store stub (hangs ~forever) or a stale interpreter — give it the full
+    path in the exec environment's path style
+    (msys = /c/..., native = as-is).
     """
     exe = str(getattr(sys, "executable", ""))
     if not exe:
         return ""
     if style == "msys":
         exe = windows_path_to_msys(exe)
-    elif style == "mnt":
-        exe = windows_path_to_mnt(exe)
     return (
         f"推荐 Python 解释器：{exe}。"
         "运行 python 脚本请直接用这个完整路径，避免 PATH 上其他 "
         "python 启动卡顿（如商店占位程序）。"
+    )
+
+
+def _sandbox_python_note(sandbox_manager: Any) -> str:
+    """Tell the AI how to run Python INSIDE the bwrap sandbox.
+
+    The sandbox ro-binds the distro's /usr, so python3 is always present
+    (the WSL readiness probe only passes with python3 + pip available).
+    The host interpreter disclosure (_python_note) is wrong here: bwrap's
+    namespace isolation removes the WSL interop bridge, so Windows .exe
+    files under /mnt/c — including the bridge's own venv python — can
+    never start, and recommending one makes the AI retry a dead path
+    (#822).
+    """
+    if _is_windows():
+        interop = (
+            "沙箱内无 WSL interop：/mnt/c/... 下的 Windows 程序（含 Windows 侧 "
+            "python.exe）无法启动，不要尝试运行。"
+        )
+    else:
+        interop = ""
+    install = (
+        "Python 依赖用 python3 -m pip install --user <包名> 安装（写入沙箱 HOME，"
+        "沙箱销毁后不保留）；pip 报 externally-managed 时改用 "
+        "python3 -m venv ~/.venv && ~/.venv/bin/pip install <包名>。"
+    )
+    if getattr(sandbox_manager, "allow_system_installs", False):
+        install += (
+            "需要长期可用的依赖可直接 sudo apt-get install python3-<包名>"
+            "（随发行版持久化，装完沙箱内立即可用）。"
+        )
+    return (
+        f"沙箱内请使用 python3（发行版自带，只读挂载始终可用）。{interop}{install}"
     )
 
 
@@ -250,7 +283,7 @@ def describe_exec_environment(
         return (
             " ".join(parts)
             + _skills_dirs_note(workspace, "mnt")
-            + _python_note("mnt")
+            + _sandbox_python_note(sandbox_manager)
         )
     if os.name == "nt":
         if find_git_bash() is not None:

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -22,9 +22,15 @@ from miqi.sandbox.manager import (
 
 
 class FakeSandboxManager:
-    def __init__(self, enabled: bool = False, initialized: bool = False):
+    def __init__(
+        self,
+        enabled: bool = False,
+        initialized: bool = False,
+        allow_system_installs: bool = False,
+    ):
         self.enabled = enabled
         self._initialized = initialized
+        self.allow_system_installs = allow_system_installs
 
 
 @pytest.mark.parametrize(
@@ -192,6 +198,52 @@ def test_describe_exec_environment_sandbox_active():
     text = describe_exec_environment(manager)
     assert "WSL" in text
     assert "/home/miqi/workspace" in text
+
+
+def test_describe_exec_environment_sandbox_python_guidance(monkeypatch):
+    """#822: inside the bwrap sandbox Windows .exe cannot run (no WSL
+    interop), so the description must recommend sandbox-internal python3
+    instead of the host venv interpreter path."""
+    manager = FakeSandboxManager(enabled=True, initialized=True)
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: True)
+
+    class _FakeSys:
+        executable = r"C:\git-program\venv\Scripts\python.exe"
+
+    monkeypatch.setattr("miqi.sandbox.manager.sys", _FakeSys(), raising=False)
+    text = describe_exec_environment(manager, workspace=r"C:\Users\demo\ws")
+    assert "python3" in text
+    assert "pip install --user" in text
+    assert "externally-managed" in text
+    assert "interop" in text
+    # the host venv python must NOT be recommended inside the sandbox
+    assert "推荐 Python 解释器" not in text
+    assert "Scripts/python.exe" not in text
+
+
+def test_describe_exec_environment_sandbox_python_no_interop_note_on_posix(monkeypatch):
+    """The interop caveat is WSL-specific — on a POSIX host it must not
+    mention /mnt/c or Windows .exe."""
+    manager = FakeSandboxManager(enabled=True, initialized=True)
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
+    text = describe_exec_environment(manager)
+    assert "python3" in text
+    assert "pip install --user" in text
+    assert "interop" not in text
+    assert "python.exe" not in text
+    assert "Windows 程序" not in text
+
+
+def test_describe_exec_environment_sandbox_python_persistent_install(monkeypatch):
+    """With system installs enabled, python deps can be installed into the
+    distro persistently via apt — the description should say so."""
+    manager = FakeSandboxManager(
+        enabled=True, initialized=True, allow_system_installs=True,
+    )
+    monkeypatch.setattr("miqi.sandbox.manager._is_windows", lambda: False)
+    text = describe_exec_environment(manager)
+    assert "python3" in text
+    assert "apt-get install python3-" in text
 
 
 def test_describe_exec_environment_no_sandbox_windows_cmd_fallback(monkeypatch):


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

沙箱激活时,exec 环境描述改推沙箱内 python3 + 依赖安装指引,不再推荐无法启动的 Windows venv Python。

## 背景/问题

系统提示在沙箱激活时仍推荐 Windows venv Python(如 `/mnt/c/.../.venv/Scripts/python.exe`)作为解释器,但 bwrap 的 `--unshare-*` 命名空间隔离移除了 WSL interop 桥接,沙箱内任何 Windows .exe(含 Windows 侧 python)都无法启动,报 `UtilConnectUnix:535: connect failed 2`。agent 按推荐反复尝试失败后才转向沙箱内 python3 + pip 重装依赖(沙箱环境不持久,每次任务重装),误导消耗大量步骤。这是 #795(沙箱关闭后描述未更新)的反向同族:推荐信息未按沙箱实际能力生成。

## 关联 issue

- Closes #822

## 变更内容

- `miqi/sandbox/manager.py`:
  - 新增 `_sandbox_python_note(sandbox_manager)`,沙箱激活分支改用它替代 `_python_note("mnt")`:
    - 明确推荐 `python3`(发行版 ro-bind 到 /usr,就绪探针保证可用)
    - 明确告知沙箱内无 WSL interop、`/mnt/c/...` 下的 Windows 程序无法启动、不要尝试(POSIX 宿主不注入该警告)
    - 依赖安装指引:`python3 -m pip install --user <包名>`(写入沙箱 HOME,销毁不保留);pip 报 `externally-managed` 时退 `python3 -m venv ~/.venv`
    - 开启 `allow_system_installs` 时追加持久化方案:`sudo apt-get install python3-<包名>`
  - `_python_note` 移除已无调用方的 "mnt" 分支,文档注明仅限宿主直执行路径使用
- `tests/sandbox/test_exec_environment_description.py`:新增 3 项回归(沙箱内不出现 Windows 解释器路径、POSIX 无 interop 警告、持久化安装指引)

覆盖所有提示注入点:ExecTool 描述、`build_session_context` 每回合上下文、legacy task_runner 均经 `describe_exec_environment` 生成,单点修复全部生效。

## 日志/验证证据

```
修复后沙箱激活时的环境描述:

exec 在 WSL 沙箱中运行——... 沙箱内请使用 python3(发行版自带,只读挂载始终可用)。沙箱内无 WSL interop:/mnt/c/... 下的 Windows 程序(含 Windows 侧 python.exe)无法启动,不要尝试运行。Python 依赖用 python3 -m pip install --user <包名> 安装(写入沙箱 HOME,沙箱销毁后不保留);pip 报 externally-managed 时改用 python3 -m venv ~/.venv && ~/.venv/bin/pip install <包名>。

修复前同分支文本为:推荐 Python 解释器:/mnt/c/.../Scripts/python.exe。(沙箱内执行即 interop 连接失败)
```

## 测试情况

- `tests/sandbox` 全量 194 项通过(含新增 3 项回归)
- ExecTool 相关 `tests/execution/test_exec_tool_sandbox_selection.py`、`test_exec_events.py`、`tests/agent/tools/test_shell_artifact_tracking.py` 119 项通过
- `tests/runtime/test_agent_control.py` 26 项、`tests/kun_runtime/test_legacy_loop_replacement.py` 8 项通过
- ruff check / format 通过

## 截图

无需截图(纯提示词文本变更,无 UI 变化)

## 后续计划

无