### PR TITLE
fix(e2e): 图片资产 hash 改为进程内计算，兼容非 ASCII 文件名

### DIFF
--- a/apps/desktop/tests/e2e/helpers/pr-image-post.ts
+++ b/apps/desktop/tests/e2e/helpers/pr-image-post.ts
@@ -11,9 +11,10 @@
  * checked-out PR branch (PR number resolved via `gh pr view`).
  */
 
+import { createHash } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { basename } from 'node:path';
 
 const REPO = process.env.MIQI_IMG_REPO ?? '14790897/MiQi';
 const RELEASE_TAG = '_gh-imgup';
@@ -109,12 +110,12 @@ async function uploadImage(imagePath: string): Promise<string> {
   const uploadUrl = uploadUrlTemplate.replace('{?name,label}', '');
   const stem = basename(imagePath).replace(/\.[^.]+$/, '');
   const ext = basename(imagePath).split('.').pop() ?? 'png';
-  const hash = execSync(`sha256sum "${imagePath}" | cut -c1-8`, {
-    encoding: 'utf8',
-    windowsHide: true,
-  }).trim();
-  const name = `${stem}-${hash}.${ext}`;
+  // Content hash in-process: shelling out to `sha256sum` breaks on Windows
+  // Git Bash with non-ASCII filenames (octal-escaped args → empty hash →
+  // mangled asset names like `A-session-.-rm--rf-.-.--.png`).
   const buf = readFileSync(imagePath);
+  const hash = createHash('sha256').update(buf).digest('hex').slice(0, 8);
+  const name = `${stem}-${hash}.${ext}`;
   const up = await fetch(`${uploadUrl}?name=${name}`, {
     method: 'POST',
     headers: {
@@ -162,6 +163,3 @@ export async function postScreenshotToPr(
     body: JSON.stringify({ body }),
   });
 }
-
-/** Internal helpers exposed for the upload script path. */
-export const _internal = { join, dirname };


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

e2e 贴图 helper 的资产名 hash 从 shell `sha256sum` 改为进程内 `createHash`，修复非 ASCII 文件名下资产名乱码的问题。

## 背景/问题

`pr-image-post.ts` 用 `execSync('sha256sum "$imagePath" | cut -c1-8')` 计算内容 hash。Windows Git Bash 下中文文件名会被转成八进制转义传给子进程 → `sha256sum` 拿到的是转义后的假路径 → hash 为空 → 资产名退化成 `A-session-.-rm--rf-.-.--.png` 这类乱名，内容 hash 去重也失效。

## 变更内容

- 删 shell 版 `sha256sum | cut`，改为 `createHash('sha256').update(buf).digest('hex').slice(0, 8)`，提前 `readFileSync(imagePath)`
- 清理不再使用的 `_internal` 导出与多余 import（`dirname`/`join` 只在死代码里用过）
- `execSync` 保留给 `token()` 与 `prNumber()`（仍走 `gh` CLI）

## 日志/验证证据

```
$ npx tsc --noEmit -p tsconfig.node.json
exit 0
```

## 测试情况

- 类型检查通过；改动仅影响 e2e 贴图 helper 的 hash 计算，无运行时路径变化
- 原功能（release assets 上传、422 复用）逻辑不变

## 截图

无需截图

🤖 Generated with [Claude Code](https://claude.com/claude-code)