### PR TITLE
feat(sandbox): 路径感知能力护栏——session 内 rm -rf 放行、逐子命令判定、结构化拒绝（#811）

### DIFF
--- a/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
+++ b/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
@@ -18,8 +18,10 @@
  * agent 只能换写法绕过（shutil.rmtree）——本 spec 断言期望行为，修复前运行
  * 失败（即复现 bug）。
  *
- * 不依赖 bwrap 沙箱：mock 全部使用相对路径（相对 exec cwd），沙箱内
- * （/home/miqi/workspace）与主机回退（session files 目录）均可执行。
+ * 不依赖 bwrap 沙箱：mock 全部使用相对路径（相对 exec cwd），且
+ * patchConfig 显式关闭沙箱（Linux CI 的 bwrap 因受限 user namespaces
+ * 无法运行）——本 spec 验证的是护栏层本身，护栏在沙箱创建之前执行，
+ * 与沙箱无关。exec 在主机直执行（Windows Git Bash / Linux bash）。
  *
  * Run: cd apps/desktop && npx playwright test \
  *      --config=playwright.config.ts --project=electron -g "护栏811"
@@ -127,13 +129,21 @@ test.describe('Issue #811 护栏误拦截复现', () => {
         }
       }
       config.providers = providers;
-      // Issue #811: the guard now lets real execs run; on Windows E2E the
-      // first Git Bash spawns take ~25-30 s (Defender/cold start), so the
-      // SandboxSelection timeout must leave headroom above the 30 s
-      // engine default.
+      // Issue #811: the guard now lets real execs run.  Two environment
+      // accommodations:
+      // 1. Sandbox disabled — the Linux CI runner has bwrap installed
+      //    (so BWRAP gets selected) but its user namespaces are
+      //    restricted ("bwrap: loopback: Failed to mount"), which would
+      //    fail every exec.  The guard runs BEFORE any sandbox and its
+      //    semantics here are host-path based, so this spec verifies the
+      //    guard layer itself on direct host execution.
+      // 2. tools.exec.timeout raised to 120 — on Windows E2E the first
+      //    Git Bash spawns take ~25-30 s (Defender/cold start), which
+      //    races the SandboxSelection timeout (30 s engine default).
       config.tools = {
         ...config.tools,
         exec: { ...(config.tools?.exec ?? {}), timeout: 120 },
+        sandbox: { ...(config.tools?.sandbox ?? {}), enabled: false },
       };
     });
     electronApp = fixture.electronApp;

--- a/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
+++ b/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * E2E: Issue #811 沙箱护栏误拦截复现 — rm -rf / 复合命令 / sudo
+ *
+ * 用本地 mock OpenAI 服务器（scripts/mock_openai.py，确定性状态机）驱动，
+ * mock 按「护栏811」触发词推进 exec 工具调用序列，验证 KUN runtime 的
+ * ExecTool._guard_command 行为（approval 层在 E2E 中被 bypass_all 跳过，
+ * 护栏是 exec 的最终防线——正是 #811 所报告的那一层）：
+ *
+ *   A. session 目录内的 rm -rf 清理 → 期望放行（目录真的被删掉）
+ *   B. 越界删除（/etc）          → 期望结构化拒绝 + 安全替代指引
+ *   C. 复合命令（echo && rm -rf）→ 期望逐子命令判定后整条放行
+ *   D. sudo 提权                 → 期望结构化声明不可用 + 替代指引
+ *
+ * mock 会把 exec 工具结果折算成最终回复文本（REPRO_X_DONE OK/BLOCKED/GENERIC），
+ * 如同真实 LLM 向用户报告工具结果——测试断言最终标记，是用户可感知的结果。
+ *
+ * 现状（修复前）：A/C/D 被 deny 模式一刀切拦截（"检测到危险模式"，无指引），
+ * agent 只能换写法绕过（shutil.rmtree）——本 spec 断言期望行为，修复前运行
+ * 失败（即复现 bug）。
+ *
+ * 不依赖 bwrap 沙箱：mock 全部使用相对路径（相对 exec cwd），沙箱内
+ * （/home/miqi/workspace）与主机回退（session files 目录）均可执行。
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *      --config=playwright.config.ts --project=electron -g "护栏811"
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  launchElectronApp,
+  closeElectronApp,
+  createNewConversation,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+
+/** 等待 mock 的最终标记渲染（不能拿 main 文本静止当同步点——
+ *  工具执行期间 UI 静止是正常状态，且首个 exec 在冷启动下约需 25s）。 */
+async function waitForVerdict(page: Page, marker: string) {
+  await expect(
+    page.locator('main').getByText(marker, { exact: false }).first(),
+  ).toBeVisible({ timeout: 180_000 });
+}
+
+/** 标题 → 合法文件名（去掉路径分隔符和冒号）。 */
+function safeShotName(title: string): string {
+  return title.replace(/[\s/:\\()（）]+/g, '-');
+}
+
+/**
+ * Start scripts/mock_openai.py on an ephemeral port and wait for its
+ * startup line (the server prints the ACTUAL bound port after bind).
+ * Same pattern as confirm-card.spec.ts (#646).
+ */
+async function startMockOpenAI(): Promise<{ proc: ChildProcess; mockUrl: string }> {
+  const python = process.env.MIQI_PYTHON_PATH || 'python';
+  // High ephemeral range: avoids the app's own ports and 8899 legacy uses.
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_openai.py'), String(port)], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    windowsHide: true,
+  });
+
+  let readyUrl = '';
+  let stderrTail = '';
+  proc.stdout?.on('data', (d) => {
+    const t = String(d);
+    console.log(`[mock] ${t.trim()}`);
+    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => {
+    stderrTail = (stderrTail + String(d)).slice(-2000);
+    console.log(`[mock-err] ${String(d).trim()}`);
+  });
+  proc.on('exit', (code) => console.log(`[test] mock server exited: ${code}`));
+
+  const deadline = Date.now() + 30_000;
+  while (!readyUrl && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(
+        `mock OpenAI server exited early (code ${proc.exitCode}): ${stderrTail}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!readyUrl) {
+    proc.kill();
+    throw new Error(`mock OpenAI server startup line not seen in 30s: ${stderrTail}`);
+  }
+  console.log(`[test] mock OpenAI server ready at ${readyUrl}`);
+  return { proc, mockUrl: readyUrl };
+}
+
+test.describe('Issue #811 护栏误拦截复现', () => {
+  // macOS CI cannot run this spec: the runner's undici fetch fails against
+  // a local 127.0.0.1 listener and the spawned mock's stdout pipe never
+  // delivers (both observed in macos-e2e).  Same trimming as #646/#710.
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server',
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+
+  test.beforeAll(async () => {
+    const mock = await startMockOpenAI();
+    mockServer = mock.proc;
+    // Point EVERY configured provider at the mock (same as #646).
+    const fixture = await launchElectronApp((config: any) => {
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = mock.mockUrl;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+      // Issue #811: the guard now lets real execs run; on Windows E2E the
+      // first Git Bash spawns take ~25-30 s (Defender/cold start), so the
+      // SandboxSelection timeout must leave headroom above the 30 s
+      // engine default.
+      config.tools = {
+        ...config.tools,
+        exec: { ...(config.tools?.exec ?? {}), timeout: 120 },
+      };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mockServer?.kill();
+  });
+
+  test(
+    'A: session 目录内 rm -rf 清理应放行（修复前被一刀切拦截）',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '护栏811a');
+      await waitForVerdict(page, 'REPRO_A_DONE');
+
+      const mainText = (await page.locator('main').textContent()) || '';
+      console.log('[test] === 811a 最终回复 ===');
+      console.log(mainText.slice(-800));
+      console.log('[test] ===========================');
+
+      // 期望行为：rm -rf 放行 → 目录被删除（mock 折算的最终标记为 OK）
+      expect(mainText).toContain('REPRO_A_DONE OK: 目录已删除');
+      await page.screenshot({
+        path: `test-results/${safeShotName(test.info().title)}.png`,
+        fullPage: true,
+      });
+      console.log('[test] ✅ 811a: session 内 rm -rf 放行');
+    },
+  );
+
+  test(
+    'B: 越界删除（/etc）应结构化拒绝并给出安全替代指引',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '护栏811b');
+      await waitForVerdict(page, 'REPRO_B_DONE');
+
+      const mainText = (await page.locator('main').textContent()) || '';
+      console.log('[test] === 811b 最终回复 ===');
+      console.log(mainText.slice(-600));
+      console.log('[test] ===========================');
+
+      // 期望行为：结构化拒绝 + 明确的安全替代指引
+      expect(mainText).toContain('REPRO_B_DONE OK: 结构化拒绝');
+      await page.screenshot({
+        path: `test-results/${safeShotName(test.info().title)}.png`,
+        fullPage: true,
+      });
+      console.log('[test] ✅ 811b: 越界删除结构化拒绝');
+    },
+  );
+
+  test(
+    'C: 复合命令（echo && rm -rf）应逐子命令判定后整条放行',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '护栏811c');
+      await waitForVerdict(page, 'REPRO_C_DONE');
+
+      const mainText = (await page.locator('main').textContent()) || '';
+      console.log('[test] === 811c 最终回复 ===');
+      console.log(mainText.slice(-800));
+      console.log('[test] ===========================');
+
+      // 期望行为：复合命令整条放行 → rm 子命令执行 → 目录被删除
+      expect(mainText).toContain('REPRO_C_DONE OK: 复合命令放行且目录已删除');
+      await page.screenshot({
+        path: `test-results/${safeShotName(test.info().title)}.png`,
+        fullPage: true,
+      });
+      console.log('[test] ✅ 811c: 复合命令放行');
+    },
+  );
+
+  test(
+    'D: sudo 提权应结构化声明不可用并给出替代指引',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '护栏811d');
+      await waitForVerdict(page, 'REPRO_D_DONE');
+
+      const mainText = (await page.locator('main').textContent()) || '';
+      console.log('[test] === 811d 最终回复 ===');
+      console.log(mainText.slice(-600));
+      console.log('[test] ===========================');
+
+      // 期望行为：结构化声明提权不可用（带替代指引），而非一刀切拦截
+      expect(mainText).toContain('REPRO_D_DONE OK: 结构化提权声明');
+      await page.screenshot({
+        path: `test-results/${safeShotName(test.info().title)}.png`,
+        fullPage: true,
+      });
+      console.log('[test] ✅ 811d: sudo 结构化拒绝');
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
+++ b/apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts
@@ -117,6 +117,8 @@ test.describe('Issue #811 护栏误拦截复现', () => {
   let mockServer: ChildProcess;
 
   test.beforeAll(async () => {
+    // Playwright hooks take no timeout argument — set it inside the hook.
+    test.setTimeout(180_000);
     const mock = await startMockOpenAI();
     mockServer = mock.proc;
     // Point EVERY configured provider at the mock (same as #646).
@@ -149,7 +151,7 @@ test.describe('Issue #811 护栏误拦截复现', () => {
     electronApp = fixture.electronApp;
     page = fixture.page;
     miqiHome = fixture.miqiHome;
-  }, 180_000);
+  });
 
   test.afterAll(async () => {
     await closeElectronApp(electronApp, miqiHome);
@@ -162,7 +164,9 @@ test.describe('Issue #811 护栏误拦截复现', () => {
     async () => {
       await createNewConversation(page);
       await sendMessage(page, '护栏811a');
-      await waitForVerdict(page, 'REPRO_A_DONE');
+      // Wait for the FULL verdict text — matching a prefix would return
+      // mid-stream while the rest of the message is still rendering.
+      await waitForVerdict(page, 'REPRO_A_DONE OK: 目录已删除');
 
       const mainText = (await page.locator('main').textContent()) || '';
       console.log('[test] === 811a 最终回复 ===');
@@ -185,7 +189,7 @@ test.describe('Issue #811 护栏误拦截复现', () => {
     async () => {
       await createNewConversation(page);
       await sendMessage(page, '护栏811b');
-      await waitForVerdict(page, 'REPRO_B_DONE');
+      await waitForVerdict(page, 'REPRO_B_DONE OK: 结构化拒绝');
 
       const mainText = (await page.locator('main').textContent()) || '';
       console.log('[test] === 811b 最终回复 ===');
@@ -208,7 +212,7 @@ test.describe('Issue #811 护栏误拦截复现', () => {
     async () => {
       await createNewConversation(page);
       await sendMessage(page, '护栏811c');
-      await waitForVerdict(page, 'REPRO_C_DONE');
+      await waitForVerdict(page, 'REPRO_C_DONE OK: 复合命令放行且目录已删除');
 
       const mainText = (await page.locator('main').textContent()) || '';
       console.log('[test] === 811c 最终回复 ===');
@@ -231,7 +235,7 @@ test.describe('Issue #811 护栏误拦截复现', () => {
     async () => {
       await createNewConversation(page);
       await sendMessage(page, '护栏811d');
-      await waitForVerdict(page, 'REPRO_D_DONE');
+      await waitForVerdict(page, 'REPRO_D_DONE OK: 结构化提权声明');
 
       const mainText = (await page.locator('main').textContent()) || '';
       console.log('[test] === 811d 最终回复 ===');

--- a/miqi/agent/command_guard.py
+++ b/miqi/agent/command_guard.py
@@ -181,10 +181,21 @@ _SYSTEM_POSIX_ROOTS = frozenset({
 
 @dataclass
 class _Token:
-    """One shell word with quote information."""
+    """One shell word with quote information.
+
+    ``quoted`` is True when ANY part of the word was quoted — the shell
+    strips quotes before executing, so ``'rm'`` and ``s"udo"`` both
+    execute as ``rm``/``sudo`` (issue #811 review: critical bypass).
+    ``fully_quoted`` is True only when EVERY character was inside quotes.
+    ``first_quoted`` records whether the FIRST character was quoted — a
+    redirect whose operator itself was quoted (``'>' out``) is a literal
+    word, while a quoted TARGET (``2>"/etc/x"``) is still a redirect.
+    """
 
     text: str
     quoted: bool = False
+    fully_quoted: bool = False
+    first_quoted: bool = False
 
 
 def _extract_string_literals(payload: str) -> list[str]:
@@ -225,34 +236,87 @@ def _tokenize(text: str) -> list[_Token]:
     """Split *text* into shell words, tracking single/double quotes.
 
     Quote characters are stripped from ``text`` (so ``"my dir"`` is one
-    word ``my dir``) and the ``quoted`` flag records that quotes were
-    used — quoted words are never treated as operators/flags.
+    word ``my dir``); ``quoted`` records that quotes were used anywhere
+    in the word and ``fully_quoted`` that the whole word was quoted.
+    Operator classification is position-aware: a quoted word in COMMAND
+    position executes as the dequoted operator (``'rm' -rf /x`` runs
+    rm), while a fully quoted word elsewhere is a plain argument
+    (``echo "rm -rf x"`` is not a delete) — see
+    :func:`_command_positions`.
     """
     tokens: list[_Token] = []
     buf: list[str] = []
     quote: str | None = None
-    was_quoted = False
+    n_quoted = 0
+    saw_quote = False
+    first_quoted = False
+    first_seen = False
     for ch in text:
         if quote is not None:
             if ch == quote:
                 quote = None
             else:
+                if not first_seen:
+                    first_quoted = True
+                    first_seen = True
                 buf.append(ch)
+                n_quoted += 1
             continue
         if ch in ("'", '"'):
             quote = ch
-            was_quoted = True
+            saw_quote = True
             continue
         if ch.isspace():
-            if buf:
-                tokens.append(_Token("".join(buf), was_quoted))
+            if buf or saw_quote:
+                tokens.append(_Token(
+                    "".join(buf),
+                    quoted=n_quoted > 0 or saw_quote,
+                    fully_quoted=n_quoted > 0 and n_quoted == len(buf),
+                    first_quoted=first_quoted,
+                ))
                 buf = []
-                was_quoted = False
+                n_quoted = 0
+                saw_quote = False
+                first_quoted = False
+                first_seen = False
             continue
+        if not first_seen:
+            first_quoted = False
+            first_seen = True
         buf.append(ch)
-    if buf:
-        tokens.append(_Token("".join(buf), was_quoted))
+    if buf or saw_quote:
+        tokens.append(_Token(
+            "".join(buf),
+            quoted=n_quoted > 0 or saw_quote,
+            fully_quoted=n_quoted > 0 and n_quoted == len(buf),
+            first_quoted=first_quoted,
+        ))
     return tokens
+
+
+_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _command_positions(tokens: list[_Token]) -> set[int]:
+    """Indices of COMMAND WORDS in a subcommand's token list.
+
+    A simple command starts at the beginning of the subcommand or after
+    an unquoted pipe (``ls | rm -rf /x``); env-assignment prefixes
+    (``FOO=1``) are skipped.  Only these positions are classified as
+    operators when the word was quoted — the shell executes the dequoted
+    word there regardless of quoting.
+    """
+    positions: set[int] = set()
+    expect = True
+    for i, tok in enumerate(tokens):
+        if expect:
+            if _ASSIGNMENT_RE.match(tok.text):
+                continue
+            positions.add(i)
+            expect = False
+        elif not tok.quoted and tok.text == "|":
+            expect = True
+    return positions
 
 
 def split_subcommands(command: str) -> list[str]:
@@ -469,14 +533,19 @@ def _is_flag(tok: _Token, windows_flags: bool = False) -> bool:
 def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
     """Find destructive file operations in one subcommand's token list.
 
-    Quoted tokens never act as operator words (``echo "rm -rf x"`` is
-    not a delete), but they DO act as operands (paths with spaces).
+    Operator classification is position-aware (issue #811 review,
+    critical bypass): in COMMAND position the dequoted text always
+    counts (``'rm' -rf /x`` runs rm), elsewhere a quoted word never
+    does (``echo "rm -rf x"`` is not a delete) while an UNQUOTED word
+    still does — so ``xargs rm -rf /x`` keeps its rm detection.
+    Quoted tokens also act as operands (paths with spaces).
     """
     ops: list[_FileOp] = []
     n = len(tokens)
+    cmd_positions = _command_positions(tokens)
     for i, tok in enumerate(tokens):
-        if tok.quoted:
-            continue
+        if tok.quoted and i not in cmd_positions:
+            continue  # quoted argument — never an operator
         text = tok.text
         if text in _DELETE_WORDS:
             ops.append(_FileOp(
@@ -558,14 +627,18 @@ def _check_redirects(
 ) -> tuple[bool, str, str]:
     """Classify shell redirect targets (``>``/``>>``) in a subcommand.
 
-    Returns (ok, reason_code, display).  fd redirects (``2>&1``) and
-    harmless device targets are allowed.  Process substitution (``>(...)``/
-    ``<(...)``) next to a destructive operation is UNCERTAIN → denied;
-    without a destructive op it is skipped (not a path write).
+    Returns (ok, reason_code, display).  EVERY redirect target is
+    classified — returning only on the first failure (issue #811 review:
+    ``echo a > ok.txt 2> /etc/evil`` must be refused).  fd redirects
+    (``2>&1``) and harmless device targets are allowed.  A redirect
+    whose OPERATOR was quoted (``'>' out``) is a literal word; a quoted
+    TARGET (``2>"/etc/x"``) is still a redirect.  Process substitution
+    (``>(...)``/``<(...)``) next to a destructive operation is
+    UNCERTAIN → denied; without a destructive op it is skipped.
     """
     for i, tok in enumerate(tokens):
-        if tok.quoted:
-            continue
+        if tok.quoted and tok.first_quoted:
+            continue  # the ">" itself was quoted — a literal word
         m = _REDIRECT_RE.match(tok.text)
         if not m:
             continue
@@ -588,7 +661,9 @@ def _check_redirects(
             if strict:
                 return False, "uncertain_path", ttext
             continue
-        return _classify_operand(ttext, rt, for_write=True)
+        ok, code, display = _classify_operand(ttext, rt, for_write=True)
+        if not ok:
+            return ok, code, display
     return True, "", ""
 
 
@@ -887,7 +962,12 @@ def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
         tokens = _tokenize(sub)
 
         # 1. Privilege escalation — always refused, with alternatives.
-        if any(t.text == "sudo" and not t.quoted for t in tokens):
+        #    Command-position aware: `'sudo'` / `s"udo"` execute as sudo
+        #    (quote removal) and must be refused (issue #811 review).
+        if any(
+            i in _command_positions(tokens) and tok.text == "sudo"
+            for i, tok in enumerate(tokens)
+        ):
             verdict.allowed = False
             verdict.reason_code = "privilege"
             verdict.message = _PRIVILEGE_MSG

--- a/miqi/agent/command_guard.py
+++ b/miqi/agent/command_guard.py
@@ -1,0 +1,984 @@
+"""Capability-based command guard for the exec tool (issue #811).
+
+The old guard denied DANGEROUS COMMAND STRINGS (``rm -rf`` blocked
+everywhere, compound commands blocked as a whole, refusals carried no
+guidance) — agents worked around it by switching spellings
+(``shutil.rmtree``) or splitting commands.  This module replaces that
+pattern-stacking with a path-aware capability check:
+
+  * The command is split into subcommands on top-level ``&&`` / ``||`` /
+    ``;`` / ``&`` (quote-, backtick- and paren-aware).
+  * Every subcommand is inspected for destructive file operations —
+    shell forms (``rm``/``rmdir``/``del``/``unlink``/``shred``,
+    ``cp``/``mv``/``install``, ``find -delete``/``-exec``, ``tee``/
+    ``mkdir``/``touch``/``ln``, redirect targets) AND inline-script
+    forms (``python -c``/``perl -e``/``node -e``/``php -r``/``bash -c``
+    payloads containing ``shutil.rmtree``, ``os.remove``, ``fs.rmSync``,
+    nested ``rm -rf``, ...) — so re-spelling the operation does not
+    bypass the check (capability parity).
+  * Every affected path is resolved (canonical ``.``/``..`` handling,
+    symlink resolution on the host) and classified against the session
+    scope.  Permission levels:
+
+      Level 0  system paths (/etc, /usr, C:\\Windows, drive roots,
+               ~/.ssh, the MiqroForge config home)        → deny
+      Level 1  global workspace (outside the session tree) → read-only
+               (writes/deletes denied with guidance)
+      Level 2  current session tree / exec cwd subtree      → read-write
+      other sessions / outside workspace / statically
+      unresolvable targets ($VAR, globs, command
+      substitution) — UNCERTAIN → DENY (fail closed)
+
+    Sandbox semantics: when the exec runs inside the bwrap sandbox,
+    ``/home/miqi/**`` and ``/tmp`` are sandbox-internal overlays
+    (per-sandbox home/workspace or the session's own bind-mounted
+    workspace) and are writable; ``/mnt/c/...`` maps to host paths and
+    is classified like a host path.  Deleting the workspace/session
+    ROOT itself is always refused.
+  * Refusals are structured: reason code + policy + resolved target +
+    a safe alternative the agent can act on, so a blocked command
+    teaches the agent the legal spelling instead of leaving it to
+    guess.  ``sudo`` gets a dedicated
+    ``PRIVILEGE_ESCALATION_UNAVAILABLE`` answer.
+
+Pure static analysis — no subprocess, no network.  Conservative by
+design: anything that cannot be statically resolved is denied.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── Structured refusal templates ─────────────────────────────────────────
+
+_HEADER = "Error: 命令被沙箱护栏拦截。"
+
+_REASON_TEXTS: dict[str, str] = {
+    "privilege": "检测到提权操作（sudo）——沙箱内不提供 root 权限。",
+    "system_path": "目标解析后位于系统路径（受保护）。",
+    "other_session": "目标位于其他 session 的目录。",
+    "outside_workspace": "目标解析后位于当前 session 可操作范围之外。",
+    "workspace_level1": (
+        "目标位于全局工作区内、但不在当前 session 可操作范围内"
+        "（全局工作区只读）。"
+    ),
+    "workspace_root": "目标是工作区或 session 根目录本身。",
+    "uncertain_path": "目标含变量/通配符/命令替换等无法静态解析的成分。",
+    "script_uncertain": "内联脚本中的破坏性操作无法静态确定目标路径。",
+    "find_exec": "find 的 -exec/-execdir 会执行任意程序，无法静态验证删除范围。",
+}
+
+_POLICY_TEXTS: dict[str, str] = {
+    "delete": "只允许删除当前 session 工作区内的文件。",
+    "write": "只允许写入当前 session 工作区内的文件。",
+    "move": "只允许在当前 session 工作区内移动/重命名文件。",
+    "uncertain": "无法确认作用范围的破坏性操作一律拒绝（宁可误拒）。",
+    "workspace_root": "禁止删除工作区或 session 根目录。",
+    "find_exec": "无法确认删除范围的 find 操作一律拒绝。",
+    "privilege": "沙箱为无特权环境，系统目录只读，提权命令不可用。",
+}
+
+_SAFE_TEXTS: dict[str, str] = {
+    "delete": (
+        "请将目标限定在当前 session 目录内，例如：rm -rf ./run-output"
+    ),
+    "write": "请将写入目标限定在当前 session 目录内。",
+    "move": "请将源与目标都限定在当前 session 目录内。",
+    "uncertain": (
+        "请使用明确的目录名（如 rm -rf ./run-output），"
+        "不要使用 $变量、通配符或命令替换。"
+    ),
+    "workspace_root": (
+        "请指定根目录下的具体子目录，例如：rm -rf ./run-output"
+    ),
+    "find_exec": (
+        "请用 rm 加明确路径逐个删除，或对 session 目录内的明确子目录"
+        "执行 find。"
+    ),
+    "privilege": (
+        "用户级安装：python3 -m pip install --user <包名>；"
+        "系统包安装：请用户在配置中开启 tools.sandbox.allow_system_installs 后，"
+        "sudo apt-get install ... 会自动路由到 WSL 发行版以 root 执行"
+        "（仅 Windows + WSL）。"
+    ),
+}
+
+# ── Operation vocabulary ──────────────────────────────────────────────────
+
+_DELETE_WORDS = frozenset({"rm", "rmdir", "del", "unlink", "shred"})
+_COPY_MOVE_WORDS = frozenset({"cp", "mv"})
+_WRITE_WORDS = frozenset({"tee", "mkdir", "touch", "ln"})
+
+_SCRIPT_LAUNCHERS = frozenset({
+    "python", "python2", "python3", "py", "perl", "ruby",
+    "node", "nodejs", "php",
+})
+_SHELL_LAUNCHERS = frozenset({"bash", "sh", "zsh", "dash", "ksh", "ash"})
+_SCRIPT_FLAGS = frozenset({"-c", "-e", "-r"})
+
+#: Words that make a following ``install`` NOT a POSIX file-copy install.
+_INSTALL_EXCLUDE_PREV = frozenset({
+    "pip", "pip2", "pip3", "npm", "yarn", "pnpm", "make", "run",
+    "apt", "apt-get", "dnf", "yum", "zypper", "apk", "pacman",
+    "brew", "cargo", "go", "gem", "bundle", "poetry", "uv",
+    "composer", "conda", "mamba", "pdm", "hatch", "rye", "meson",
+    "ninja", "cmake", "xcodebuild", "dotnet", "nuget", "choco",
+    "scoop", "flatpak", "snap", "emerge",
+})
+
+#: Destructive call names inside inline-script payloads (issue #811:
+#: ``shutil.rmtree`` must be caught the same way ``rm -rf`` is).
+_DESTRUCTIVE_CALL_RE = re.compile(
+    r"\bshutil\.rmtree\b"
+    r"|\bshutil\.move\b"
+    r"|\bos\.(remove|unlink|rmdir|removedirs)\b"
+    r"|\bos\.system\b"
+    r"|\bpathlib\.[^;)]*\.unlink\("
+    r"|\.unlink\(\s*\)"
+    r"|\bfs\.(rmSync|rmdirSync|unlinkSync|rm|rmdir|unlink)\s*\("
+    r"|\bFile\.(delete|unlink)\b"
+    r"|\bFileUtils\.(rm|rm_r|rm_rf|rmdir|remove_dir)\b"
+    r"|\bunlink\b"
+    r"|\brmtree\b"
+    r"|\brm\s+-[a-zA-Z]*r"
+)
+
+#: String literals inside a script payload are extracted with a LINEAR
+#: scanner (_extract_string_literals) — a backreference regex here would
+#: be ReDoS-prone (CodeQL high-severity on the original pattern).
+
+#: Redirect tokens (">", "2>", "&>", "2>>", ...), with an optional
+#: attached target ("2>/dev/null", ">>file") or fd form ("2>&1").
+_REDIRECT_RE = re.compile(r"^(?:[12]?&?)?>{1,2}(.*)$")
+
+#: Harmless device targets.
+_DEV_NULL_TARGETS = frozenset({
+    "/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty",
+    "/dev/zero", "/dev/random", "/dev/urandom",
+})
+
+#: deny-pattern sources from ExecTool's defaults that the capability
+#: engine subsumes for file-op subcommands (kept for the system-install
+#: routed path and for non-file-op subcommands).
+FILE_OP_PATTERN_EXCLUSIONS = frozenset({
+    r"\brm\s+-[rf]{1,2}\b",
+    r"\bdel\s+/[fq]\b",
+    r"\brmdir\s+/s\b",
+})
+
+_SYSTEM_POSIX_ROOTS = frozenset({
+    "/etc", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/opt",
+    "/var", "/root", "/boot", "/dev", "/proc", "/sys", "/run",
+    "/mnt", "/tmp", "/var/tmp",
+})
+
+
+# ── Tokenizing / splitting ────────────────────────────────────────────────
+
+
+@dataclass
+class _Token:
+    """One shell word with quote information."""
+
+    text: str
+    quoted: bool = False
+
+
+def _extract_string_literals(payload: str) -> list[str]:
+    """Extract quoted string literals from a script payload.
+
+    Linear scan (no backreference regex — avoids catastrophic
+    backtracking on malformed quotes, CodeQL high-severity fix).
+    Backslash escapes are kept verbatim inside the literal.
+    """
+    literals: list[str] = []
+    i, n = 0, len(payload)
+    while i < n:
+        if payload[i] not in ("'", '"'):
+            i += 1
+            continue
+        quote = payload[i]
+        i += 1
+        buf: list[str] = []
+        closed = False
+        while i < n:
+            c = payload[i]
+            if c == "\\" and i + 1 < n:
+                buf.append(payload[i:i + 2])
+                i += 2
+                continue
+            if c == quote:
+                closed = True
+                i += 1
+                break
+            buf.append(c)
+            i += 1
+        if closed:
+            literals.append("".join(buf))
+    return literals
+
+
+def _tokenize(text: str) -> list[_Token]:
+    """Split *text* into shell words, tracking single/double quotes.
+
+    Quote characters are stripped from ``text`` (so ``"my dir"`` is one
+    word ``my dir``) and the ``quoted`` flag records that quotes were
+    used — quoted words are never treated as operators/flags.
+    """
+    tokens: list[_Token] = []
+    buf: list[str] = []
+    quote: str | None = None
+    was_quoted = False
+    for ch in text:
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            else:
+                buf.append(ch)
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            was_quoted = True
+            continue
+        if ch.isspace():
+            if buf:
+                tokens.append(_Token("".join(buf), was_quoted))
+                buf = []
+                was_quoted = False
+            continue
+        buf.append(ch)
+    if buf:
+        tokens.append(_Token("".join(buf), was_quoted))
+    return tokens
+
+
+def split_subcommands(command: str) -> list[str]:
+    """Split *command* on top-level ``&&``/``||``/``;``/``&`` separators.
+
+    Separators inside quotes, backticks or parentheses (``$(...)``,
+    command groups) are NOT split points — the whole substitution stays
+    in one subcommand so the deny-pattern / capability checks see it as
+    a unit.  Unbalanced quotes/backticks/parens degrade to "one
+    subcommand" (conservative, never more permissive).
+    """
+    parts: list[str] = []
+    start = 0
+    i = 0
+    n = len(command)
+    quote: str | None = None
+    paren = 0
+    backtick = False
+    while i < n:
+        ch = command[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        if ch == "`":
+            backtick = not backtick
+            i += 1
+            continue
+        if backtick:
+            i += 1
+            continue
+        if ch == "(":
+            paren += 1
+            i += 1
+            continue
+        if ch == ")" and paren > 0:
+            paren -= 1
+            i += 1
+            continue
+        if paren == 0:
+            two = command[i:i + 2]
+            if two in ("&&", "||"):
+                parts.append(command[start:i].strip())
+                start = i + 2
+                i += 2
+                continue
+            if ch == ";":
+                parts.append(command[start:i].strip())
+                start = i + 1
+                i += 1
+                continue
+            if ch == "&":
+                # "&>" / "&>>" is a redirect; "2>&1" is an fd redirect
+                # (& follows ">").  Neither is a background separator.
+                if command[i + 1:i + 2] == ">" or command[i - 1:i] == ">":
+                    i += 1
+                    continue
+                parts.append(command[start:i].strip())
+                start = i + 1
+                i += 1
+                continue
+        i += 1
+    parts.append(command[start:].strip())
+    return [p for p in parts if p]
+
+
+# ── Path machinery ────────────────────────────────────────────────────────
+
+
+def _lex_norm(path: str) -> str:
+    """Lexically normalize a POSIX-style path (resolve ``.``/``..``).
+
+    Pure string operation — no filesystem access, safe for sandbox
+    paths that do not exist on the host.
+    """
+    parts: list[str] = []
+    for seg in path.replace("\\", "/").split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            if parts and parts[-1] != "..":
+                parts.pop()
+            elif not parts:
+                continue  # above root: clamp
+            else:
+                parts.append(seg)
+        else:
+            parts.append(seg)
+    return "/" + "/".join(parts)
+
+
+def _norm_str(path: str) -> str:
+    """Normalize a host path to a comparable string (fw slashes, lowercase
+    on Windows)."""
+    s = path.replace("\\", "/")
+    return s.lower() if os.name == "nt" else s
+
+
+def _under(path: str, parent: str) -> bool:
+    if not parent:
+        return False
+    p, q = _norm_str(path), _norm_str(parent).rstrip("/")
+    return p.startswith(q + "/") or p == q
+
+
+def _is_system_path(pstr: str, rt: "RuntimePaths") -> bool:
+    """True when *pstr* (normalized host path) is a protected system path."""
+    n = _norm_str(pstr).rstrip("/")
+    if os.name == "nt":
+        # drive roots and protected drive trees (any drive letter)
+        if re.match(r"^[a-z]:/?$", n):
+            return True
+        if re.match(
+            r"^[a-z]:/(windows|program files|program files \(x86\)|"
+            r"programdata|system32)(/|$)",
+            n,
+        ):
+            return True
+    else:
+        for root in _SYSTEM_POSIX_ROOTS:
+            if n == root or n.startswith(root + "/"):
+                return True
+    if rt.host_home:
+        home = _norm_str(rt.host_home).rstrip("/")
+        if n == home or n.startswith(home + "/.ssh"):
+            return True
+    if rt.miqi_home:
+        mh = _norm_str(rt.miqi_home).rstrip("/")
+        if n == mh or n.startswith(mh + "/"):
+            return True
+    return False
+
+
+def _msys_to_windows(path: str) -> str:
+    """``/c/Users/x`` → ``C:/Users/x`` (Git Bash msys form)."""
+    m = re.match(r"^/([a-zA-Z])/(.+)$", path)
+    if not m:
+        return path
+    return f"{m.group(1).upper()}:/{m.group(2)}"
+
+
+# ── Runtime context / verdict ─────────────────────────────────────────────
+
+
+@dataclass
+class RuntimePaths:
+    """Host/sandbox path context for one guard evaluation."""
+
+    host_cwd: str
+    host_workspace: str | None = None
+    session_files_dir: str | None = None
+    sandbox_active: bool = False
+    sandbox_cwd: str = "/home/miqi/workspace"
+    miqi_home: str | None = None
+    host_home: str | None = None
+
+    @property
+    def current_session_key(self) -> str | None:
+        """The on-disk session dir key (``sessions/<key>/files`` parent)."""
+        if not self.session_files_dir:
+            return None
+        return Path(self.session_files_dir).parent.name
+
+
+@dataclass
+class GuardVerdict:
+    """Result of evaluating one exec command."""
+
+    allowed: bool = True
+    message: str = ""
+    reason_code: str = ""
+    subcommands: list[str] = field(default_factory=list)
+    #: indices of subcommands the capability engine checked (file ops) —
+    #: callers skip legacy string checks for these.
+    handled: list[int] = field(default_factory=list)
+
+
+# ── Operation detection ───────────────────────────────────────────────────
+
+
+@dataclass
+class _FileOp:
+    kind: str  # delete | copy | move | write | find_delete | inline_script
+    display: str
+    operands: list[_Token] = field(default_factory=list)
+    #: for find: starting paths; for scripts: the payload string
+    extra: str = ""
+
+
+def _op_descriptions() -> dict[str, str]:
+    return {
+        "delete": "删除操作（{verb}）",
+        "copy": "复制操作（{verb}）",
+        "move": "移动操作（{verb}）",
+        "write": "写入操作（{verb}）",
+        "find_delete": "find 批量删除",
+        "inline_script": "内联脚本破坏性调用（{verb}）",
+    }
+
+
+def _is_flag(tok: _Token, windows_flags: bool = False) -> bool:
+    if tok.text.startswith("-"):
+        return True
+    if windows_flags and re.match(r"^/[A-Za-z]+$", tok.text):
+        return True
+    return False
+
+
+def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
+    """Find destructive file operations in one subcommand's token list.
+
+    Quoted tokens never act as operator words (``echo "rm -rf x"`` is
+    not a delete), but they DO act as operands (paths with spaces).
+    """
+    ops: list[_FileOp] = []
+    n = len(tokens)
+    for i, tok in enumerate(tokens):
+        if tok.quoted:
+            continue
+        text = tok.text
+        if text in _DELETE_WORDS:
+            ops.append(_FileOp(
+                kind="delete", display=text,
+                operands=[t for t in tokens[i + 1:]
+                          if not _is_flag(t, windows_flags=(text in ("del", "rmdir")))
+                          and not re.search(r"[<>]", t.text)],
+            ))
+            continue
+        if text in _COPY_MOVE_WORDS:
+            kind = "move" if text == "mv" else "copy"
+            ops.append(_FileOp(
+                kind=kind, display=text,
+                operands=[t for t in tokens[i + 1:]
+                          if not _is_flag(t)
+                          and not re.search(r"[<>]", t.text)],
+            ))
+            continue
+        if text == "install":
+            prev = tokens[i - 1].text if i > 0 else ""
+            if prev not in _INSTALL_EXCLUDE_PREV:
+                ops.append(_FileOp(
+                    kind="copy", display=text,
+                    operands=[t for t in tokens[i + 1:]
+                              if not _is_flag(t)
+                              and not re.search(r"[<>]", t.text)],
+                ))
+            continue
+        if text == "find":
+            rest = tokens[i + 1:]
+            has_delete = any(t.text == "-delete" and not t.quoted for t in rest)
+            has_exec = any(
+                t.text in ("-exec", "-execdir") and not t.quoted for t in rest
+            )
+            if has_delete or has_exec:
+                paths: list[_Token] = []
+                for t in rest:
+                    if not t.quoted and (
+                        t.text.startswith("-") or t.text in ("!", "(", ")")
+                    ):
+                        break
+                    paths.append(t)
+                ops.append(_FileOp(
+                    kind="find_delete", display="find",
+                    operands=paths, extra="exec" if has_exec else "delete",
+                ))
+            continue
+        if text in _SCRIPT_LAUNCHERS | _SHELL_LAUNCHERS:
+            for j in range(i + 1, n):
+                ftok = tokens[j]
+                if ftok.quoted or ftok.text not in _SCRIPT_FLAGS:
+                    continue
+                payload = tokens[j + 1].text if j + 1 < n else ""
+                if payload:
+                    ops.append(_FileOp(
+                        kind="inline_script", display=text,
+                        operands=[], extra=payload,
+                    ))
+                break
+            continue
+        if text in _WRITE_WORDS:
+            operands = [t for t in tokens[i + 1:]
+                        if not _is_flag(t)
+                        and not re.search(r"[<>]", t.text)]
+            if text == "ln":
+                # ln: only the link NAME is a write target (the -s target
+                # is just a string stored in the link — dangling links are
+                # legal and resolve() catches actual escapes elsewhere).
+                operands = operands[-1:]
+            ops.append(_FileOp(
+                kind="write", display=text, operands=operands,
+            ))
+            continue
+    return ops
+
+
+def _check_redirects(
+    tokens: list[_Token], rt: RuntimePaths, *, strict: bool,
+) -> tuple[bool, str, str]:
+    """Classify shell redirect targets (``>``/``>>``) in a subcommand.
+
+    Returns (ok, reason_code, display).  fd redirects (``2>&1``) and
+    harmless device targets are allowed.  Process substitution (``>(...)``/
+    ``<(...)``) next to a destructive operation is UNCERTAIN → denied;
+    without a destructive op it is skipped (not a path write).
+    """
+    for i, tok in enumerate(tokens):
+        if tok.quoted:
+            continue
+        m = _REDIRECT_RE.match(tok.text)
+        if not m:
+            continue
+        rest = m.group(1)
+        if rest.startswith("&"):
+            continue  # fd redirect (2>&1)
+        if rest:
+            ttext = rest
+        else:
+            target = tokens[i + 1] if i + 1 < len(tokens) else None
+            if target is None:
+                continue
+            ttext = target.text
+        ttext = ttext.strip('\'"')
+        if not ttext or ttext.startswith("&"):
+            continue
+        if ttext in _DEV_NULL_TARGETS:
+            continue
+        if ttext.startswith("("):
+            if strict:
+                return False, "uncertain_path", ttext
+            continue
+        return _classify_operand(ttext, rt, for_write=True)
+    return True, "", ""
+
+
+# ── Classification ────────────────────────────────────────────────────────
+
+
+def _classify_operand(
+    raw: str,
+    rt: RuntimePaths,
+    *,
+    for_write: bool,
+) -> tuple[bool, str, str]:
+    """Classify one path operand.  Returns (ok, reason_code, display)."""
+    text = raw.strip().strip('\'"')
+    display = text
+    if not text:
+        return False, "uncertain_path", display
+
+    # Windows absolute (native or UNC) — backslashes are separators here,
+    # not escapes, so the escape check below must not see them.
+    win_abs = bool(re.match(r"^[A-Za-z]:[\\/]", text)) or text.startswith("\\\\")
+
+    # Shell expansion / globbing / escapes: statically unresolvable.
+    if any(c in text for c in ("$", "`", "*", "?", "[")):
+        return False, "uncertain_path", display
+    if not win_abs and "\\" in text:
+        return False, "uncertain_path", display
+
+    if win_abs:
+        return _classify_host(text, rt, for_write=for_write)
+
+    # Tilde expansion — runtime HOME depends on the execution context.
+    if text.startswith("~"):
+        if rt.sandbox_active:
+            if text == "~":
+                text = "/home/miqi"
+            elif text.startswith("~/"):
+                text = "/home/miqi" + text[1:]
+            else:
+                return False, "uncertain_path", display
+        else:
+            expanded = os.path.expanduser(text)
+            if expanded == text:
+                return False, "uncertain_path", display
+            text = expanded
+
+    # Git Bash /c/... msys form (host execution only).
+    if not rt.sandbox_active:
+        msys = re.match(r"^/([a-zA-Z])/(.+)$", text)
+        if msys:
+            return _classify_host(
+                f"{msys.group(1).upper()}:/{msys.group(2)}",
+                rt, for_write=for_write,
+            )
+
+    if text.startswith("/"):
+        if rt.sandbox_active:
+            return _classify_sandbox_abs(text, rt, for_write=for_write)
+        return _classify_host(text, rt, for_write=for_write)
+
+    # Relative — resolve against the RUNTIME cwd.
+    if rt.sandbox_active:
+        return _classify_sandbox_abs(
+            _lex_norm(rt.sandbox_cwd + "/" + text), rt, for_write=for_write,
+        )
+    return _classify_host(text, rt, for_write=for_write, relative=True)
+
+
+def _classify_sandbox_abs(
+    path: str, rt: RuntimePaths, *, for_write: bool,
+) -> tuple[bool, str, str]:
+    """Classify a POSIX path inside the bwrap sandbox."""
+    norm = _lex_norm(path)
+    if norm == "/home/miqi" or norm == "/home/miqi/workspace":
+        if for_write:
+            return False, "workspace_root", norm
+        return True, "", norm
+    # Sandbox-internal home/workspace overlay — per-sandbox files (default
+    # workspace) or the session's own bind-mounted workspace (custom).
+    if norm.startswith("/home/miqi/"):
+        return True, "", norm
+    # Sandbox tmpfs overlays
+    if norm in ("/tmp", "/var/tmp") or norm.startswith("/tmp/") or norm.startswith("/var/tmp/"):
+        return True, "", norm
+    # WSL interop bridge — real host files, classify like host paths.
+    if norm.startswith("/mnt/"):
+        m = re.match(r"^/mnt/([a-zA-Z])/(.+)$", norm)
+        if m:
+            return _classify_host(
+                f"{m.group(1).upper()}:/{m.group(2)}", rt, for_write=for_write,
+            )
+        return False, "outside_workspace", norm
+    if _norm_str(norm) == "/" or any(
+        _norm_str(norm) == r or _norm_str(norm).startswith(r + "/")
+        for r in _SYSTEM_POSIX_ROOTS
+    ):
+        if for_write:
+            return False, "system_path", norm
+        return True, "", norm
+    if for_write:
+        return False, "outside_workspace", norm
+    return True, "", norm
+
+
+def _classify_host(
+    path: str, rt: RuntimePaths, *, for_write: bool, relative: bool = False,
+) -> tuple[bool, str, str]:
+    """Classify a host path (symlink-resolving) against the session scope."""
+    try:
+        base = Path(rt.host_cwd)
+        p = (base / path if relative else Path(path)).resolve()
+    except (ValueError, OSError):
+        return False, "uncertain_path", path
+    pstr = _norm_str(str(p)).rstrip("/") or "/"
+    ws = _norm_str(rt.host_workspace).rstrip("/") if rt.host_workspace else None
+    sess = _norm_str(rt.session_files_dir).rstrip("/") if rt.session_files_dir else None
+    cwd = _norm_str(rt.host_cwd).rstrip("/")
+
+    # 1. Workspace root itself — never a write/delete target.
+    if ws and pstr == ws:
+        if for_write:
+            return False, "workspace_root", pstr
+        return True, "", pstr
+
+    # 2. Session files dir root itself — never a delete target.
+    if sess and pstr == sess:
+        if for_write:
+            return False, "workspace_root", pstr
+        return True, "", pstr
+
+    # 3. Session trees: current session → Level 2 (its root dir excluded);
+    #    others → deny for reads AND writes (cross-session out of scope).
+    if ws and (pstr == ws + "/sessions" or pstr.startswith(ws + "/sessions/")):
+        key = pstr[len(ws + "/sessions/"):].split("/")[0]
+        if key != _norm_str(rt.current_session_key or ""):
+            return False, "other_session", pstr
+        if for_write and pstr == f"{ws}/sessions/{key}":
+            return False, "workspace_root", pstr
+        return True, "", pstr
+
+    # 4. Inside the exec cwd subtree → the session's active working area.
+    if _under(pstr, cwd):
+        return True, "", pstr
+
+    # 5. Reads anywhere else are unrestricted (cp sources etc.).
+    if not for_write:
+        return True, "", pstr
+
+    # 6. System paths → deny.
+    if _is_system_path(pstr, rt):
+        return False, "system_path", pstr
+
+    # 7. Global workspace but outside the session tree → Level 1 read-only.
+    if ws and _under(pstr, ws):
+        return False, "workspace_level1", pstr
+
+    return False, "outside_workspace", pstr
+
+
+# ── Refusals ──────────────────────────────────────────────────────────────
+
+
+def _refusal(op_desc: str, code: str, target: str, policy_kind: str) -> str:
+    reason = _REASON_TEXTS.get(code, "目标不在允许范围内。")
+    policy = _POLICY_TEXTS.get(policy_kind, _POLICY_TEXTS["uncertain"])
+    safe = _SAFE_TEXTS.get(policy_kind, _SAFE_TEXTS["uncertain"])
+    return (
+        f"{_HEADER}\n"
+        f"原因：检测到{op_desc}，{reason}\n"
+        f"当前策略：{policy}\n"
+        f"目标：{target}\n"
+        f"安全替代：{safe}"
+    )
+
+
+_PRIVILEGE_MSG = (
+    f"{_HEADER}\n"
+    f"原因：{_REASON_TEXTS['privilege']}\n"
+    f"当前策略：{_POLICY_TEXTS['privilege']}\n"
+    f"安全替代：{_SAFE_TEXTS['privilege']}"
+)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────
+
+
+def _check_find_op(
+    op: _FileOp, rt: RuntimePaths, sub: str,
+) -> tuple[bool, str, str, str]:
+    """Check a find_delete op (-exec denied; -delete paths classified).
+
+    find never deletes its starting point itself — only the CONTENTS
+    matter, so session-tree roots are allowed while workspace / sessions
+    roots (whose contents span other sessions) stay denied.
+    """
+    desc = _op_descriptions()["find_delete"].format(verb=op.display)
+    if op.extra == "exec":
+        return (
+            False, "find_exec", sub[:200],
+            _refusal(desc, "find_exec", sub[:200], "find_exec"),
+        )
+    targets = op.operands or [_Token(".")]
+    for t in targets:
+        ok, code, display = _classify_operand(t.text, rt, for_write=True)
+        if not ok and code == "workspace_root":
+            d = _norm_str(display).rstrip("/") or "/"
+            ws = (
+                _norm_str(rt.host_workspace).rstrip("/")
+                if rt.host_workspace else ""
+            )
+            sess = (
+                _norm_str(rt.session_files_dir).rstrip("/")
+                if rt.session_files_dir else ""
+            )
+            key = _norm_str(rt.current_session_key or "")
+            if d in ("/home/miqi", "/home/miqi/workspace"):
+                ok = True  # sandbox-internal contents
+            elif ws and (d == ws or d == ws + "/sessions"):
+                ok = False  # spans other sessions
+            elif sess and d == sess:
+                ok = True  # session files dir contents
+            elif ws and key and d == f"{ws}/sessions/{key}":
+                ok = True  # session tree contents
+            else:
+                ok = False
+        if not ok:
+            return (
+                False, code, display,
+                _refusal(desc, code, display, "delete"),
+            )
+    return True, "", "", ""
+
+
+def _check_ops_operands(
+    op: _FileOp, rt: RuntimePaths,
+) -> tuple[bool, str, str, str]:
+    """Classify a delete/copy/move/write op's operands.
+
+    Returns (ok, reason_code, display, refusal_message); on pass the
+    message fields are empty.  COPY: source readable + target writable;
+    MOVE: source AND target writable (move removes the source);
+    DELETE/WRITE: every operand writable (i.e. inside session scope).
+    """
+    desc = _op_descriptions()[op.kind].format(verb=op.display)
+    operands = op.operands
+    policy = {"delete": "delete", "copy": "write",
+              "move": "move", "write": "write"}.get(op.kind)
+    if policy is None:
+        return True, "", "", ""  # unknown kind — not a file op we check
+    if op.kind in ("copy", "move") and len(operands) < 2:
+        return True, "", "", ""  # shell will error; nothing is copied/moved
+    if op.kind in ("delete", "write") and not operands:
+        return True, "", "", ""
+    if op.kind in ("copy", "move"):
+        sources = operands[:-1]
+        target = operands[-1]
+        # Sources: readable unless in ANOTHER session's tree.
+        for src in sources:
+            ok, code, display = _classify_operand(
+                src.text, rt, for_write=False,
+            )
+            if not ok:
+                return False, code, display, _refusal(desc, code, display, policy)
+        # mv removes the source: source must be in-scope too.
+        if op.kind == "move":
+            for src in sources:
+                ok, code, display = _classify_operand(
+                    src.text, rt, for_write=True,
+                )
+                if not ok:
+                    return False, code, display, _refusal(desc, code, display, policy)
+        ok, code, display = _classify_operand(target.text, rt, for_write=True)
+        if not ok:
+            return False, code, display, _refusal(desc, code, display, policy)
+        return True, "", "", ""
+    # delete / write (rm, tee, mkdir, touch, ln targets)
+    for t in operands:
+        ok, code, display = _classify_operand(t.text, rt, for_write=True)
+        if not ok:
+            return False, code, display, _refusal(desc, code, display, policy)
+    return True, "", "", ""
+
+
+def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
+    """Evaluate *command* with the capability engine.
+
+    Splits into subcommands, checks each for destructive file
+    operations and classifies every affected path.  Returns a verdict
+    with a structured refusal message when denied.
+    """
+    subcommands = split_subcommands(command)
+    verdict = GuardVerdict(subcommands=subcommands)
+    desc_map = _op_descriptions()
+
+    for idx, sub in enumerate(subcommands):
+        tokens = _tokenize(sub)
+
+        # 1. Privilege escalation — always refused, with alternatives.
+        if any(t.text == "sudo" and not t.quoted for t in tokens):
+            verdict.allowed = False
+            verdict.reason_code = "privilege"
+            verdict.message = _PRIVILEGE_MSG
+            return verdict
+
+        # 2. Destructive file operations — path-aware capability check.
+        ops = _detect_ops(tokens)
+
+        # 3. Redirect targets — every subcommand's write targets must be
+        #    in scope.  Process substitution is UNCERTAIN only next to a
+        #    destructive operation (see _check_redirects).
+        ok, code, display = _check_redirects(tokens, rt, strict=bool(ops))
+        if not ok:
+            verdict.allowed = False
+            verdict.reason_code = code
+            verdict.message = _refusal(
+                "写入操作（重定向）", code, display, "write",
+            )
+            return verdict
+
+        if not ops:
+            continue
+        verdict.handled.append(idx)
+        for op in ops:
+            op_desc = desc_map[op.kind].format(verb=op.display)
+
+            if op.kind == "find_delete":
+                ok, code, display, msg = _check_find_op(op, rt, sub)
+                if not ok:
+                    verdict.allowed = False
+                    verdict.reason_code = code
+                    verdict.message = msg
+                    return verdict
+                continue
+
+            if op.kind == "inline_script":
+                payload = op.extra
+                # Nested shell (bash -c "rm -rf /x"): parse the payload as
+                # a mini subcommand so its file ops get precise path
+                # classification instead of a blanket UNCERTAIN.
+                if op.display in _SHELL_LAUNCHERS:
+                    for inner in _detect_ops(_tokenize(payload)):
+                        if inner.kind == "inline_script":
+                            continue  # deeper nesting — not parsed
+                        inner.display = f"{op.display} -c"
+                        if inner.kind == "find_delete":
+                            ok, code, display, msg = _check_find_op(
+                                inner, rt, payload[:200],
+                            )
+                        else:
+                            ok, code, display, msg = _check_ops_operands(
+                                inner, rt,
+                            )
+                        if not ok:
+                            verdict.allowed = False
+                            verdict.reason_code = code
+                            verdict.message = msg
+                            return verdict
+                    continue
+                if not _DESTRUCTIVE_CALL_RE.search(payload):
+                    continue  # plain python -c "print(1)" etc.
+                literals = _extract_string_literals(payload)
+                path_literals = [
+                    lit for lit in literals
+                    if "/" in lit or "\\" in lit
+                    or lit.startswith(".") or lit.startswith("~")
+                ]
+                if not path_literals:
+                    verdict.allowed = False
+                    verdict.reason_code = "script_uncertain"
+                    verdict.message = _refusal(
+                        op_desc, "script_uncertain", payload[:200], "uncertain",
+                    )
+                    return verdict
+                for lit in path_literals:
+                    ok, code, display = _classify_operand(
+                        lit, rt, for_write=True,
+                    )
+                    if not ok:
+                        verdict.allowed = False
+                        verdict.reason_code = code
+                        verdict.message = _refusal(op_desc, code, display, "delete")
+                        return verdict
+                continue
+
+            # delete / copy / move / write
+            ok, code, display, msg = _check_ops_operands(op, rt)
+            if not ok:
+                verdict.allowed = False
+                verdict.reason_code = code
+                verdict.message = msg
+                return verdict
+
+    return verdict

--- a/miqi/agent/command_guard.py
+++ b/miqi/agent/command_guard.py
@@ -190,12 +190,112 @@ class _Token:
     ``first_quoted`` records whether the FIRST character was quoted — a
     redirect whose operator itself was quoted (``'>' out``) is a literal
     word, while a quoted TARGET (``2>"/etc/x"``) is still a redirect.
+    ``first_escaped`` records whether the first character came from a
+    backslash escape (``\\>`` is the literal word ``>``, not a redirect).
     """
 
     text: str
     quoted: bool = False
     fully_quoted: bool = False
     first_quoted: bool = False
+    first_escaped: bool = False
+
+
+#: In double quotes the shell treats ``\`` as an escape only before
+#: these characters; elsewhere it stays literal (``"C:\temp"`` keeps
+#: its backslash).
+_DQ_ESCAPED_CHARS = frozenset({'$', '`', '"', '\\', '\n'})
+
+
+def _tokenize(text: str) -> list[_Token]:
+    """Split *text* into shell words, tracking quotes and backslash
+    escapes with shell semantics.
+
+    Quote characters are stripped from ``text``; outside quotes a
+    backslash escapes the NEXT character (``\\rm`` executes as ``rm`` —
+    issue #811 review), inside single quotes everything is literal, and
+    inside double quotes ``\`` escapes only ``$ ` " \\`` and newline.
+    Flags record quote/escape usage per token (see :class:`_Token`).
+    """
+    tokens: list[_Token] = []
+    buf: list[str] = []
+    quote: str | None = None
+    n_quoted = 0
+    saw_quote = False
+    first_quoted = False
+    first_escaped = False
+    first_seen = False
+
+    def _append(ch: str, *, quoted: bool = False, escaped: bool = False) -> None:
+        nonlocal first_quoted, first_escaped, first_seen, n_quoted
+        if not first_seen:
+            first_quoted = quoted
+            first_escaped = escaped
+            first_seen = True
+        if quoted:
+            n_quoted += 1
+        buf.append(ch)
+
+    def _flush() -> None:
+        nonlocal buf, n_quoted, saw_quote, first_quoted, first_escaped, first_seen
+        if buf or saw_quote:
+            tokens.append(_Token(
+                "".join(buf),
+                quoted=n_quoted > 0 or saw_quote,
+                fully_quoted=n_quoted > 0 and n_quoted == len(buf),
+                first_quoted=first_quoted,
+                first_escaped=first_escaped,
+            ))
+            buf = []
+            n_quoted = 0
+            saw_quote = False
+            first_quoted = False
+            first_escaped = False
+            first_seen = False
+
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            if quote == "'":
+                if ch == "'":
+                    quote = None
+                else:
+                    _append(ch, quoted=True)
+                i += 1
+                continue
+            # double quotes
+            if ch == '"':
+                quote = None
+                i += 1
+                continue
+            if ch == "\\" and i + 1 < n and text[i + 1] in _DQ_ESCAPED_CHARS:
+                _append(text[i + 1], quoted=True, escaped=True)
+                i += 2
+                continue
+            _append(ch, quoted=True)
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            saw_quote = True
+            i += 1
+            continue
+        if ch == "\\":
+            if i + 1 < n:
+                _append(text[i + 1], escaped=True)
+                i += 2
+                continue
+            i += 1  # dangling escape at end of input — drop it
+            continue
+        if ch.isspace():
+            _flush()
+            i += 1
+            continue
+        _append(ch)
+        i += 1
+    _flush()
+    return tokens
 
 
 def _extract_string_literals(payload: str) -> list[str]:
@@ -230,68 +330,6 @@ def _extract_string_literals(payload: str) -> list[str]:
         if closed:
             literals.append("".join(buf))
     return literals
-
-
-def _tokenize(text: str) -> list[_Token]:
-    """Split *text* into shell words, tracking single/double quotes.
-
-    Quote characters are stripped from ``text`` (so ``"my dir"`` is one
-    word ``my dir``); ``quoted`` records that quotes were used anywhere
-    in the word and ``fully_quoted`` that the whole word was quoted.
-    Operator classification is position-aware: a quoted word in COMMAND
-    position executes as the dequoted operator (``'rm' -rf /x`` runs
-    rm), while a fully quoted word elsewhere is a plain argument
-    (``echo "rm -rf x"`` is not a delete) — see
-    :func:`_command_positions`.
-    """
-    tokens: list[_Token] = []
-    buf: list[str] = []
-    quote: str | None = None
-    n_quoted = 0
-    saw_quote = False
-    first_quoted = False
-    first_seen = False
-    for ch in text:
-        if quote is not None:
-            if ch == quote:
-                quote = None
-            else:
-                if not first_seen:
-                    first_quoted = True
-                    first_seen = True
-                buf.append(ch)
-                n_quoted += 1
-            continue
-        if ch in ("'", '"'):
-            quote = ch
-            saw_quote = True
-            continue
-        if ch.isspace():
-            if buf or saw_quote:
-                tokens.append(_Token(
-                    "".join(buf),
-                    quoted=n_quoted > 0 or saw_quote,
-                    fully_quoted=n_quoted > 0 and n_quoted == len(buf),
-                    first_quoted=first_quoted,
-                ))
-                buf = []
-                n_quoted = 0
-                saw_quote = False
-                first_quoted = False
-                first_seen = False
-            continue
-        if not first_seen:
-            first_quoted = False
-            first_seen = True
-        buf.append(ch)
-    if buf or saw_quote:
-        tokens.append(_Token(
-            "".join(buf),
-            quoted=n_quoted > 0 or saw_quote,
-            fully_quoted=n_quoted > 0 and n_quoted == len(buf),
-            first_quoted=first_quoted,
-        ))
-    return tokens
 
 
 _ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -576,9 +614,12 @@ def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
             continue
         if text == "find":
             rest = tokens[i + 1:]
-            has_delete = any(t.text == "-delete" and not t.quoted for t in rest)
+            # Flags are matched on the dequoted/de-escaped text — the
+            # shell strips quotes/escapes, so find /etc '-delete' still
+            # deletes (issue #811 review).
+            has_delete = any(t.text == "-delete" for t in rest)
             has_exec = any(
-                t.text in ("-exec", "-execdir") and not t.quoted for t in rest
+                t.text in ("-exec", "-execdir") for t in rest
             )
             if has_delete or has_exec:
                 paths: list[_Token] = []
@@ -596,7 +637,9 @@ def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
         if text in _SCRIPT_LAUNCHERS | _SHELL_LAUNCHERS:
             for j in range(i + 1, n):
                 ftok = tokens[j]
-                if ftok.quoted or ftok.text not in _SCRIPT_FLAGS:
+                # Flag matching on dequoted/de-escaped text: python '-c'
+                # still runs the -c code path (issue #811 review).
+                if ftok.text not in _SCRIPT_FLAGS:
                     continue
                 payload = tokens[j + 1].text if j + 1 < n else ""
                 if payload:
@@ -637,8 +680,8 @@ def _check_redirects(
     UNCERTAIN → denied; without a destructive op it is skipped.
     """
     for i, tok in enumerate(tokens):
-        if tok.quoted and tok.first_quoted:
-            continue  # the ">" itself was quoted — a literal word
+        if (tok.quoted and tok.first_quoted) or tok.first_escaped:
+            continue  # the ">" itself was quoted/escaped — a literal word
         m = _REDIRECT_RE.match(tok.text)
         if not m:
             continue
@@ -1006,10 +1049,25 @@ def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
             if op.kind == "inline_script":
                 payload = op.extra
                 # Nested shell (bash -c "rm -rf /x"): parse the payload as
-                # a mini subcommand so its file ops get precise path
-                # classification instead of a blanket UNCERTAIN.
+                # a mini subcommand so its file ops AND redirect targets
+                # get precise path classification instead of a blanket
+                # UNCERTAIN (issue #811 review: bash -c "echo x >
+                # /etc/evil" must be refused).
                 if op.display in _SHELL_LAUNCHERS:
-                    for inner in _detect_ops(_tokenize(payload)):
+                    inner_tokens = _tokenize(payload)
+                    inner_ops = _detect_ops(inner_tokens)
+                    ok, code, display = _check_redirects(
+                        inner_tokens, rt, strict=bool(inner_ops),
+                    )
+                    if not ok:
+                        verdict.allowed = False
+                        verdict.reason_code = code
+                        verdict.message = _refusal(
+                            f"{op.display} -c 中的写入操作（重定向）",
+                            code, display, "write",
+                        )
+                        return verdict
+                    for inner in inner_ops:
                         if inner.kind == "inline_script":
                             continue  # deeper nesting — not parsed
                         inner.display = f"{op.display} -c"

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -382,7 +382,24 @@ class ExecTool(Tool):
                     )
                     return _ExecResult(output=msg, exit_code=1)
             else:
-                guard_error = self._guard_command(command, cwd)
+                # Guard runs before any sandbox creation — sandbox_active
+                # only changes PATH SEMANTICS (sandbox overlays vs host paths).
+                guard_error = self._guard_command(
+                    command, cwd,
+                    sandbox_active=(
+                        (
+                            _sandbox is not None
+                            and getattr(_sandbox, "sandbox_type", None)
+                            == SandboxType.BWRAP
+                        )
+                        or (
+                            self._sandbox_manager is not None
+                            and getattr(
+                                self._sandbox_manager, "active_sandbox", None,
+                            ) is not None
+                        )
+                    ),
+                )
                 if guard_error:
                     return _ExecResult(output=guard_error, exit_code=1)
 
@@ -1866,40 +1883,139 @@ class ExecTool(Tool):
             sandbox_type="bwrap",
         )
 
-    def _guard_command(self, command: str, cwd: str) -> str | None:
-        """Best-effort safety guard for potentially destructive commands."""
-        cmd = command.strip()
-        lower = cmd.lower()
+    def _guard_command(
+        self, command: str, cwd: str, *, sandbox_active: bool = False,
+    ) -> str | None:
+        """Path-aware capability guard for exec commands (issue #811).
 
-        for pattern in self.deny_patterns:
-            if re.search(pattern, lower):
-                return "Error: 命令被安全护栏拦截（检测到危险模式）"
+        Replaces the blanket deny-pattern scan for destructive file
+        operations with the capability engine (``miqi.agent.command_guard``):
+        the command is split into subcommands (``&&`` / ``||`` / ``;`` /
+        ``&`` chains) and each is checked independently — rm/cp/mv/find/
+        inline-script operations and redirect targets are allowed only when
+        every affected path resolves inside the session scope (canonical
+        ``..``/symlink checks, UNCERTAIN → deny), and refusals carry a
+        structured reason + safe alternative instead of the old
+        one-line "检测到危险模式".  ``sudo`` gets a dedicated
+        PRIVILEGE_ESCALATION_UNAVAILABLE answer.
+
+        Non-file-op subcommands keep the legacy deny-pattern scan;
+        ``restrict_to_workspace`` string checks still apply to them.
+        ``allow_patterns`` (when configured) still applies to the whole
+        command.
+        """
+        from miqi.agent.command_guard import (
+            FILE_OP_PATTERN_EXCLUSIONS,
+            RuntimePaths,
+            evaluate_command,
+        )
+
+        verdict = evaluate_command(
+            command, self._guard_runtime_paths(cwd, sandbox_active),
+        )
+        if not verdict.allowed:
+            return verdict.message
 
         if self.allow_patterns:
+            lower = command.strip().lower()
             if not any(re.search(p, lower) for p in self.allow_patterns):
                 return "Error: 命令被安全护栏拦截（不在白名单中）"
 
+        # Legacy deny-pattern scan, per subcommand.  Capability-checked
+        # (file-op) subcommands skip only the rm/del/rmdir blanket patterns
+        # the engine subsumes — everything else (fork bomb, dd, command
+        # substitution, pipe-to-shell, ...) still applies everywhere.
+        for idx, sub in enumerate(verdict.subcommands):
+            sub_lower = sub.lower()
+            if idx in verdict.handled:
+                patterns = [
+                    p for p in self.deny_patterns
+                    if p not in FILE_OP_PATTERN_EXCLUSIONS
+                ]
+            else:
+                patterns = self.deny_patterns
+            for pattern in patterns:
+                if re.search(pattern, sub_lower):
+                    return "Error: 命令被安全护栏拦截（检测到危险模式）"
+
         if self.restrict_to_workspace:
-            if "..\\" in cmd or "../" in cmd:
-                return "Error: 命令被安全护栏拦截（检测到路径穿越）"
+            legacy = " ".join(
+                sub for idx, sub in enumerate(verdict.subcommands)
+                if idx not in verdict.handled
+            )
+            if legacy:
+                guard_error = self._legacy_restrict_check(legacy, cwd)
+                if guard_error:
+                    return guard_error
+        return None
 
-            cwd_path = Path(cwd).resolve()
+    def _legacy_restrict_check(self, cmd: str, cwd: str) -> str | None:
+        """Legacy restrict_to_workspace string checks (non-file-op only)."""
+        if "..\\" in cmd or "../" in cmd:
+            return "Error: 命令被安全护栏拦截（检测到路径穿越）"
 
-            win_paths = re.findall(r"[A-Za-z]:\\[^\\\"']+", cmd)
-            # Only match absolute paths — avoid false positives on relative
-            # paths like ".venv/bin/python" where "/bin/python" would be
-            # incorrectly extracted by the old pattern.
-            posix_paths = re.findall(r"(?:^|[\s|>])(/[^\s\"'>]+)", cmd)
+        cwd_path = Path(cwd).resolve()
 
-            for raw in win_paths + posix_paths:
-                try:
-                    p = Path(raw.strip()).resolve()
-                except Exception:
-                    continue
-                if p.is_absolute() and cwd_path not in p.parents and p != cwd_path:
-                    return "Error: 命令被安全护栏拦截（路径超出工作目录）"
+        win_paths = re.findall(r"[A-Za-z]:\\[^\\\"']+", cmd)
+        # Only match absolute paths — avoid false positives on relative
+        # paths like ".venv/bin/python" where "/bin/python" would be
+        # incorrectly extracted by the old pattern.
+        posix_paths = re.findall(r"(?:^|[\s|>])(/[^\s\"'>]+)", cmd)
+
+        for raw in win_paths + posix_paths:
+            try:
+                p = Path(raw.strip()).resolve()
+            except Exception:
+                continue
+            if p.is_absolute() and cwd_path not in p.parents and p != cwd_path:
+                return "Error: 命令被安全护栏拦截（路径超出工作目录）"
 
         return None
+
+    def _guard_runtime_paths(self, cwd: str, sandbox_active: bool):
+        """Build the RuntimePaths context for the capability engine.
+
+        Resolves the host workspace root and the session files dir
+        (``<workspace>/sessions/<key>/files``) so the engine can apply
+        the Level 0/1/2 path hierarchy from issue #811.
+        """
+        from miqi.agent.command_guard import RuntimePaths
+
+        ws: Path | None = None
+        try:
+            from miqi.runtime.file_handlers import _get_workspace_path
+
+            ws = Path(_get_workspace_path()).resolve()
+        except Exception:
+            ws = None
+
+        session_dir: str | None = None
+        if ws is not None and self.working_dir:
+            try:
+                wd = Path(self.working_dir).resolve()
+                sessions_root = (ws / "sessions").resolve()
+                wd.relative_to(sessions_root)
+                session_dir = str(wd)
+            except ValueError:
+                session_dir = None
+
+        miqi_home: str | None = None
+        try:
+            from miqi.paths import get_miqi_home
+
+            miqi_home = str(Path(get_miqi_home()).resolve())
+        except Exception:
+            miqi_home = None
+
+        return RuntimePaths(
+            host_cwd=str(Path(cwd).resolve()),
+            host_workspace=str(ws) if ws is not None else None,
+            session_files_dir=session_dir,
+            sandbox_active=sandbox_active,
+            sandbox_cwd=self._resolve_sandbox_cwd(cwd) if sandbox_active else "",
+            miqi_home=miqi_home,
+            host_home=str(Path.home()) if hasattr(Path, "home") else None,
+        )
 
     async def _mirror_downloaded_files(
         self, command: str, sandbox_selection, session_key: str | None,

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -456,6 +456,11 @@ class ExecTool(Tool):
                         sandbox, command, cwd, **exec_kwargs,
                     )
                 else:
+                    # Legacy fallback (no sandbox): same host-semantics
+                    # re-check as the BWRAP fallback (issue #811 review).
+                    fallback_guard = self._guard_host_fallback(command, cwd)
+                    if fallback_guard is not None:
+                        return fallback_guard
                     # Fall back to direct execution (no sandbox)
                     result = await self._execute_direct(command, cwd, **exec_kwargs)
             else:
@@ -831,9 +836,17 @@ class ExecTool(Tool):
                 return await self._execute_in_sandbox(
                     sandbox, command, cwd, **common,
                 )
-            # Sandbox not available — fall back to direct execution
-            # (e.g. during first-time install when bwrap isn't ready yet).
-            # Attach a note so the AI knows it's running without isolation.
+            # Sandbox not available — the pre-flight guard ran with
+            # SANDBOX path semantics (BWRAP selected) and may have
+            # allowed sandbox-internal paths (/home/miqi/**, /tmp) that
+            # mean something else on the host.  Re-check with HOST
+            # semantics before falling back (issue #811 review).
+            fallback_guard = self._guard_host_fallback(command, cwd)
+            if fallback_guard is not None:
+                return fallback_guard
+            # Fall back to direct execution (e.g. during first-time
+            # install when bwrap isn't ready yet).  Attach a note so the
+            # AI knows it's running without isolation.
             logger.warning(
                 "BWRAP sandbox not available for session_key={} — falling back to host execution",
                 session_key,
@@ -1949,6 +1962,27 @@ class ExecTool(Tool):
                     return guard_error
         return None
 
+    def _guard_host_fallback(
+        self, command: str, cwd: str,
+    ) -> _ExecResult | None:
+        """Re-check the guard with HOST path semantics before a
+        host-fallback execution (issue #811 review).
+
+        When a BWRAP-selected exec falls back to the host (no live
+        sandbox), the pre-flight guard ran with sandbox path semantics
+        and may have allowed sandbox-internal paths (``/home/miqi/**``,
+        ``/tmp``) that are REAL host paths here.  Returns a refusal
+        result, or None to proceed.  Skipped when an approval callback
+        is wired: the pre-flight guard never ran on that path, and
+        adding a new refusal layer would change the approval flow.
+        """
+        if self.approval_callback is not None:
+            return None
+        guard_error = self._guard_command(command, cwd, sandbox_active=False)
+        if guard_error:
+            return _ExecResult(output=guard_error, exit_code=1)
+        return None
+
     def _legacy_restrict_check(self, cmd: str, cwd: str) -> str | None:
         """Legacy restrict_to_workspace string checks (non-file-op only)."""
         if "..\\" in cmd or "../" in cmd:
@@ -1990,14 +2024,21 @@ class ExecTool(Tool):
             ws = None
 
         session_dir: str | None = None
-        if ws is not None and self.working_dir:
-            try:
-                wd = Path(self.working_dir).resolve()
-                sessions_root = (ws / "sessions").resolve()
-                wd.relative_to(sessions_root)
-                session_dir = str(wd)
-            except ValueError:
-                session_dir = None
+        if ws is not None:
+            # Derive from the SAME per-call cwd used for host_cwd —
+            # self.working_dir may describe a different session when the
+            # caller passes an explicit working_dir (issue #811 review).
+            sessions_root = (ws / "sessions").resolve()
+            for candidate in (cwd, self.working_dir):
+                if not candidate:
+                    continue
+                try:
+                    wd = Path(candidate).resolve()
+                    wd.relative_to(sessions_root)
+                    session_dir = str(wd)
+                    break
+                except ValueError:
+                    continue
 
         miqi_home: str | None = None
         try:

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -393,7 +393,13 @@ class ExecTool(Tool):
                             == SandboxType.BWRAP
                         )
                         or (
-                            self._sandbox_manager is not None
+                            # Only the legacy no-selection path may fall
+                            # back to the manager's active sandbox — a
+                            # NONE/RESTRICTED selection executes on the
+                            # HOST and must keep host path semantics
+                            # (issue #811 review).
+                            _sandbox is None
+                            and self._sandbox_manager is not None
                             and getattr(
                                 self._sandbox_manager, "active_sandbox", None,
                             ) is not None

--- a/miqi/execution/factory.py
+++ b/miqi/execution/factory.py
@@ -24,6 +24,7 @@ def create_default_orchestrator(
     permanent_allowlist: set[str] | None = None,
     approval_bypass: Any | None = None,
     ledger_runtime: Any | None = None,
+    exec_timeout_ms: int | None = None,
 ) -> Any:
     """Create a ToolOrchestrator with sensible defaults.
 
@@ -34,6 +35,10 @@ def create_default_orchestrator(
         permanent_allowlist: Set of commands that bypass permission checks.
         ledger_runtime: Phase 31.8 — optional LedgerRuntime for
             replay-persistent event recording.
+        exec_timeout_ms: Per-call exec timeout for SandboxSelection.
+            Defaults to 30s; pass the configured ``tools.exec.timeout``
+            (in ms) so the selection does not silently cap commands below
+            the user's setting.
 
     Returns:
         Configured ToolOrchestrator instance.
@@ -61,7 +66,10 @@ def create_default_orchestrator(
             permanent_allowlist=_safe_defaults | (permanent_allowlist or set()),
             approval_bypass=approval_bypass,
         ),
-        sandbox_engine=SandboxPolicyEngine(bwrap_available=bwrap_available),
+        sandbox_engine=SandboxPolicyEngine(
+            bwrap_available=bwrap_available,
+            default_timeout_ms=exec_timeout_ms or 30_000,
+        ),
         hook_runtime=HookRuntime(),
         tool_registry=tool_registry,
         event_emitter=emitter,

--- a/miqi/runtime/services.py
+++ b/miqi/runtime/services.py
@@ -20,6 +20,24 @@ from loguru import logger
 from miqi.execution.hook_runtime import HookRuntime
 
 
+def _resolve_exec_timeout_ms(config: Any) -> int | None:
+    """Per-call exec timeout from ``tools.exec.timeout`` (seconds) → ms.
+
+    The SandboxSelection timeout must not silently cap commands below the
+    user's configured exec timeout (the engine's 30 s default previously
+    overrode a configured 60 s).  Returns None to keep the engine default.
+    """
+    try:
+        tools_cfg = getattr(config, "tools", None)
+        exec_cfg = getattr(tools_cfg, "exec", None) if tools_cfg is not None else None
+        timeout_s = getattr(exec_cfg, "timeout", None)
+        if isinstance(timeout_s, (int, float)) and timeout_s > 0:
+            return int(timeout_s * 1000)
+    except Exception:
+        pass
+    return None
+
+
 class RuntimeEventEmitter:
     """Event emitter that routes typed protocol events to a configurable sink."""
 
@@ -185,6 +203,7 @@ class RuntimeServices:
             event_emitter=emitter,
             bwrap_available=bwrap_available,
             approval_bypass=approval_bypass,
+            exec_timeout_ms=_resolve_exec_timeout_ms(config),
         )
 
         # Phase 52: shared agent graph persistence (created before AgentControl)

--- a/scripts/mock_openai.py
+++ b/scripts/mock_openai.py
@@ -19,6 +19,7 @@ Run:  PYTHONPATH=. .venv/Scripts/python.exe scripts/mock_openai.py
 from __future__ import annotations
 
 import json
+import re
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 EXEC_TITLE = "确认执行方案？"
@@ -323,6 +324,114 @@ class Handler(BaseHTTPRequestHandler):
                 print("  [mock] 双卡回合结束")
                 self._respond(text("双卡流程结束：两张确认卡均已处理完毕。"))
             return
+
+        # ── issue #811 guard-repro branch（护栏误拦截复现） ──
+        # Triggered by the latest user message containing "护栏811" so it
+        # never collides with the main flow.  Drives a deterministic exec
+        # tool-call sequence; counts only exec calls already in history so
+        # each fresh conversation restarts the sequence.  The final text
+        # embeds the verdict derived from the ACTUAL exec tool results —
+        # exactly what a real LLM reports back to the user.
+        n_exec = calls_seen.count("exec")
+        tool_contents = [
+            str(m.get("content", ""))
+            for m in messages
+            if m.get("role") == "tool"
+        ]
+        if "护栏811" in last_user:
+            if last_user.startswith("护栏811a"):
+                # A: session 内 rm -rf 清理临时目录 → 应成功执行
+                if n_exec == 0:
+                    print("  [mock] 811a R1 → exec mkdir + echo（造目录）")
+                    self._respond(tc("exec", {
+                        "command": "mkdir -p guard811tmp && echo guard811_hello > guard811tmp/a.txt",
+                    }, "call_811a_mkdir"))
+                elif n_exec == 1:
+                    print("  [mock] 811a R2 → exec rm -rf guard811tmp（复现核心）")
+                    self._respond(tc("exec", {
+                        "command": "rm -rf guard811tmp",
+                    }, "call_811a_rm"))
+                elif n_exec == 2:
+                    print("  [mock] 811a R3 → exec ls（验证删除）")
+                    self._respond(tc("exec", {
+                        "command": "ls guard811tmp 2>&1",
+                    }, "call_811a_ls"))
+                else:
+                    ls_out = tool_contents[-1] if tool_contents else ""
+                    if re.search(r"no such file|不存在|No such", ls_out, re.I):
+                        verdict = "REPRO_A_DONE OK: 目录已删除（ls 报目录不存在）"
+                    else:
+                        verdict = (
+                            "REPRO_A_DONE BLOCKED: 目录仍存在——rm 被护栏拦截"
+                            f"（ls 输出：{ls_out[:120]}）"
+                        )
+                    print(f"  [mock] 811a 结束 → {verdict}")
+                    self._respond(text(verdict))
+                return
+            if last_user.startswith("护栏811b"):
+                # B: 越界删除（/etc）→ 应结构化拒绝并给安全替代指引
+                if n_exec == 0:
+                    print("  [mock] 811b R1 → exec rm -rf /etc/...（越界）")
+                    self._respond(tc("exec", {
+                        "command": "rm -rf /etc/guard811-e2e-noexist",
+                    }, "call_811b_rm"))
+                else:
+                    rm_out = tool_contents[-1] if tool_contents else ""
+                    if "安全替代" in rm_out:
+                        verdict = "REPRO_B_DONE OK: 结构化拒绝（含安全替代指引）"
+                    else:
+                        verdict = f"REPRO_B_DONE GENERIC: 拦截无指引（{rm_out[:150]}）"
+                    print(f"  [mock] 811b 结束 → {verdict}")
+                    self._respond(text(verdict))
+                return
+            if last_user.startswith("护栏811c"):
+                # C: 复合命令（&&）→ 应逐子命令判定后整条放行
+                if n_exec == 0:
+                    print("  [mock] 811c R1 → exec mkdir（造目录）")
+                    self._respond(tc("exec", {
+                        "command": "mkdir -p guard811c_tmp",
+                    }, "call_811c_mkdir"))
+                elif n_exec == 1:
+                    print("  [mock] 811c R2 → exec 复合命令 echo && rm -rf")
+                    self._respond(tc("exec", {
+                        "command": "echo compound_ok && rm -rf guard811c_tmp",
+                    }, "call_811c_compound"))
+                elif n_exec == 2:
+                    print("  [mock] 811c R3 → exec ls（验证删除）")
+                    self._respond(tc("exec", {
+                        "command": "ls guard811c_tmp 2>&1",
+                    }, "call_811c_ls"))
+                else:
+                    ls_out = tool_contents[-1] if tool_contents else ""
+                    compound_out = tool_contents[-2] if len(tool_contents) >= 2 else ""
+                    if re.search(r"no such file|不存在|No such", ls_out, re.I):
+                        verdict = "REPRO_C_DONE OK: 复合命令放行且目录已删除"
+                    elif "compound_ok" not in compound_out:
+                        verdict = (
+                            "REPRO_C_DONE BLOCKED: 复合命令被整条拦截"
+                            f"（{compound_out[:120]}）"
+                        )
+                    else:
+                        verdict = f"REPRO_C_DONE UNEXPECTED: {compound_out[:120]}"
+                    print(f"  [mock] 811c 结束 → {verdict}")
+                    self._respond(text(verdict))
+                return
+            if last_user.startswith("护栏811d"):
+                # D: sudo 提权 → 应结构化声明不可用并给替代指引
+                if n_exec == 0:
+                    print("  [mock] 811d R1 → exec sudo whoami")
+                    self._respond(tc("exec", {
+                        "command": "sudo whoami",
+                    }, "call_811d_sudo"))
+                else:
+                    sudo_out = tool_contents[-1] if tool_contents else ""
+                    if "提权" in sudo_out:
+                        verdict = "REPRO_D_DONE OK: 结构化提权声明（含替代指引）"
+                    else:
+                        verdict = f"REPRO_D_DONE GENERIC: 拦截无指引（{sudo_out[:150]}）"
+                    print(f"  [mock] 811d 结束 → {verdict}")
+                    self._respond(text(verdict))
+                return
 
         # ── state machine（按工具调用序列推进） ──
         if not results:

--- a/tests/agent/test_command_guard.py
+++ b/tests/agent/test_command_guard.py
@@ -325,6 +325,10 @@ def test_sandbox_roots_and_system_denied(tmp_path):
 def test_sandbox_mnt_c_maps_to_host(tmp_path):
     rt = sandbox_rt(tmp_path)
     assert not v("rm -rf /mnt/c/Windows/System32/x", rt).allowed
+    if os.name != "nt":
+        # /mnt/c host mapping only exists on Windows + WSL; on native
+        # Linux a host path inside the sandbox context is just outside.
+        return
     # a host path inside the session scope via /mnt/c is writable
     verdict = v("rm -rf " + rt.session_files_dir.replace("\\", "/") + "/x", rt)
     assert verdict.allowed

--- a/tests/agent/test_command_guard.py
+++ b/tests/agent/test_command_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -138,6 +139,23 @@ def test_rm_uncertain_paths_denied(rt):
 def test_rm_quoted_not_an_op(rt):
     # "rm -rf" inside a quoted echo is not a delete — the engine passes it;
     # (the legacy deny-pattern scan in ExecTool still blocks it, unchanged).
+    assert v('echo "rm -rf x"', rt).allowed
+
+
+def test_partially_quoted_operators_not_bypassed(rt):
+    """Issue #811 review (critical): quote removal means 'rm' / s"udo"
+    in command position EXECUTE as rm/sudo — must not bypass the checks."""
+    # 'rm' in command position executes as rm after quote removal
+    verdict = v("'rm' -rf /etc/x", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    # s"udo" / 'sudo' in command position execute as sudo
+    assert v('s"udo" whoami', rt).reason_code == "privilege"
+    assert v("'sudo' whoami", rt).reason_code == "privilege"
+    assert v("'su''do' whoami", rt).reason_code == "privilege"
+    # quoted rm after a pipe is still the command word
+    assert not v("ls | 'rm' -rf /etc/x", rt).allowed
+    # fully quoted ARGUMENTS stay arguments
     assert v('echo "rm -rf x"', rt).allowed
 
 
@@ -286,6 +304,17 @@ def test_redirect_targets_classified(rt):
     assert v("python s.py > logs/out.txt", rt).allowed
 
 
+def test_redirect_multiple_targets_all_checked(rt):
+    """Issue #811 review: every redirect target must be classified —
+    an allowed first target must not mask a later out-of-scope one."""
+    assert not v("echo a > ok.txt 2> /etc/evil", rt).allowed
+    assert v("echo a > ok.txt 2> other.txt", rt).allowed
+    # a quoted TARGET is still a redirect (only the operator counts)
+    assert not v('echo a 2>"/etc/evil"', rt).allowed
+    # a quoted OPERATOR is a literal word, not a redirect
+    assert v("echo '>' out.txt", rt).allowed
+
+
 def test_write_ops_classified(rt):
     assert v("mkdir out", rt).allowed
     assert not v("mkdir /etc/evil", rt).allowed
@@ -329,8 +358,11 @@ def test_sandbox_mnt_c_maps_to_host(tmp_path):
         # /mnt/c host mapping only exists on Windows + WSL; on native
         # Linux a host path inside the sandbox context is just outside.
         return
-    # a host path inside the session scope via /mnt/c is writable
-    verdict = v("rm -rf " + rt.session_files_dir.replace("\\", "/") + "/x", rt)
+    # a host path inside the session scope, spelled in the /mnt/c form,
+    # is writable — exercises the /mnt/<drive> → host mapping itself
+    host = rt.session_files_dir.replace("\\", "/")
+    mnt = "/mnt/c" + host[2:]  # C:/... → /mnt/c/...
+    verdict = v(f"rm -rf {mnt}/x", rt)
     assert verdict.allowed
 
 
@@ -341,6 +373,42 @@ def test_sandbox_traversal_resolved(tmp_path):
 
 
 # ── Windows 绝对路径（仅 Windows 平台有意义） ─────────────────────────
+
+
+def test_guard_runtime_paths_uses_cwd_not_working_dir(tmp_path, monkeypatch):
+    """Issue #811 review: the session key must come from the per-call
+    cwd, not from self.working_dir (a caller-passed working_dir can
+    point at a different session)."""
+    from miqi.agent.tools.shell import ExecTool
+
+    ws = tmp_path / "workspace"
+    sess_a = ws / "sessions" / "aaa" / "files"
+    sess_b = ws / "sessions" / "bbb" / "files"
+    sess_a.mkdir(parents=True)
+    sess_b.mkdir(parents=True)
+    monkeypatch.setattr(
+        "miqi.runtime.file_handlers._get_workspace_path", lambda: str(ws),
+    )
+    tool = ExecTool(working_dir=str(sess_a))
+    rt = tool._guard_runtime_paths(str(sess_b), sandbox_active=False)
+    assert rt.current_session_key == "bbb"
+    assert rt.host_workspace == str(ws.resolve())
+    assert Path(rt.session_files_dir) == sess_b.resolve()
+
+
+def test_guard_runtime_paths_falls_back_to_working_dir(tmp_path, monkeypatch):
+    from miqi.agent.tools.shell import ExecTool
+
+    ws = tmp_path / "workspace"
+    sess_a = ws / "sessions" / "aaa" / "files"
+    sess_a.mkdir(parents=True)
+    monkeypatch.setattr(
+        "miqi.runtime.file_handlers._get_workspace_path", lambda: str(ws),
+    )
+    tool = ExecTool(working_dir=str(sess_a))
+    # per-call cwd outside any session → fall back to working_dir
+    rt = tool._guard_runtime_paths(str(tmp_path), sandbox_active=False)
+    assert rt.current_session_key == "aaa"
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")

--- a/tests/agent/test_command_guard.py
+++ b/tests/agent/test_command_guard.py
@@ -1,0 +1,359 @@
+"""Unit tests for the capability-based command guard (issue #811)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from miqi.agent.command_guard import (
+    RuntimePaths,
+    evaluate_command,
+    split_subcommands,
+)
+
+
+@pytest.fixture
+def rt(tmp_path) -> RuntimePaths:
+    ws = tmp_path / "workspace"
+    sess = ws / "sessions" / "desktop_abc" / "files"
+    sess.mkdir(parents=True)
+    other = ws / "sessions" / "other_key" / "files"
+    other.mkdir(parents=True)
+    return RuntimePaths(
+        host_cwd=str(sess),
+        host_workspace=str(ws),
+        session_files_dir=str(sess),
+        sandbox_active=False,
+        sandbox_cwd="/home/miqi/workspace",
+        miqi_home=str(tmp_path / "miqi-home"),
+        host_home=str(tmp_path / "home"),
+    )
+
+
+def sandbox_rt(tmp_path) -> RuntimePaths:
+    ws = tmp_path / "workspace"
+    sess = ws / "sessions" / "desktop_abc" / "files"
+    sess.mkdir(parents=True)
+    return RuntimePaths(
+        host_cwd=str(sess),
+        host_workspace=str(ws),
+        session_files_dir=str(sess),
+        sandbox_active=True,
+        sandbox_cwd="/home/miqi/workspace",
+        miqi_home=str(tmp_path / "miqi-home"),
+        host_home=str(tmp_path / "home"),
+    )
+
+
+def v(cmd: str, rt: RuntimePaths):
+    return evaluate_command(cmd, rt)
+
+
+# ── split_subcommands ────────────────────────────────────────────────
+
+
+def test_split_basic_operators():
+    assert split_subcommands("a && b") == ["a", "b"]
+    assert split_subcommands("a; b") == ["a", "b"]
+    assert split_subcommands("a || b") == ["a", "b"]
+    assert split_subcommands("a & b") == ["a", "b"]
+    assert split_subcommands("a && b && c") == ["a", "b", "c"]
+    assert split_subcommands("a;b") == ["a", "b"]
+
+
+def test_split_quotes_backticks_parens_protect():
+    assert split_subcommands('echo "a && b"') == ['echo "a && b"']
+    assert split_subcommands("echo $(echo a && b)") == ["echo $(echo a && b)"]
+    assert split_subcommands("echo `echo a && b`") == ["echo `echo a && b`"]
+    assert split_subcommands("(a && b) && c") == ["(a && b)", "c"]
+
+
+def test_split_redirects_not_separators():
+    assert split_subcommands("echo x 2>&1") == ["echo x 2>&1"]
+    assert split_subcommands("echo x &> out") == ["echo x &> out"]
+
+
+def test_split_unbalanced_quote_is_single_part():
+    assert split_subcommands('echo "a && b') == ['echo "a && b']
+
+
+# ── session 内 rm -rf 放行（issue #811 核心） ─────────────────────────
+
+
+def test_rm_in_scope_allowed(rt):
+    assert v("rm -rf ./run-output", rt).allowed
+    assert v("rm -rf run-output", rt).allowed
+    assert v("rm -rf build*", rt).allowed is False  # glob → uncertain
+    assert v("rm file.txt", rt).allowed
+
+
+def test_rm_session_tree_allowed(rt):
+    # ../out resolves into sessions/desktop_abc/out — the session tree.
+    assert v("rm -rf ../out", rt).allowed
+    assert v("rm -rf ../..", rt).allowed is False  # sessions root
+    # the session tree ROOT itself is protected
+    verdict = v("rm -rf ../", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "workspace_root"
+
+
+def test_rm_other_session_denied(rt):
+    # ../../other_key from files/ → sessions/other_key (sibling session)
+    verdict = v("rm -rf ../../other_key", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "other_session"
+    assert "其他 session" in verdict.message
+    assert "安全替代" in verdict.message
+
+
+def test_rm_system_and_outside_denied(rt):
+    verdict = v("rm -rf /etc/guard811-test", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    assert verdict.message.startswith("Error: 命令被沙箱护栏拦截。")
+    assert "安全替代" in verdict.message
+
+    assert not v("rm -rf /", rt).allowed
+
+
+def test_rm_workspace_root_denied(rt):
+    verdict = v(f"rm -rf {rt.host_workspace}", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "workspace_root"
+
+    # "rm -rf ." from the session files dir = deleting the files root
+    verdict = v("rm -rf .", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "workspace_root"
+
+
+def test_rm_uncertain_paths_denied(rt):
+    assert not v("rm -rf $BUILD_DIR", rt).allowed
+    assert not v("rm -rf $(pwd)", rt).allowed
+    assert not v("rm -rf build*", rt).allowed
+    assert not v("rm -rf ~/outside", rt).allowed  # home outside ws
+
+
+def test_rm_quoted_not_an_op(rt):
+    # "rm -rf" inside a quoted echo is not a delete — the engine passes it;
+    # (the legacy deny-pattern scan in ExecTool still blocks it, unchanged).
+    assert v('echo "rm -rf x"', rt).allowed
+
+
+# ── 复合命令逐子命令判定 ──────────────────────────────────────────────
+
+
+def test_compound_per_subcommand(rt):
+    verdict = v("ls && rm -rf ./run-output", rt)
+    assert verdict.allowed
+    assert verdict.subcommands == ["ls", "rm -rf ./run-output"]
+    assert verdict.handled == [1]
+
+
+def test_compound_any_bad_subcommand_denies(rt):
+    verdict = v("mkdir a && rm -rf /etc/b", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    assert "安全替代" in verdict.message
+
+
+def test_compound_command_substitution_stays_atomic(rt):
+    # The whole $(...) stays ONE subcommand (no split inside); the engine
+    # sees no top-level file op here — the $() deny pattern in
+    # ExecTool._guard_command is the backstop that blocks it.
+    verdict = v("echo $(rm -rf /etc/x && echo done)", rt)
+    assert verdict.subcommands == ["echo $(rm -rf /etc/x && echo done)"]
+
+
+# ── cp / mv 双侧检查 ──────────────────────────────────────────────────
+
+
+def test_cp_target_classified(rt):
+    assert v("cp a.txt b.txt", rt).allowed
+    assert v("cp a.txt /etc/evil", rt).allowed is False
+    # source readable even from system paths
+    assert v("cp /etc/hostname ./out", rt).allowed
+    # source from ANOTHER session is a cross-session read → denied
+    assert v("cp ../../other_key/files/x.txt ./out", rt).allowed is False
+
+
+def test_mv_source_and_target_classified(rt):
+    assert v("mv a.txt b.txt", rt).allowed
+    assert v("mv /etc/x ./out", rt).allowed is False  # source out of scope
+    assert v("mv ./out /etc/x", rt).allowed is False  # target system
+
+
+def test_install_as_file_op_only_standalone(rt):
+    assert v("install -m 644 a.txt b.txt", rt).allowed
+    assert v("install a.txt /etc/evil", rt).allowed is False
+    # package managers are NOT file ops
+    assert v("pip install requests", rt).allowed
+    assert v("npm install react", rt).allowed
+    assert v("make install", rt).allowed
+    assert v("cmake --install build", rt).allowed
+
+
+# ── 内联脚本能力对等（换个写法同样被拦） ────────────────────────────────
+
+
+def test_inline_python_shutil_in_scope_allowed(rt):
+    verdict = v('python -c "import shutil; shutil.rmtree(\'./out\')"', rt)
+    assert verdict.allowed
+
+
+def test_inline_python_shutil_out_of_scope_denied(rt):
+    verdict = v("python -c \"import shutil; shutil.rmtree('/etc/x')\"", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+
+
+def test_inline_python_unresolvable_denied(rt):
+    verdict = v('python -c "import shutil, sys; shutil.rmtree(sys.argv[1])"', rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "script_uncertain"
+    assert "安全替代" in verdict.message
+
+
+def test_inline_node_fs_denied(rt):
+    verdict = v("node -e \"fs.rmSync('/etc/x', {recursive: true})\"", rt)
+    assert not verdict.allowed
+
+
+def test_inline_perl_unlink_denied(rt):
+    verdict = v("perl -e 'unlink \"/etc/x\"'", rt)
+    assert not verdict.allowed
+
+
+def test_nested_bash_c_parsed(rt):
+    verdict = v('bash -c "rm -rf /etc/x"', rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    assert v('bash -c "rm -rf ./out"', rt).allowed
+
+
+def test_nested_bash_c_find_denied(rt):
+    verdict = v('bash -c "find /etc -delete"', rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    # nested find -exec is refused outright
+    verdict = v('bash -c "find . -exec rm {} \\\\;"', rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "find_exec"
+
+
+def test_plain_python_c_not_flagged(rt):
+    assert v('python -c "print(1)"', rt).allowed
+
+
+# ── sudo 结构化拒绝 ───────────────────────────────────────────────────
+
+
+def test_sudo_structured_refusal(rt):
+    verdict = v("sudo whoami", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "privilege"
+    assert "提权" in verdict.message
+    assert "pip install --user" in verdict.message
+    assert "allow_system_installs" in verdict.message
+    # even compound sudo in any subcommand
+    verdict = v("echo ok && sudo rm -rf ./x", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "privilege"
+
+
+# ── find / 重定向 / 写入操作 ──────────────────────────────────────────
+
+
+def test_find_delete_in_scope_allowed(rt):
+    assert v("find . -name '*.pyc' -delete", rt).allowed
+    assert v("find ./sub -type d -empty -delete", rt).allowed
+
+
+def test_find_out_of_scope_or_exec_denied(rt):
+    assert not v("find /etc -delete", rt).allowed
+    verdict = v("find . -exec rm {} \\;", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "find_exec"
+
+
+def test_redirect_targets_classified(rt):
+    assert v("echo x > out.txt", rt).allowed
+    assert not v("echo x > /etc/evil", rt).allowed
+    assert v("echo x 2>/dev/null", rt).allowed
+    assert v("echo x > /dev/null", rt).allowed
+    assert v("cmd 2>&1", rt).allowed
+    assert v("python s.py > logs/out.txt", rt).allowed
+
+
+def test_write_ops_classified(rt):
+    assert v("mkdir out", rt).allowed
+    assert not v("mkdir /etc/evil", rt).allowed
+    assert v("touch a.txt", rt).allowed
+    assert not v("tee /etc/evil", rt).allowed
+    assert not v("touch /etc/evil", rt).allowed
+
+
+def test_ln_checks_only_link_name(rt):
+    # dangling /etc target is legal; only the link NAME must be in scope
+    assert v("ln -s /etc/passwd out", rt).allowed
+    assert not v("ln -s x /etc/evil", rt).allowed
+
+
+# ── 沙箱语义 ──────────────────────────────────────────────────────────
+
+
+def test_sandbox_internal_paths_allowed(tmp_path):
+    rt = sandbox_rt(tmp_path)
+    assert v("rm -rf /home/miqi/workspace/x", rt).allowed
+    assert v("rm -rf /home/miqi/.venv", rt).allowed
+    assert v("rm -rf /tmp/x", rt).allowed
+    assert v("rm -rf ./run-output", rt).allowed  # relative → sandbox cwd
+    assert v("rm -rf ~/x", rt).allowed  # ~ → /home/miqi
+
+
+def test_sandbox_roots_and_system_denied(tmp_path):
+    rt = sandbox_rt(tmp_path)
+    verdict = v("rm -rf /home/miqi/workspace", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code == "workspace_root"
+    assert not v("rm -rf /", rt).allowed
+    assert not v("rm -rf /etc/x", rt).allowed
+    assert not v("rm -rf /usr/bin/python3", rt).allowed
+
+
+def test_sandbox_mnt_c_maps_to_host(tmp_path):
+    rt = sandbox_rt(tmp_path)
+    assert not v("rm -rf /mnt/c/Windows/System32/x", rt).allowed
+    # a host path inside the session scope via /mnt/c is writable
+    verdict = v("rm -rf " + rt.session_files_dir.replace("\\", "/") + "/x", rt)
+    assert verdict.allowed
+
+
+def test_sandbox_traversal_resolved(tmp_path):
+    rt = sandbox_rt(tmp_path)
+    # /home/miqi/workspace/../../etc/x → /etc/x → system
+    assert not v("rm -rf /home/miqi/workspace/../../etc/x", rt).allowed
+
+
+# ── Windows 绝对路径（仅 Windows 平台有意义） ─────────────────────────
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
+def test_windows_system_paths_denied(rt):
+    assert not v(r"rm -rf C:\Windows\Temp", rt).allowed
+    assert not v(r"rm -rf C:\\", rt).allowed
+    assert not v(r"del /f /q C:\Windows\Temp\x.txt", rt).allowed
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
+def test_windows_session_scope_allowed(rt):
+    target = str(
+        rt.session_files_dir + os.sep + "out"
+    )
+    assert v(f"rm -rf {target}", rt).allowed
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
+def test_windows_unc_denied(rt):
+    assert not v(r"rm -rf \\server\share\x", rt).allowed

--- a/tests/agent/test_command_guard.py
+++ b/tests/agent/test_command_guard.py
@@ -119,7 +119,9 @@ def test_rm_system_and_outside_denied(rt):
 
 
 def test_rm_workspace_root_denied(rt):
-    verdict = v(f"rm -rf {rt.host_workspace}", rt)
+    # Windows paths must be QUOTED: unquoted backslashes are shell
+    # escapes (bash executes C:\ws as C:ws).
+    verdict = v(f'rm -rf "{rt.host_workspace}"', rt)
     assert not verdict.allowed
     assert verdict.reason_code == "workspace_root"
 
@@ -157,6 +159,28 @@ def test_partially_quoted_operators_not_bypassed(rt):
     assert not v("ls | 'rm' -rf /etc/x", rt).allowed
     # fully quoted ARGUMENTS stay arguments
     assert v('echo "rm -rf x"', rt).allowed
+
+
+def test_backslash_escaped_operators_not_bypassed(rt):
+    """Issue #811 review: the shell removes backslash escapes, so
+    \\rm executes as rm — must not bypass the checks."""
+    verdict = v("\\rm -rf /etc/x", rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    assert v("\\sudo whoami", rt).reason_code == "privilege"
+    assert not v("\\r\\m -rf /etc/x", rt).allowed
+    # an escaped redirect operator is a literal word, not a redirect
+    assert v("echo \\> out.txt", rt).allowed
+
+
+def test_quoted_flags_still_classified(rt):
+    """Issue #811 review: quoted/escaped flags execute as flags —
+    python '-c' and find '-delete' must not skip the checks."""
+    verdict = v("python '-c' \"import shutil; shutil.rmtree('/etc/x')\"", rt)
+    assert not verdict.allowed
+    verdict = v("find /etc '-delete'", rt)
+    assert not verdict.allowed
+    assert v("find . '-delete'", rt).allowed
 
 
 # ── 复合命令逐子命令判定 ──────────────────────────────────────────────
@@ -260,6 +284,15 @@ def test_nested_bash_c_find_denied(rt):
     assert verdict.reason_code == "find_exec"
 
 
+def test_nested_bash_c_redirects_checked(rt):
+    """Issue #811 review: redirect targets inside a nested shell payload
+    must be classified — bash -c "echo x > /etc/evil" writes /etc/evil."""
+    verdict = v('bash -c "echo x > /etc/evil"', rt)
+    assert not verdict.allowed
+    assert verdict.reason_code in ("system_path", "outside_workspace")
+    assert v('bash -c "echo x > ./out.txt"', rt).allowed
+
+
 def test_plain_python_c_not_flagged(rt):
     assert v('python -c "print(1)"', rt).allowed
 
@@ -358,10 +391,12 @@ def test_sandbox_mnt_c_maps_to_host(tmp_path):
         # /mnt/c host mapping only exists on Windows + WSL; on native
         # Linux a host path inside the sandbox context is just outside.
         return
-    # a host path inside the session scope, spelled in the /mnt/c form,
-    # is writable — exercises the /mnt/<drive> → host mapping itself
+    # a host path inside the session scope, spelled in the /mnt/<drive>
+    # form, is writable — exercises the /mnt/<drive> → host mapping
+    # itself.  The drive letter comes from the actual host path (CI
+    # runners may put TEMP on D: — issue #811 review).
     host = rt.session_files_dir.replace("\\", "/")
-    mnt = "/mnt/c" + host[2:]  # C:/... → /mnt/c/...
+    mnt = f"/mnt/{host[0].lower()}" + host[2:]  # C:/... → /mnt/c/...
     verdict = v(f"rm -rf {mnt}/x", rt)
     assert verdict.allowed
 
@@ -413,9 +448,11 @@ def test_guard_runtime_paths_falls_back_to_working_dir(tmp_path, monkeypatch):
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
 def test_windows_system_paths_denied(rt):
-    assert not v(r"rm -rf C:\Windows\Temp", rt).allowed
-    assert not v(r"rm -rf C:\\", rt).allowed
-    assert not v(r"del /f /q C:\Windows\Temp\x.txt", rt).allowed
+    # Windows paths must be QUOTED: unquoted backslashes are shell
+    # escapes (bash executes C:\Windows as C:Windows).
+    assert not v(r'rm -rf "C:\Windows\Temp"', rt).allowed
+    assert not v(r'rm -rf "C:\\"', rt).allowed
+    assert not v(r'del /f /q "C:\Windows\Temp\x.txt"', rt).allowed
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
@@ -423,9 +460,9 @@ def test_windows_session_scope_allowed(rt):
     target = str(
         rt.session_files_dir + os.sep + "out"
     )
-    assert v(f"rm -rf {target}", rt).allowed
+    assert v(f'rm -rf "{target}"', rt).allowed
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows path semantics")
 def test_windows_unc_denied(rt):
-    assert not v(r"rm -rf \\server\share\x", rt).allowed
+    assert not v(r'rm -rf "\\\\server\\share\\x"', rt).allowed

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -869,6 +869,27 @@ async def test_restricted_rejects_input_redirect_from_outside(tmp_path):
     assert "超出" in result or "工作区" in result
 
 
+@pytest.mark.asyncio
+async def test_bwrap_fallback_requards_with_host_semantics(tmp_path):
+    """BWRAP selection with no live sandbox → the host fallback must
+    re-check the guard with HOST path semantics (issue #811 review).
+
+    The pre-flight guard ran with sandbox semantics (BWRAP selected) and
+    allowed the sandbox-internal path /home/miqi/...; on the host that
+    is a REAL path, so the fallback must refuse it instead of executing
+    against the wrong filesystem.
+    """
+    tool = ExecTool(timeout=5, working_dir=str(tmp_path))
+    sel = _make_selection(SandboxType.BWRAP)
+
+    result = await tool.execute(
+        "rm -rf /home/miqi/workspace/x",
+        working_dir=str(tmp_path),
+        _sandbox=sel,
+    )
+    assert "沙箱护栏拦截" in result
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 33.3: RESTRICTED policy enforcement — network
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -827,7 +827,10 @@ async def test_restricted_rejects_redirect_to_outside(tmp_path):
         _sandbox=sel,
     )
 
-    assert "未执行" in result
+    # Issue #811: the capability guard now intercepts this BEFORE the
+    # RESTRICTED enforcement, with a structured refusal (沙箱护栏拦截);
+    # the RESTRICTED path ("命令未执行") remains as the fallback.
+    assert "未执行" in result or "沙箱护栏拦截" in result
     assert "超出" in result or "工作区" in result
 
 
@@ -844,7 +847,8 @@ async def test_restricted_rejects_append_redirect_to_outside(tmp_path):
         _sandbox=sel,
     )
 
-    assert "未执行" in result
+    # Issue #811: structured guard refusal before RESTRICTED enforcement.
+    assert "未执行" in result or "沙箱护栏拦截" in result
     assert "超出" in result or "工作区" in result
 
 

--- a/tests/execution/test_exec_tool_sandbox_selection.py
+++ b/tests/execution/test_exec_tool_sandbox_selection.py
@@ -890,6 +890,33 @@ async def test_bwrap_fallback_requards_with_host_semantics(tmp_path):
     assert "沙箱护栏拦截" in result
 
 
+class _FakeActiveSandbox:
+    is_running = True
+
+
+class _FakeManagerWithActiveSandbox:
+    def __init__(self):
+        self.active_sandbox = _FakeActiveSandbox()
+
+
+@pytest.mark.asyncio
+async def test_none_selection_keeps_host_semantics_with_active_sandbox(tmp_path):
+    """NONE/RESTRICTED selections execute on the HOST — the guard must
+    use host path semantics even when the manager holds an active
+    sandbox (issue #811 review)."""
+    tool = ExecTool(
+        timeout=5, working_dir=str(tmp_path),
+        sandbox_manager=_FakeManagerWithActiveSandbox(),
+    )
+    for st in (SandboxType.NONE, SandboxType.RESTRICTED):
+        result = await tool.execute(
+            "rm -rf /home/miqi/workspace/x",
+            working_dir=str(tmp_path),
+            _sandbox=_make_selection(st),
+        )
+        assert "沙箱护栏拦截" in result, f"{st} must keep host semantics"
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Phase 33.3: RESTRICTED policy enforcement — network
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

exec 护栏从「危险命令字符串匹配」升级为路径感知的 capability/policy engine：session 可操作范围内的 `rm -rf`/`cp`/`mv` 合法放行，越界操作一律结构化拒绝并给出安全替代指引；复合命令逐子命令独立判定；`sudo` 明确声明沙箱内不可用（PRIVILEGE_ESCALATION_UNAVAILABLE）。内联脚本（`python -c "shutil.rmtree(...)"` 等）与 shell 写法能力对等——换个写法同样被拦。

## 背景/问题

#811：2026-08-24 generate-analysis-report 实测——`rm -rf` 清理旧 run 目录被护栏一刀切拦截（agent 被迫改用 Python `shutil.rmtree` 绕过）、`cp && ls` 复合命令被拦只能拆分、被拦截时无任何指引（不知道为何拦、如何合法完成）。#759 根因②（`sudo -n true` 被护栏拒绝）同因。

修复前 E2E 复现（mock 驱动的 4 用例全红）：
- session 内 `rm -rf guard811tmp` → 被拦，`ls` 验证目录仍存在
- 越界删除 `/etc` → 一句「检测到危险模式」，无指引
- `echo && rm -rf` 复合命令 → 整条被拦
- `sudo whoami` → 无结构化声明

## 变更内容

- **新增 `miqi/agent/command_guard.py`**（capability engine）：
  - `split_subcommands()`：按顶层 `&&`/`||`/`;`/`&` 分解（引号/反引号/括号感知，`$(...)` 保持原子）
  - 文件操作检测：rm/rmdir/del/unlink/shred（DELETE）、cp/mv/install（COPY/MOVE）、find -delete/-exec、tee/mkdir/touch/ln、重定向目标（WRITE），以及内联脚本（python/perl/node/php/bash -c payload 中的 shutil.rmtree/os.remove/fs.rmSync/嵌套 rm 等）
  - 路径分类（Level 0/1/2）：系统路径（/etc、C:\Windows、~/.ssh、配置目录）→ 拒；其他 session → 拒（读写双向）；全局工作区（Level 1）→ 写/删拒绝；session 树 + cwd 子树（Level 2）→ 放行；`$VAR`/glob/命令替换等无法静态解析 → UNCERTAIN → DENY；canonical resolve 处理 `../` 与 symlink 逃逸；沙箱语义（`/home/miqi/**`、`/tmp` 为沙箱内部可写，`/mnt/c/...` 映射宿主路径）；工作区/session 根目录本身禁止删除
  - 结构化拒绝：原因 + 当前策略 + 解析后目标 + 安全替代（如 `rm -rf ./run-output`）；sudo → 提权不可用 + 用户级安装/系统安装路由指引
- **`miqi/agent/tools/shell.py`**：`_guard_command` 接入 engine（file-op 子命令跳过 rm/del/rmdir 旧 deny 模式，其余 deny 模式与 `restrict_to_workspace` 检查保留；系统安装路由的 deny 检查不受影响）；新增 `_guard_runtime_paths` 构建 session 上下文
- **`miqi/execution/factory.py` + `miqi/runtime/services.py`**：SandboxSelection 超时改读 `tools.exec.timeout` 配置（原硬编码 30s 静默覆盖用户配置的 60s）
- **`scripts/mock_openai.py`**：新增「护栏811」exec 状态机分支（确定性驱动 mkdir → rm → ls 序列，把 exec 结果折算进最终回复）
- **测试**：`tests/agent/test_command_guard.py`（38 例）；`apps/desktop/tests/e2e/guard-issue-811-repro.spec.ts`（4 例，修复前全红复现 / 修复后全绿）

## 日志/验证证据

```
修复前（E2E mock 折算的 agent 最终报告）：
REPRO_A_DONE BLOCKED: 目录仍存在——rm 被护栏拦截（ls 输出：a.txt）
REPRO_B_DONE GENERIC: 拦截无指引（Error: 命令被安全护栏拦截（检测到危险模式））
REPRO_C_DONE BLOCKED: 复合命令被整条拦截（...）
REPRO_D_DONE GENERIC: 拦截无指引（Error: 命令被安全护栏拦截（检测到危险模式））

修复后：
REPRO_A_DONE OK: 目录已删除（ls 报目录不存在）
REPRO_B_DONE OK: 结构化拒绝（含安全替代指引）
REPRO_C_DONE OK: 复合命令放行且目录已删除
REPRO_D_DONE OK: 结构化提权声明（含替代指引）

结构化拒绝示例（越界删除）：
Error: 命令被沙箱护栏拦截。
原因：检测到删除操作（rm），目标解析后位于系统路径（受保护）。
当前策略：只允许删除当前 session 工作区内的文件。
目标：c:\etc\guard811-e2e-noexist
安全替代：请将目标限定在当前 session 目录内，例如：rm -rf ./run-output
```

## 测试情况

- `pytest tests/agent/test_command_guard.py`：38 passed
- `pytest tests/execution/`：412 passed
- `pytest tests/agent/ tests/kun_runtime/ tests/sandbox/`：719 passed, 2 skipped
- E2E `guard-issue-811-repro.spec.ts`（electron 项目，本机跑通）：4 passed

## 截图

修复后 E2E 截图：session 内 `rm -rf guard811tmp` 放行执行，三个 exec 调用全部执行，AI 报告「REPRO_A_DONE OK: 目录已删除」。修复前同用例截图显示「REPRO_A_DONE BLOCKED: 目录仍存在」。截图产物存于 `apps/desktop/test-results/`（本地运行产物，未入库）。
