### PR TITLE
ci(wecom): PR 通知去掉 review_requested 触发，避免重复发两次

### DIFF
--- a/.github/workflows/wecom-notify.yml
+++ b/.github/workflows/wecom-notify.yml
@@ -6,7 +6,7 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [opened, review_requested]
+    types: [opened]
 
 jobs:
   notify:


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 WeCom 通知在创建 PR 时同一通知重复推送两次的问题。

## 背景/问题

`wecom-notify.yml` 的 `pull_request` 触发器同时监听 `opened` 和 `review_requested` 两种事件。创建 PR 时这两个事件相隔约 1 秒连续触发，而通知内容都取同一个 `pull_request.title`（PR 通知只带标题，不带正文），导致同一条 PR 通知被推送两次。

实测 PR #857 时间线：

```
opened            07:03:40Z
review_requested  07:03:41Z
```

## 变更内容

- `.github/workflows/wecom-notify.yml`：`pull_request.types` 从 `[opened, review_requested]` 改为 `[opened]`，PR 打开时只通知一次。

## 日志/验证证据

```
$ gh api repos/14790897/MiQi/issues/857/events --jq '.[] | "\(.event) at \(.created_at)"'
review_requested at 2026-08-27T07:03:41Z
merged at 2026-08-27T07:12:08Z
...
```

## 测试情况

- 纯 CI 配置改动，无代码逻辑变更。
- 已用 `git diff` 确认仅删除了 `review_requested` 触发项。