### PR TITLE
feat(desktop): 对话消息排版——气泡改为 Claude 式全文流

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.20.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.5",
+        "@fontsource/jetbrains-mono": "^5.3.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -21,6 +22,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
+        "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.24.4"
@@ -1220,6 +1222,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+      "integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -5363,6 +5374,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -5390,6 +5414,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -5401,6 +5441,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.2",
+      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-11.11.2.tgz",
+      "integrity": "sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -6042,6 +6091,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -7814,6 +7878,23 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -8664,6 +8745,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",
+    "@fontsource/jetbrains-mono": "^5.3.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-scroll-area": "^1.2.10",
@@ -41,6 +42,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.24.4"

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -49,6 +49,7 @@ import type {
   FilesRevertResult,
   FilesOpenExternalResult,
   FilesOpenContainingFolderResult,
+  HtmlOpenInBrowserResult,
   DocumentsParseResult,
   TrackedFileInfo,
   ChatProgress,
@@ -407,6 +408,12 @@ const api = {
       ipcRenderer.invoke(IPC.FILES_OPEN_CONTAINING_FOLDER, { path }),
     /** #740: open AI-generated HTML in the system browser (temp file + auto-cleanup). */
     openInBrowser: (html: string): Promise<{ opened: boolean; path: string; error?: string }> =>
+      ipcRenderer.invoke(IPC.HTML_OPEN_IN_BROWSER, { html }),
+  },
+
+  // -- HTML preview (issue #751): open an HTML string in the system browser --
+  html: {
+    openInBrowser: (html: string): Promise<HtmlOpenInBrowserResult> =>
       ipcRenderer.invoke(IPC.HTML_OPEN_IN_BROWSER, { html }),
   },
 

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1850,7 +1850,7 @@ export function ChatConsole({
   const [reasoningMode, setReasoningMode] = useState<ReasoningMode>(() => {
     try {
       const saved = sessionStorage.getItem('miqi-reasoning-mode');
-      return saved === 'fast' ? 'fast' : 'think';
+      return saved === 'think' ? 'think' : 'fast';
     } catch {
       return 'fast';
     }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo, memo, type ComponentProps } from 'react';
-import { AgentAvatar, UserAvatar } from './components/Avatars';
+import { AgentAvatar } from './components/Avatars';
 import { MarkdownContent } from './components/MarkdownContent';
 import { SandboxHtmlFrame } from './components/SandboxHtmlFrame';
 import { ThinkBlock } from './components/ThinkBlock';
@@ -1308,7 +1308,9 @@ function removeTransientTurnMessagesSinceLastUser(messages: Message[]): Message[
 
 type ChatGroup =
   | { kind: 'msg'; msg: Message }
-  | { kind: 'chain'; rows: Message[]; done: boolean };
+  | { kind: 'chain'; rows: Message[]; done: boolean }
+  | { kind: 'reply-head'; thinking: Message }
+  | { kind: 'reply-content'; msg: Message };
 
 /** Group consecutive tool rows into a single chain so the final rendering can
  *  collapse them into one「工具调用 · N」block (live rows stay expanded while
@@ -1317,6 +1319,10 @@ function groupChatMessages(messages: Message[]): ChatGroup[] {
   const out: ChatGroup[] = [];
   let chain: Message[] | null = null;
   let chainDone = false;
+  // A progress+reasoning message starts a reply header (avatar + name +
+  // "已深度思考") that stays at the TOP of the turn, above any tool rows —
+  // the reply's body is emitted later as reply-content, after the tools.
+  let pendingReply = false;
   const flush = () => {
     if (chain) {
       out.push({ kind: 'chain', rows: chain, done: chainDone });
@@ -1333,6 +1339,17 @@ function groupChatMessages(messages: Message[]): ChatGroup[] {
     }
     if (chain) chainDone = true;
     flush();
+    if (m.role === 'progress' && m.reasoning) {
+      out.push({ kind: 'reply-head', thinking: m });
+      pendingReply = true;
+      continue;
+    }
+    if (m.role === 'assistant' && pendingReply) {
+      out.push({ kind: 'reply-content', msg: m });
+      pendingReply = false;
+      continue;
+    }
+    if (m.role === 'user') pendingReply = false;
     out.push({ kind: 'msg', msg: m });
   }
   flush();
@@ -1357,10 +1374,32 @@ function dedupeReasoningBlocks(messages: Message[]): Message[] {
       out.push(pending);
       continue;
     }
-    pending = null;
+    // Agentic turns think between tool calls, so only a user boundary (or the
+    // final assistant message) ends the merge chain — tool rows (progress with
+    // toolHint) and subagent/error rows stay inside the same turn's thinking.
+    if (m.role === 'user' || m.role === 'assistant') pending = null;
     out.push(m);
   }
   return out;
+}
+
+/** Drop snapshot rows already represented in `merged`.  The backend persists
+ *  reasoning on assistant messages, so sessionMsgsToUi re-creates a completed
+ *  turn's thinking block — splicing the snapshot's copy back in would add one
+ *  more "已深度思考" header on every window switch-back.  Live/in-flight
+ *  thinking (not yet persisted) has no counterpart in `merged` and is kept. */
+function dedupeSnapshotRows(merged: Message[], rows: Message[]): Message[] {
+  return rows.filter((row) => {
+    if (row.role === 'progress' && row.reasoning) {
+      return !merged.some(
+        (m) =>
+          m.role === 'progress' &&
+          m.reasoning &&
+          (m.content.startsWith(row.content) || row.content.startsWith(m.content))
+      );
+    }
+    return !merged.some((m) => m.role === row.role && m.content === row.content);
+  });
 }
 
 /** Promote an existing thinking block, or insert one after the user message.
@@ -1811,7 +1850,7 @@ export function ChatConsole({
   const [reasoningMode, setReasoningMode] = useState<ReasoningMode>(() => {
     try {
       const saved = sessionStorage.getItem('miqi-reasoning-mode');
-      return saved === 'think' ? 'think' : 'fast';
+      return saved === 'fast' ? 'fast' : 'think';
     } catch {
       return 'fast';
     }
@@ -2560,14 +2599,15 @@ export function ChatConsole({
               _snapNonReply.push(_sm);
             }
           }
-          if (_snapNonReply.length > 0) {
+          const _snapNonReplyDeduped = dedupeSnapshotRows(merged, _snapNonReply);
+          if (_snapNonReplyDeduped.length > 0) {
             const insIdx = (() => {
               for (let _i = merged.length - 1; _i >= 0; _i -= 1) {
                 if (merged[_i].role === 'user') return _i + 1;
               }
               return merged.length;
             })();
-            merged.splice(insIdx, 0, ..._snapNonReply);
+            merged.splice(insIdx, 0, ..._snapNonReplyDeduped);
           }
         }
 
@@ -2598,7 +2638,9 @@ export function ChatConsole({
             const _snapThinkingClean = turnDone
               ? _snapThinking.map((_sm) => (_sm.isLiveReasoning ? { ..._sm, isLiveReasoning: false } : _sm))
               : _snapThinking;
-            merged.splice(insIdx, 0, ..._snapThinkingClean);
+            // Dedupe against already-merged rows so a switch-back never
+            // duplicates the "已深度思考" header.
+            merged.splice(insIdx, 0, ...dedupeSnapshotRows(merged, _snapThinkingClean));
           }
         }
 
@@ -5363,7 +5405,7 @@ export function ChatConsole({
             className="flex-1 overflow-y-auto"
             style={{ background: 'var(--background)' }}
           >
-            <div className="max-w-[760px] mx-auto px-6 py-5 flex flex-col gap-2">
+            <div className="max-w-[760px] mx-auto px-4 py-5 flex flex-col gap-2">
               {!historyLoaded ? (
                 <div className="flex flex-col items-center justify-center min-h-[300px] gap-2.5">
                   <Loader2 size={16} className="animate-spin text-text-faint" />
@@ -5407,10 +5449,28 @@ export function ChatConsole({
                       downloadingPaperId={downloadingPaperId}
                       paperDownloadStates={paperDownloadStates}
                     />
+                  ) : group.kind === 'reply-head' ? (
+                    <div key={`head-${group.thinking.timestamp}-${i}`}>
+                      <div className="flex items-center gap-2 mb-3 pl-2">
+                        <AgentAvatar />
+                        <span className="text-[16px] font-semibold shrink-0 whitespace-nowrap" style={{ color: 'var(--text)' }}>
+                          MiqroForge
+                        </span>
+                      </div>
+                      {reasoningMode !== 'fast' && (
+                        <ThinkBlock
+                          reasoning={group.thinking.reasoning ?? ''}
+                          defaultOpen={group.thinking.isLiveReasoning}
+                          elapsedSeconds={group.thinking.reasoningElapsedS}
+                          live={group.thinking.isLiveReasoning}
+                        />
+                      )}
+                    </div>
                   ) : (
                     <div key={`${group.msg.timestamp}-${i}`}>
                       <MessageBubble
                         msg={group.msg}
+                        hideHeader={group.kind === 'reply-content'}
                         sessionKey={sessionKey}
                         turnIndex={i}
                         execOutputs={execOutputs}
@@ -5452,6 +5512,15 @@ export function ChatConsole({
               )}
             </div>
           </div>
+
+          {/* 渐变晕染分界线：固定在输入框上方，消息滚到附近时柔和淡出到背景 */}
+          <div
+            className="pointer-events-none shrink-0 -mt-10 h-10"
+            style={{
+              background:
+                'linear-gradient(to bottom, color-mix(in srgb, var(--background) 0%, transparent) 0%, color-mix(in srgb, var(--background) 0%, transparent) 40%, var(--background) 100%)',
+            }}
+          />
 
           {/* Composer */}
           <div
@@ -6467,12 +6536,12 @@ function ToolChainGroup({
 
   const label = `工具调用 · ${rows.length}`;
   return (
-    <div className="my-0.5 flex min-w-0">
+    <div className="my-0.5 flex min-w-0 pl-2">
       <div className="flex w-4 flex-col items-center self-stretch">
         <span className="text-[13px] leading-none">🔧</span>
         <span className="mt-0.5 w-[2px] flex-1 min-h-2 rounded-full" style={{ background: 'var(--border-subtle)' }} />
       </div>
-      <div className="min-w-0 flex-1 pl-2">
+      <div className="min-w-0 flex-1">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
@@ -6515,6 +6584,9 @@ interface MessageBubbleProps {
   /** Reasoning mode of the active conversation — fast hides thinking blocks
    *  (issue #680: 极速回答不展示思考过程). */
   reasoningMode?: ReasoningMode;
+  /** True when this bubble is the reply-content of a split turn (the
+   *  avatar/name/thinking header was already rendered by its reply-head). */
+  hideHeader?: boolean;
   /** Current session key — scopes persisted 👍/👎 feedback to this session. */
   sessionKey: string;
   /** Stable per-turn index (chatGroups 下标) — reload-stable feedback key. */
@@ -6554,6 +6626,7 @@ interface MessageBubbleProps {
 
 const MessageBubble = memo(function MessageBubble({
   msg,
+  hideHeader,
   sessionKey,
   execOutputs,
   inlineExecOutput,
@@ -6607,6 +6680,16 @@ const MessageBubble = memo(function MessageBubble({
   const [dislikeSending, setDislikeSending] = useState(false);
   const [dislikeDone, setDislikeDone] = useState(false);
   const [dislikeError, setDislikeError] = useState('');
+
+  // ── Hook-count uniformity ─────────────────────────────────────────────
+  // These three hooks must run BEFORE the role-based early returns below
+  // (progress / error / subagent).  A fiber reconciled across a role change
+  // (e.g. a window-switch restore that swaps a bubble's role at the same
+  // key) would otherwise call 9 hooks on the early-return path vs 12 on the
+  // main path — React throws "Rendered fewer hooks than expected".
+  const bubbleRef = useRef<HTMLDivElement>(null);
+  const capturedSelectionRef = useRef('');
+  const [copyHovered, setCopyHovered] = useState(false);
 
   const persistFeedback = (v: 'up' | 'down' | null) => {
     try {
@@ -6967,7 +7050,6 @@ const MessageBubble = memo(function MessageBubble({
 
   // 复制选区（restored from pre-#577, issue #677）：选中即复制选中、
   // 否则复制全文。hover 不得清掉菜单打开时捕获的选区。
-  const bubbleRef = useRef<HTMLDivElement>(null);
   const selectMessageText = () => {
     const textEl = bubbleRef.current?.querySelector('[data-message-body]') as HTMLElement | null;
     if (!textEl) return;
@@ -6980,8 +7062,6 @@ const MessageBubble = memo(function MessageBubble({
   const deselectMessageText = () => {
     window.getSelection()?.removeAllRanges();
   };
-  const capturedSelectionRef = useRef('');
-  const [copyHovered, setCopyHovered] = useState(false);
   const copyWithSelection = () => {
     const selected = capturedSelectionRef.current;
     onCopy(selected.length > 0 ? selected : msg.content, copyIdx ?? turnIndex ?? 0);
@@ -7042,7 +7122,13 @@ const MessageBubble = memo(function MessageBubble({
       {({ onContextMenu }) => (
         <div
           ref={bubbleRef}
-          className={cn('flex min-w-0 items-start gap-3', isUser && 'justify-end')}
+          className={cn(
+            'flex min-w-0 gap-3',
+            isUser ? 'items-start justify-end' : 'flex-col items-start',
+            // reply-content (thinking/tools already rendered the icon rail) —
+            // indent the body so it lines up with the thinking/tool labels.
+            hideHeader && !isUser && 'pl-4'
+          )}
           onContextMenu={(e) => {
             // Capture any manual selection before hover-preview can replace it
             capturedSelectionRef.current = window.getSelection()?.toString() ?? '';
@@ -7050,7 +7136,14 @@ const MessageBubble = memo(function MessageBubble({
           }}
           data-testid={isUser ? 'chat-message-user' : 'chat-message-assistant'}
         >
-          {!isUser && <AgentAvatar />}
+          {!isUser && !hideHeader && (
+            <div className="flex items-center gap-2 mb-3 pl-2">
+              <AgentAvatar />
+              <span className="text-[16px] font-semibold shrink-0 whitespace-nowrap" style={{ color: 'var(--text)' }}>
+                MiqroForge
+              </span>
+            </div>
+          )}
 
           {/* Pending spinner — the optimistic user bubble is shown before the
               backend has accepted the send; a small spinning icon (no text)
@@ -7064,7 +7157,7 @@ const MessageBubble = memo(function MessageBubble({
           <div
             className={cn(
               'group flex min-w-0 flex-col gap-1.5',
-              isUser ? 'items-end max-w-[70%]' : 'max-w-[82%]'
+              isUser ? 'items-end max-w-[calc(100%-48px)]' : 'w-full'
             )}
           >
             {/* image attachments */}
@@ -7174,19 +7267,16 @@ const MessageBubble = memo(function MessageBubble({
                 ));
               })()}
 
-            {/* Main bubble */}
+            {/* Main bubble — AI 侧去气泡：正文直接落在 chat 背景上撑满列宽（issue #772） */}
             <div
               data-message-body
-              className="text-sm leading-relaxed rounded-2xl px-4 py-3 transition-shadow"
+              className={cn('text-sm transition-shadow', isUser && 'rounded-2xl rounded-br-none px-4 py-3')}
               style={{
+                lineHeight: 'var(--leading-relaxed)',
                 ...(isUser
                   ? { background: 'var(--bubble-user-bg)', color: 'var(--bubble-user-text)' }
-                  : {
-                      background: 'var(--bubble-ai-bg)',
-                      color: 'var(--bubble-ai-text)',
-                      border: '1px solid var(--bubble-ai-border)',
-                    }),
-                // 经典蓝色框（#547 hover 复制预览）：跟随气泡圆角的外框
+                  : { color: 'var(--bubble-ai-text)' }),
+                // 经典蓝色框（#547 hover 复制预览）：跟随气泡/正文外框
                 ...(copyHovered ? { boxShadow: '0 0 0 2px var(--accent)' } : {}),
               }}
             >
@@ -7311,8 +7401,6 @@ const MessageBubble = memo(function MessageBubble({
               </div>
             )}
           </div>
-
-          {isUser && <UserAvatar />}
         </div>
       )}
     </ContextMenu>

--- a/apps/desktop/src/renderer/features/chat/components/Avatars.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/Avatars.tsx
@@ -8,14 +8,3 @@ export function AgentAvatar() {
     </div>
   );
 }
-
-export function UserAvatar() {
-  return (
-    <div
-      className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-xs font-bold text-white mt-0.5"
-      style={{ background: 'var(--avatar-dark)' }}
-    >
-      U
-    </div>
-  );
-}

--- a/apps/desktop/src/renderer/features/chat/components/HtmlPreviewCard.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/HtmlPreviewCard.tsx
@@ -67,7 +67,7 @@ export function HtmlPreviewCard({ html }: { html: string }) {
           </button>
           <button
             type="button"
-            onClick={() => window.miqi.files.openInBrowser(html)}
+            onClick={() => window.miqi.html.openInBrowser(html)}
             className="px-2 py-0.5 text-xs rounded text-[var(--text-muted)] hover:bg-[var(--surface-muted)]"
             title="用系统默认浏览器打开完整页面（脚本可运行）"
           >

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.test.ts
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.test.ts
@@ -27,3 +27,21 @@ describe('MarkdownContent HTML preview swap', () => {
     expect(markup).toContain('加粗');
   });
 });
+
+describe('MarkdownContent syntax highlighting', () => {
+  it('adds a language label and hljs token spans to a fenced code block', () => {
+    const md = '```ts\nconst x: number = 1;\n```';
+    const markup = renderToStaticMarkup(createElement(MarkdownContent, { content: md }));
+    expect(markup).toContain('>TypeScript</span>');
+    expect(markup).toContain('hljs-keyword');
+    expect(markup).toContain('hljs-built_in');
+    expect(markup).toContain('hljs-number');
+  });
+
+  it('keeps plain text (no label, no hljs) for a code block without a language', () => {
+    const md = '```\nplain text\n```';
+    const markup = renderToStaticMarkup(createElement(MarkdownContent, { content: md }));
+    expect(markup).toContain('plain text');
+    expect(markup).not.toContain('hljs-keyword');
+  });
+});

--- a/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/MarkdownContent.tsx
@@ -1,6 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
+import { Copy, Check } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
 import { cn } from '../../../lib/utils';
 import { HtmlPreviewCard, detectHtmlDocument } from './HtmlPreviewCard';
 
@@ -9,6 +11,60 @@ function stripThinkBlocks(text: string): string {
   let result = text.replace(/<\/?think>/gi, '');
   return result.trim();
 }
+
+/** Flatten highlighted <span> tokens back to plain code text (for copy). */
+function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join('');
+  if (node && typeof node === 'object' && 'props' in node && (node as any).props?.children != null) {
+    return extractText((node as any).props.children);
+  }
+  return '';
+}
+
+/** Display names for common language codes shown in the code-block header. */
+const LANG_LABELS: Record<string, string> = {
+  ts: 'TypeScript',
+  tsx: 'TSX',
+  js: 'JavaScript',
+  jsx: 'JSX',
+  py: 'Python',
+  html: 'HTML',
+  htm: 'HTML',
+  css: 'CSS',
+  scss: 'SCSS',
+  less: 'Less',
+  json: 'JSON',
+  yaml: 'YAML',
+  yml: 'YAML',
+  toml: 'TOML',
+  md: 'Markdown',
+  markdown: 'Markdown',
+  go: 'Go',
+  rs: 'Rust',
+  rust: 'Rust',
+  java: 'Java',
+  kt: 'Kotlin',
+  swift: 'Swift',
+  c: 'C',
+  cpp: 'C++',
+  cs: 'C#',
+  sh: 'Shell',
+  bash: 'Bash',
+  zsh: 'Zsh',
+  powershell: 'PowerShell',
+  ps1: 'PowerShell',
+  sql: 'SQL',
+  xml: 'XML',
+  svg: 'SVG',
+  diff: 'Diff',
+  dockerfile: 'Dockerfile',
+  makefile: 'Makefile',
+  ini: 'INI',
+  env: 'ENV',
+  plaintext: 'Plain text',
+  text: 'Plain text',
+};
 
 export function MarkdownContent({ content }: { content: string }) {
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
@@ -23,19 +79,19 @@ export function MarkdownContent({ content }: { content: string }) {
 
   const components = useMemo(
     () => ({
-      p: ({ children }: any) => <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>,
-      h1: ({ children }: any) => <h1 className="text-base font-bold mt-3 mb-1.5 first:mt-0">{children}</h1>,
-      h2: ({ children }: any) => <h2 className="text-sm font-bold mt-3 mb-1 first:mt-0">{children}</h2>,
-      h3: ({ children }: any) => <h3 className="text-sm font-semibold mt-2 mb-0.5 first:mt-0">{children}</h3>,
-      ul: ({ children }: any) => <ul className="list-disc pl-5 my-1.5 space-y-0.5">{children}</ul>,
-      ol: ({ children }: any) => <ol className="list-decimal pl-5 my-1.5 space-y-0.5">{children}</ol>,
-      li: ({ children }: any) => <li className="leading-relaxed">{children}</li>,
+      p: ({ children }: any) => <p className="my-2 first:mt-0 last:mb-0">{children}</p>,
+      h1: ({ children }: any) => <h1 className="text-[17px] font-bold mt-4 mb-2 first:mt-0">{children}</h1>,
+      h2: ({ children }: any) => <h2 className="text-[15px] font-bold mt-4 mb-1.5 first:mt-0">{children}</h2>,
+      h3: ({ children }: any) => <h3 className="text-sm font-semibold mt-3 mb-1 first:mt-0">{children}</h3>,
+      ul: ({ children }: any) => <ul className="list-disc pl-5 my-2 space-y-1 first:mt-0 last:mb-0">{children}</ul>,
+      ol: ({ children }: any) => <ol className="list-decimal pl-5 my-2 space-y-1 first:mt-0 last:mb-0">{children}</ol>,
+      li: ({ children }: any) => <li>{children}</li>,
       blockquote: ({ children }: any) => (
-        <blockquote className="border-l-2 pl-3 my-2 italic" style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}>{children}</blockquote>
+        <blockquote className="border-l-2 pl-3 my-3 first:mt-0 last:mb-0 italic" style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}>{children}</blockquote>
       ),
       strong: ({ children }: any) => <strong className="font-semibold">{children}</strong>,
       em: ({ children }: any) => <em className="italic">{children}</em>,
-      hr: () => <hr className="my-3" style={{ borderColor: 'var(--border-subtle)' }} />,
+      hr: () => <hr className="my-4" style={{ borderColor: 'var(--border-subtle)' }} />,
       img: ({ src, alt }: any) => (
         <img src={src} alt={alt ?? ''} className='max-w-full h-auto rounded-lg my-2' />
       ),
@@ -43,28 +99,60 @@ export function MarkdownContent({ content }: { content: string }) {
         <a href={href} className="underline cursor-pointer break-words" style={{ color: 'var(--accent)' }}
            onClick={(e) => { e.preventDefault(); if (href) window.open(href, '_blank'); }}>{children}</a>
       ),
-      table: ({ children }: any) => <div className="overflow-x-auto my-2"><table className="text-xs w-full border-collapse">{children}</table></div>,
-      th: ({ children }: any) => <th className="border px-2 py-1.5 text-left font-medium" style={{ borderColor: 'var(--border)', background: 'var(--surface-muted)' }}>{children}</th>,
-      td: ({ children }: any) => <td className="border px-2 py-1.5" style={{ borderColor: 'var(--border-subtle)' }}>{children}</td>,
-      pre: ({ children }: any) => <pre className="relative group my-2 rounded-lg overflow-x-auto max-w-full" style={{ background: 'rgba(0,0,0,0.06)' }}>{children}</pre>,
-      code: ({ className, children, ...props }: any) => {
-        const codeStr = String(children);
-        if (codeStr.endsWith('\n')) {
-          const code = codeStr.replace(/\n$/, '');
-          return (
-            <code className={cn('block text-xs font-mono p-3', className)} {...props}>
+      table: ({ children }: any) => <div className="overflow-x-auto my-2 rounded-[10px]" style={{ border: '1px solid var(--table-border)' }}><table className="text-xs w-full border-collapse">{children}</table></div>,
+      th: ({ children }: any) => <th className="px-3 py-2 text-left font-semibold" style={{ background: 'var(--table-head-bg)' }}>{children}</th>,
+      td: ({ children }: any) => <td className="px-3 py-2">{children}</td>,
+      pre: ({ children }: any) => {
+        // Codex-style block header: language left, copy right, a divider under
+        // the header; the code body scrolls in the inner <pre> below it.
+        const child = Array.isArray(children) ? children[0] : children;
+        const codeProps =
+          child && typeof child === 'object' && 'props' in child ? (child as any).props ?? {} : {};
+        const lang = ((codeProps.className ?? '').match(/language-([\w+-]+)/)?.[1] ?? '').toLowerCase();
+        const langLabel = LANG_LABELS[lang] ?? lang;
+        const codeText = extractText(codeProps.children).replace(/\n$/, '');
+        return (
+          <div
+            className="group my-2 overflow-hidden rounded-lg"
+            style={{ background: 'var(--code-bg)', border: '1px solid var(--border-subtle)' }}
+          >
+            <div
+              className="flex items-center gap-2 pl-3 pr-2 h-8"
+              style={{ borderBottom: '1px solid var(--border-subtle)' }}
+            >
+              {lang && (
+                <span className="text-[11px] font-medium select-none" style={{ color: 'var(--text-faint)' }}>
+                  {langLabel}
+                </span>
+              )}
               <button
-                onClick={() => handleCopyCode(code)}
-                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded px-1.5 py-0.5 text-size-2xs leading-none"
-                style={{ background: 'var(--surface)', border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+                onClick={() => handleCopyCode(codeText)}
+                className="ml-auto rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:opacity-100"
+                style={{ color: copiedCode === codeText ? 'var(--success)' : 'var(--text-muted)' }}
+                aria-label="复制代码"
+                title="复制"
               >
-                {copiedCode === code ? 'Copied' : 'Copy'}
+                {copiedCode === codeText ? <Check size={14} /> : <Copy size={14} />}
               </button>
-              {code}
+            </div>
+            <pre className="m-0 overflow-x-auto max-w-full" style={{ background: 'transparent', border: 0, padding: 0 }}>
+              {children}
+            </pre>
+          </div>
+        );
+      },
+      code: ({ className, children, ...props }: any) => {
+        const cls = className ?? '';
+        const isBlock =
+          /language-[\w+-]+/.test(cls) || (typeof children === 'string' && children.endsWith('\n'));
+        if (isBlock) {
+          return (
+            <code className={cn('block text-[13px] leading-[1.6] font-mono p-3', cls)} {...props}>
+              {children}
             </code>
           );
         }
-        return <code className="text-xs font-mono px-1.5 py-0.5 rounded" style={{ background: 'rgba(0,0,0,0.08)' }} {...props}>{children}</code>;
+        return <code className="font-mono text-[0.9em] leading-none px-1.5 py-[2px] rounded" style={{ background: 'rgba(0,0,0,0.08)' }} {...props}>{children}</code>;
       },
     }),
     [copiedCode]
@@ -79,7 +167,7 @@ export function MarkdownContent({ content }: { content: string }) {
 
   return (
     <div className="min-w-0 break-words" style={{ overflowWrap: 'anywhere' }}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]} components={components}>
         {displayContent}
       </ReactMarkdown>
     </div>

--- a/apps/desktop/src/renderer/features/chat/components/ThinkBlock.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/ThinkBlock.tsx
@@ -80,7 +80,7 @@ export function ThinkBlock({
         : mode === 'fast' ? '快速思考' : '深度思考');
 
   return (
-    <div className="my-0.5 flex min-w-0">
+    <div className="my-0.5 flex min-w-0 pl-2">
       <div className="flex w-4 flex-col items-center self-stretch">
         <span
           className={
@@ -91,7 +91,7 @@ export function ThinkBlock({
         </span>
         <span className="mt-0.5 w-[2px] flex-1 min-h-2 rounded-full" style={{ background: 'var(--border-subtle)' }} />
       </div>
-      <div className="min-w-0 flex-1 pl-2">
+      <div className="min-w-0 flex-1">
         <button
           type="button"
           onClick={toggle}

--- a/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
+++ b/apps/desktop/src/renderer/features/chat/components/renderContent.tsx
@@ -9,8 +9,8 @@ export function renderContent(text: string) {
       return (
         <pre
           key={i}
-          className="my-2 text-xs rounded-lg px-3 py-2 overflow-x-auto max-w-full"
-          style={{ background: 'rgba(0,0,0,0.06)' }}
+          className="my-2 text-[13px] leading-[1.6] rounded-lg px-3 py-2.5 overflow-x-auto max-w-full"
+          style={{ background: 'var(--code-bg)' }}
         >
           <code>{code}</code>
         </pre>
@@ -26,7 +26,7 @@ export function renderContent(text: string) {
             return (
               <code
                 key={j}
-                className="text-xs font-mono px-1 rounded"
+                className="font-mono text-[0.9em] leading-none px-1.5 py-[2px] rounded"
                 style={{ background: 'rgba(0,0,0,0.08)' }}
               >
                 {seg.slice(1, -1)}

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 @import '@fontsource/inter';
+@import '@fontsource/jetbrains-mono';
+@import '@fontsource/jetbrains-mono/600.css';
 
 /* ------------------------------------------------------------------ */
 /* MiqroForge Desktop — Design Tokens (原型配色)                              */
@@ -94,7 +96,7 @@
   --info-bg: #e0edff;
 
   /* Chat bubbles */
-  --bubble-user-bg: #2a2a48;
+  --bubble-user-bg: #4e5e73;
   --bubble-user-text: #ffffff;
   --bubble-ai-bg: #ffffff;
   --bubble-ai-text: #222222;
@@ -124,6 +126,24 @@
   --shadow: 0 1px 2px rgba(23, 24, 28, 0.03), 0 16px 40px rgba(23, 24, 28, 0.06);
   --ui-contrast: 45%;
   --code-font-size: 14px;
+
+  /* Code block surface + syntax tokens (rehype-highlight) — derived from
+     design tokens so both themes stay on-family. */
+  --code-bg: color-mix(in srgb, var(--background) 76%, var(--border));
+  --code-token-keyword: color-mix(in srgb, var(--danger) 80%, var(--text));
+  --code-token-string: color-mix(in srgb, var(--success) 66%, var(--text));
+  --code-token-comment: var(--text-faint);
+  --code-token-function: color-mix(in srgb, var(--accent) 55%, var(--danger));
+  --code-token-number: color-mix(in srgb, var(--warning) 55%, var(--text));
+  --code-token-builtin: color-mix(in srgb, var(--info) 62%, var(--text));
+  --code-token-type: color-mix(in srgb, var(--bypass) 62%, var(--text));
+  --code-token-attr: color-mix(in srgb, var(--danger) 50%, var(--text));
+  --code-token-meta: var(--text-faint);
+
+  /* Table surface (Markdown) — 从背景色派生，抹茶/白色/自定义背景都自动协调 */
+  --table-border: color-mix(in srgb, var(--background) 84%, var(--text));
+  --table-head-bg: color-mix(in srgb, var(--background) 92%, var(--text));
+  --table-stripe: color-mix(in srgb, var(--background) 96%, var(--text));
 
   color-scheme: light;
 }
@@ -172,7 +192,7 @@
   --danger-bg: rgba(248, 113, 113, 0.16);
   --info: #60a5fa;
   --info-bg: rgba(96, 165, 250, 0.16);
-  --bubble-user-bg: #3a3a5a;
+  --bubble-user-bg: #4e5e73;
   --bubble-user-text: #ffffff;
   --bubble-ai-bg: #2e2e2e;
   --bubble-ai-text: #e4e4e0;
@@ -186,6 +206,17 @@
   --tag-cc-bg: rgba(168, 85, 247, 0.18);
   --tag-cc-text: #c4b5fd;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 16px 40px rgba(0, 0, 0, 0.28);
+
+  --code-bg: color-mix(in srgb, var(--background) 96%, #ffffff);
+  --code-token-keyword: var(--accent);
+  --code-token-string: var(--success);
+  --code-token-comment: var(--text-faint);
+  --code-token-function: color-mix(in srgb, var(--accent) 50%, var(--info));
+  --code-token-number: var(--warning);
+  --code-token-builtin: color-mix(in srgb, var(--info) 78%, #ffffff);
+  --code-token-type: var(--bypass);
+  --code-token-attr: var(--danger);
+  --code-token-meta: var(--text-faint);
 
   color-scheme: dark;
 }
@@ -217,6 +248,10 @@
   --font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC',
     'Microsoft YaHei', ui-sans-serif, system-ui, sans-serif;
+
+  --font-mono:
+    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
+    monospace;
 }
 
 html[data-font-family='system'] {
@@ -581,7 +616,7 @@ pre {
 
 code {
   font-family:
-    ui-monospace, SFMono-Regular, Menlo, Consolas, 'JetBrains Mono',
+    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas,
     monospace;
   font-size: 0.9em;
   font-variant-ligatures: none;
@@ -593,24 +628,99 @@ code {
   border-radius: 4px;
 }
 
-/* Markdown tables: keep long-form content compact and readable */
+/* Syntax highlighting (rehype-highlight) — hues derived from design tokens */
+.hljs {
+  color: var(--text);
+  background: transparent;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-doctag {
+  color: var(--code-token-keyword);
+  font-weight: 600;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-addition {
+  color: var(--code-token-string);
+}
+.hljs-comment,
+.hljs-quote {
+  color: var(--code-token-comment);
+  font-style: italic;
+}
+.hljs-number,
+.hljs-literal,
+.hljs-symbol,
+.hljs-deletion {
+  color: var(--code-token-number);
+}
+.hljs-title,
+.hljs-title.function_,
+.hljs-function .hljs-title,
+.hljs-selector-id {
+  color: var(--code-token-function);
+}
+.hljs-built_in,
+.hljs-builtin-name {
+  color: var(--code-token-builtin);
+}
+.hljs-type,
+.hljs-class .hljs-title,
+.hljs-selector-class {
+  color: var(--code-token-type);
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-property,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-selector-attr,
+.hljs-selector-pseudo {
+  color: var(--code-token-attr);
+}
+.hljs-params,
+.hljs-operator {
+  color: var(--text-muted);
+}
+.hljs-meta,
+.hljs-section,
+.hljs-name,
+.hljs-tag {
+  color: var(--code-token-meta);
+}
+
+/* Markdown tables: 圆角容器 + 暖灰表头 + 斑马纹 */
 table {
   border-collapse: collapse;
   font-size: var(--text-xs);
   line-height: 1.55;
+  width: 100%;
 }
 
 th,
 td {
-  padding: 6px 10px;
-  border: 1px solid var(--border-subtle);
+  padding: 6px 11px;
   text-align: left;
   vertical-align: top;
 }
 
 th {
-  background: var(--surface-muted);
+  background: var(--table-head-bg);
   font-weight: 600;
+  border-bottom: 1px solid var(--table-border);
+}
+
+tbody td {
+  border-bottom: 1px solid var(--table-border);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+tbody tr:nth-child(even) td {
+  background: var(--table-stripe);
 }
 
 /* Status tag utilities */

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.15.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

AI 回复去气泡改为撑满可读列宽的全文流，代码块白底描边 + 语法高亮 + 复制键。

## 背景/问题

当前 AI/用户消息都被限制在 max-width 70%/82% 的圆角气泡里，长 Markdown、代码块、表格被反复换行，读感像"短信"而非"长文"。对应 issue #772。

## 关联 issue

- Closes #772

## 变更内容

- `ChatConsole.tsx`：AI 回复去气泡、撑满列宽；头像+名字置顶；思考块并入回复顶部；用户气泡右下角直角、宽度对齐名字首字母；带输入框与回复内容中间增加渐变晕染
- `MarkdownContent.tsx`：接入 rehype-highlight 语法高亮、语言标签、Codex 风格代码块 header + 复制按钮；表格圆角容器
- `globals.css`：代码语法 token、表格背景派生配色、用户气泡品牌蓝灰
- `renderContent.tsx` / `ThinkBlock.tsx` / `Avatars.tsx` 等配套调整

## 日志/验证证据

```
typecheck:web 通过（tsc --noEmit）
vitest: 274 passed / 3 skipped
```

## 测试情况

- `npm run typecheck:web` 通过
- `npx vitest run` 274 passed / 3 skipped

## 截图
回复内容去掉气泡框
<img width="1230" height="853" alt="image" src="https://github.com/user-attachments/assets/495ab8c4-bf5f-40ca-8369-97efc27cb68d" />
代码可以显示彩色高亮
<img width="1230" height="853" alt="image" src="https://github.com/user-attachments/assets/8880164a-2ac4-4073-a2a1-26d7f83ebc5c" />
修改表格外观及其配色
<img width="1230" height="853" alt="image" src="https://github.com/user-attachments/assets/15b659bb-4b19-4fbe-abb9-92525d55e3b5" />
改变提问气泡最大宽度，修改形状
<img width="1230" height="853" alt="image" src="https://github.com/user-attachments/assets/5ff4ce41-41c2-4ddb-8a89-8d19e02ef7bd" />

## 后续计划

- 无