### PR TITLE
fix(agent): 思考时长显示真实化——后端测量服务端思考耗时，恢复路径不固定 1 秒 (#834)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4257,7 +4257,7 @@ export function ChatConsole({
                   1000
               )
             )
-          : undefined;
+          : undefined);
       thinkingStartedAtRef.current = null;
       lastReasoningDeltaAtRef.current = null;
       // Close any live reasoning block — whether or not this render's session

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4295,20 +4295,20 @@ export function ChatConsole({
         data.reasoning_elapsed_s != null
           ? Math.max(1, Math.round(data.reasoning_elapsed_s))
           : data.reasoning || hadLiveReasoning
-          ? // Pure thinking span: first→last reasoning delta. Falls back to the
-            // final-event time when no live reasoning was seen. Never 0s.
-            // (#834) Server-measured value arrives as reasoning_elapsed_s and
-            // is preferred — this local span is only the transport-time
-            // fallback for buffered providers.
-            Math.max(
-              1,
-              Math.round(
-                ((lastReasoningDeltaAtRef.current ?? Date.now()) -
-                  (thinkingStartedAtRef.current ?? turnStartMs)) /
-                  1000
+            ? // Pure thinking span: first→last reasoning delta. Falls back to the
+              // final-event time when no live reasoning was seen. Never 0s.
+              // (#834) Server-measured value arrives as reasoning_elapsed_s and
+              // is preferred — this local span is only the transport-time
+              // fallback for buffered providers.
+              Math.max(
+                1,
+                Math.round(
+                  ((lastReasoningDeltaAtRef.current ?? Date.now()) -
+                    (thinkingStartedAtRef.current ?? turnStartMs)) /
+                    1000
+                )
               )
-            )
-          : undefined;
+            : undefined;
       thinkingStartedAtRef.current = null;
       lastReasoningDeltaAtRef.current = null;
       // Close any live reasoning block — whether or not this render's session

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1923,9 +1923,11 @@ function splitCachedMessages(events: InFlightEvent[]): {
       thinking.push({ role: 'progress', content: '已停止。', timestamp: Date.now() });
     } else if (ev.type === 'final') {
       const fd = ev.data as ChatFinal;
-      if (fd?.content) {
-        finalReply = fd.content;
-        if (fd.reasoning) finalReasoning = fd.reasoning;
+      // CR #856-6: capture reasoning even when content is empty (pure
+      // thinking turn) — dropping it loses the thinking block entirely.
+      if (fd?.content) finalReply = fd.content;
+      if (fd?.reasoning) {
+        finalReasoning = fd.reasoning;
         if (fd.reasoning_elapsed_s != null) {
           finalReasoningElapsedS = Math.max(1, Math.round(fd.reasoning_elapsed_s));
         }
@@ -2867,10 +2869,37 @@ export function ChatConsole({
               merged.push({
                 role: 'assistant',
                 content: _split.finalReply,
-                reasoning: _split.finalReasoning,
-                reasoningElapsedS: _split.finalReasoningElapsedS,
                 timestamp: Date.now(),
               });
+            }
+            // #834 / CR #856-2: the cached final carries the server-measured
+            // thinking proxy, but only role==='progress' renders a ThinkBlock.
+            // Attach it to the LAST reasoning block (or insert a standalone
+            // one) so the restored bubble shows the real duration, not 1s.
+            if (_split.finalReasoning) {
+              let _attached = false;
+              for (let _ti = merged.length - 1; _ti >= 0; _ti -= 1) {
+                const _tm = merged[_ti];
+                if (_tm.role === 'progress' && _tm.reasoning) {
+                  if (_tm.reasoningElapsedS === undefined) {
+                    merged[_ti] = {
+                      ..._tm,
+                      reasoningElapsedS: _split.finalReasoningElapsedS,
+                    };
+                  }
+                  _attached = true;
+                  break;
+                }
+              }
+              if (!_attached) {
+                merged.push({
+                  role: 'progress',
+                  content: _split.finalReasoning,
+                  reasoning: _split.finalReasoning,
+                  reasoningElapsedS: _split.finalReasoningElapsedS,
+                  timestamp: Date.now(),
+                });
+              }
             }
           }
           // Exec inline output → merge into execOutputs for the session
@@ -4261,8 +4290,11 @@ export function ChatConsole({
       // bubble never re-renders reasoning, so there is no layout jump.
       const hadLiveReasoning = liveReasoningTsRef.current !== null;
       const finalReasoningElapsedS =
-        data.reasoning_elapsed_s ??
-        (data.reasoning || hadLiveReasoning
+        // CR #856-7: normalize the server value the same way as the cache /
+        // snapshot paths (≥1s, rounded) so live and restored views agree.
+        data.reasoning_elapsed_s != null
+          ? Math.max(1, Math.round(data.reasoning_elapsed_s))
+          : data.reasoning || hadLiveReasoning
           ? // Pure thinking span: first→last reasoning delta. Falls back to the
             // final-event time when no live reasoning was seen. Never 0s.
             // (#834) Server-measured value arrives as reasoning_elapsed_s and
@@ -4276,7 +4308,7 @@ export function ChatConsole({
                   1000
               )
             )
-          : undefined);
+          : undefined;
       thinkingStartedAtRef.current = null;
       lastReasoningDeltaAtRef.current = null;
       // Close any live reasoning block — whether or not this render's session

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2872,13 +2872,17 @@ export function ChatConsole({
                 timestamp: Date.now(),
               });
             }
-            // #834 / CR #856-2: the cached final carries the server-measured
-            // thinking proxy, but only role==='progress' renders a ThinkBlock.
-            // Attach it to the LAST reasoning block (or insert a standalone
-            // one) so the restored bubble shows the real duration, not 1s.
+            // #834 / CR #856-2 + #856-6: the cached final carries the
+            // server-measured thinking proxy, but only role==='progress'
+            // renders a ThinkBlock.  Attach it to the LAST reasoning block of
+            // the CURRENT turn (scan stops at the last user boundary, matching
+            // insertStandaloneReasoning) — or insert a standalone block
+            // BEFORE the final assistant reply so the thinking stays visually
+            // above the answer.
             if (_split.finalReasoning) {
               let _attached = false;
               for (let _ti = merged.length - 1; _ti >= 0; _ti -= 1) {
+                if (merged[_ti].role === 'user') break; // current-turn boundary
                 const _tm = merged[_ti];
                 if (_tm.role === 'progress' && _tm.reasoning) {
                   if (_tm.reasoningElapsedS === undefined) {
@@ -2892,13 +2896,24 @@ export function ChatConsole({
                 }
               }
               if (!_attached) {
-                merged.push({
+                const _standalone: Message = {
                   role: 'progress',
                   content: _split.finalReasoning,
                   reasoning: _split.finalReasoning,
                   reasoningElapsedS: _split.finalReasoningElapsedS,
                   timestamp: Date.now(),
-                });
+                };
+                // Insert before the final assistant reply (the last non-user
+                // message of the turn), keeping the visual order thinking →
+                // answer.
+                let _insAt = merged.length;
+                for (let _ti = merged.length - 1; _ti >= 0; _ti -= 1) {
+                  if (merged[_ti].role === 'user') {
+                    _insAt = _ti + 1;
+                    break;
+                  }
+                }
+                merged.splice(_insAt, 0, _standalone);
               }
             }
           }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1209,6 +1209,12 @@ export function insertInterruptedTurns(merged: Message[], interruptedTurns: any[
       role: 'assistant',
       content: _halfContent,
       reasoning: String(_it.reasoning_content ?? '') || undefined,
+      // #834: server-measured thinking proxy persisted on the snapshot —
+      // the resume card must not fall back to 1s.
+      reasoningElapsedS:
+        _it.reasoning_elapsed_s != null
+          ? Math.max(1, Math.round(Number(_it.reasoning_elapsed_s)))
+          : undefined,
       interrupted: true,
       interruptedMeta: {
         turnId: String(_it.turn_id ?? ''),
@@ -4236,9 +4242,13 @@ export function ChatConsole({
       // bubble never re-renders reasoning, so there is no layout jump.
       const hadLiveReasoning = liveReasoningTsRef.current !== null;
       const finalReasoningElapsedS =
-        data.reasoning || hadLiveReasoning
+        data.reasoning_elapsed_s ??
+        (data.reasoning || hadLiveReasoning
           ? // Pure thinking span: first→last reasoning delta. Falls back to the
             // final-event time when no live reasoning was seen. Never 0s.
+            // (#834) Server-measured value arrives as reasoning_elapsed_s and
+            // is preferred — this local span is only the transport-time
+            // fallback for buffered providers.
             Math.max(
               1,
               Math.round(
@@ -7255,6 +7265,7 @@ const MessageBubble = memo(function MessageBubble({
         }
         reasoning={msg.reasoning}
         content={String(msg.content ?? '')}
+        elapsedSeconds={msg.reasoningElapsedS}
         onResume={onResume}
         onRestart={onRestart}
       />

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1889,9 +1889,16 @@ function cachedEventsToMessages(events: InFlightEvent[], mode?: ReasoningMode): 
 function splitCachedMessages(events: InFlightEvent[]): {
   thinking: Message[];
   finalReply: string | null;
+  /** #834: server-measured thinking proxy, preserved across the off-session
+   *  final cache so the restored thinking block doesn't fall back to the
+   *  local delta-span approximation. */
+  finalReasoning?: string;
+  finalReasoningElapsedS?: number;
 } {
   const thinking: Message[] = [];
   let finalReply: string | null = null;
+  let finalReasoning: string | undefined;
+  let finalReasoningElapsedS: number | undefined;
   for (const ev of events) {
     if (ev.type === 'progress') {
       const pd = ev.data as ChatProgress;
@@ -1916,10 +1923,16 @@ function splitCachedMessages(events: InFlightEvent[]): {
       thinking.push({ role: 'progress', content: '已停止。', timestamp: Date.now() });
     } else if (ev.type === 'final') {
       const fd = ev.data as ChatFinal;
-      if (fd?.content) finalReply = fd.content;
+      if (fd?.content) {
+        finalReply = fd.content;
+        if (fd.reasoning) finalReasoning = fd.reasoning;
+        if (fd.reasoning_elapsed_s != null) {
+          finalReasoningElapsedS = Math.max(1, Math.round(fd.reasoning_elapsed_s));
+        }
+      }
     }
   }
-  return { thinking, finalReply };
+  return { thinking, finalReply, finalReasoning, finalReasoningElapsedS };
 }
 
 /* ─── Main component ─────────────────────────────────────────────── */
@@ -2851,7 +2864,13 @@ export function ChatConsole({
               if (!_dup) merged.push(_ctm);
             }
             if (_split.finalReply) {
-              merged.push({ role: 'assistant', content: _split.finalReply, timestamp: Date.now() });
+              merged.push({
+                role: 'assistant',
+                content: _split.finalReply,
+                reasoning: _split.finalReasoning,
+                reasoningElapsedS: _split.finalReasoningElapsedS,
+                timestamp: Date.now(),
+              });
             }
           }
           // Exec inline output → merge into execOutputs for the session

--- a/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
@@ -12,6 +12,7 @@ export function InterruptedTurnCard({
   meta,
   reasoning,
   content,
+  elapsedSeconds,
   onResume,
   onRestart,
 }: {
@@ -22,6 +23,9 @@ export function InterruptedTurnCard({
   };
   reasoning?: string;
   content: string;
+  /** #834: server-measured thinking proxy from the snapshot; falls back to
+   *  1s only when no measurement was ever taken. */
+  elapsedSeconds?: number;
   onResume?: () => void;
   onRestart?: () => void;
 }) {
@@ -121,7 +125,11 @@ export function InterruptedTurnCard({
 
         {/* 已生成的思考块（可展开） */}
         {reasoning ? (
-          <ThinkBlock reasoning={reasoning} defaultOpen={false} elapsedSeconds={1} />
+          <ThinkBlock
+            reasoning={reasoning}
+            defaultOpen={false}
+            elapsedSeconds={elapsedSeconds ?? 1}
+          />
         ) : null}
 
         {/* 半截回答 */}

--- a/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/InterruptedTurnCard.tsx
@@ -125,11 +125,7 @@ export function InterruptedTurnCard({
 
         {/* 已生成的思考块（可展开） */}
         {reasoning ? (
-          <ThinkBlock
-            reasoning={reasoning}
-            defaultOpen={false}
-            elapsedSeconds={elapsedSeconds ?? 1}
-          />
+          <ThinkBlock reasoning={reasoning} defaultOpen={false} elapsedSeconds={elapsedSeconds} />
         ) : null}
 
         {/* 半截回答 */}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -988,6 +988,11 @@ export interface ChatFinal {
   /** Model reasoning / chain-of-thought from thinking models
    *  (DeepSeek-R1, Kimi). Rendered as a collapsible thinking block. */
   reasoning?: string;
+  /** Server-side thinking proxy (seconds): time from request start to the
+   *  first reasoning delta, measured by the backend (#834). Preferred over
+   *  frontend first/last-delta timing, which only measures transport time
+   *  for buffered reasoning providers (DeepSeek). */
+  reasoning_elapsed_s?: number;
   /** Session key for frontend-side event filtering (fix #212).  Optional
    *  for backward compatibility; see ChatProgress.session_key. */
   session_key?: string;

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1317,6 +1317,8 @@ class BridgeRuntimeLoop:
                     }
                     if event.reasoning:
                         final_payload["reasoning"] = event.reasoning
+                    if event.reasoning_elapsed_s is not None:
+                        final_payload["reasoning_elapsed_s"] = event.reasoning_elapsed_s
                     await _emit_terminal("final", final_payload)
                     # Do NOT break — consume the TurnCompleteEvent that
                     # follows so the next drain task starts with a clean queue.

--- a/miqi/protocol/events.py
+++ b/miqi/protocol/events.py
@@ -99,6 +99,7 @@ class AgentMessageEvent:
     finish_reason: str = "stop"
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     reasoning: str | None = None
+    reasoning_elapsed_s: float | None = None  # #834: server-side thinking proxy
 
 
 # ── Tool Call Events ────────────────────────────────────────

--- a/miqi/providers/base.py
+++ b/miqi/providers/base.py
@@ -25,6 +25,7 @@ class LLMResponse:
     usage: dict[str, int] = field(default_factory=dict)
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1 etc.
     reasoning_elapsed_s: float | None = None  # request-start → first reasoning delta
+    reasoning_elapsed_suppressed: bool = False  # #834: streaming CoT — proxy invalid
     error_kind: str | None = None
 
     @property

--- a/miqi/providers/base.py
+++ b/miqi/providers/base.py
@@ -24,6 +24,7 @@ class LLMResponse:
     finish_reason: str = "stop"
     usage: dict[str, int] = field(default_factory=dict)
     reasoning_content: str | None = None  # Kimi, DeepSeek-R1 etc.
+    reasoning_elapsed_s: float | None = None  # request-start → first reasoning delta
     error_kind: str | None = None
 
     @property

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import time
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -417,8 +418,17 @@ class OpenAIProvider(LLMProvider):
             kwargs["tool_choice"] = "auto"
 
         try:
+            request_started = time.monotonic()
+
+            def _do_create() -> Any:
+                nonlocal request_started
+                # Per-attempt start: a retry after a timeout still measures
+                # the attempt that actually produced the reasoning stream.
+                request_started = time.monotonic()
+                return self._client.chat.completions.create(**kwargs)
+
             stream = await resilience.with_retry(
-                lambda: self._client.chat.completions.create(**kwargs),
+                _do_create,
                 max_attempts=3,
             )
         except Exception as e:
@@ -441,6 +451,13 @@ class OpenAIProvider(LLMProvider):
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
         reasoning_chunks = 0
+        # Time from request start to the FIRST reasoning delta — the closest
+        # host-side proxy for server-side thinking time (DeepSeek etc. buffer
+        # the whole reasoning pass server-side, so the first delta arrives
+        # only after thinking finished; transport latency is negligible).
+        # Suppressed for streaming CoT models (see interleaved_reasoning).
+        first_reasoning_elapsed: float | None = None
+        interleaved_reasoning = False
         # Accumulate tool calls incrementally (OpenAI sends index + fragments)
         tool_call_accum: dict[int, dict[str, Any]] = {}
         finish_reason: str | None = None
@@ -516,6 +533,8 @@ class OpenAIProvider(LLMProvider):
             # Reasoning delta (Kimi, DeepSeek-R1, etc.)
             reasoning_text = getattr(delta, "reasoning_content", None) or ""
             if reasoning_text:
+                if first_reasoning_elapsed is None:
+                    first_reasoning_elapsed = time.monotonic() - request_started
                 reasoning_parts.append(reasoning_text)
                 reasoning_chunks += 1
                 if reasoning_chunks % 10 == 0:
@@ -577,6 +596,7 @@ class OpenAIProvider(LLMProvider):
                 finish_reason=finish_reason or "stop",
                 usage=usage,
                 reasoning_content=full_reasoning,
+                reasoning_elapsed_s=first_reasoning_elapsed,
             ),
         )
 

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -612,6 +612,7 @@ class OpenAIProvider(LLMProvider):
                 reasoning_elapsed_s=(
                     None if interleaved_reasoning else first_reasoning_elapsed
                 ),
+                reasoning_elapsed_suppressed=interleaved_reasoning,
             ),
         )
 

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -388,6 +388,11 @@ class OpenAIProvider(LLMProvider):
 
         spec = self._selected_spec or find_by_model(original_model)
         keep_reasoning = bool(spec and spec.supports_reasoning_history)
+        # #834 / CodeRabbit: models that STREAM reasoning CoT (Kimi/Qwen/GPT-5)
+        # invalidate the request→first-delta thinking proxy up front — do not
+        # wait for interleaving to show up in the delta order (a reasoning-first
+        # stream would otherwise slip through the content_parts check).
+        streams_reasoning = bool(spec and spec.streams_reasoning)
 
         kwargs: dict[str, Any] = {
             "model": resolved,
@@ -541,9 +546,12 @@ class OpenAIProvider(LLMProvider):
                 # CoT models (Kimi, Qwen, GPT-5) interleave reasoning and content
                 # deltas — for them the frontend's local first→last span is the
                 # correct total, and our proxy would show a tiny first-token
-                # latency instead.  Detect interleaving: reasoning seen AFTER
-                # content started ⇒ streaming CoT ⇒ suppress the proxy.
-                if content_parts:
+                # latency instead.  Suppress when the provider capability says
+                # streaming (up front, covers reasoning-first streams too) OR
+                # when interleaving is observed in the delta order.
+                if streams_reasoning:
+                    interleaved_reasoning = True
+                elif content_parts:
                     interleaved_reasoning = True
                 reasoning_parts.append(reasoning_text)
                 reasoning_chunks += 1

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -426,6 +426,7 @@ class OpenAIProvider(LLMProvider):
             request_started = time.monotonic()
 
             def _do_create() -> Any:
+                """Per-attempt create wrapper: restarts the timing window on retry (#834)."""
                 nonlocal request_started
                 # Per-attempt start: a retry after a timeout still measures
                 # the attempt that actually produced the reasoning stream.

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -535,6 +535,16 @@ class OpenAIProvider(LLMProvider):
             if reasoning_text:
                 if first_reasoning_elapsed is None:
                     first_reasoning_elapsed = time.monotonic() - request_started
+                # #834 / review: request→first-reasoning-delta only equals the
+                # thinking duration for BUFFERED reasoning providers (DeepSeek
+                # emits reasoning only after the whole pass finished).  Streaming
+                # CoT models (Kimi, Qwen, GPT-5) interleave reasoning and content
+                # deltas — for them the frontend's local first→last span is the
+                # correct total, and our proxy would show a tiny first-token
+                # latency instead.  Detect interleaving: reasoning seen AFTER
+                # content started ⇒ streaming CoT ⇒ suppress the proxy.
+                if content_parts:
+                    interleaved_reasoning = True
                 reasoning_parts.append(reasoning_text)
                 reasoning_chunks += 1
                 if reasoning_chunks % 10 == 0:
@@ -596,7 +606,12 @@ class OpenAIProvider(LLMProvider):
                 finish_reason=finish_reason or "stop",
                 usage=usage,
                 reasoning_content=full_reasoning,
-                reasoning_elapsed_s=first_reasoning_elapsed,
+                # Streaming CoT models interleave reasoning/content — the
+                # first-delta proxy would under-report badly, so suppress it
+                # and let the frontend use its local first→last span.
+                reasoning_elapsed_s=(
+                    None if interleaved_reasoning else first_reasoning_elapsed
+                ),
             ),
         )
 

--- a/miqi/providers/registry.py
+++ b/miqi/providers/registry.py
@@ -62,6 +62,13 @@ class ProviderSpec:
     # conversations (DeepSeek official API for deepseek-reasoner requires this).
     supports_reasoning_history: bool = False
 
+    # #834: provider streams reasoning CoT incrementally (interleaved with
+    # content — Kimi/Qwen/GPT-5 style) instead of buffering the whole pass
+    # server-side (DeepSeek).  For streaming providers the request→first-delta
+    # proxy does NOT equal thinking time, so it must be suppressed regardless
+    # of delta ordering.
+    streams_reasoning: bool = False
+
     @property
     def label(self) -> str:
         return self.display_name or self.name.title()
@@ -281,6 +288,9 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
         is_gateway=False,
         is_local=False,
         detect_by_key_prefix="",
+        # #834: Kimi streams reasoning CoT incrementally (interleaved with
+        # content) — the request→first-delta thinking proxy is invalid here.
+        streams_reasoning=True,
         detect_by_base_keyword="",
         default_api_base="https://api.moonshot.ai/v1",   # intl; use api.moonshot.cn for China
         strip_model_prefix=False,

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -146,6 +146,14 @@ class HistoryRuntime:
                 updated_at REAL NOT NULL
             )
         """)
+        # #834: reasoning_elapsed_s — added later, so older DBs need a
+        # migration (SQLite has no ADD COLUMN IF NOT EXISTS before 3.35).
+        async with self._db.execute("PRAGMA table_info(execution_snapshots)") as cursor:
+            cols = {row[1] for row in await cursor.fetchall()}
+        if "reasoning_elapsed_s" not in cols:
+            await self._db.execute(
+                "ALTER TABLE execution_snapshots ADD COLUMN reasoning_elapsed_s REAL"
+            )
         await self._db.commit()
 
     async def close(self) -> None:
@@ -388,6 +396,7 @@ class HistoryRuntime:
         reasoning_content: str = "",
         tool_state: list[dict] | None = None,
         version: int = 1,
+        reasoning_elapsed_s: float | None = None,
     ) -> None:
         """Persist (or update) an in-flight turn's execution snapshot.
 
@@ -398,20 +407,22 @@ class HistoryRuntime:
         await db.execute(
             """INSERT INTO execution_snapshots
                (turn_id, thread_id, session_id, status, assistant_content,
-                reasoning_content, tool_state_json, version, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                reasoning_content, tool_state_json, version, updated_at,
+                reasoning_elapsed_s)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(turn_id) DO UPDATE SET
-                 status = excluded.status,
-                 assistant_content = excluded.assistant_content,
-                 reasoning_content = excluded.reasoning_content,
-                 tool_state_json = excluded.tool_state_json,
-                 version = excluded.version,
-                 updated_at = excluded.updated_at""",
+                status = excluded.status,
+                assistant_content = excluded.assistant_content,
+                reasoning_content = excluded.reasoning_content,
+                tool_state_json = excluded.tool_state_json,
+                version = excluded.version,
+                updated_at = excluded.updated_at,
+                reasoning_elapsed_s = excluded.reasoning_elapsed_s""",
             (
                 turn_id, thread_id, self.session_id, status,
                 assistant_content, reasoning_content,
                 json.dumps(tool_state or [], ensure_ascii=False),
-                version, time.time(),
+                version, time.time(), reasoning_elapsed_s,
             ),
         )
         await db.commit()
@@ -474,6 +485,7 @@ class HistoryRuntime:
             "status": row["status"],
             "assistant_content": row["assistant_content"],
             "reasoning_content": row["reasoning_content"],
+            "reasoning_elapsed_s": row["reasoning_elapsed_s"],
             "tool_state": json.loads(row["tool_state_json"] or "[]"),
             "version": row["version"],
             "updated_at": row["updated_at"],

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -492,6 +492,7 @@ class HistoryRuntime:
 
     @staticmethod
     def _snapshot_row_to_dict(row: Any) -> dict[str, Any]:
+        """Convert a snapshot row to the dict shape consumed by the load path."""
         return {
             "turn_id": row["turn_id"],
             "thread_id": row["thread_id"],

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -143,17 +143,30 @@ class HistoryRuntime:
                 reasoning_content TEXT NOT NULL DEFAULT '',
                 tool_state_json TEXT NOT NULL DEFAULT '[]',
                 version INTEGER NOT NULL DEFAULT 1,
-                updated_at REAL NOT NULL
+                updated_at REAL NOT NULL,
+                reasoning_elapsed_s REAL
             )
         """)
-        # #834: reasoning_elapsed_s — added later, so older DBs need a
-        # migration (SQLite has no ADD COLUMN IF NOT EXISTS before 3.35).
+        # #834: reasoning_elapsed_s was added after the original table schema,
+        # so older DBs need a migration (SQLite has no ADD COLUMN IF NOT
+        # EXISTS before 3.35).  Fresh DBs already have the column via the
+        # CREATE above; the ALTER only fires for pre-existing tables.
+        # Check-then-act is racy across concurrent connections, so the ALTER
+        # itself is guarded (CR #856-4).
         async with self._db.execute("PRAGMA table_info(execution_snapshots)") as cursor:
             cols = {row[1] for row in await cursor.fetchall()}
         if "reasoning_elapsed_s" not in cols:
-            await self._db.execute(
-                "ALTER TABLE execution_snapshots ADD COLUMN reasoning_elapsed_s REAL"
-            )
+            try:
+                await self._db.execute(
+                    "ALTER TABLE execution_snapshots ADD COLUMN reasoning_elapsed_s REAL"
+                )
+            except Exception:
+                # Concurrent initializer may have won the race — verify the
+                # column now exists before treating anything as an error.
+                async with self._db.execute("PRAGMA table_info(execution_snapshots)") as cursor:
+                    cols2 = {row[1] for row in await cursor.fetchall()}
+                if "reasoning_elapsed_s" not in cols2:
+                    raise
         await self._db.commit()
 
     async def close(self) -> None:

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -985,6 +985,7 @@ class TaskRunner:
                 finish_reason="stop",
                 tool_calls=tool_calls,
                 reasoning=result.reasoning,
+                reasoning_elapsed_s=result.reasoning_elapsed_s,
             ))
             await self._events.put(TurnCompleteEvent(
                 turn_id=turn_id,

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -824,6 +824,7 @@ class TurnRunner:
                 messages=messages,
                 tools_used=tools_used,
                 messages_delta=messages_delta,
+                reasoning_elapsed_s=reasoning_elapsed_s,
             )
         diagnosis = self._build_exhaustion_diagnosis(messages)
         content = (
@@ -843,6 +844,7 @@ class TurnRunner:
             messages=messages,
             tools_used=tools_used,
             messages_delta=messages_delta,
+            reasoning_elapsed_s=reasoning_elapsed_s,
         )
 
     async def run_agent_job(self, job: Any) -> TurnResult:

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -272,11 +272,12 @@ class TurnRunner:
         _turn_started = time.perf_counter()
         _first_token_logged = False
         # #834: server-side thinking proxy — set on the first reasoning delta.
-        # Timed from the CURRENT model call start (`_round_started`), NOT the
-        # turn start: a tool round before thinking (e.g. 60s web_search) or a
-        # retry backoff must not inflate the displayed thinking time (CR #856-1).
+        # Timed from the CURRENT model call start (`_round_started`, reset per
+        # round), NOT the turn start: a tool round before thinking (e.g. 60s
+        # web_search) or a retry backoff must not inflate the displayed
+        # thinking time.  The provider's per-attempt value (request→first
+        # delta) takes precedence when available.
         reasoning_elapsed_s: float | None = None
-        _round_started = time.perf_counter()
 
         # #821: auto-sense directories the user named in their message
         # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
@@ -478,16 +479,14 @@ class TurnRunner:
                         )
                 elif stream_event.kind == "completed":
                     response = stream_event.response
-                    # #834 / CR #856-5: the provider's per-attempt measurement
+                    # #834 / review: the provider's per-attempt measurement
                     # (request→first reasoning delta, retries excluded) is the
-                    # most accurate — prefer it over the coarse round clock.
+                    # most accurate — always prefer it over the coarse round
+                    # clock, which includes failed-attempt/backoff time.
                     provider_elapsed = getattr(
                         response, "reasoning_elapsed_s", None
                     )
-                    if (
-                        provider_elapsed is not None
-                        and reasoning_elapsed_s is None
-                    ):
+                    if provider_elapsed is not None:
                         reasoning_elapsed_s = float(provider_elapsed)
                         if snapshot_buffer is not None:
                             snapshot_buffer.reasoning_elapsed_s = reasoning_elapsed_s

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -67,6 +67,7 @@ class TurnResult:
     token_usage: dict[str, int] = field(default_factory=dict)
     messages_delta: list[dict[str, Any]] = field(default_factory=list)
     reasoning: str | None = None
+    reasoning_elapsed_s: float | None = None  # first-round server-side thinking proxy
 
 
 class _SnapshotBuffer:
@@ -79,6 +80,7 @@ class _SnapshotBuffer:
     def __init__(self) -> None:
         self.content: list[str] = []
         self.reasoning: list[str] = []
+        self.reasoning_elapsed_s: float | None = None
         self.last_flush = time.perf_counter()
         self.flushed_len = 0
 
@@ -106,6 +108,7 @@ class _SnapshotBuffer:
             status=status,
             assistant_content=content,
             reasoning_content=reasoning,
+            reasoning_elapsed_s=self.reasoning_elapsed_s,
         )
         self.last_flush = time.perf_counter()
         self.flushed_len = len(content) + len(reasoning)
@@ -268,6 +271,8 @@ class TurnRunner:
         # first streamed delta (content or reasoning)，使端到端首字延迟可观测。
         _turn_started = time.perf_counter()
         _first_token_logged = False
+        # #834: server-side thinking proxy — set on the first reasoning delta.
+        reasoning_elapsed_s: float | None = None
 
         # #821: auto-sense directories the user named in their message
         # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
@@ -431,10 +436,16 @@ class TurnRunner:
                             "turn_runner: first_token_latency_ms={:.0f} for turn={} (reasoning)",
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
+                    # Server-side thinking proxy (#834): the first reasoning
+                    # delta arrives only after the provider finished thinking,
+                    # so (now - turn_started) is the honest thinking duration.
+                    if reasoning_elapsed_s is None:
+                        reasoning_elapsed_s = time.perf_counter() - _turn_started
                     reasoning_parts.append(stream_event.delta)
                     reasoning_chunks += 1
                     if snapshot_buffer is not None:
                         snapshot_buffer.reasoning.append(stream_event.delta)
+                        snapshot_buffer.reasoning_elapsed_s = reasoning_elapsed_s
                         if snapshot_buffer.due(self._history):
                             await snapshot_buffer.flush(self._history, turn, status="running")
                     from miqi.protocol.events import AgentReasoningEvent
@@ -629,6 +640,7 @@ class TurnRunner:
                     token_usage=getattr(response, "usage", {}) or {},
                     messages_delta=messages_delta,
                     reasoning=merged_reasoning,
+                    reasoning_elapsed_s=reasoning_elapsed_s,
                 )
 
             # Phase 24: record tool call starts in ledger

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -276,8 +276,12 @@ class TurnRunner:
         # round), NOT the turn start: a tool round before thinking (e.g. 60s
         # web_search) or a retry backoff must not inflate the displayed
         # thinking time.  The provider's per-attempt value (request→first
-        # delta) takes precedence when available.
+        # delta) takes precedence when available; `provider_established`
+        # distinguishes a confirmed provider value from the coarse-clock
+        # placeholder so a later suppressed round can't clobber round one's
+        # confirmed value (CodeRabbit #856).
         reasoning_elapsed_s: float | None = None
+        provider_established = False
 
         # #821: auto-sense directories the user named in their message
         # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
@@ -486,8 +490,21 @@ class TurnRunner:
                     provider_elapsed = getattr(
                         response, "reasoning_elapsed_s", None
                     )
-                    if provider_elapsed is not None:
+                    suppressed = getattr(
+                        response, "reasoning_elapsed_suppressed", False
+                    )
+                    if suppressed:
+                        # Streaming CoT (interleaved) round: the proxy is
+                        # invalid for THIS model — discard the coarse-clock
+                        # placeholder unless an earlier round already
+                        # established a confirmed provider value.
+                        if not provider_established:
+                            reasoning_elapsed_s = None
+                            if snapshot_buffer is not None:
+                                snapshot_buffer.reasoning_elapsed_s = None
+                    elif provider_elapsed is not None:
                         reasoning_elapsed_s = float(provider_elapsed)
+                        provider_established = True
                         if snapshot_buffer is not None:
                             snapshot_buffer.reasoning_elapsed_s = reasoning_elapsed_s
 

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -272,7 +272,11 @@ class TurnRunner:
         _turn_started = time.perf_counter()
         _first_token_logged = False
         # #834: server-side thinking proxy — set on the first reasoning delta.
+        # Timed from the CURRENT model call start (`_round_started`), NOT the
+        # turn start: a tool round before thinking (e.g. 60s web_search) or a
+        # retry backoff must not inflate the displayed thinking time (CR #856-1).
         reasoning_elapsed_s: float | None = None
+        _round_started = time.perf_counter()
 
         # #821: auto-sense directories the user named in their message
         # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
@@ -389,6 +393,8 @@ class TurnRunner:
             content_parts: list[str] = []
             reasoning_parts: list[str] = []
             reasoning_chunks = 0
+            # Each model call starts a fresh thinking-timer window (CR #856-1).
+            _round_started = time.perf_counter()
             async for stream_event in self._provider.stream_chat(
                 messages=messages,
                 tools=tools,
@@ -437,10 +443,14 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     # Server-side thinking proxy (#834): the first reasoning
-                    # delta arrives only after the provider finished thinking,
-                    # so (now - turn_started) is the honest thinking duration.
+                    # delta arrives only after the provider finished thinking.
+                    # Timed from the CURRENT model call (not turn start) so
+                    # tool-execution time and retry backoff stay excluded.
+                    # The provider's per-attempt measurement (request→first
+                    # delta) is preferred; this coarse clock is the fallback
+                    # for providers that don't report it.
                     if reasoning_elapsed_s is None:
-                        reasoning_elapsed_s = time.perf_counter() - _turn_started
+                        reasoning_elapsed_s = time.perf_counter() - _round_started
                     reasoning_parts.append(stream_event.delta)
                     reasoning_chunks += 1
                     if snapshot_buffer is not None:
@@ -468,6 +478,19 @@ class TurnRunner:
                         )
                 elif stream_event.kind == "completed":
                     response = stream_event.response
+                    # #834 / CR #856-5: the provider's per-attempt measurement
+                    # (request→first reasoning delta, retries excluded) is the
+                    # most accurate — prefer it over the coarse round clock.
+                    provider_elapsed = getattr(
+                        response, "reasoning_elapsed_s", None
+                    )
+                    if (
+                        provider_elapsed is not None
+                        and reasoning_elapsed_s is None
+                    ):
+                        reasoning_elapsed_s = float(provider_elapsed)
+                        if snapshot_buffer is not None:
+                            snapshot_buffer.reasoning_elapsed_s = reasoning_elapsed_s
 
             if reasoning_parts:
                 logger.info(

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -371,3 +371,76 @@ async def test_stream_no_reasoning_elapsed_is_none():
     completed = events[-1]
     assert completed.response is not None
     assert completed.response.reasoning_elapsed_s is None
+
+
+@pytest.mark.asyncio
+async def test_stream_interleaved_reasoning_suppresses_elapsed():
+    """#834 / review: streaming CoT models (Kimi/Qwen) interleave reasoning
+    with content — the first-delta proxy would under-report badly, so the
+    completed response carries reasoning_elapsed_s=None and the frontend
+    falls back to its local first→last span."""
+    import asyncio
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    # Kimi-style: reasoning, content, then MORE reasoning (interleaved).
+    chunks = [
+        [_FakeChoice(_FakeDelta(reasoning_content="Let me think"))],
+        [_FakeChoice(_FakeDelta(content="answer part"))],
+        [_FakeChoice(_FakeDelta(reasoning_content=" still thinking"))],
+        [_FakeChoice(_FakeDelta(content=" rest"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        await asyncio.sleep(0.1)  # thinking delay that must be suppressed
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4o",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    # Interleaved ⇒ streaming CoT ⇒ proxy suppressed (frontend local span wins).
+    assert completed.response.reasoning_elapsed_s is None
+    assert completed.response.reasoning_content == "Let me think still thinking"
+
+
+@pytest.mark.asyncio
+async def test_stream_buffered_reasoning_keeps_elapsed():
+    """#834: DeepSeek-style BUFFERED reasoning (all reasoning before any
+    content) keeps the request→first-delta proxy — no interleaving detected."""
+    import asyncio
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    chunks = [
+        [_FakeChoice(_FakeDelta(reasoning_content="Let me think"))],
+        [_FakeChoice(_FakeDelta(reasoning_content=" more"))],
+        [_FakeChoice(_FakeDelta(content="answer"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        await asyncio.sleep(0.2)
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4o",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    assert completed.response.reasoning_elapsed_s is not None
+    assert completed.response.reasoning_elapsed_s >= 0.15

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -327,7 +327,8 @@ async def test_stream_reasoning_elapsed_s_measured_on_first_delta():
 
     async def _fake_create(**kw):
         # Simulate server-side thinking before the reasoning stream starts.
-        await asyncio.sleep(0.05)
+        # 0.2s leaves generous headroom for Windows timer precision (~15.6ms).
+        await asyncio.sleep(0.2)
         return _FakeStream(chunks)
 
     provider._client.chat.completions.create = _fake_create
@@ -342,7 +343,7 @@ async def test_stream_reasoning_elapsed_s_measured_on_first_delta():
     assert completed.response is not None
     # Measured from monotonic request start — includes the simulated thinking.
     assert completed.response.reasoning_elapsed_s is not None
-    assert completed.response.reasoning_elapsed_s >= 0.05
+    assert completed.response.reasoning_elapsed_s >= 0.15
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -444,3 +444,76 @@ async def test_stream_buffered_reasoning_keeps_elapsed():
     assert completed.response is not None
     assert completed.response.reasoning_elapsed_s is not None
     assert completed.response.reasoning_elapsed_s >= 0.15
+
+
+@pytest.mark.asyncio
+async def test_stream_reasoning_first_streaming_provider_suppressed_by_capability():
+    """#834 / CodeRabbit: a STREAMING-CoT provider (Kimi, spec.streams_reasoning)
+    suppresses the proxy even when reasoning arrives BEFORE any content — the
+    delta-order check alone would miss this shape."""
+    import asyncio
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    # Kimi-style but reasoning-first (no interleaving in delta order):
+    # capability metadata must still suppress the proxy.
+    chunks = [
+        [_FakeChoice(_FakeDelta(reasoning_content="Let me think"))],
+        [_FakeChoice(_FakeDelta(reasoning_content=" more"))],
+        [_FakeChoice(_FakeDelta(content="answer"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        await asyncio.sleep(0.1)
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="kimi-k2.5",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    # streams_reasoning=True ⇒ suppressed despite reasoning-first ordering.
+    assert completed.response.reasoning_elapsed_s is None
+    assert completed.response.reasoning_elapsed_suppressed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_buffered_provider_not_suppressed_by_capability():
+    """#834 / CodeRabbit: providers WITHOUT the streaming capability keep the
+    proxy (DeepSeek-style buffered reasoning, reasoning-first ordering)."""
+    import asyncio
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    chunks = [
+        [_FakeChoice(_FakeDelta(reasoning_content="Let me think"))],
+        [_FakeChoice(_FakeDelta(reasoning_content=" more"))],
+        [_FakeChoice(_FakeDelta(content="answer"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        await asyncio.sleep(0.2)
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="deepseek-reasoner",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    assert completed.response.reasoning_elapsed_s is not None
+    assert completed.response.reasoning_elapsed_s >= 0.15
+    assert completed.response.reasoning_elapsed_suppressed is False

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -72,6 +72,7 @@ async def test_openai_streaming_emits_content_deltas():
     # Replace the internal client's create — must be a coroutine function
     # so that `await client.chat.completions.create()` works.
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         return _FakeStream(chunks)
     provider._client.chat.completions.create = _fake_create
 
@@ -128,6 +129,7 @@ async def test_openai_streaming_emits_reasoning_deltas():
 
     provider = OpenAIProvider(api_key="sk-test")
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         return _FakeStream(chunks)
     provider._client.chat.completions.create = _fake_create
 
@@ -159,6 +161,7 @@ async def test_openai_streaming_enables_thinking_for_deepseek_v4():
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         captured.update(kw)
         return _FakeStream([[_FakeChoice(_FakeDelta(content="hi"), finish_reason="stop")]])
 
@@ -182,6 +185,7 @@ async def test_openai_streaming_does_not_force_thinking_for_non_reasoning_models
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         captured.update(kw)
         return _FakeStream([[_FakeChoice(_FakeDelta(content="hi"), finish_reason="stop")]])
 
@@ -227,6 +231,7 @@ async def _stream_with_tool_args(provider, arguments_str: str) -> list[LLMStream
     ]
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         return _FakeStream(chunks)
 
     provider._client.chat.completions.create = _fake_create
@@ -328,6 +333,7 @@ async def test_stream_reasoning_elapsed_s_measured_on_first_delta():
     async def _fake_create(**kw):
         # Simulate server-side thinking before the reasoning stream starts.
         # 0.2s leaves generous headroom for Windows timer precision (~15.6ms).
+        """Fake create: simulates buffered server-side thinking before reasoning."""
         await asyncio.sleep(0.2)
         return _FakeStream(chunks)
 
@@ -358,6 +364,7 @@ async def test_stream_no_reasoning_elapsed_is_none():
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create: content-only stream, no reasoning."""
         return _FakeStream(chunks)
 
     provider._client.chat.completions.create = _fake_create
@@ -394,6 +401,7 @@ async def test_stream_interleaved_reasoning_suppresses_elapsed():
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         await asyncio.sleep(0.1)  # thinking delay that must be suppressed
         return _FakeStream(chunks)
 
@@ -429,6 +437,7 @@ async def test_stream_buffered_reasoning_keeps_elapsed():
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         await asyncio.sleep(0.2)
         return _FakeStream(chunks)
 
@@ -466,6 +475,7 @@ async def test_stream_reasoning_first_streaming_provider_suppressed_by_capabilit
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         await asyncio.sleep(0.1)
         return _FakeStream(chunks)
 
@@ -501,6 +511,7 @@ async def test_stream_buffered_provider_not_suppressed_by_capability():
     provider = OpenAIProvider(api_key="sk-test")
 
     async def _fake_create(**kw):
+        """Fake create for this test scenario."""
         await asyncio.sleep(0.2)
         return _FakeStream(chunks)
 

--- a/tests/providers/test_openai_streaming.py
+++ b/tests/providers/test_openai_streaming.py
@@ -304,3 +304,69 @@ async def test_stream_malformed_tool_args_logs_warning():
     assert any("malformed tool args" in m for m in messages), (
         f"expected a malformed-tool-args warning, got: {messages}"
     )
+
+
+# ── #834: reasoning_elapsed_s (server-side thinking proxy) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_stream_reasoning_elapsed_s_measured_on_first_delta():
+    """#834: completed response carries reasoning_elapsed_s = request-start →
+    first reasoning delta (server-side thinking proxy)."""
+    import asyncio
+
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    chunks = [
+        [_FakeChoice(_FakeDelta(reasoning_content="Let me think"))],
+        [_FakeChoice(_FakeDelta(reasoning_content=" about this"))],
+        [_FakeChoice(_FakeDelta(content="answer"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        # Simulate server-side thinking before the reasoning stream starts.
+        await asyncio.sleep(0.05)
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4o",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    # Measured from monotonic request start — includes the simulated thinking.
+    assert completed.response.reasoning_elapsed_s is not None
+    assert completed.response.reasoning_elapsed_s >= 0.05
+
+
+@pytest.mark.asyncio
+async def test_stream_no_reasoning_elapsed_is_none():
+    """#834: plain content streams (no reasoning) leave reasoning_elapsed_s None."""
+    from miqi.providers.openai_provider import OpenAIProvider
+
+    chunks = [
+        [_FakeChoice(_FakeDelta(content="hello"), finish_reason="stop")],
+    ]
+
+    provider = OpenAIProvider(api_key="sk-test")
+
+    async def _fake_create(**kw):
+        return _FakeStream(chunks)
+
+    provider._client.chat.completions.create = _fake_create
+
+    events = await _stream_events(
+        provider,
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4o",
+    )
+
+    completed = events[-1]
+    assert completed.response is not None
+    assert completed.response.reasoning_elapsed_s is None

--- a/tests/runtime/test_fast_budget.py
+++ b/tests/runtime/test_fast_budget.py
@@ -323,3 +323,55 @@ async def test_think_exhaustion_keeps_diagnosis():
         tools=[],
     )
     assert "已达到最大迭代次数" in result.final_content
+
+
+@pytest.mark.asyncio
+async def test_reasoning_elapsed_s_measured_from_turn_start():
+    """#834: 首个 reasoning delta 到达时记录思考耗时（turn 开始→首 delta），
+    随 TurnResult 返回——前端 final 事件优先使用该服务端值。"""
+    import asyncio
+
+    class _ReasoningProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(tool_rounds=0)
+            self.reasoning_yielded = False
+
+        async def stream_chat(self, **kwargs):
+            self.calls += 1
+            # 模拟服务端先思考再下发：首 delta 前 sleep 50ms
+            await asyncio.sleep(0.05)
+            yield SimpleNamespace(kind="reasoning_delta", delta="先思考")
+            yield SimpleNamespace(kind="reasoning_delta", delta="再思考")
+            yield SimpleNamespace(kind="content_delta", delta="最终回答")
+            yield SimpleNamespace(
+                kind="completed",
+                response=SimpleNamespace(
+                    has_tool_calls=False,
+                    tool_calls=[],
+                    content="最终回答",
+                    reasoning_content="先思考再思考",
+                    usage={},
+                    finish_reason="stop",
+                ),
+            )
+
+    clock = FakeClock()
+    provider = _ReasoningProvider()
+    tools = FakeTools()
+    emitter = FakeEmitter()
+    runner = TurnRunner(
+        provider=provider,
+        tool_runtime=tools,
+        context_runtime=FakeContext(),
+        event_emitter=emitter,
+        max_iterations=10,
+        clock=clock,
+    )
+    result = await runner.run(
+        turn=_mk_turn("think"),
+        user_content="hi",
+        system_prompt="",
+        tools=[],
+    )
+    assert result.reasoning_elapsed_s is not None
+    assert result.reasoning_elapsed_s >= 0.05

--- a/tests/runtime/test_fast_budget.py
+++ b/tests/runtime/test_fast_budget.py
@@ -429,3 +429,127 @@ async def test_reasoning_elapsed_s_prefers_provider_value():
     )
     # provider 值（0.05）优先，而非粗钟测到的 ~0.2s
     assert result.reasoning_elapsed_s == 0.05
+
+
+@pytest.mark.asyncio
+async def test_reasoning_elapsed_first_value_survives_later_suppressed_round():
+    """CodeRabbit #856: 第 1 轮 DeepSeek 建立 provider 值（60s）→ 第 2 轮
+    交错流式 suppressed → 首值保留（跨轮权威），不被后续抑制清掉。"""
+    import asyncio
+
+    class _MixedProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(tool_rounds=0)
+
+        async def stream_chat(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                # 第 1 轮：缓冲思考（DeepSeek），请求工具
+                yield SimpleNamespace(kind="reasoning_delta", delta="思考一")
+                yield SimpleNamespace(
+                    kind="completed",
+                    response=SimpleNamespace(
+                        has_tool_calls=True,
+                        tool_calls=[SimpleNamespace(
+                            id="tc1", name="web_search",
+                            arguments={}, arguments_json="{}",
+                        )],
+                        content="",
+                        reasoning_content="思考一",
+                        reasoning_elapsed_s=60.0,
+                        reasoning_elapsed_suppressed=False,
+                        usage={},
+                        finish_reason="tool_calls",
+                    ),
+                )
+            else:
+                # 第 2 轮：交错流式（Kimi）→ 抑制
+                await asyncio.sleep(0.05)
+                yield SimpleNamespace(kind="reasoning_delta", delta="思考二")
+                yield SimpleNamespace(kind="content_delta", delta="最终回答")
+                yield SimpleNamespace(
+                    kind="completed",
+                    response=SimpleNamespace(
+                        has_tool_calls=False,
+                        tool_calls=[],
+                        content="最终回答",
+                        reasoning_content="思考二",
+                        reasoning_elapsed_s=None,
+                        reasoning_elapsed_suppressed=True,
+                        usage={},
+                        finish_reason="stop",
+                    ),
+                )
+
+    clock = FakeClock()
+    provider = _MixedProvider()
+    tools = FakeTools()
+    emitter = FakeEmitter()
+    runner = TurnRunner(
+        provider=provider,
+        tool_runtime=tools,
+        context_runtime=FakeContext(),
+        event_emitter=emitter,
+        max_iterations=10,
+        clock=clock,
+    )
+    result = await runner.run(
+        turn=_mk_turn("think"),
+        user_content="hi",
+        system_prompt="",
+        tools=[],
+    )
+    assert len(tools.executed) == 1  # 第 1 轮工具已执行
+    # 首轮 provider 值（60s）跨轮保留，不被第 2 轮抑制清掉
+    assert result.reasoning_elapsed_s == 60.0
+
+
+@pytest.mark.asyncio
+async def test_reasoning_elapsed_suppressed_clears_coarse_placeholder():
+    """CodeRabbit #856: 首轮就是交错流式（suppressed）时，粗钟占位必须被
+    清除——TurnResult 返回 None，前端回退本地 span。"""
+    import asyncio
+
+    class _InterleavedProvider(FakeProvider):
+        def __init__(self):
+            super().__init__(tool_rounds=0)
+
+        async def stream_chat(self, **kwargs):
+            self.calls += 1
+            await asyncio.sleep(0.05)  # 粗钟会占到 ~0.05s
+            yield SimpleNamespace(kind="reasoning_delta", delta="思考")
+            yield SimpleNamespace(kind="content_delta", delta="回答")
+            yield SimpleNamespace(
+                kind="completed",
+                response=SimpleNamespace(
+                    has_tool_calls=False,
+                    tool_calls=[],
+                    content="回答",
+                    reasoning_content="思考",
+                    reasoning_elapsed_s=None,
+                    reasoning_elapsed_suppressed=True,
+                    usage={},
+                    finish_reason="stop",
+                ),
+            )
+
+    clock = FakeClock()
+    provider = _InterleavedProvider()
+    tools = FakeTools()
+    emitter = FakeEmitter()
+    runner = TurnRunner(
+        provider=provider,
+        tool_runtime=tools,
+        context_runtime=FakeContext(),
+        event_emitter=emitter,
+        max_iterations=10,
+        clock=clock,
+    )
+    result = await runner.run(
+        turn=_mk_turn("think"),
+        user_content="hi",
+        system_prompt="",
+        tools=[],
+    )
+    # 粗钟占位（~0.05s）被抑制信号清除 → None（前端本地 span 兜底）
+    assert result.reasoning_elapsed_s is None

--- a/tests/runtime/test_fast_budget.py
+++ b/tests/runtime/test_fast_budget.py
@@ -26,6 +26,7 @@ class FakeClock:
     """
 
     def __init__(self, start: float = 0.0, auto_advance: float = 0.0):
+        """Test double for the reasoning-elapsed scenarios."""
         self._now = start
         self._auto = auto_advance
 
@@ -43,11 +44,13 @@ class FakeProvider:
     """返回预编排的响应序列：先 N 轮 tool_calls，最后收尾回答。"""
 
     def __init__(self, tool_rounds: int = 0, all_search: bool = False):
+        """Test double for the reasoning-elapsed scenarios."""
         self._rounds = tool_rounds
         self._all_search = all_search
         self.calls = 0
 
     async def stream_chat(self, **kwargs):
+        """Test double for the reasoning-elapsed scenarios."""
         self.calls += 1
         if self.calls <= self._rounds:
             yield SimpleNamespace(kind="content_delta", delta="")
@@ -86,6 +89,7 @@ class FakeProvider:
 
 class FakeTools:
     def __init__(self):
+        """Test double for the reasoning-elapsed scenarios."""
         self.executed: list[str] = []
 
     async def execute_many(self, turn, tool_calls):
@@ -104,6 +108,7 @@ class FakeTools:
 
 class FakeContext:
     def __init__(self):
+        """Test double for the reasoning-elapsed scenarios."""
         self.messages: list[dict] = []
 
     def build_initial_messages(self, **kwargs):
@@ -128,6 +133,7 @@ class FakeContext:
 
 class FakeEmitter:
     def __init__(self):
+        """Test double for the reasoning-elapsed scenarios."""
         self.events: list[str] = []
 
     async def emit(self, event):
@@ -334,10 +340,12 @@ async def test_reasoning_elapsed_s_measured_from_round_start():
 
     class _ReasoningProvider(FakeProvider):
         def __init__(self):
+            """Reasoning-first provider for the round-start timing test."""
             super().__init__(tool_rounds=0)
             self.reasoning_yielded = False
 
         async def stream_chat(self, **kwargs):
+            """Yield reasoning deltas after a simulated thinking delay."""
             self.calls += 1
             # 模拟服务端先思考再下发：首 delta 前 sleep 200ms（0.2s 留足
             # Windows 计时器精度余量，见 test_openai_streaming 同模式修复）
@@ -387,9 +395,11 @@ async def test_reasoning_elapsed_s_prefers_provider_value():
 
     class _ProviderWithElapsed(FakeProvider):
         def __init__(self):
+            """Test double for the reasoning-elapsed scenarios."""
             super().__init__(tool_rounds=0)
 
         async def stream_chat(self, **kwargs):
+            """Test double for the reasoning-elapsed scenarios."""
             self.calls += 1
             # 粗钟会测到 0.2s+（首 delta 前 sleep）；provider 上报的精确值
             # 应覆盖它（如 0.05s 的小值、或真实服务端思考的大值）。
@@ -439,9 +449,11 @@ async def test_reasoning_elapsed_first_value_survives_later_suppressed_round():
 
     class _MixedProvider(FakeProvider):
         def __init__(self):
+            """Test double for the reasoning-elapsed scenarios."""
             super().__init__(tool_rounds=0)
 
         async def stream_chat(self, **kwargs):
+            """Test double for the reasoning-elapsed scenarios."""
             self.calls += 1
             if self.calls == 1:
                 # 第 1 轮：缓冲思考（DeepSeek），请求工具
@@ -512,9 +524,11 @@ async def test_reasoning_elapsed_suppressed_clears_coarse_placeholder():
 
     class _InterleavedProvider(FakeProvider):
         def __init__(self):
+            """Test double for the reasoning-elapsed scenarios."""
             super().__init__(tool_rounds=0)
 
         async def stream_chat(self, **kwargs):
+            """Test double for the reasoning-elapsed scenarios."""
             self.calls += 1
             await asyncio.sleep(0.05)  # 粗钟会占到 ~0.05s
             yield SimpleNamespace(kind="reasoning_delta", delta="思考")

--- a/tests/runtime/test_fast_budget.py
+++ b/tests/runtime/test_fast_budget.py
@@ -338,8 +338,9 @@ async def test_reasoning_elapsed_s_measured_from_turn_start():
 
         async def stream_chat(self, **kwargs):
             self.calls += 1
-            # 模拟服务端先思考再下发：首 delta 前 sleep 50ms
-            await asyncio.sleep(0.05)
+            # 模拟服务端先思考再下发：首 delta 前 sleep 200ms（0.2s 留足
+            # Windows 计时器精度余量，见 test_openai_streaming 同模式修复）
+            await asyncio.sleep(0.2)
             yield SimpleNamespace(kind="reasoning_delta", delta="先思考")
             yield SimpleNamespace(kind="reasoning_delta", delta="再思考")
             yield SimpleNamespace(kind="content_delta", delta="最终回答")
@@ -374,4 +375,4 @@ async def test_reasoning_elapsed_s_measured_from_turn_start():
         tools=[],
     )
     assert result.reasoning_elapsed_s is not None
-    assert result.reasoning_elapsed_s >= 0.05
+    assert result.reasoning_elapsed_s >= 0.15

--- a/tests/runtime/test_fast_budget.py
+++ b/tests/runtime/test_fast_budget.py
@@ -326,9 +326,10 @@ async def test_think_exhaustion_keeps_diagnosis():
 
 
 @pytest.mark.asyncio
-async def test_reasoning_elapsed_s_measured_from_turn_start():
-    """#834: 首个 reasoning delta 到达时记录思考耗时（turn 开始→首 delta），
-    随 TurnResult 返回——前端 final 事件优先使用该服务端值。"""
+async def test_reasoning_elapsed_s_measured_from_round_start():
+    """#834: 首个 reasoning delta 到达时记录思考耗时（本轮模型调用开始→首
+    delta，粗钟兜底路径），随 TurnResult 返回——前端 final 事件优先使用
+    该服务端值。"""
     import asyncio
 
     class _ReasoningProvider(FakeProvider):
@@ -376,3 +377,55 @@ async def test_reasoning_elapsed_s_measured_from_turn_start():
     )
     assert result.reasoning_elapsed_s is not None
     assert result.reasoning_elapsed_s >= 0.15
+
+
+@pytest.mark.asyncio
+async def test_reasoning_elapsed_s_prefers_provider_value():
+    """#834 / review: completed 事件携带的 provider per-attempt 值（重试排除）
+    无条件优先于粗钟——粗钟只做 provider 未上报时的兜底。"""
+    import asyncio
+
+    class _ProviderWithElapsed(FakeProvider):
+        def __init__(self):
+            super().__init__(tool_rounds=0)
+
+        async def stream_chat(self, **kwargs):
+            self.calls += 1
+            # 粗钟会测到 0.2s+（首 delta 前 sleep）；provider 上报的精确值
+            # 应覆盖它（如 0.05s 的小值、或真实服务端思考的大值）。
+            await asyncio.sleep(0.2)
+            yield SimpleNamespace(kind="reasoning_delta", delta="思考")
+            yield SimpleNamespace(kind="content_delta", delta="回答")
+            yield SimpleNamespace(
+                kind="completed",
+                response=SimpleNamespace(
+                    has_tool_calls=False,
+                    tool_calls=[],
+                    content="回答",
+                    reasoning_content="思考",
+                    reasoning_elapsed_s=0.05,  # provider 精确测量（排除失败尝试）
+                    usage={},
+                    finish_reason="stop",
+                ),
+            )
+
+    clock = FakeClock()
+    provider = _ProviderWithElapsed()
+    tools = FakeTools()
+    emitter = FakeEmitter()
+    runner = TurnRunner(
+        provider=provider,
+        tool_runtime=tools,
+        context_runtime=FakeContext(),
+        event_emitter=emitter,
+        max_iterations=10,
+        clock=clock,
+    )
+    result = await runner.run(
+        turn=_mk_turn("think"),
+        user_content="hi",
+        system_prompt="",
+        tools=[],
+    )
+    # provider 值（0.05）优先，而非粗钟测到的 ~0.2s
+    assert result.reasoning_elapsed_s == 0.05

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -557,32 +557,33 @@ async def test_snapshot_persists_reasoning_elapsed_s(tmp_path):
     """#834: reasoning_elapsed_s round-trips through upsert_snapshot and
     get_interrupted_snapshots (中断恢复卡不再固定 1 秒)."""
     runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
-    await runtime.initialize()
+    try:
+        await runtime.initialize()
 
-    await runtime.upsert_snapshot(
-        "turn-1", "thread-1",
-        status="interrupted",
-        assistant_content="half",
-        reasoning_content="deep thought",
-        reasoning_elapsed_s=612.5,
-    )
+        await runtime.upsert_snapshot(
+            "turn-1", "thread-1",
+            status="interrupted",
+            assistant_content="half",
+            reasoning_content="deep thought",
+            reasoning_elapsed_s=612.5,
+        )
 
-    snapshots = await runtime.get_interrupted_snapshots()
-    assert len(snapshots) == 1
-    assert snapshots[0]["reasoning_elapsed_s"] == 612.5
-    assert snapshots[0]["reasoning_content"] == "deep thought"
+        snapshots = await runtime.get_interrupted_snapshots()
+        assert len(snapshots) == 1
+        assert snapshots[0]["reasoning_elapsed_s"] == 612.5
+        assert snapshots[0]["reasoning_content"] == "deep thought"
 
-    # Snapshot without a measurement stays None (old-buffer behavior).
-    await runtime.upsert_snapshot(
-        "turn-2", "thread-2",
-        status="interrupted",
-        assistant_content="x",
-    )
-    snapshots = await runtime.get_interrupted_snapshots()
-    by_turn = {s["turn_id"]: s for s in snapshots}
-    assert by_turn["turn-2"]["reasoning_elapsed_s"] is None
-
-    await runtime.close()
+        # Snapshot without a measurement stays None (old-buffer behavior).
+        await runtime.upsert_snapshot(
+            "turn-2", "thread-2",
+            status="interrupted",
+            assistant_content="x",
+        )
+        snapshots = await runtime.get_interrupted_snapshots()
+        by_turn = {s["turn_id"]: s for s in snapshots}
+        assert by_turn["turn-2"]["reasoning_elapsed_s"] is None
+    finally:
+        await runtime.close()
 
 
 @pytest.mark.asyncio
@@ -611,15 +612,16 @@ async def test_snapshot_table_migrates_old_db_without_column(tmp_path):
     conn.close()
 
     runtime = HistoryRuntime(db_path, session_id="test-session")
-    await runtime.initialize()  # must migrate without error
+    try:
+        await runtime.initialize()  # must migrate without error
 
-    await runtime.upsert_snapshot(
-        "turn-1", "thread-1",
-        status="interrupted",
-        assistant_content="half",
-        reasoning_elapsed_s=42.0,
-    )
-    snapshots = await runtime.get_interrupted_snapshots()
-    assert snapshots[0]["reasoning_elapsed_s"] == 42.0
-
-    await runtime.close()
+        await runtime.upsert_snapshot(
+            "turn-1", "thread-1",
+            status="interrupted",
+            assistant_content="half",
+            reasoning_elapsed_s=42.0,
+        )
+        snapshots = await runtime.get_interrupted_snapshots()
+        assert snapshots[0]["reasoning_elapsed_s"] == 42.0
+    finally:
+        await runtime.close()

--- a/tests/runtime/test_history_runtime.py
+++ b/tests/runtime/test_history_runtime.py
@@ -547,3 +547,79 @@ async def test_load_messages_isolates_different_sessions_same_thread_id(tmp_path
         )
     finally:
         await runtime_b.close()
+
+
+# ── #834: reasoning_elapsed_s persisted on execution snapshots ──────────
+
+
+@pytest.mark.asyncio
+async def test_snapshot_persists_reasoning_elapsed_s(tmp_path):
+    """#834: reasoning_elapsed_s round-trips through upsert_snapshot and
+    get_interrupted_snapshots (中断恢复卡不再固定 1 秒)."""
+    runtime = HistoryRuntime(tmp_path / "runtime.db", session_id="test-session")
+    await runtime.initialize()
+
+    await runtime.upsert_snapshot(
+        "turn-1", "thread-1",
+        status="interrupted",
+        assistant_content="half",
+        reasoning_content="deep thought",
+        reasoning_elapsed_s=612.5,
+    )
+
+    snapshots = await runtime.get_interrupted_snapshots()
+    assert len(snapshots) == 1
+    assert snapshots[0]["reasoning_elapsed_s"] == 612.5
+    assert snapshots[0]["reasoning_content"] == "deep thought"
+
+    # Snapshot without a measurement stays None (old-buffer behavior).
+    await runtime.upsert_snapshot(
+        "turn-2", "thread-2",
+        status="interrupted",
+        assistant_content="x",
+    )
+    snapshots = await runtime.get_interrupted_snapshots()
+    by_turn = {s["turn_id"]: s for s in snapshots}
+    assert by_turn["turn-2"]["reasoning_elapsed_s"] is None
+
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_table_migrates_old_db_without_column(tmp_path):
+    """#834: a pre-existing DB without reasoning_elapsed_s still opens and
+    snapshots work (ALTER TABLE migration adds the column)."""
+    import sqlite3
+
+    db_path = tmp_path / "runtime.db"
+    # Simulate an old-schema DB: create the table WITHOUT the new column.
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE execution_snapshots (
+            turn_id TEXT PRIMARY KEY,
+            thread_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'running',
+            assistant_content TEXT NOT NULL DEFAULT '',
+            reasoning_content TEXT NOT NULL DEFAULT '',
+            tool_state_json TEXT NOT NULL DEFAULT '[]',
+            version INTEGER NOT NULL DEFAULT 1,
+            updated_at REAL NOT NULL
+        )"""
+    )
+    conn.commit()
+    conn.close()
+
+    runtime = HistoryRuntime(db_path, session_id="test-session")
+    await runtime.initialize()  # must migrate without error
+
+    await runtime.upsert_snapshot(
+        "turn-1", "thread-1",
+        status="interrupted",
+        assistant_content="half",
+        reasoning_elapsed_s=42.0,
+    )
+    snapshots = await runtime.get_interrupted_snapshots()
+    assert snapshots[0]["reasoning_elapsed_s"] == 42.0
+
+    await runtime.close()


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

前端「深度思考 · X 秒」显示不真实：缓冲流式（DeepSeek）显示的是传输时间、中断/恢复路径固定 1 秒——改为后端测量服务端真实思考耗时并在 final 事件携带，恢复路径读取持久化值。

## 背景/问题

两种失真场景：

1. **思考十几分钟，显示几秒**：DeepSeek-reasoner 类模型 reasoning 是服务端完整生成后才开始流式下发（非边思考边发）。前端用「首尾 reasoning delta 到达时间差」测思考时长 = 传输时间（几秒），而非服务端真实思考时间（十几分钟）。后端也只是转发 delta，同样不知道服务端思考耗时。
2. **固定显示 1 秒**：中断恢复卡（`InterruptedTurnCard.tsx`）硬编码 `elapsedSeconds={1}`；恢复路径消息没有持久化思考时长，`reasoningElapsedS ?? 1` 固定显示「深度思考 · 1 秒」。

## 关联 issue

- Closes #834 前端思考时长显示不真实：缓冲流式显示传输时间、恢复路径固定 1 秒

## 变更内容

- **后端测量服务端思考耗时**：`openai_provider.stream_chat` 记录「请求发出 → 首个 reasoning delta 到达」耗时（服务端完整思考后才开始下发，传输延迟可忽略 → 该值 = 服务端真实思考时间的可靠近似）；per-attempt 计时（重试重置）
- **事件链路携带**：`LLMResponse.reasoning_elapsed_s` → `TurnResult`（turn 开始→首 delta 双保险）→ `AgentMessageEvent` → bridge final payload → `ChatFinal.reasoning_elapsed_s`
- **快照持久化**：`execution_snapshots` 表新增 `reasoning_elapsed_s` 列（含旧库 ALTER 迁移），中断/恢复路径读取真实耗时
- **前端优先服务端值**：`finalReasoningElapsedS = data.reasoning_elapsed_s ?? 本地测量`；`InterruptedTurnCard` 新增 `elapsedSeconds` prop（不再硬编码 1）
- **测试**：provider 计时 2 用例（含无 reasoning 为 None）、快照往返 + 旧库迁移 2 用例、turn_runner 传递 1 用例

## 日志/验证证据

```
修复前（场景 A，缓冲流式）：
bridge: got reasoning delta len=1 for model=deepseek-v4-pro
前端：思考十几分钟后显示「深度思考 · 8 秒」（= 首尾 delta 传输时间差）

修复前（场景 B）：
InterruptedTurnCard.tsx:124  <ThinkBlock elapsedSeconds={1} />
中断恢复卡显示「深度思考 · 1 秒」

修复后：
- provider 首 delta 计时：request_started(monotonic) → first reasoning delta
- final 事件携带 reasoning_elapsed_s（如 612.5 = 服务端真实思考秒数）
- 快照持久化 reasoning_elapsed_s，中断卡显示真实耗时

测试（本地）：
tests/providers/test_openai_streaming.py::test_stream_reasoning_elapsed_s_measured_on_first_delta PASSED
  - fake 流模拟 50ms 服务端思考 → completed.response.reasoning_elapsed_s >= 0.05
tests/runtime/test_history_runtime.py::test_snapshot_persists_reasoning_elapsed_s PASSED
  - upsert(612.5) → get_interrupted_snapshots()[0].reasoning_elapsed_s == 612.5
tests/runtime/test_history_runtime.py::test_snapshot_table_migrates_old_db_without_column PASSED
  - 旧 schema DB 打开自动 ALTER 加列，往返正常
tests/runtime/test_fast_budget.py::test_reasoning_elapsed_s_measured_from_turn_start PASSED
  - turn 开始→首 delta >= 0.05，随 TurnResult 返回
```

## 测试情况

- 新增 5 用例全过
- `tests/providers/` + `tests/runtime/test_history_runtime.py` + `test_fast_budget.py` + `test_task_runner_history_integration.py` + `test_runtime_task_runner.py` + `tests/bridge/`：315 passed
- 前端 `tsc --noEmit`：零错误

## 截图

无需截图（纯时长显示逻辑修复，无 UI 布局变更；实机验证后续补）

## 后续计划

无
