### PR TITLE
fix(agent): 文件工具自动感知用户点名输出目录——桌面等自定义目录读写放行（#821）

### DIFF
--- a/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
+++ b/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
@@ -67,7 +67,16 @@ test.describe('用户点名输出目录自动授权 (#821)', () => {
   );
 
   test.beforeAll(async () => {
-    const fixture = await launchElectronApp();
+    // 本 spec 回归的是 WSL 合法根检查：必须启用沙箱，否则 native 路径
+    // 没有 contain 检查、断言会空转通过（sandbox-exec 同款考量）。
+    // 临时 MIQI_HOME 会复制用户 config，此处仅强制打开 sandbox 开关。
+    const fixture = await launchElectronApp((config: any) => {
+      const tools = config.tools ?? {};
+      config.tools = {
+        ...tools,
+        sandbox: { ...(tools.sandbox ?? {}), enabled: true },
+      };
+    });
     electronApp = fixture.electronApp;
     page = fixture.page;
     miqiHome = fixture.miqiHome;
@@ -80,11 +89,12 @@ test.describe('用户点名输出目录自动授权 (#821)', () => {
 
   test(
     'write_file 写入用户点名的 workspace 外目录（临时目录模拟桌面输出目录）',
-    { timeout: LLM_TIMEOUT * 2 },
+    { timeout: LLM_TIMEOUT * 5 },
     async () => {
-      const ready = await waitForSandboxReady(page, 300_000);
+      // WSL 冷启动（export/import/apt）可能超过 5 分钟，放宽到 10 分钟
+      const ready = await waitForSandboxReady(page, 600_000);
       if (!ready) {
-        throw new Error('Sandbox manager did not become ready within 300s');
+        throw new Error('Sandbox manager did not become ready within 600s');
       }
 
       await page.evaluate(() =>

--- a/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
+++ b/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
@@ -27,25 +27,21 @@
  *     issue-821-user-output-dir.spec.ts --workers=1
  */
 
-import { _electron as electron, test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import {
-  APPS_DESKTOP,
   LLM_TIMEOUT,
   waitForBridgeInitialized,
   sendMessage,
-  waitForResponseComplete,
   createNewConversation,
-  approveLoop,
   launchElectronApp,
   closeElectronApp,
   waitForSandboxReady,
 } from './helpers/electron-setup';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import {
   existsSync,
-  writeFileSync,
   readFileSync,
   unlinkSync,
   mkdirSync,
@@ -118,16 +114,19 @@ test.describe('用户点名输出目录自动授权 (#821)', () => {
         `只回复工具结果原文，不要添加解释，不要用 exec。`;
 
       await sendMessage(page, trigger);
-      await approveLoop(page, 240_000);
-      await waitForResponseComplete(page, 240_000);
+
+      // 不依赖 approveLoop/waitForResponseComplete 的"文本稳定即完成"判定
+      // （回复开始流式前文本也稳定，会提前返回）；launchElectronApp 已写
+      // approvals.bypass_all: true，审批不会阻塞。改用 Playwright 轮询：
+      // 修复前 write_file 会被 "不在任何合法根目录" 拒绝、agent 被迫
+      // exec+Python 绕过（回复不会出现 write_file 的成功原文）。
+      await expect(
+        page.locator('main'),
+        'write_file 应返回成功原文（而非被合法根拒绝后走 exec 绕过）',
+      ).toContainText('Successfully wrote', { timeout: 600_000 });
 
       const mainText = await page.locator('main').textContent();
       console.log('[test] AI response:', mainText?.substring(0, 500));
-
-      // 修复前：write_file 被 "不在任何合法根目录" 拒绝，agent 被迫
-      // exec+Python 绕过（回复不会出现 write_file 的成功原文）
-      expect(mainText, 'write_file 应返回成功原文（而非被合法根拒绝后走 exec 绕过）')
-        .toContain('Successfully wrote');
       expect(mainText, '不应出现合法根拒绝错误').not.toContain('权限被拒绝');
 
       // 产物确实落在 workspace 之外的用户点名目录

--- a/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
+++ b/apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * E2E — issue #821 用户点名输出目录自动授权
+ *
+ * 验证链路（用户视角）：
+ *   1. 用户要求 agent 把结果写到工作区外的自定义目录
+ *      （如 C:\Users\<user>\Desktop\test_result —— 本测试用系统临时目录代替，
+ *      同样在 workspace 之外）
+ *   2. KUN 循环从用户消息提取点名目录 → ToolHostContext →
+ *      tool_host 注入 _user_roots → 文件工具放行
+ *   3. write_file 成功写入，而不是像修复前那样被
+ *      "不在任何合法根目录" 拒绝、被迫 exec+Python 绕过
+ *
+ * ══════════════════════════════════════════════════════════════
+ *  NOTE: Python 单元测试（tests/agent/tools/test_user_roots.py 28 用例 +
+ *  tests/sandbox/test_wsl_sandbox_path_mapping.py 3 用例 +
+ *  tests/kun_runtime 注入/传播用例）是 PRIMARY validation。
+ *
+ *  本 E2E 是补充验证，仅按需运行：
+ *    - 需要 Windows + WSL 沙箱（修复前的拒绝发生在 WSL 合法根检查）
+ *    - 需要真实 LLM provider
+ *    - CI 默认跳过，除非 MIQI_RUN_SANDBOX_E2E=1
+ * ══════════════════════════════════════════════════════════════
+ *
+ * 运行：
+ *   cd apps/desktop
+ *   npx playwright test --config=playwright.config.ts --project=electron \
+ *     issue-821-user-output-dir.spec.ts --workers=1
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  APPS_DESKTOP,
+  LLM_TIMEOUT,
+  waitForBridgeInitialized,
+  sendMessage,
+  waitForResponseComplete,
+  createNewConversation,
+  approveLoop,
+  launchElectronApp,
+  closeElectronApp,
+  waitForSandboxReady,
+} from './helpers/electron-setup';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+  existsSync,
+  writeFileSync,
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+  rmSync,
+} from 'node:fs';
+
+const SKIP_SANDBOX_E2E =
+  !!process.env.CI && process.env.MIQI_RUN_SANDBOX_E2E !== '1';
+
+test.describe('用户点名输出目录自动授权 (#821)', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  // Skip entire suite when WSL is not available (non-Windows / CI without flag)
+  test.skip(
+    () => SKIP_SANDBOX_E2E || process.platform !== 'win32',
+    '本 E2E 需要 Windows + WSL 沙箱；CI 默认跳过（MIQI_RUN_SANDBOX_E2E=1 开启）',
+  );
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+    await waitForBridgeInitialized(page);
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test(
+    'write_file 写入用户点名的 workspace 外目录（临时目录模拟桌面输出目录）',
+    { timeout: LLM_TIMEOUT * 2 },
+    async () => {
+      const ready = await waitForSandboxReady(page, 300_000);
+      if (!ready) {
+        throw new Error('Sandbox manager did not become ready within 300s');
+      }
+
+      await page.evaluate(() =>
+        (window as any).miqi.approvals.addPermanent('*:*', 'always'),
+      );
+
+      // 输出目录：系统临时目录下（workspace 之外），模拟用户点名的桌面目录
+      const timestamp = Date.now();
+      const outDir = join(tmpdir(), `miqi_e2e_821_out_${timestamp}`);
+      mkdirSync(outDir, { recursive: true });
+      const fname = `e2e_821_report_${timestamp}.md`;
+      const content = `E2E #821 user-mentioned output dir test ${timestamp}`;
+      console.log(`[test] Output dir (outside workspace): ${outDir}`);
+
+      await createNewConversation(page);
+
+      // 关键：消息里必须带完整绝对路径（含反斜杠），与 issue 用户原话同形
+      const trigger =
+        `请使用 write_file 工具，把结果写入这个目录里的文件：` +
+        `${outDir}\\${fname}，文件内容为 "${content}"。` +
+        `只回复工具结果原文，不要添加解释，不要用 exec。`;
+
+      await sendMessage(page, trigger);
+      await approveLoop(page, 240_000);
+      await waitForResponseComplete(page, 240_000);
+
+      const mainText = await page.locator('main').textContent();
+      console.log('[test] AI response:', mainText?.substring(0, 500));
+
+      // 修复前：write_file 被 "不在任何合法根目录" 拒绝，agent 被迫
+      // exec+Python 绕过（回复不会出现 write_file 的成功原文）
+      expect(mainText, 'write_file 应返回成功原文（而非被合法根拒绝后走 exec 绕过）')
+        .toContain('Successfully wrote');
+      expect(mainText, '不应出现合法根拒绝错误').not.toContain('权限被拒绝');
+
+      // 产物确实落在 workspace 之外的用户点名目录
+      await page.waitForTimeout(3000); // Allow filesystem sync
+      const hostFile = join(outDir, fname);
+      expect(existsSync(hostFile), `Host file not found: ${hostFile}`).toBe(true);
+      const actual = readFileSync(hostFile, 'utf-8');
+      console.log(`[test] File content on host: "${actual}"`);
+      expect(actual).toContain(content);
+      console.log('[test] ✅ write_file 写入用户点名目录成功');
+
+      // Cleanup
+      try { unlinkSync(hostFile); } catch {}
+      try { rmSync(outDir, { recursive: true, force: true }); } catch {}
+      await page.screenshot({
+        path: `test-results/issue-821-user-output-dir.png`,
+      });
+    },
+  );
+});

--- a/docs/backend/tools.md
+++ b/docs/backend/tools.md
@@ -84,11 +84,11 @@ class ToolResult:
 
 | 工具 | 功能 | 安全限制 |
 |------|------|----------|
-| `read_file` | 读取文件内容 | 工作区 + `memory/`/`skills/`/`.skills/`；`tools.extra_roots` 可额外授权；config.json 仅只读 |
-| `write_file` | 写入/创建文件 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，自动创建快照 |
-| `edit_file` | 精确字符串替换 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写 |
-| `list_dir` | 列出目录 | 工作区 + 默认共享目录 + `tools.extra_roots` |
-| `apply_patch` | Unified Diff 补丁应用 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，版本快照 |
+| `read_file` | 读取文件内容 | 工作区 + `memory/`/`skills/`/`.skills/`；`tools.extra_roots` 可额外授权；config.json 仅只读；用户消息中点名的输出目录本回合内自动授权（#821） |
+| `write_file` | 写入/创建文件 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，自动创建快照；用户点名的输出目录自动授权 |
+| `edit_file` | 精确字符串替换 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写；用户点名的输出目录自动授权 |
+| `list_dir` | 列出目录 | 工作区 + 默认共享目录 + `tools.extra_roots`；用户点名的输出目录自动授权 |
+| `apply_patch` | Unified Diff 补丁应用 | 工作区 + 默认共享目录 + `tools.extra_roots`；config/session 路径不可写，版本快照；用户点名的输出目录自动授权 |
 
 ### 办公文档工具
 
@@ -230,11 +230,12 @@ get_document_category(path) → "pdf" | "word" | "ppt" | "excel" | ...
 ## 安全机制
 
 1. **工作区隔离**：文件操作受 `workspace` 目录约束（由 `restrict_to_workspace` 控制），WSL 沙箱下默认放行 `memory/`、`skills/`、`.skills/` 与配置文件；`tools.extra_roots` 可显式授权 workspace 外目录
-2. **危险命令审批**：39 种危险命令模式需用户确认（`miqi/agent/command_approval.py`）
-3. **bwrap 沙箱**：LANDLOCK 文件系统规则，FIFO 驱逐（最多 10 个）
-4. **快照保护**：文件写入前自动创建原始内容快照，支持回滚
-5. **超时终止**：工具执行超时自动中断
-6. **默认拒绝**：PermissionEngine 采用 deny-by-default 策略
+2. **用户输出目录自动授权（#821）**：KUN 运行时从用户本条消息中自动提取点名的目录（如「结果输出到 `C:\Users\x\Desktop\test_result`」），该回合内授权文件工具（read/write/edit/list/apply_patch/graph_render）读写；仅扫描用户消息、不扫描模型输出或文档内容，且配置目录、会话文件目录、用户主目录、盘符根与系统顶层目录（Windows/Program Files 等）永不授权；可用 `tools.auto_user_dirs: false` 关闭
+3. **危险命令审批**：39 种危险命令模式需用户确认（`miqi/agent/command_approval.py`）
+4. **bwrap 沙箱**：LANDLOCK 文件系统规则，FIFO 驱逐（最多 10 个）
+5. **快照保护**：文件写入前自动创建原始内容快照，支持回滚
+6. **超时终止**：工具执行超时自动中断
+7. **默认拒绝**：PermissionEngine 采用 deny-by-default 策略
 
 ## Hook 系统
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ MiqroForge Desktop 的全局配置存储在 `~/.miqi/config.json` 中。
   "tools": {
     "restrict_to_workspace": false,
     "extra_roots": [],
+    "auto_user_dirs": true,
     "web": {
       "search": {
         "provider": "ddgs",
@@ -129,6 +130,7 @@ shows a persistent warning in the top bar.
 |------|------|--------|------|
 | `restrict_to_workspace` | bool | false | 文件操作限制在工作区 |
 | `extra_roots` | array | [] | 文件工具额外允许的根目录（支持 workspace 外目录，WSL 沙箱白名单） |
+| `auto_user_dirs` | bool | true | 自动感知用户消息中点名的输出目录（如 `C:\Users\x\Desktop\test_result`），本回合内授权文件工具读写该目录（#821）；仅扫描用户自己的消息，配置/会话文件、用户主目录、盘符根与系统顶层目录始终除外；关闭后仅静态 `extra_roots` 生效 |
 | `web.search.provider` | string | "ddgs" | 搜索引擎 (ddgs/brave/hybrid) |
 | `web.search.apiKey` | string | "" | Brave Search API Key，仅 brave/hybrid 使用 |
 | `web.search.maxResults` | int | 5 | 最大搜索结果数量 |

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
 from miqi.agent.tools.filesystem import (
+    _effective_shared_roots,
     _get_active_sandbox,
     _get_session_workspace,
     _is_default_workspace,
@@ -283,6 +284,7 @@ class ApplyPatchTool(Tool):
         shared_roots: Iterable[Path] | None = None,
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -291,6 +293,7 @@ class ApplyPatchTool(Tool):
         self._shared_roots = list(shared_roots or [])
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
+        self._allow_user_roots = allow_user_roots
 
     @property
     def name(self) -> str:
@@ -321,6 +324,9 @@ class ApplyPatchTool(Tool):
         if not isinstance(patch, str) or not patch:
             return "Error: 缺少必要参数 'patch'"
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         try:
             file_patches = parse_patch(patch)
         except PatchParseError as e:
@@ -331,7 +337,7 @@ class ApplyPatchTool(Tool):
 
         for fp in file_patches:
             try:
-                result = await self._apply_one_file(fp, sandbox, _sess_key)
+                result = await self._apply_one_file(fp, sandbox, _sess_key, shared)
             except PatchApplyError as e:
                 return f"Error applying patch to {fp.path}: {e}"
             except PermissionError as e:
@@ -345,7 +351,13 @@ class ApplyPatchTool(Tool):
             return "No files changed"
         return f"Applied patch to: {', '.join(changed)}"
 
-    async def _apply_one_file(self, file_patch: FilePatch, sandbox, _sess_key: str | None = None):
+    async def _apply_one_file(
+        self,
+        file_patch: FilePatch,
+        sandbox,
+        _sess_key: str | None = None,
+        shared: list[Path] | None = None,
+    ):
         path = file_patch.path
 
         # Session isolation (#221 / #613 follow-up): patch targets written
@@ -359,9 +371,10 @@ class ApplyPatchTool(Tool):
         session_dir = _resolve_session_dir(
             self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
+        shared = shared if shared is not None else self._shared_roots
         path = await _redirect_new_file_write(
             path, base_ws, session_dir,
-            _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
+            _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
 
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
@@ -370,7 +383,7 @@ class ApplyPatchTool(Tool):
             # patch could target another session's files dir.
             sandbox_path = _resolve_sandbox_path(
                 path, self._workspace, sandbox,
-                extra_roots=self._shared_roots,
+                extra_roots=shared,
                 session_files_dir=session_dir or session_ws,
             )
             _log.info("apply_patch [sandbox]: %s → %s", path, sandbox_path)
@@ -404,7 +417,7 @@ class ApplyPatchTool(Tool):
             session_dir or self._workspace,
             self._allowed_dir,
             self._sandbox_manager,
-            shared_roots=self._shared_roots,
+            shared_roots=shared,
         )
         _reject_foreign_session_path(file_path, base_ws, session_dir)
         snap_ok = _maybe_snapshot(file_path, snapshot_dir=self._snapshot_dir)

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -163,6 +163,31 @@ def _get_active_sandbox(sandbox_manager):
     return None
 
 
+def _effective_shared_roots(
+    base: Iterable[Path],
+    user_roots: Iterable[Any] | None,
+    allow_user_roots: bool,
+) -> list[Path]:
+    """Merge per-call user-mentioned roots into the static shared roots.
+
+    The KUN runtime injects ``_user_roots`` (auto-sensed directories from
+    the user's message, issue #821) into each file-tool call.  When
+    ``tools.auto_user_dirs`` is disabled, or no roots were injected, the
+    static shared roots are returned unchanged.
+    """
+    merged = list(base or [])
+    if not allow_user_roots or not user_roots:
+        return merged
+    for r in user_roots:
+        try:
+            p = Path(r)
+        except (TypeError, ValueError):
+            continue
+        if p not in merged:
+            merged.append(p)
+    return merged
+
+
 def _persist_tracked_file(
     workspace: Path | None,
     file_path: str | Path,
@@ -941,12 +966,14 @@ class ReadFileTool(Tool):
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
         session_files_dir: Path | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
         self._session_files_dir = session_files_dir
+        self._allow_user_roots = allow_user_roots
 
     @property
     def name(self) -> str:
@@ -971,6 +998,9 @@ class ReadFileTool(Tool):
 
     async def execute(self, path: str, **kwargs: Any) -> str:
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         # Factory-provided session dir wins over the sandbox-derived one: it
@@ -989,7 +1019,7 @@ class ReadFileTool(Tool):
             # enforced separately via session_files_dir (#613 follow-up).
             sandbox_path = _resolve_sandbox_path(
                 path, self._workspace, sandbox,
-                extra_roots=self._shared_roots,
+                extra_roots=shared,
                 session_files_dir=session_ws,
             )
             _log.info("read_file [sandbox]: %s → %s", path, sandbox_path)
@@ -1005,7 +1035,7 @@ class ReadFileTool(Tool):
                 if alt:
                     alt_sandbox = _resolve_sandbox_path(
                         alt, self._workspace, sandbox,
-                        extra_roots=self._shared_roots,
+                        extra_roots=shared,
                         session_files_dir=session_ws,
                     )
                     if alt_sandbox != sandbox_path:
@@ -1036,7 +1066,7 @@ class ReadFileTool(Tool):
                     self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
-                    shared_roots=self._shared_roots,
+                    shared_roots=shared,
                 )
                 # Cross-session isolation for native reads too: another
                 # session's files dir must not be readable (CodeRabbit #731).
@@ -1053,7 +1083,7 @@ class ReadFileTool(Tool):
                             session_dir or self._workspace,
                             self._allowed_dir,
                             self._sandbox_manager,
-                            shared_roots=self._shared_roots,
+                            shared_roots=shared,
                         )
                         if alt_path != file_path and alt_path.exists():
                             _reject_foreign_session_path(alt_path, base_ws, session_dir)
@@ -1082,6 +1112,7 @@ class WriteFileTool(Tool):
         shared_roots: Iterable[Path] | None = None,
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1093,6 +1124,7 @@ class WriteFileTool(Tool):
         # re-anchor absolute root paths into the session dir.
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
+        self._allow_user_roots = allow_user_roots
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1138,6 +1170,9 @@ class WriteFileTool(Tool):
             )
 
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         base_ws = self._base_workspace or (
@@ -1152,14 +1187,14 @@ class WriteFileTool(Tool):
         # root (the dir the system prompt advertises) land in the session
         # files dir instead of the shared root.
         path = await _redirect_new_file_write(
-            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
+            path, base_ws, session_dir, _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
             # under another session's files dir is rejected (CodeRabbit #731).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots,
+                path, session_ws, sandbox, extra_roots=shared,
                 session_files_dir=session_dir,
             )
             _log.info("write_file [sandbox]: %s → %s", path, sandbox_path)
@@ -1199,7 +1234,7 @@ class WriteFileTool(Tool):
                     session_dir or self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
-                    shared_roots=self._shared_roots,
+                    shared_roots=shared,
                 )
                 _reject_foreign_session_path(file_path, base_ws, session_dir)
                 # Snapshot original content before first write (enables non-git diff/revert)
@@ -1232,6 +1267,7 @@ class EditFileTool(Tool):
         shared_roots: Iterable[Path] | None = None,
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1240,6 +1276,7 @@ class EditFileTool(Tool):
         self._shared_roots = list(shared_roots or [])
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
+        self._allow_user_roots = allow_user_roots
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1277,6 +1314,9 @@ class EditFileTool(Tool):
 
     async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str:
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         base_ws = self._base_workspace or (
@@ -1288,14 +1328,14 @@ class EditFileTool(Tool):
         # Session isolation: edits of files that only exist in the session
         # dir resolve there; shared root files are edited in place.
         path = await _redirect_new_file_write(
-            path, base_ws, session_dir, _make_exists_check(self._shared_roots, sandbox, session_ws, native_base_dir=self._workspace),
+            path, base_ws, session_dir, _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
             # under another session's files dir is rejected (CodeRabbit #731).
             sandbox_path = _resolve_sandbox_path(
-                path, session_ws, sandbox, extra_roots=self._shared_roots,
+                path, session_ws, sandbox, extra_roots=shared,
                 session_files_dir=session_dir,
             )
             _log.info("edit_file [sandbox]: %s → %s", path, sandbox_path)
@@ -1351,7 +1391,7 @@ class EditFileTool(Tool):
                     session_dir or self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
-                    shared_roots=self._shared_roots,
+                    shared_roots=shared,
                 )
                 _reject_foreign_session_path(file_path, base_ws, session_dir)
                 if not file_path.exists():
@@ -1417,11 +1457,13 @@ class ListDirTool(Tool):
         allowed_dir: Path | None = None,
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
+        self._allow_user_roots = allow_user_roots
 
     @property
     def name(self) -> str:
@@ -1446,6 +1488,9 @@ class ListDirTool(Tool):
 
     async def execute(self, path: str, **kwargs: Any) -> str:
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         session_ws = _get_session_workspace(self._workspace, sandbox)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
@@ -1454,7 +1499,7 @@ class ListDirTool(Tool):
             # isolation enforced via session_files_dir (#613 follow-up).
             sandbox_path = _resolve_sandbox_path(
                 path, self._workspace, sandbox,
-                extra_roots=self._shared_roots,
+                extra_roots=shared,
                 session_files_dir=session_ws,
             )
             _log.info("list_dir [sandbox]: %s → %s", path, sandbox_path)
@@ -1481,7 +1526,7 @@ class ListDirTool(Tool):
                     self._workspace,
                     self._allowed_dir,
                     self._sandbox_manager,
-                    shared_roots=self._shared_roots,
+                    shared_roots=shared,
                 )
                 if not dir_path.exists():
                     return f"Error: 目录不存在：{path}"

--- a/miqi/agent/tools/graph_render.py
+++ b/miqi/agent/tools/graph_render.py
@@ -28,9 +28,12 @@ from miqi.agent.tools.filesystem import (
     _effective_shared_roots,
     _ensure_sandbox,
     _get_session_workspace,
+    _is_default_workspace,
     _persist_tracked_file,
+    _reject_foreign_session_path,
     _resolve_path,
     _resolve_sandbox_path,
+    _resolve_session_dir,
     _sandbox_read_file,
     _sandbox_write_file,
 )
@@ -667,12 +670,17 @@ class GraphRenderTool(Tool):
         )
 
     async def _read_text(
-        self, resolved: Path, sandbox, shared: Iterable[Path] | None = None,
+        self,
+        resolved: Path,
+        sandbox,
+        shared: Iterable[Path] | None = None,
+        session_dir: Path | None = None,
     ) -> str:
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             sandbox_path = _resolve_sandbox_path(
                 str(resolved), self._workspace, sandbox,
                 extra_roots=list(shared) if shared is not None else self._shared_roots,
+                session_files_dir=session_dir,
             )
             return await _sandbox_read_file(sandbox, sandbox_path)
         return resolved.read_text(encoding="utf-8")
@@ -684,6 +692,8 @@ class GraphRenderTool(Tool):
         sandbox,
         session_key: str | None = None,
         shared: Iterable[Path] | None = None,
+        session_dir: Path | None = None,
+        base_ws: Path | None = None,
     ) -> None:
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             from miqi.agent.tools.filesystem import _sandbox_to_host_path
@@ -691,6 +701,7 @@ class GraphRenderTool(Tool):
             sandbox_path = _resolve_sandbox_path(
                 str(resolved), self._workspace, sandbox,
                 extra_roots=list(shared) if shared is not None else self._shared_roots,
+                session_files_dir=session_dir,
             )
             await _sandbox_write_file(sandbox, sandbox_path, content)
             # 镜像到宿主 workspace，供 files.read 读取（与 WriteFileTool 一致）
@@ -703,6 +714,8 @@ class GraphRenderTool(Tool):
                 self._tracking_workspace, host_path, op="write", session_key=session_key,
             )
             return
+        # Cross-session isolation for the native path (CodeRabbit #851).
+        _reject_foreign_session_path(resolved, base_ws, session_dir)
         resolved.parent.mkdir(parents=True, exist_ok=True)
         resolved.write_text(content, encoding="utf-8")
         # 资产栏追踪（结果文件）：svg/html 随源 JSON 旁交付，前端按
@@ -712,16 +725,25 @@ class GraphRenderTool(Tool):
         )
 
     async def _collect_targets(
-        self, path: str, sandbox, shared: Iterable[Path] | None = None,
+        self,
+        path: str,
+        sandbox,
+        shared: Iterable[Path] | None = None,
+        session_dir: Path | None = None,
+        base_ws: Path | None = None,
     ) -> list[tuple[Path, str]]:
         """返回 [(源 JSON resolved 路径, 文件名)]；目录则自动发现。"""
         roots = list(shared) if shared is not None else self._shared_roots
         resolved = self._resolve(path, roots)
+        # Cross-session isolation for the native path (CodeRabbit #851):
+        # another session's files dir must not be readable.
+        _reject_foreign_session_path(resolved, base_ws, session_dir)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             from miqi.agent.tools.filesystem import _sandbox_dir_exists, _sandbox_file_exists
 
             sp = _resolve_sandbox_path(
                 str(resolved), self._workspace, sandbox, extra_roots=roots,
+                session_files_dir=session_dir,
             )
             is_dir = await _sandbox_dir_exists(sandbox, sp)
             is_file = await _sandbox_file_exists(sandbox, sp)
@@ -737,6 +759,7 @@ class GraphRenderTool(Tool):
                     sp = _resolve_sandbox_path(
                         str(candidate), self._workspace, sandbox,
                         extra_roots=roots,
+                        session_files_dir=session_dir,
                     )
                     exists = await _sandbox_file_exists(sandbox, sp)
                 else:
@@ -758,12 +781,21 @@ class GraphRenderTool(Tool):
             self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
         )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
-        _get_session_workspace(self._workspace, sandbox)
+        session_ws = _get_session_workspace(self._workspace, sandbox)
+        base_ws = self._base_workspace or (
+            self._workspace if _is_default_workspace(self._workspace) else None
+        )
+        # Cross-session isolation (CodeRabbit #851): the workspace root is a
+        # shared legal root, so without the session dir a foreign session's
+        # files dir would pass the WSL containment check.
+        session_dir = _resolve_session_dir(
+            None, session_ws, self._workspace, _sess_key, base_ws,
+        )
 
         results = []
         errors = []
         try:
-            targets = await self._collect_targets(path, sandbox, shared)
+            targets = await self._collect_targets(path, sandbox, shared, session_dir, base_ws)
         except GraphDataError as exc:
             return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
         except PermissionError as exc:
@@ -771,7 +803,7 @@ class GraphRenderTool(Tool):
 
         for resolved, name in targets:
             try:
-                raw = await self._read_text(resolved, sandbox, shared)
+                raw = await self._read_text(resolved, sandbox, shared, session_dir)
                 # 资产栏追踪（过程文件）：源图数据 JSON 随 skill 产物生成
                 _persist_tracked_file(
                     self._tracking_workspace, resolved, op="read", session_key=_sess_key,
@@ -791,18 +823,27 @@ class GraphRenderTool(Tool):
                 if format == "html":
                     svg_path = base_dir / f"{stem}.svg"
                     html_path = base_dir / f"{stem}.html"
-                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key, shared=shared)
+                    await self._write_text(
+                        svg_path, svg_content, sandbox,
+                        session_key=_sess_key, shared=shared,
+                        session_dir=session_dir, base_ws=base_ws,
+                    )
                     await self._write_text(
                         html_path,
                         _render_html(graph, layout, svg_content),
                         sandbox,
                         session_key=_sess_key,
                         shared=shared,
+                        session_dir=session_dir, base_ws=base_ws,
                     )
                     out_paths = [svg_path, html_path]
                 else:
                     svg_path = base_dir / f"{stem}.svg"
-                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key, shared=shared)
+                    await self._write_text(
+                        svg_path, svg_content, sandbox,
+                        session_key=_sess_key, shared=shared,
+                        session_dir=session_dir, base_ws=base_ws,
+                    )
                     out_paths = [svg_path]
 
                 results.append(

--- a/miqi/agent/tools/graph_render.py
+++ b/miqi/agent/tools/graph_render.py
@@ -25,6 +25,7 @@ from typing import Any, Iterable
 
 from miqi.agent.tools.base import Tool
 from miqi.agent.tools.filesystem import (
+    _effective_shared_roots,
     _ensure_sandbox,
     _get_session_workspace,
     _persist_tracked_file,
@@ -595,12 +596,14 @@ class GraphRenderTool(Tool):
         sandbox_manager=None,
         shared_roots: Iterable[Path] | None = None,
         base_workspace: Path | None = None,
+        allow_user_roots: bool = True,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
         self._sandbox_manager = sandbox_manager
         self._shared_roots = list(shared_roots or [])
         self._base_workspace = base_workspace
+        self._allow_user_roots = allow_user_roots
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -654,31 +657,40 @@ class GraphRenderTool(Tool):
         }
 
     # ── 文件读写（native + WSL sandbox，与 filesystem 工具一致）─────────
-    def _resolve(self, path: str) -> Path:
+    def _resolve(self, path: str, shared: Iterable[Path] | None = None) -> Path:
         return _resolve_path(
             path,
             self._workspace,
             self._allowed_dir,
             self._sandbox_manager,
-            shared_roots=self._shared_roots,
+            shared_roots=list(shared) if shared is not None else self._shared_roots,
         )
 
-    async def _read_text(self, resolved: Path, sandbox) -> str:
+    async def _read_text(
+        self, resolved: Path, sandbox, shared: Iterable[Path] | None = None,
+    ) -> str:
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             sandbox_path = _resolve_sandbox_path(
-                str(resolved), self._workspace, sandbox, extra_roots=self._shared_roots,
+                str(resolved), self._workspace, sandbox,
+                extra_roots=list(shared) if shared is not None else self._shared_roots,
             )
             return await _sandbox_read_file(sandbox, sandbox_path)
         return resolved.read_text(encoding="utf-8")
 
     async def _write_text(
-        self, resolved: Path, content: str, sandbox, session_key: str | None = None
+        self,
+        resolved: Path,
+        content: str,
+        sandbox,
+        session_key: str | None = None,
+        shared: Iterable[Path] | None = None,
     ) -> None:
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             from miqi.agent.tools.filesystem import _sandbox_to_host_path
 
             sandbox_path = _resolve_sandbox_path(
-                str(resolved), self._workspace, sandbox, extra_roots=self._shared_roots,
+                str(resolved), self._workspace, sandbox,
+                extra_roots=list(shared) if shared is not None else self._shared_roots,
             )
             await _sandbox_write_file(sandbox, sandbox_path, content)
             # 镜像到宿主 workspace，供 files.read 读取（与 WriteFileTool 一致）
@@ -699,14 +711,17 @@ class GraphRenderTool(Tool):
             self._tracking_workspace, resolved, op="write", session_key=session_key,
         )
 
-    async def _collect_targets(self, path: str, sandbox) -> list[tuple[Path, str]]:
+    async def _collect_targets(
+        self, path: str, sandbox, shared: Iterable[Path] | None = None,
+    ) -> list[tuple[Path, str]]:
         """返回 [(源 JSON resolved 路径, 文件名)]；目录则自动发现。"""
-        resolved = self._resolve(path)
+        roots = list(shared) if shared is not None else self._shared_roots
+        resolved = self._resolve(path, roots)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             from miqi.agent.tools.filesystem import _sandbox_dir_exists, _sandbox_file_exists
 
             sp = _resolve_sandbox_path(
-                str(resolved), self._workspace, sandbox, extra_roots=self._shared_roots,
+                str(resolved), self._workspace, sandbox, extra_roots=roots,
             )
             is_dir = await _sandbox_dir_exists(sandbox, sp)
             is_file = await _sandbox_file_exists(sandbox, sp)
@@ -721,7 +736,7 @@ class GraphRenderTool(Tool):
                 if sandbox is not None and getattr(sandbox, "_use_wsl", False):
                     sp = _resolve_sandbox_path(
                         str(candidate), self._workspace, sandbox,
-                        extra_roots=self._shared_roots,
+                        extra_roots=roots,
                     )
                     exists = await _sandbox_file_exists(sandbox, sp)
                 else:
@@ -739,13 +754,16 @@ class GraphRenderTool(Tool):
         self, path: str, format: str = "svg", out_dir: str | None = None, **kwargs: Any
     ) -> str:
         _sess_key = kwargs.pop("_session_key", None)
+        shared = _effective_shared_roots(
+            self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
+        )
         sandbox = await _ensure_sandbox(self._sandbox_manager, session_key=_sess_key)
         _get_session_workspace(self._workspace, sandbox)
 
         results = []
         errors = []
         try:
-            targets = await self._collect_targets(path, sandbox)
+            targets = await self._collect_targets(path, sandbox, shared)
         except GraphDataError as exc:
             return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
         except PermissionError as exc:
@@ -753,7 +771,7 @@ class GraphRenderTool(Tool):
 
         for resolved, name in targets:
             try:
-                raw = await self._read_text(resolved, sandbox)
+                raw = await self._read_text(resolved, sandbox, shared)
                 # 资产栏追踪（过程文件）：源图数据 JSON 随 skill 产物生成
                 _persist_tracked_file(
                     self._tracking_workspace, resolved, op="read", session_key=_sess_key,
@@ -765,7 +783,7 @@ class GraphRenderTool(Tool):
                 out_paths = []
                 svg_content = _render_svg(graph, layout)
                 base_dir = (
-                    self._resolve(out_dir)
+                    self._resolve(out_dir, shared)
                     if out_dir
                     else resolved.parent
                 )
@@ -773,17 +791,18 @@ class GraphRenderTool(Tool):
                 if format == "html":
                     svg_path = base_dir / f"{stem}.svg"
                     html_path = base_dir / f"{stem}.html"
-                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key)
+                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key, shared=shared)
                     await self._write_text(
                         html_path,
                         _render_html(graph, layout, svg_content),
                         sandbox,
                         session_key=_sess_key,
+                        shared=shared,
                     )
                     out_paths = [svg_path, html_path]
                 else:
                     svg_path = base_dir / f"{stem}.svg"
-                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key)
+                    await self._write_text(svg_path, svg_content, sandbox, session_key=_sess_key, shared=shared)
                     out_paths = [svg_path]
 
                 results.append(

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -65,10 +65,18 @@ _POSIX_PATH_RE = _re.compile(
 # "输出到 C:\Users\x\Desktop\test_result，", "……test_result。"
 _TRAILING_PUNCT = ".,;:!?，。；：！？)）]】\"'"
 
-# Depth-1 directories of a drive that must never become roots.
+# Depth-1 directories of a drive (Windows) or of ``/`` (POSIX) that must
+# never become roots (CodeRabbit #851).
 _TOP_LEVEL_SYSTEM_DIRS = frozenset({
+    # Windows
     "users", "windows", "program files", "program files (x86)",
     "programdata", "perflogs", "$recycle.bin", "system volume information",
+    # POSIX
+    "bin", "boot", "dev", "etc", "home", "lib", "lib32", "lib64", "libx32",
+    "opt", "proc", "root", "run", "sbin", "srv", "sys", "usr", "var",
+    "mnt", "media",
+    # macOS
+    "system", "library", "applications",
 })
 
 # Default cap on auto-sensed roots per turn.

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -1,0 +1,248 @@
+"""User-mentioned output directories — dynamic extra roots (issue #821).
+
+When a user asks "结果输出到 C:\\Users\\x\\Desktop\\test_result\\<dir>",
+the file tools must be able to read/write there even though the directory
+is outside the workspace and not listed in ``tools.extra_roots``.  This
+module extracts absolute directory mentions from the user's own messages so
+the runtime can authorize them for the session (per tool call, never
+persisted).
+
+Security model:
+
+- ONLY the user's message text is scanned — never model output, tool
+  results, or documents (prompt injection via file content cannot grant
+  roots).
+- A mentioned path becomes a root as: itself when it is (or is intended
+  as) a directory — including a not-yet-created one, so "输出到 新目录"
+  works on the first write; the parent directory when it is an existing
+  file.
+- Mentions that would cover the host config, per-session files, the user
+  profile root, a drive root, or a top-level system directory are dropped.
+- Roots are capped (``max_roots``) per extraction; callers re-extract each
+  turn so authorization never outlives the user's request.
+"""
+
+from __future__ import annotations
+
+import logging
+import os as _os
+import re as _re
+import sys as _sys
+from pathlib import Path
+from typing import Iterable
+
+from miqi.paths import get_config_path
+
+_log = logging.getLogger(__name__)
+
+# Characters that may precede a path mention (whitespace, quotes, opening
+# brackets/parens, CJK punctuation, list separators).  A path glued to CJK
+# prose (e.g. "test_result目录") is intentionally NOT extracted — the
+# boundary requirement keeps false positives out of ordinary sentences.
+_BOUNDARY_CHARS = r"\s\"'`,，;；:：。!！?？、()（[【"
+
+# Path characters: anything but whitespace, quotes, Windows-illegal
+# separators, and CJK punctuation (which otherwise glues the surrounding
+# prose to the path, e.g. "输出到 C:\x，然后…").  CJK directory names
+# (mof_price相关) are matched in full.
+_PATH_CHARS = r"[^\s\"'`<>|*?，。；：！？、（）【】《》「」『』…—]+"
+
+_WIN_PATH_RE = _re.compile(
+    rf"(?<![^{_BOUNDARY_CHARS}])([A-Za-z]:[\\/]{_PATH_CHARS})"
+)
+_MNT_PATH_RE = _re.compile(
+    rf"(?<![^{_BOUNDARY_CHARS}])(/mnt/[A-Za-z]/{_PATH_CHARS})"
+)
+# The ``(?<!:)`` keeps URL path segments out ("https://x/a/b" — the "/a"
+# follows a colon), while drive-letter mentions still match after a colon
+# via the Windows pattern ("目录:C:\x" works; "目录:/tmp" is dropped —
+# colon-adjacent POSIX paths are almost always URLs or prose).
+_POSIX_PATH_RE = _re.compile(
+    rf"(?<![^{_BOUNDARY_CHARS}])(?<!:)(?:~)?/{_PATH_CHARS}"
+)
+
+# Trailing punctuation that gets glued to a path by the surrounding prose:
+# "输出到 C:\Users\x\Desktop\test_result，", "……test_result。"
+_TRAILING_PUNCT = ".,;:!?，。；：！？)）]】\"'"
+
+# Depth-1 directories of a drive that must never become roots.
+_TOP_LEVEL_SYSTEM_DIRS = frozenset({
+    "users", "windows", "program files", "program files (x86)",
+    "programdata", "perflogs", "$recycle.bin", "system volume information",
+})
+
+# Default cap on auto-sensed roots per turn.
+DEFAULT_MAX_USER_ROOTS = 8
+
+
+def _is_protected_extra_root(root: Path, workspace: Path) -> bool:
+    """Return True when *root* would make protected paths writable.
+
+    Auto-sensed (and user-configured) extra roots must never cover the host
+    config file or per-session files, otherwise a broad root (e.g. ``~/.miqi``
+    or the workspace itself) could bypass read-only config handling and
+    session isolation.
+    """
+    config = get_config_path().resolve()
+    sessions = (workspace / "sessions").resolve()
+    if config.is_relative_to(root):
+        return True
+    if sessions.is_relative_to(root) or root.is_relative_to(sessions):
+        return True
+    return False
+
+
+def _is_top_level_system_dir(root: Path) -> bool:
+    """True for drive-level system dirs, incl. space-truncated matches.
+
+    A mention of ``C:\\Program Files`` is tokenized up to the space
+    (``C:\\Program``) because path tokens cannot contain whitespace; the
+    prefix check keeps that residue from becoming a root.
+    """
+    if root.parent != Path(root.anchor):
+        return False
+    name = root.name.lower()
+    for sys_name in _TOP_LEVEL_SYSTEM_DIRS:
+        if name == sys_name or sys_name.startswith(name + " "):
+            return True
+    return False
+
+
+def _strip_trailing(raw: str) -> str:
+    """Strip trailing separators and prose punctuation from a raw mention."""
+    s = raw
+    for _ in range(2):
+        s = s.rstrip("/\\")
+        s = s.rstrip(_TRAILING_PUNCT)
+    return s
+
+
+def _raw_mentions(text: str) -> list[str]:
+    """Extract raw absolute-path mentions from one message text."""
+    found: list[str] = []
+    for pattern in (_WIN_PATH_RE, _MNT_PATH_RE, _POSIX_PATH_RE):
+        for m in pattern.finditer(text):
+            raw = _strip_trailing(m.group(0))
+            if len(raw) < 2:
+                continue
+            if raw.endswith(":"):
+                continue  # bare drive root like "C:"
+            if raw not in found:
+                found.append(raw)
+    return found
+
+
+def _to_host_path(raw: str) -> str | None:
+    """Convert a raw mention to a normalized host path string.
+
+    ``/mnt/c/...`` becomes ``C:/...``; backslashes become forward slashes.
+    Drive-letter mentions are dropped on non-Windows hosts (they cannot be
+    meaningful there, and ``Path.resolve()`` would prepend the CWD).
+    """
+    s = raw.replace("\\", "/")
+    m = _re.match(r"^/mnt/([a-zA-Z])/(.*)$", s)
+    if m:
+        s = f"{m.group(1).upper()}:/{m.group(2)}"
+    m = _re.match(r"^([a-zA-Z]):/(.*)$", s)
+    if m:
+        s = f"{m.group(1).upper()}:/{m.group(2)}"
+        if _sys.platform != "win32":
+            return None
+    return _os.path.normpath(s).replace("\\", "/")
+
+
+def _candidate_root(host: str) -> Path | None:
+    """Resolve a host path into a root Path, or None when unusable.
+
+    On Windows the path is fully resolved (symlinks, 8.3 short names,
+    ``..``).  On POSIX drive-letter paths never get here (see
+    ``_to_host_path``), and POSIX absolute paths resolve normally.
+    """
+    try:
+        if _sys.platform == "win32":
+            return Path(host).expanduser().resolve()
+        return Path(_os.path.normpath(host)).expanduser().resolve()
+    except (OSError, ValueError):
+        _log.debug("user_roots: cannot resolve mention %r", host)
+        return None
+
+
+def extract_user_mentioned_roots(
+    texts: Iterable[str],
+    *,
+    workspace: Path | None = None,
+    max_roots: int = DEFAULT_MAX_USER_ROOTS,
+) -> list[Path]:
+    """Extract legal roots from directory mentions in user message texts.
+
+    Args:
+        texts: The user's message texts for the current turn (only user-role
+            content — never model/tool content).
+        workspace: Session workspace; used to drop mentions that are already
+            legal roots or that would cover protected config/session paths.
+        max_roots: Cap on the number of returned roots.
+
+    Returns:
+        Canonical host ``Path`` roots that file tools may accept in
+        addition to their static shared roots.  May include not-yet-created
+        directories (output dirs the user asked for).
+    """
+    raws: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        for raw in _raw_mentions(str(text)):
+            if raw not in raws:
+                raws.append(raw)
+
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for raw in raws:
+        host = _to_host_path(raw)
+        if not host:
+            continue
+        cand = _candidate_root(host)
+        if cand is None:
+            continue
+
+        # An existing file's parent is the writable root; a directory (or a
+        # not-yet-existing path, i.e. a future output dir) roots itself.
+        try:
+            if cand.is_dir():
+                root = cand
+            elif cand.is_file():
+                root = cand.parent
+            else:
+                root = cand
+        except OSError:
+            root = cand
+
+        # Drive root (e.g. C:\) — Path.parent of a drive root is itself.
+        if root.parent == root:
+            continue
+        # The user profile root itself is too broad.
+        if root == Path.home().resolve():
+            continue
+        # Top-level system directories of a drive.
+        if _is_top_level_system_dir(root):
+            continue
+        # Protected paths: config file / per-session files.
+        if workspace is not None and _is_protected_extra_root(root, workspace):
+            continue
+        # Already covered by the workspace root — no need to add.
+        if workspace is not None:
+            try:
+                root.relative_to(workspace.resolve())
+                continue
+            except ValueError:
+                pass
+
+        key = _os.path.normcase(str(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+        if len(roots) >= max_roots:
+            break
+
+    return roots

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -533,6 +533,7 @@ class ToolsConfig(Base):
     papers: PapersToolConfig = Field(default_factory=PapersToolConfig)
     restrict_to_workspace: bool = False  # If true, restrict all tool access to workspace directory
     extra_roots: list[str] = Field(default_factory=list)  # Additional filesystem roots allowed by file tools
+    auto_user_dirs: bool = True  # Auto-sense output directories the user mentions and authorize file tools for the session (#821)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -171,6 +171,9 @@ class ToolExecutionContext:
     # Execution policy flags
     bypass_approval: bool = False
     force_approval: bool = False
+    # #821: directories the user mentioned this turn (auto-sensed by the
+    # turn runner); injected into file tools as ``_user_roots``.
+    user_mentioned_roots: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -841,6 +844,11 @@ class ToolOrchestrator:
             kwargs["_sandbox"] = sandbox
             # _session_key already includes client_id prefix (e.g. "miqi-desktop:desktop:xxx")
             kwargs["_session_key"] = ctx.session_id
+            # #821: auto-sensed user-mentioned output dirs — mirrors the KUN
+            # tool host injection so file tools accept the user's explicitly
+            # requested output location (e.g. Desktop/test_result).
+            if ctx.user_mentioned_roots:
+                kwargs["_user_roots"] = list(ctx.user_mentioned_roots)
         elif sandbox.sandbox_type != SandboxType.NONE:
             kwargs["_sandbox"] = sandbox
 

--- a/miqi/kun_runtime/loop.py
+++ b/miqi/kun_runtime/loop.py
@@ -9,12 +9,14 @@ All dependencies are constructor-injected for testability.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 import time
 import uuid
 from typing import Any, Literal
 
 from loguru import logger
 
+from miqi.agent.tools.user_roots import extract_user_mentioned_roots
 from miqi.kun_runtime.cancellation import CancellationToken, InflightTracker
 from miqi.kun_runtime.compactor import ContextCompactor
 from miqi.kun_runtime.event_recorder import RuntimeEventRecorder
@@ -94,6 +96,30 @@ def _remember_key(payload: dict[str, Any]) -> str:
     )
     raw = f"{title}|{message}|{steps}|{choices}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _turn_user_texts(
+    thread: dict[str, Any], items: list[dict[str, Any]], turn_id: str,
+) -> list[str]:
+    """Collect the current turn's user-message texts (prompt + steering).
+
+    Issue #821: only user-role content is scanned for directory mentions —
+    never model output or tool results, so prompt injection via documents
+    cannot grant roots.
+    """
+    texts: list[str] = []
+    for turn in thread.get("turns") or []:
+        if turn.get("id") == turn_id:
+            prompt = str(turn.get("prompt") or "")
+            if prompt:
+                texts.append(prompt)
+            break
+    for item in items:
+        if item.get("turnId") == turn_id and item.get("kind") == "user_message":
+            text = str(item.get("text") or "")
+            if text and text not in texts:
+                texts.append(text)
+    return texts
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -408,6 +434,22 @@ class AgentLoop:
         # generation, parallel search), think = current behavior.
         mode_cfg = get_mode_config((thread.get("metadata") or {}).get("mode"))
 
+        # User-mentioned output dirs (issue #821): auto-sense directories the
+        # user named in this turn's messages so file tools can read/write
+        # them (e.g. "输出到 C:\Users\x\Desktop\test_result").  Extraction is
+        # best-effort — a failure must never kill the turn.
+        _user_texts = _turn_user_texts(thread, loaded_items, turn_id)
+        _ws_raw = thread.get("workspace") or ""
+        try:
+            _user_roots = extract_user_mentioned_roots(
+                _user_texts, workspace=Path(_ws_raw) if _ws_raw else None,
+            )
+        except Exception:
+            logger.warning("user_roots extraction failed — continuing without extra roots", exc_info=True)
+            _user_roots = []
+        if _user_roots:
+            logger.debug("turn {}: user-mentioned roots: {}", turn_id, _user_roots)
+
         # List tools
         tool_context = ToolHostContext(
             thread_id=thread_id,
@@ -424,6 +466,7 @@ class AgentLoop:
             mode=mode_cfg.mode,
             search_strategy=mode_cfg.search,
             parallel_limit=mode_cfg.tool.parallel_limit,
+            user_mentioned_roots=[str(r) for r in _user_roots],
         )
         tools = await self._opts.tool_host.list_tools(tool_context)
         tool_specs = [ModelToolSpec(

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -61,6 +61,13 @@ class ToolHostContext:
     search_strategy: Any = None
     parallel_limit: int | None = None
 
+    # Directories the user mentioned in their message this turn (issue #821).
+    # The agent loop extracts them from user_message items; the tool host
+    # injects them as ``_user_roots`` so file tools can read/write the
+    # user-requested output dirs (e.g. Desktop/test_result) without static
+    # tools.extra_roots config.
+    user_mentioned_roots: list[str] = field(default_factory=list)
+
 
 @dataclass
 class ToolHostResult:
@@ -84,6 +91,8 @@ ASK_USER_CONFIRM_TOOL = "ask_user_confirm_card"
 # (sessions/<key>/files) can only engage when the tool knows which session
 # is executing — the KUN tool host is the single execution point here, so it
 # must do the same injection or file writes land in the shared root.
+# graph_render is included for parity with the legacy orchestrator
+# (CodeRabbit #761) — it writes svg/html artifacts and reads source JSON.
 _SESSION_KEY_TOOLS = frozenset({
     "exec",
     "write_file", "edit_file", "delete_file", "apply_patch",
@@ -93,6 +102,16 @@ _SESSION_KEY_TOOLS = frozenset({
     "create_pdf", "pdf_write", "pdf_read",
     "edit_docx", "append_xlsx",
     "paper_download",
+    "graph_render",
+})
+
+# File tools that accept the injected ``_user_roots`` — directories the
+# user mentioned in their message (issue #821), auto-sensed by the agent
+# loop.  Only file-ish tools consume them; injecting into every tool would
+# be harmless but pointless.
+_USER_ROOTS_TOOLS = frozenset({
+    "write_file", "edit_file", "read_file", "list_dir",
+    "apply_patch", "graph_render",
 })
 
 
@@ -317,6 +336,12 @@ class MiQiToolHost:
                 session_key = thread_id_to_session_key(context.thread_id) or context.thread_id
                 if session_key:
                     extra["_session_key"] = session_key
+            # User-mentioned output dirs (issue #821): pass the turn's
+            # auto-sensed roots to file tools so the user's explicitly
+            # requested output location (e.g. Desktop/test_result) works
+            # without static tools.extra_roots config.
+            if tool_name in _USER_ROOTS_TOOLS and context.user_mentioned_roots:
+                extra["_user_roots"] = list(context.user_mentioned_roots)
             # Reasoning mode (issue #680): hand the fast-mode search strategy
             # to web_search so it can fan out (parallel queries + fetches).
             if tool_name == "web_search" and context.search_strategy is not None:

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -609,6 +609,19 @@ class AgentControl:
                             client_id=turn_ctx.client_id,
                             session_id=turn_ctx.session_id,
                         )
+                        # #821: sub-agents inherit the parent task's
+                        # user-mentioned output dirs (the spawn prompt usually
+                        # echoes them).
+                        try:
+                            from miqi.agent.tools.user_roots import extract_user_mentioned_roots
+
+                            ctx.user_mentioned_roots = [
+                                str(r) for r in extract_user_mentioned_roots(
+                                    [task], workspace=self.workspace,
+                                )
+                            ]
+                        except Exception:
+                            ctx.user_mentioned_roots = []
                         ctx = await self._orchestrator.execute(ctx)
                         result = ctx.result or ""
                         success = ctx.status == OrchestrationResult.SUCCESS

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -14,26 +14,10 @@ from pathlib import Path
 from typing import Any
 
 from miqi.agent.tools.registry import ToolRegistry
+from miqi.agent.tools.user_roots import _is_protected_extra_root
 from miqi.paths import get_config_path
 
 _log = logging.getLogger(__name__)
-
-
-def _is_protected_extra_root(root: Path, workspace: Path) -> bool:
-    """Return True when *root* would make protected paths writable.
-
-    User-configured extra roots must never cover the host config file or
-    per-session files, otherwise a broad root (e.g. ``~/.miqi`` or the
-    workspace itself) could bypass read-only config handling and session
-    isolation.
-    """
-    config = get_config_path().resolve()
-    sessions = (workspace / "sessions").resolve()
-    if config.is_relative_to(root):
-        return True
-    if sessions.is_relative_to(root) or root.is_relative_to(sessions):
-        return True
-    return False
 
 
 def _resolve_default_shared_dir(workspace: Path, sub: str) -> Path | None:
@@ -185,6 +169,14 @@ def create_runtime_tool_registry(
             continue
         _shared_roots.append(_root)
 
+    # Auto-sensed user-mentioned output dirs (issue #821): the KUN runtime
+    # injects them per tool call (``_user_roots``); this flag gates the
+    # tools' acceptance of that injection.
+    _auto_user_dirs = (
+        bool(getattr(tools_cfg, "auto_user_dirs", True))
+        if tools_cfg is not None else True
+    )
+
     # Read-only whitelist for the host config file (issue #553): agents may
     # inspect settings, but write/edit/patch tools keep rejecting it so the
     # config (API keys, model setup) can never be tampered with.
@@ -228,6 +220,7 @@ def create_runtime_tool_registry(
             allowed_dir=allowed_dir,
             sandbox_manager=_sbm,
             shared_roots=_read_shared_roots,
+            allow_user_roots=_auto_user_dirs,
         )
     )
     # ReadFileTool additionally gets the per-session files dir so reads of
@@ -240,6 +233,7 @@ def create_runtime_tool_registry(
             sandbox_manager=_sbm,
             shared_roots=_read_shared_roots,
             session_files_dir=_work_dir,
+            allow_user_roots=_auto_user_dirs,
         )
     )
     registry.register(
@@ -251,6 +245,7 @@ def create_runtime_tool_registry(
             shared_roots=_shared_roots,
             session_files_dir=_work_dir,
             base_workspace=workspace,
+            allow_user_roots=_auto_user_dirs,
         )
     )
     registry.register(
@@ -262,6 +257,7 @@ def create_runtime_tool_registry(
             shared_roots=_shared_roots,
             session_files_dir=_work_dir,
             base_workspace=workspace,
+            allow_user_roots=_auto_user_dirs,
         )
     )
     registry.register(
@@ -273,6 +269,7 @@ def create_runtime_tool_registry(
             shared_roots=_shared_roots,
             session_files_dir=_work_dir,
             base_workspace=workspace,
+            allow_user_roots=_auto_user_dirs,
         )
     )
 
@@ -455,6 +452,7 @@ def create_runtime_tool_registry(
             sandbox_manager=_sbm,
             shared_roots=_shared_roots,
             base_workspace=workspace,
+            allow_user_roots=_auto_user_dirs,
         )
     )
 

--- a/miqi/runtime/tool_runtime.py
+++ b/miqi/runtime/tool_runtime.py
@@ -41,6 +41,10 @@ class ToolRuntime:
             # Execution policy flags
             bypass_approval=getattr(turn, "bypass_approval", False),
             force_approval=getattr(turn, "force_approval", False),
+            # #821: user-mentioned output dirs auto-sensed by the turn runner
+            user_mentioned_roots=[
+                str(r) for r in getattr(turn, "user_mentioned_roots", []) or []
+            ],
         )
         # Phase 13: pass per-turn permission profile to orchestrator
         permission_profile = getattr(turn, "permission_profile", None)

--- a/miqi/runtime/turn_context.py
+++ b/miqi/runtime/turn_context.py
@@ -51,3 +51,7 @@ class TurnContext:
     # Execution policy flags for approval layer
     bypass_approval: bool = False    # skip all approval checks
     force_approval: bool = False     # require approval even if switch is off
+    # #821: directories the user mentioned in this turn's messages
+    # (auto-sensed by the turn runner; injected into file tools as
+    # ``_user_roots`` via ToolRuntime/orchestrator).  Host Paths.
+    user_mentioned_roots: list[Path] = field(default_factory=list)

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from loguru import logger
 
+from miqi.agent.tools.user_roots import extract_user_mentioned_roots
 from miqi.execution.hook_runtime import (
     HookPoint,
     HookRuntime,
@@ -234,6 +235,15 @@ class TurnRunner:
         # first streamed delta (content or reasoning)，使端到端首字延迟可观测。
         _turn_started = time.perf_counter()
         _first_token_logged = False
+
+        # #821: auto-sense directories the user named in their message
+        # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
+        # read/write them.  Extracted once per turn from user-role text only;
+        # mid-turn steering messages refresh the roots below.
+        _user_texts = [user_content]
+        turn.user_mentioned_roots = extract_user_mentioned_roots(
+            _user_texts, workspace=getattr(turn, "workspace", None),
+        )
 
         messages = self._context.build_initial_messages(
             turn=turn,
@@ -489,6 +499,13 @@ class TurnRunner:
                         if steer.get("input_items"):
                             delta["input_items"] = steer["input_items"]
                         messages_delta.append(delta)
+                    # #821: refresh auto-sensed roots with the steering text
+                    # (the user may name a new output dir mid-turn).
+                    for steer in steers:
+                        _user_texts.append(steer["content"])
+                    turn.user_mentioned_roots = extract_user_mentioned_roots(
+                        _user_texts, workspace=getattr(turn, "workspace", None),
+                    )
                     continue
 
                 content = response.content or ""

--- a/tests/agent/tools/test_graph_render.py
+++ b/tests/agent/tools/test_graph_render.py
@@ -519,3 +519,41 @@ class TestCodeRabbitFixes:
         tool = make_tool(tmp_path)
         result = json.loads(await tool.execute(path=str(src)))
         assert result["ok"] is True
+
+
+# ── 跨会话隔离（CodeRabbit #851）────────────────────────────────────────
+class TestSessionIsolation:
+    """graph_render 不得读取/写入其他会话的 files 目录（#689 红线）。"""
+
+    @pytest.mark.asyncio
+    async def test_foreign_session_graphs_rejected(self) -> None:
+        from miqi.paths import get_miqi_home
+
+        ws = Path(get_miqi_home()) / "workspace"
+        other = ws / "sessions" / "other-session-851" / "files"
+        other.mkdir(parents=True, exist_ok=True)
+        (other / "step-graph.json").write_text(
+            json.dumps(STEP_GRAPH, ensure_ascii=False), encoding="utf-8",
+        )
+        tool = GraphRenderTool(workspace=ws, base_workspace=ws)
+        result = json.loads(
+            await tool.execute(str(other), _session_key="desktop:own-session-851")
+        )
+        assert result["ok"] is False
+        assert "权限拒绝" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_own_session_graphs_allowed(self) -> None:
+        from miqi.paths import get_miqi_home
+
+        ws = Path(get_miqi_home()) / "workspace"
+        own = ws / "sessions" / "desktop_own-session-851" / "files"
+        own.mkdir(parents=True, exist_ok=True)
+        (own / "step-graph.json").write_text(
+            json.dumps(STEP_GRAPH, ensure_ascii=False), encoding="utf-8",
+        )
+        tool = GraphRenderTool(workspace=ws, base_workspace=ws)
+        result = json.loads(
+            await tool.execute(str(own), _session_key="desktop:own-session-851")
+        )
+        assert result["ok"] is True

--- a/tests/agent/tools/test_user_roots.py
+++ b/tests/agent/tools/test_user_roots.py
@@ -1,0 +1,202 @@
+"""Unit tests for user-mentioned output directory extraction (issue #821).
+
+The KUN agent loop auto-senses directories the user names in their message
+(e.g. "输出到 C:\\Users\\x\\Desktop\\test_result") so file tools can
+read/write them without static ``tools.extra_roots`` config.  These tests
+cover extraction, root classification, and the guard rails (home root,
+system dirs, protected config/session paths, workspace dedupe, caps).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import _effective_shared_roots
+from miqi.agent.tools.user_roots import (
+    DEFAULT_MAX_USER_ROOTS,
+    _is_protected_extra_root,
+    _raw_mentions,
+    extract_user_mentioned_roots,
+)
+from miqi.paths import get_config_path
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+# ── _raw_mentions ────────────────────────────────────────────────────────
+
+
+class TestRawMentions:
+    def test_windows_paths(self) -> None:
+        raw = _raw_mentions(
+            r"输出到 C:\Users\wangsaibo\Desktop\test_result 和 D:\data\mof_price相关"
+        )
+        assert r"C:\Users\wangsaibo\Desktop\test_result" in raw
+        assert r"D:\data\mof_price相关" in raw
+
+    def test_forward_slash_and_mnt_forms(self) -> None:
+        raw = _raw_mentions("放 C:/Users/x/out/ 与 /mnt/d/share/ 里")
+        assert "C:/Users/x/out" in raw
+        assert "/mnt/d/share" in raw
+
+    def test_posix_and_home_forms(self) -> None:
+        raw = _raw_mentions("写到 ~/Desktop/work 和 /tmp/out_dir 里")
+        assert "~/Desktop/work" in raw
+        assert "/tmp/out_dir" in raw
+
+    def test_trailing_punctuation_stripped(self) -> None:
+        raw = _raw_mentions(r"输出到 C:\Users\x\Desktop\test_result，然后分析。")
+        assert raw == [r"C:\Users\x\Desktop\test_result"]
+
+    def test_path_glued_to_cjk_prose_not_extracted(self, tmp_path: Path) -> None:
+        # "输出到<路径>" with no separator — the boundary requirement keeps
+        # prose-glued CJK out to avoid false positives.
+        assert extract_user_mentioned_roots([f"输出到{tmp_path}"] ) == []
+
+    def test_drive_root_skipped(self) -> None:
+        assert _raw_mentions(r"看下 C:\ 的内容") == []
+
+    def test_plain_text_returns_empty(self) -> None:
+        assert _raw_mentions("帮我写一个报告，关于 MOF 材料的价格分析") == []
+
+    def test_urls_not_matched(self) -> None:
+        assert _raw_mentions("参考 https://example.com/a/b 和 http://x.y/z") == []
+
+
+# ── extract_user_mentioned_roots ─────────────────────────────────────────
+
+
+class TestExtractUserMentionedRoots:
+    def test_empty_input(self) -> None:
+        assert extract_user_mentioned_roots([]) == []
+        assert extract_user_mentioned_roots(["没有路径"]) == []
+
+    def test_existing_dir_roots_itself(self, tmp_path: Path) -> None:
+        out = tmp_path / "test_result"
+        out.mkdir()
+        roots = extract_user_mentioned_roots([f"结果输出到 {out}，谢谢"])
+        assert roots == [out.resolve()]
+
+    def test_existing_file_uses_parent(self, tmp_path: Path) -> None:
+        f = tmp_path / "report.json"
+        f.write_text("{}", encoding="utf-8")
+        roots = extract_user_mentioned_roots([f"输出到 {f}"])
+        assert roots == [tmp_path.resolve()]
+
+    def test_nonexistent_output_dir_rooted_itself(self, tmp_path: Path) -> None:
+        # "输出到 尚不存在的目录" — the mention itself becomes the root so
+        # the first write_file can create it.
+        out = tmp_path / "not_yet_created" / "esm2"
+        roots = extract_user_mentioned_roots([f"结果输出到 {out}"])
+        assert roots == [out.resolve()]
+
+    def test_dedupe_and_cap(self, tmp_path: Path) -> None:
+        dirs = [tmp_path / f"d{i}" for i in range(DEFAULT_MAX_USER_ROOTS + 4)]
+        for d in dirs:
+            d.mkdir()
+        text = "输出到 " + " ".join(str(d) for d in dirs)
+        # same text twice → dedupe
+        roots = extract_user_mentioned_roots([text, text])
+        assert len(roots) == DEFAULT_MAX_USER_ROOTS
+
+    def test_workspace_mentions_skipped(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "ws" / "sub"
+        out.mkdir()
+        roots = extract_user_mentioned_roots([f"输出到 {out}"], workspace=ws)
+        assert roots == []
+
+    def test_home_root_skipped(self) -> None:
+        roots = extract_user_mentioned_roots([f"把文件放到 {Path.home()}"])
+        assert roots == []
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-root/system-dir guards are Windows-only")
+    def test_top_level_system_dirs_skipped(self) -> None:
+        roots = extract_user_mentioned_roots([
+            r"放 C:\Windows 和 C:\Users 以及 C:\Program Files",
+        ])
+        assert roots == []
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter mentions Windows-only")
+    def test_windows_desktop_mention_allowed(self) -> None:
+        # C:\Users\<user>\Desktop is depth-3 — allowed (the issue's scenario).
+        desktop = Path.home() / "Desktop"
+        roots = extract_user_mentioned_roots([f"结果输出到 {desktop}"])
+        assert desktop.resolve() in roots
+
+    def test_protected_config_root_skipped(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        config_dir = Path(get_config_path()).parent
+        roots = extract_user_mentioned_roots([f"看下 {config_dir}"], workspace=ws)
+        assert roots == []
+
+    def test_protected_sessions_root_skipped(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        sessions = ws / "sessions"
+        sessions.mkdir()
+        roots = extract_user_mentioned_roots([f"输出到 {sessions}"], workspace=ws)
+        assert roots == []
+
+    def test_workspace_none_skips_protected_check(self, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        out.mkdir()
+        assert extract_user_mentioned_roots([str(out)], workspace=None) == [out.resolve()]
+
+
+# ── _is_protected_extra_root ─────────────────────────────────────────────
+
+
+class TestIsProtectedExtraRoot:
+    def test_config_path_covered(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        root = Path(get_config_path()).parent
+        assert _is_protected_extra_root(root, ws) is True
+
+    def test_sessions_dir_covered(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        assert _is_protected_extra_root(ws / "sessions", ws) is True
+
+    def test_ordinary_dir_not_protected(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        assert _is_protected_extra_root(out, ws) is False
+
+
+# ── _effective_shared_roots ──────────────────────────────────────────────
+
+
+class TestEffectiveSharedRoots:
+    def test_merge_user_roots(self, tmp_path: Path) -> None:
+        base = [tmp_path / "ws"]
+        out = tmp_path / "out"
+        merged = _effective_shared_roots(base, [str(out)], allow_user_roots=True)
+        assert merged == [*base, out]
+
+    def test_disabled_flag_ignores_user_roots(self, tmp_path: Path) -> None:
+        base = [tmp_path / "ws"]
+        merged = _effective_shared_roots(base, [str(tmp_path / "out")], allow_user_roots=False)
+        assert merged == base
+
+    def test_none_user_roots_returns_base(self, tmp_path: Path) -> None:
+        base = [tmp_path / "ws"]
+        assert _effective_shared_roots(base, None, True) == base
+
+    def test_duplicates_skipped(self, tmp_path: Path) -> None:
+        base = [tmp_path / "ws"]
+        merged = _effective_shared_roots(base, [str(base[0]), str(base[0])], True)
+        assert merged == base
+
+    def test_invalid_entries_ignored(self, tmp_path: Path) -> None:
+        base = [tmp_path / "ws"]
+        merged = _effective_shared_roots(base, [None, 123, b"bytes"], True)
+        assert merged == base

--- a/tests/agent/tools/test_user_roots.py
+++ b/tests/agent/tools/test_user_roots.py
@@ -121,6 +121,11 @@ class TestExtractUserMentionedRoots:
         ])
         assert roots == []
 
+    def test_posix_top_level_system_dirs_skipped(self) -> None:
+        """POSIX 顶层系统目录（/etc、/usr、/var）同样永不授权（CodeRabbit #851）。"""
+        roots = extract_user_mentioned_roots(["看 /etc 和 /usr 还有 /var 目录"])
+        assert roots == []
+
     @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter mentions Windows-only")
     def test_windows_desktop_mention_allowed(self) -> None:
         # C:\Users\<user>\Desktop is depth-3 — allowed (the issue's scenario).

--- a/tests/kun_runtime/test_agent_loop_basic.py
+++ b/tests/kun_runtime/test_agent_loop_basic.py
@@ -371,3 +371,51 @@ class TestAgentLoopUsage:
 
         snap = usage.for_thread(thread_id)
         assert snap.get("promptTokens", 0) >= 100
+
+
+class TestAgentLoopUserRoots:
+    """Issue #821: directories the user mentions reach the tool host context."""
+
+    @pytest.mark.asyncio
+    async def test_user_mentioned_roots_reach_tool_context(
+        self,
+        loop_opts: AgentLoopOptions,
+        thread_store: FileThreadStore,
+        turn_svc: TurnService,
+        tmp_path: Path,
+    ) -> None:
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        # The thread workspace is tmp_path/"ws" so the mentioned dir sits
+        # OUTSIDE it — an inside mention would be skipped as already legal.
+        thread = {
+            "id": "th1",
+            "title": "Test Thread",
+            "workspace": str(tmp_path / "ws"),
+            "model": "fake-model",
+            "mode": "agent",
+            "status": "idle",
+            "approvalPolicy": "auto",
+            "sandboxMode": "workspace-write",
+            "relation": "primary",
+            "costBudgetWarningSent": False,
+            "createdAt": FIXED_TIME,
+            "updatedAt": FIXED_TIME,
+            "turns": [],
+        }
+        await thread_store.upsert(thread)
+        result = await turn_svc.start_turn("th1", f"处理 XX，结果输出到 {out_dir}，谢谢")
+        turn_id = result["turnId"]
+
+        loop_opts.model = FakeModelClient(
+            text_chunks=["Let me check..."],
+            tool_calls=[{"id": "call_1", "name": "read", "arguments": {"path": "test.txt"}}],
+        )
+        loop = AgentLoop(loop_opts)
+        status = await loop.run_turn("th1", turn_id)
+        assert status == "completed"
+
+        assert loop_opts.tool_host.calls, "expected at least one tool dispatch"
+        context = loop_opts.tool_host.calls[-1][1]
+        roots = [str(Path(r)) for r in context.user_mentioned_roots]
+        assert str(out_dir.resolve()) in roots

--- a/tests/kun_runtime/test_tool_host.py
+++ b/tests/kun_runtime/test_tool_host.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -409,3 +410,70 @@ class TestFakeToolHost:
             ToolCallLike(call_id="c2", tool_name="read", arguments={}),
         ]
         assert host.should_parallelize(calls) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Issue #821 — user-mentioned roots injection
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class _RecordingWriteTool(Tool):
+    """Captures the kwargs injected by MiQiToolHost.execute."""
+
+    name = "write_file"
+    description = "Write a file"
+    parameters = {"type": "object", "properties": {"path": {"type": "string"}}}
+
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, object] | None = None
+
+    async def execute(self, path: str = "", content: str = "", **kwargs: Any) -> str:
+        self.last_kwargs = dict(kwargs)
+        return f"wrote {path}"
+
+
+class TestUserRootsInjection:
+    @pytest.mark.asyncio
+    async def test_user_roots_injected_for_file_tools(self) -> None:
+        tool = _RecordingWriteTool()
+        reg = ToolRegistry()
+        reg.register(tool)
+        host = MiQiToolHost(reg)
+
+        ctx = ToolHostContext(
+            thread_id="th1",
+            turn_id="t1",
+            workspace="/tmp",
+            user_mentioned_roots=["C:/Users/x/Desktop/test_result"],
+        )
+        call = ToolCallLike(
+            call_id="c1", tool_name="write_file",
+            arguments={"path": "C:/Users/x/Desktop/test_result/report.md"},
+        )
+        result = await host.execute(call, ctx)
+        assert result.item["isError"] is False
+        assert tool.last_kwargs is not None
+        assert tool.last_kwargs["_user_roots"] == ["C:/Users/x/Desktop/test_result"]
+        # Session key is injected alongside (KUN file-tool contract).
+        assert "_session_key" in tool.last_kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_user_roots_when_context_empty(self) -> None:
+        tool = _RecordingWriteTool()
+        reg = ToolRegistry()
+        reg.register(tool)
+        host = MiQiToolHost(reg)
+
+        ctx = ToolHostContext(thread_id="th1", turn_id="t1", workspace="/tmp")
+        call = ToolCallLike(call_id="c1", tool_name="write_file", arguments={"path": "a.txt"})
+        await host.execute(call, ctx)
+        assert tool.last_kwargs is not None
+        assert "_user_roots" not in tool.last_kwargs
+
+    def test_graph_render_receives_session_key(self) -> None:
+        # Parity with the legacy orchestrator (CodeRabbit #761): graph_render
+        # writes artifacts and reads source JSON, so it must be in the
+        # session-key injection set on the KUN tool host.
+        from miqi.kun_runtime.tool_host import _SESSION_KEY_TOOLS
+
+        assert "graph_render" in _SESSION_KEY_TOOLS

--- a/tests/runtime/test_turn_runner_user_roots.py
+++ b/tests/runtime/test_turn_runner_user_roots.py
@@ -1,0 +1,335 @@
+"""Legacy (desktop) path tests for user-mentioned output dirs (issue #821).
+
+The desktop bridge runs RuntimeSession → TurnRunner → ToolRuntime →
+ToolOrchestrator (not the KUN loop), so the auto-sensed roots must flow:
+  TurnRunner (extract from user_content, refresh on steering)
+    → TurnContext.user_mentioned_roots
+    → ToolRuntime → ToolExecutionContext.user_mentioned_roots
+    → ToolOrchestrator._execute_in_sandbox → `_user_roots` kwargs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.execution.hook_runtime import HookRuntime, HookOutcome
+from miqi.execution.orchestrator import (
+    ToolExecutionContext,
+    ToolOrchestrator,
+)
+from miqi.execution.permission_engine import (
+    PermissionDecision,
+    PermissionEngine,
+    PermissionVerdict,
+)
+from miqi.config.schema import ApprovalBypassConfig
+from miqi.providers.base import LLMResponse, LLMStreamEvent
+from miqi.runtime.tool_runtime import ToolRuntime
+from miqi.runtime.turn_runner import TurnRunner
+
+
+class _FakeContextRuntime:
+    def build_initial_messages(
+        self,
+        *,
+        turn: Any,
+        user_content: str,
+        system_prompt: str,
+        history: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        return [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ]
+
+    def add_assistant_message(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        content: str,
+        tool_calls: list[dict[str, Any]] | None = None,
+        reasoning_content: str | None = None,
+    ) -> list[dict[str, Any]]:
+        return [*messages, {"role": "assistant", "content": content}]
+
+    def trim_for_model(self, messages: Any, model: str) -> Any:
+        return messages
+
+
+class _FakeToolRuntime:
+    async def execute_many(self, turn: Any, tool_calls: list[Any]) -> list[Any]:
+        return []
+
+
+class _FakeProvider:
+    async def stream_chat(self, **kwargs: Any):
+        yield LLMStreamEvent(
+            kind="completed",
+            response=LLMResponse(content="hello"),
+        )
+
+
+class _FakeEventEmitter:
+    async def emit(self, event: Any) -> None:
+        pass
+
+
+def _make_runner() -> TurnRunner:
+    return TurnRunner(
+        provider=_FakeProvider(),
+        tool_runtime=_FakeToolRuntime(),
+        context_runtime=_FakeContextRuntime(),
+        event_emitter=_FakeEventEmitter(),
+        max_iterations=3,
+    )
+
+
+# ── TurnRunner: extraction ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_extracts_user_mentioned_roots(tmp_path: Path) -> None:
+    """A dir the user names in their message lands on turn.user_mentioned_roots."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "Desktop_out"
+    out.mkdir()
+    runner = _make_runner()
+
+    turn = SimpleNamespace(
+        turn_id="turn-1",
+        thread_id="thread-1",
+        model="default",
+        temperature=0.1,
+        max_tokens=100,
+        workspace=ws,
+    )
+    await runner.run(
+        turn=turn,
+        user_content=f"结果输出到 {out}，谢谢",
+        system_prompt="sys",
+        tools=None,
+    )
+    assert turn.user_mentioned_roots == [out.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_skips_workspace_covered_mentions(tmp_path: Path) -> None:
+    """A mention already inside the workspace adds no root."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    sub = ws / "sub"
+    sub.mkdir()
+    runner = _make_runner()
+
+    turn = SimpleNamespace(
+        turn_id="turn-1",
+        thread_id="thread-1",
+        model="default",
+        temperature=0.1,
+        max_tokens=100,
+        workspace=ws,
+    )
+    await runner.run(
+        turn=turn,
+        user_content=f"输出到 {sub}",
+        system_prompt="sys",
+        tools=None,
+    )
+    assert turn.user_mentioned_roots == []
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_refreshes_roots_on_steering(tmp_path: Path) -> None:
+    """A steering message naming a new output dir refreshes the roots."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    first = tmp_path / "first_out"
+    first.mkdir()
+    second = tmp_path / "second_out"
+    second.mkdir()
+    steer_queue: asyncio.Queue = asyncio.Queue()
+    steer_queue.put_nowait({"content": f"改放到 {second} 里"})
+    runner = _make_runner()
+
+    turn = SimpleNamespace(
+        turn_id="turn-1",
+        thread_id="thread-1",
+        model="default",
+        temperature=0.1,
+        max_tokens=100,
+        workspace=ws,
+    )
+    await runner.run(
+        turn=turn,
+        user_content=f"结果输出到 {first}",
+        system_prompt="sys",
+        tools=None,
+        steer_queue=steer_queue,
+    )
+    assert first.resolve() in turn.user_mentioned_roots
+    assert second.resolve() in turn.user_mentioned_roots
+
+
+# ── ToolRuntime: context propagation ─────────────────────────────────────────
+
+
+class _CapturingOrchestrator:
+    def __init__(self) -> None:
+        self.last_ctx: ToolExecutionContext | None = None
+
+    async def execute(self, ctx: ToolExecutionContext) -> ToolExecutionContext:
+        self.last_ctx = ctx
+        ctx.result = "ok"
+        return ctx
+
+
+@pytest.mark.asyncio
+async def test_tool_runtime_passes_user_roots_to_context(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+    orch = _CapturingOrchestrator()
+    runtime = ToolRuntime(orchestrator=orch)
+
+    turn = SimpleNamespace(
+        turn_id="turn-1",
+        thread_id="thread-1",
+        agent_metadata=SimpleNamespace(name="main"),
+        client_id="",
+        session_id="",
+        user_mentioned_roots=[out.resolve()],
+    )
+    call = SimpleNamespace(name="write_file", id="call-1", arguments={"path": "x"})
+    await runtime.execute_one(turn, call)
+
+    assert orch.last_ctx is not None
+    assert orch.last_ctx.user_mentioned_roots == [str(out.resolve())]
+
+
+# ── Orchestrator: `_user_roots` kwarg injection ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_injects_user_roots_kwargs(tmp_path: Path) -> None:
+    """ToolOrchestrator passes ctx.user_mentioned_roots as `_user_roots`."""
+    out = tmp_path / "out"
+    out.mkdir()
+    components: dict[str, Any] = {
+        "permission_engine": MagicMock(),
+        "sandbox_engine": MagicMock(),
+        "hook_runtime": MagicMock(),
+        "tool_registry": MagicMock(),
+        "event_emitter": MagicMock(),
+    }
+    components["permission_engine"].check = AsyncMock(
+        return_value=PermissionDecision(
+            verdict=PermissionVerdict.ALLOW,
+            category="file_write",
+            description="ok",
+            allow_permanent=False,
+        )
+    )
+    components["sandbox_engine"].select = AsyncMock(
+        return_value=MagicMock(
+            sandbox_type="none",
+            filesystem_policy=MagicMock(),
+            network_policy="allow_all",
+        )
+    )
+    components["hook_runtime"].run = AsyncMock()
+    components["hook_runtime"].run_with_outcome = AsyncMock(
+        return_value=HookOutcome.continue_()
+    )
+    components["event_emitter"].emit = AsyncMock()
+
+    tool_mock = MagicMock()
+    tool_mock.execute = AsyncMock(return_value="Successfully wrote 5 bytes")
+    components["tool_registry"].get.return_value = tool_mock
+
+    orch = ToolOrchestrator(
+        permission_engine=components["permission_engine"],
+        sandbox_engine=components["sandbox_engine"],
+        hook_runtime=components["hook_runtime"],
+        tool_registry=components["tool_registry"],
+        event_emitter=components["event_emitter"],
+    )
+
+    ctx = ToolExecutionContext(
+        tool_name="write_file",
+        tool_call_id="call-1",
+        arguments={"path": str(out / "r.md"), "content": "hi"},
+        turn_id="turn-1",
+        thread_id="thread-1",
+        agent_type="main",
+        session_id="desktop:test",
+        user_mentioned_roots=[str(out.resolve())],
+    )
+    result = await orch.execute(ctx)
+
+    assert "Successfully wrote" in (result.result or "")
+    kwargs = tool_mock.execute.call_args.kwargs
+    assert kwargs["_user_roots"] == [str(out.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_user_roots_when_empty(tmp_path: Path) -> None:
+    """No user roots on ctx → no `_user_roots` kwarg injected."""
+    components: dict[str, Any] = {
+        "permission_engine": MagicMock(),
+        "sandbox_engine": MagicMock(),
+        "hook_runtime": MagicMock(),
+        "tool_registry": MagicMock(),
+        "event_emitter": MagicMock(),
+    }
+    components["permission_engine"].check = AsyncMock(
+        return_value=PermissionDecision(
+            verdict=PermissionVerdict.ALLOW,
+            category="file_write",
+            description="ok",
+            allow_permanent=False,
+        )
+    )
+    components["sandbox_engine"].select = AsyncMock(
+        return_value=MagicMock(
+            sandbox_type="none",
+            filesystem_policy=MagicMock(),
+            network_policy="allow_all",
+        )
+    )
+    components["hook_runtime"].run = AsyncMock()
+    components["hook_runtime"].run_with_outcome = AsyncMock(
+        return_value=HookOutcome.continue_()
+    )
+    components["event_emitter"].emit = AsyncMock()
+
+    tool_mock = MagicMock()
+    tool_mock.execute = AsyncMock(return_value="Successfully wrote 5 bytes")
+    components["tool_registry"].get.return_value = tool_mock
+
+    orch = ToolOrchestrator(
+        permission_engine=components["permission_engine"],
+        sandbox_engine=components["sandbox_engine"],
+        hook_runtime=components["hook_runtime"],
+        tool_registry=components["tool_registry"],
+        event_emitter=components["event_emitter"],
+    )
+
+    ctx = ToolExecutionContext(
+        tool_name="write_file",
+        tool_call_id="call-1",
+        arguments={"path": "/tmp/x.txt", "content": "hi"},
+        turn_id="turn-1",
+        thread_id="thread-1",
+        agent_type="main",
+        session_id="desktop:test",
+    )
+    await orch.execute(ctx)
+
+    kwargs = tool_mock.execute.call_args.kwargs
+    assert "_user_roots" not in kwargs

--- a/tests/sandbox/test_wsl_sandbox_path_mapping.py
+++ b/tests/sandbox/test_wsl_sandbox_path_mapping.py
@@ -381,3 +381,79 @@ class TestSandboxToHostPath:
         sb = _make_wsl_sandbox()
         assert _sandbox_to_host_path("", tmp_path, sb) == ""
         assert _sandbox_to_host_path(None, tmp_path, sb) is None
+
+
+# ── Issue #821: _user_roots injection into WriteFileTool ────────────────
+
+class TestWriteFileUserRootsWSL:
+    """Per-call user-mentioned roots authorize the user's output dirs under
+    the WSL sandbox (issue #821), and are ignored when disabled."""
+
+    def _make_manager(self, ws: Path):
+        from unittest.mock import AsyncMock
+
+        sb = _make_wsl_sandbox()
+        sb.is_running = True
+        sb.workspace = ws
+        sb.run_command = AsyncMock(return_value=(0, "", ""))
+        manager = MagicMock()
+        manager.active_sandbox = sb
+        manager.get_or_create = AsyncMock(return_value=sb)
+        return manager
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    @pytest.mark.asyncio
+    async def test_user_roots_allow_write_outside_workspace(self, tmp_path):
+        from miqi.agent.tools.filesystem import WriteFileTool
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "Desktop_out"
+        out.mkdir()
+        manager = self._make_manager(ws)
+        tool = WriteFileTool(
+            workspace=ws, sandbox_manager=manager, shared_roots=[ws],
+        )
+        target = out / "report.md"
+        result = await tool.execute(
+            str(target), "hello", _session_key="s1", _user_roots=[str(out)],
+        )
+        assert result.startswith("Successfully wrote")
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    @pytest.mark.asyncio
+    async def test_without_user_roots_write_rejected(self, tmp_path):
+        from miqi.agent.tools.filesystem import WriteFileTool
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "Desktop_out"
+        out.mkdir()
+        manager = self._make_manager(ws)
+        tool = WriteFileTool(
+            workspace=ws, sandbox_manager=manager, shared_roots=[ws],
+        )
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
+            await tool.execute(
+                str(out / "report.md"), "hello", _session_key="s1",
+            )
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="WSL containment Windows-only")
+    @pytest.mark.asyncio
+    async def test_disabled_flag_ignores_user_roots(self, tmp_path):
+        from miqi.agent.tools.filesystem import WriteFileTool
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "Desktop_out"
+        out.mkdir()
+        manager = self._make_manager(ws)
+        tool = WriteFileTool(
+            workspace=ws, sandbox_manager=manager, shared_roots=[ws],
+            allow_user_roots=False,
+        )
+        with pytest.raises(PermissionError, match="超出|不在|根目录"):
+            await tool.execute(
+                str(out / "report.md"), "hello", _session_key="s1",
+                _user_roots=[str(out)],
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.15.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

文件工具自动感知用户消息中点名的输出目录（如桌面 `C:\Users\x\Desktop\test_result`），本回合内放行 read/write/edit/list/apply_patch/graph_render 读写，消除 #689 修复后的残留缺口。KUN 与桌面生产（legacy TurnRunner/Orchestrator）两条路径均已接入。

## 背景/问题

#821：用户明确要求"输出到桌面某目录"时，合法根仍只有 `~/.miqi/workspace` + `memory/`/`skills/` + 静态 `tools.extra_roots`。文件工具读写双拒：

```
PermissionError: 路径 'C:[path]'（规范化后：'C:\Users\wangsaibo\Desktop\mof_price相关'）
解析为 'C:\Users\wangsaibo\Desktop\mof_price相关'，不在任何合法根目录
[C:\Users\wangsaibo\.miqi\workspace, ...]
```

agent 被迫全程 exec + Python 写文件绕过文件工具，graph_render 无法直接渲染桌面产物。根因：`_canonicalize_wsl_mnt_path` 的合法根集合只来自注册表静态构建，完全不感知用户请求。

## 变更内容

- **新增 `miqi/agent/tools/user_roots.py`**：从用户消息提取绝对路径提及（Windows 反斜杠/正斜杠、`/mnt/`、POSIX、`~/` 形式，CJK 目录名如 `mof_price相关` 完整匹配）。目录提及以其自身为根（含尚不存在的输出目录，首次 write 即可建目录）；已有文件提及取其父目录。护栏：配置目录/`sessions/`、用户主目录、盘符根、系统顶层目录（Windows + POSIX/macOS 全名单，含空格截断残留）永不授权；每回合上限 8 个；**仅扫描用户消息，模型输出/工具结果/文档内容永不参与提取**（提示注入无法获得根）
- **桌面生产路径（TurnRunner/ToolRuntime/Orchestrator）**：TurnRunner 回合开始从 user_content 提取（steering 消息到达时刷新）→ TurnContext 字段 → ToolRuntime 写入 ToolExecutionContext → Orchestrator 对文件工具注入 `_user_roots`；AgentControl spawn 子代理从任务文本继承
- **KUN 路径（loop/tool_host）**：每步从当前回合 `user_message` 项提取 → `ToolHostContext.user_mentioned_roots` → 注入文件工具；顺带把 `graph_render` 补进 `_SESSION_KEY_TOOLS`（对齐 legacy orchestrator #761）
- **文件工具（read/write/edit/list/apply_patch/graph_render）**：每次调用把注入根合并进合法根（WSL `_canonicalize_wsl_mnt_path` 与 native `_resolve_path` 两条路径）；graph_render 补上跨会话隔离（CodeRabbit #851：派生 session_files_dir + `_reject_foreign_session_path`），此前可读/写其他会话的 files 目录
- **配置**：`tools.auto_user_dirs`（默认 `true`）开关，关闭后只认静态 `extra_roots`；`tool_registry_factory` 读取并传入各工具
- **文档**：`docs/configuration.md`、`docs/backend/tools.md` 同步新字段与安全机制说明
- **E2E**：`apps/desktop/tests/e2e/issue-821-user-output-dir.spec.ts`——真实 LLM + WSL 沙箱，消息点名 workspace 外目录，断言 write_file 返回成功原文且产物落盘；spec 内 patchConfig 强制启用沙箱（否则 native 路径无 contain 检查、断言空转通过）

## 日志/验证证据

```
$ python -m pytest tests/agent/tools/test_user_roots.py tests/runtime/test_turn_runner_user_roots.py -q
34 passed

$ python -m pytest tests/agent/tools tests/kun_runtime tests/runtime tests/sandbox tests/execution -q
2417 passed, 3 skipped

$ npx playwright test --config=playwright.config.ts --project=electron issue-821-user-output-dir.spec.ts --workers=1
[test] Sandbox ready after 0s
[test] Output dir (outside workspace): C:\Users\INTERS~1\AppData\Local\Temp\miqi_e2e_821_out_1787795888213
[test] File content on host: "E2E #821 user-mentioned output dir test 1787795888213"
[test] ✅ write_file 写入用户点名目录成功
  1 passed (1.0m)
```

修复前同一场景：write_file 被「不在任何合法根目录」拒绝，agent 被迫 exec+Python 绕过（issue #821 日志）。

## 截图

E2E 结束截屏（真实桌面应用，write_file 成功写入用户点名目录后）：

![issue-821 write_file 成功写入用户点名目录](https://github.com/14790897/MiQi/releases/download/_gh-imgup/issue-821-65e9c2e0.png)

## 测试情况

- 新增 `tests/agent/tools/test_user_roots.py`（28 用例）：提取形态（Win/`/mnt/`/POSIX/`~/`）、尾随标点剥离、CJK 粘连不误提、URL 不误提、已存在目录/文件/尚不存在目录分类、去重与上限、主目录/盘符根/系统顶层目录（Windows+POSIX）/配置目录/sessions 护栏
- 新增 `tests/runtime/test_turn_runner_user_roots.py`（6 用例）：TurnRunner 提取/workspace 覆盖跳过/steering 刷新、ToolRuntime ctx 传播、Orchestrator `_user_roots` 注入/空根不注入
- `tests/sandbox/test_wsl_sandbox_path_mapping.py` 新增 3 用例：WSL 沙箱下 `_user_roots` 放行/无根拒绝/开关关闭忽略注入
- `tests/kun_runtime/test_tool_host.py` 新增注入用例 + `graph_render ∈ _SESSION_KEY_TOOLS` 断言；`test_agent_loop_basic.py` 新增端到端用例（用户消息点名目录 → loop → ToolHostContext）
- `tests/agent/tools/test_graph_render.py` 新增跨会话拒绝/本会话放行用例
- 新增 E2E `issue-821-user-output-dir.spec.ts`，本地实测通过（1.0m）；CI 默认跳过（需 Windows+WSL+真实 LLM，`MIQI_RUN_SANDBOX_E2E=1` 开启）
- 回归：`tests/agent/tools tests/kun_runtime tests/runtime tests/sandbox tests/execution` 全绿（2417 passed, 3 skipped）
