### PR TITLE
fix(sandbox): cmd 回退时告知 AI 本机无 bash/WSL，勿再发 bash 命令

### DIFF
--- a/apps/desktop/tests/e2e/no-git-bash-cmd-fallback.spec.ts
+++ b/apps/desktop/tests/e2e/no-git-bash-cmd-fallback.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * No-Git-Bash cmd-fallback E2E (#865)
+ *
+ * Regression coverage for a Windows host that has NEITHER Git Bash NOR an
+ * enabled WSL: `find_git_bash()` returns None, so exec falls back to
+ * Windows cmd.  The environment description must warn the AI not to run
+ * bash/wsl commands — PATH resolves `bash` to System32\bash.exe (the WSL
+ * entrypoint stub), which errors with `EXECUTABLE NOT FOUND` /
+ * `WSL not installed`.
+ *
+ * We force that environment deterministically with MIQI_FORCE_CMD_EXEC=1
+ * (`find_git_bash()` short-circuits to None even when Git Bash is
+ * installed) plus sandbox disabled, then ask the AI to run a cmd-only
+ * marker `echo NO_GITBASH_CMD_OK_%RANDOM%`.  `%RANDOM%` expands to digits
+ * under cmd but stays literal under bash, so matching `_\d+` proves the
+ * cmd path was taken — and the absence of the WSL-stub errors proves the
+ * original failure is gone.
+ *
+ * Run:
+ *   cd apps/desktop
+ *   npx playwright test --config=playwright.config.ts --project=electron no-git-bash-cmd-fallback.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { postScreenshotToPr } from './helpers/pr-image-post';
+import {
+  LLM_TIMEOUT,
+  waitForBridgeInitialized,
+  sendMessage,
+  waitForResponseComplete,
+  approveLoop,
+  launchElectronApp,
+  closeElectronApp,
+} from './helpers/electron-setup';
+
+// Force the cmd fallback path regardless of Git Bash being installed.
+// Must be set before launchElectronApp() reads process.env.
+process.env.MIQI_FORCE_CMD_EXEC = '1';
+
+test.describe('No-Git-Bash cmd fallback E2E', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test.beforeAll(async () => {
+    const fixture = await launchElectronApp((config) => {
+      config.tools = {
+        ...config.tools,
+        sandbox: { ...config.tools?.sandbox, enabled: false },
+      };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+
+    await waitForBridgeInitialized(page);
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+  });
+
+  test.afterEach(async () => {
+    if (test.info().status === 'passed') return;
+    const fail = join(test.info().outputDir, 'test-failed-1.png');
+    if (existsSync(fail)) {
+      await postScreenshotToPr(fail, `❌ E2E 失败：${test.info().title}`);
+    }
+  });
+
+  test(
+    'exec runs in cmd and no WSL-stub error when Git Bash is absent',
+    { timeout: 8 * 60_000 },
+    async () => {
+      test.setTimeout(8 * 60_000);
+
+      // `%RANDOM%` is cmd-only: cmd expands it to digits, bash keeps it
+      // literal.  A `_\d+` match proves the command actually ran under
+      // cmd — the deterministic proof that MIQI_FORCE_CMD_EXEC took the
+      // cmd fallback rather than Git Bash.
+      const prompt =
+        `必须使用 exec 工具执行下面这条命令，然后只回复命令的完整输出，` +
+        `不要解释、不要改写：` +
+        `echo NO_GITBASH_CMD_OK_%RANDOM%`;
+
+      await sendMessage(page, prompt);
+      await approveLoop(page, LLM_TIMEOUT);
+
+      const RUN_CAP = 8 * 60_000;
+      const IDLE_DEADLINE = 3 * 60_000;
+      const runStart = Date.now();
+      let idleDeadline = runStart + IDLE_DEADLINE;
+      let text = '';
+      let lastText = '';
+      while (Date.now() - runStart < RUN_CAP && Date.now() < idleDeadline) {
+        // Auto-confirm any approval dialog (networked exec / confirm card).
+        const primary = page.locator('[data-testid="confirm-card-primary"]');
+        if (await primary.isVisible({ timeout: 400 }).catch(() => false)) {
+          await primary.first().click();
+          idleDeadline = Date.now() + IDLE_DEADLINE;
+        } else {
+          const choices = page.locator('[data-testid="confirm-card-choice"]');
+          const count = await choices.count();
+          let clicked = false;
+          for (let i = 0; i < count; i++) {
+            const c = choices.nth(i);
+            const label = (await c.textContent()) ?? '';
+            if (/取消/.test(label)) continue;
+            if (await c.isVisible({ timeout: 400 }).catch(() => false)) {
+              await c.click();
+              idleDeadline = Date.now() + IDLE_DEADLINE;
+              clicked = true;
+              break;
+            }
+          }
+          if (!clicked) {
+            const confirmBtn = page.getByRole('button', { name: '确认执行' });
+            if (await confirmBtn.isVisible({ timeout: 400 }).catch(() => false)) {
+              await confirmBtn.click();
+              idleDeadline = Date.now() + IDLE_DEADLINE;
+            }
+          }
+        }
+        text = (await page.locator('main').textContent()) ?? '';
+        if (/NO_GITBASH_CMD_OK_\d+/.test(text)) break;
+        if (text !== lastText) {
+          lastText = text;
+          idleDeadline = Date.now() + IDLE_DEADLINE;
+        }
+        await page.waitForTimeout(1500);
+      }
+
+      // cmd executed the marker and expanded %RANDOM% to digits.
+      expect(text).toMatch(/NO_GITBASH_CMD_OK_\d+/);
+
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      text = (await page.locator('main').textContent()) ?? '';
+
+      // The original failure mode — PATH → System32\bash.exe WSL stub —
+      // must not appear.
+      expect(text).not.toContain('EXECUTABLE NOT FOUND');
+      expect(text).not.toContain('子系统未安装');
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        fullPage: true,
+      });
+
+      await postScreenshotToPr(
+        `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        '✅ E2E 通过：无 Git Bash 时 cmd 回退链路（无 WSL 桩报错）',
+      );
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/no-git-bash-cmd-fallback.spec.ts
+++ b/apps/desktop/tests/e2e/no-git-bash-cmd-fallback.spec.ts
@@ -16,6 +16,9 @@
  * cmd path was taken — and the absence of the WSL-stub errors proves the
  * original failure is gone.
  *
+ * Windows-only: `%RANDOM%` is a cmd-ism.  On macOS/Linux the suite is
+ * skipped (exec uses bash there, and the marker never expands).
+ *
  * Run:
  *   cd apps/desktop
  *   npx playwright test --config=playwright.config.ts --project=electron no-git-bash-cmd-fallback.spec.ts
@@ -36,9 +39,11 @@ import {
   closeElectronApp,
 } from './helpers/electron-setup';
 
-// Force the cmd fallback path regardless of Git Bash being installed.
-// Must be set before launchElectronApp() reads process.env.
-process.env.MIQI_FORCE_CMD_EXEC = '1';
+// Capture the prior value at module load so afterAll can restore it —
+// module-level process.env mutation otherwise leaks into sibling specs
+// that share this worker process.
+const CMD_EXEC_ENV = 'MIQI_FORCE_CMD_EXEC';
+const priorCmdExec = process.env[CMD_EXEC_ENV];
 
 test.describe('No-Git-Bash cmd fallback E2E', () => {
   let electronApp: ElectronApplication;
@@ -46,10 +51,24 @@ test.describe('No-Git-Bash cmd fallback E2E', () => {
   let miqiHome: string;
 
   test.beforeAll(async () => {
+    test.skip(process.platform !== 'win32', 'cmd %RANDOM% marker is Windows-only');
+
+    // Force the cmd fallback regardless of Git Bash being installed.  Must
+    // be set before launchElectronApp() snapshots process.env into the
+    // Electron/bridge child.
+    process.env[CMD_EXEC_ENV] = '1';
+
     const fixture = await launchElectronApp((config) => {
       config.tools = {
         ...config.tools,
         sandbox: { ...config.tools?.sandbox, enabled: false },
+      };
+      // Surface the raw exec stdout in the chat timeline (inline exec
+      // output) so the assertion below can target the tool's own output
+      // rather than only the model's echoed reply.
+      config.desktop = {
+        ...config.desktop,
+        ui: { ...config.desktop?.ui, inlineExecOutput: true },
       };
     });
     electronApp = fixture.electronApp;
@@ -60,7 +79,15 @@ test.describe('No-Git-Bash cmd fallback E2E', () => {
   }, 180_000);
 
   test.afterAll(async () => {
-    await closeElectronApp(electronApp, miqiHome);
+    try {
+      await closeElectronApp(electronApp, miqiHome);
+    } finally {
+      if (priorCmdExec === undefined) {
+        delete process.env[CMD_EXEC_ENV];
+      } else {
+        process.env[CMD_EXEC_ENV] = priorCmdExec;
+      }
+    }
   });
 
   test.afterEach(async () => {
@@ -132,6 +159,15 @@ test.describe('No-Git-Bash cmd fallback E2E', () => {
         }
         await page.waitForTimeout(1500);
       }
+
+      // Prove the exec TOOL actually ran — the raw stdout is rendered in the
+      // inline exec-output <pre> (green block), which only populates from
+      // exec_output_delta events on real execution, never from the model's
+      // final text.  This guards against a model fabricating the marker.
+      const execOutput = page
+        .locator('pre.whitespace-pre-wrap')
+        .filter({ hasText: /NO_GITBASH_CMD_OK_\d+/ });
+      await expect(execOutput.first()).toBeVisible({ timeout: 10_000 });
 
       // cmd executed the marker and expanded %RANDOM% to digits.
       expect(text).toMatch(/NO_GITBASH_CMD_OK_\d+/);

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -307,6 +307,9 @@ def describe_exec_environment(
             "cmd 语法注意：用 && 连接多条命令（不支持 ; 分隔），"
             "ls/find/grep/sed 不可用（用 dir / where / findstr），"
             "或使用 powershell -Command \"...\"。"
+            "本机未安装 Git Bash 与 Windows 子系统，请勿运行 bash/wsl 命令"
+            "（会被 PATH 解析到 System32\\bash.exe 的子系统入口桩，"
+            "报「子系统未安装/EXECUTABLE NOT FOUND」），只用 cmd 或 powershell 语法。"
             + _skills_dirs_note(workspace, "native") + _python_note("native")
         )
     return (

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -307,9 +307,10 @@ def describe_exec_environment(
             "cmd 语法注意：用 && 连接多条命令（不支持 ; 分隔），"
             "ls/find/grep/sed 不可用（用 dir / where / findstr），"
             "或使用 powershell -Command \"...\"。"
-            "本机未安装 Git Bash 与 Windows 子系统，请勿运行 bash/wsl 命令"
-            "（会被 PATH 解析到 System32\\bash.exe 的子系统入口桩，"
-            "报「子系统未安装/EXECUTABLE NOT FOUND」），只用 cmd 或 powershell 语法。"
+            "本机未检测到 Git Bash，请只用 cmd 或 powershell 语法；"
+            "不要直接运行 bash/wsl 命令：PATH 上的 bash 可能是 "
+            "System32\\bash.exe（子系统的入口桩），若子系统未启用会报 "
+            "「EXECUTABLE NOT FOUND / 子系统未安装」。"
             + _skills_dirs_note(workspace, "native") + _python_note("native")
         )
     return (

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -257,6 +257,33 @@ def test_describe_exec_environment_no_sandbox_windows_cmd_fallback(monkeypatch):
     assert "/home/miqi" not in text
 
 
+def test_describe_exec_environment_cmd_fallback_warns_no_bash_or_wsl(monkeypatch):
+    """On a Windows host with neither Git Bash nor WSL, the cmd fallback
+    must tell the AI not to run bash/wsl commands — PATH resolves ``bash``
+    to System32\\bash.exe (the WSL entrypoint stub), which errors with
+    ``EXECUTABLE NOT FOUND`` / ``WSL not installed``."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr("miqi.sandbox.manager.find_git_bash", lambda: None)
+    text = describe_exec_environment(None)
+    assert "本机未安装 Git Bash" in text
+    assert "请勿运行 bash/wsl" in text
+    assert "EXECUTABLE NOT FOUND" in text
+    assert "System32" in text
+
+
+def test_describe_exec_environment_git_bash_omits_bash_warning(monkeypatch):
+    """The 'do not run bash/wsl' warning only applies to the cmd fallback;
+    the Git Bash branch (which CAN run bash) must not carry it."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.find_git_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+    text = describe_exec_environment(None)
+    assert "请勿运行 bash/wsl" not in text
+    assert "EXECUTABLE NOT FOUND" not in text
+
+
 def test_describe_exec_environment_no_sandbox_windows_git_bash(monkeypatch):
     monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
     monkeypatch.setattr(

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -258,17 +258,31 @@ def test_describe_exec_environment_no_sandbox_windows_cmd_fallback(monkeypatch):
 
 
 def test_describe_exec_environment_cmd_fallback_warns_no_bash_or_wsl(monkeypatch):
-    """On a Windows host with neither Git Bash nor WSL, the cmd fallback
-    must tell the AI not to run bash/wsl commands — PATH resolves ``bash``
-    to System32\\bash.exe (the WSL entrypoint stub), which errors with
-    ``EXECUTABLE NOT FOUND`` / ``WSL not installed``."""
+    """On a Windows host where find_git_bash() returns None, the cmd
+    fallback must warn the AI not to run raw bash/wsl commands — PATH may
+    resolve ``bash`` to System32\\bash.exe (the WSL entrypoint stub), which
+    errors with ``EXECUTABLE NOT FOUND`` when WSL is not enabled."""
     monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
     monkeypatch.setattr("miqi.sandbox.manager.find_git_bash", lambda: None)
     text = describe_exec_environment(None)
-    assert "本机未安装 Git Bash" in text
-    assert "请勿运行 bash/wsl" in text
+    assert "本机未检测到 Git Bash" in text
+    assert "不要直接运行 bash/wsl 命令" in text
     assert "EXECUTABLE NOT FOUND" in text
     assert "System32" in text
+
+
+def test_describe_exec_environment_cmd_fallback_does_not_assert_wsl_absent(monkeypatch):
+    """CodeRabbit #865: find_git_bash() is None only proves Git Bash is
+    missing, NOT that WSL is unavailable.  The message must phrase the
+    WSL-stub risk conditionally (``若 WSL 未启用``) rather than assert
+    ``WSL 未安装`` as fact — a host with WSL installed but no Git Bash
+    would otherwise get incorrect guidance to skip valid wsl commands."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr("miqi.sandbox.manager.find_git_bash", lambda: None)
+    text = describe_exec_environment(None)
+    assert "若子系统未启用" in text
+    assert "WSL 未安装" not in text
+    assert "Windows 子系统" not in text
 
 
 def test_describe_exec_environment_git_bash_omits_bash_warning(monkeypatch):
@@ -280,7 +294,7 @@ def test_describe_exec_environment_git_bash_omits_bash_warning(monkeypatch):
         lambda: r"C:\Program Files\Git\bin\bash.exe",
     )
     text = describe_exec_environment(None)
-    assert "请勿运行 bash/wsl" not in text
+    assert "不要直接运行 bash/wsl" not in text
     assert "EXECUTABLE NOT FOUND" not in text
 
 
@@ -426,7 +440,10 @@ def test_session_context_reflects_sandbox_state(monkeypatch, tmp_path):
     assert str(tmp_path) in ctx
     assert "/mnt/c" not in ctx
     # the legacy "不要说 /home/miqi/workspace" disclaimer may remain,
-    # but the WSL sandbox environment story must not be injected
+    # but the WSL sandbox environment story must not be injected.  The
+    # cmd-fallback caveat may mention the System32\bash.exe stub risk
+    # (lowercase "bash/wsl"), but it must never claim the AI is running
+    # IN a WSL sandbox (uppercase "WSL", /home/miqi/workspace story).
     assert "WSL" not in ctx
 
     ctx_active = build_session_context(


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [x] 🧪 测试
- [ ] 🔧 其他

## 变更概述

无沙箱、未装 Git Bash 的 Windows 机器上，exec 回退到 cmd 时，环境描述告知 AI「本机没有 Git Bash，不要发 bash/wsl 命令」，避免反复撞 System32 的 WSL 入口桩报错。

## 背景/问题

某台用户机器只装了 `C:\Windows\System32\bash.exe`（WSL 入口桩），WSL 本体未启用、也没装 Git for Windows。此时 `find_git_bash()` 正确返回 `None`，exec 回退到 Windows cmd，但环境描述只讲了 cmd 语法，没提示 AI 不要发 bash/wsl 命令。于是 AI 按 bash 语法发命令，`bash` 被 PATH 解析到 System32 的 WSL 桩，崩出一串错误：

- `bash 需要被用于 Windows Subsystem for Linux (WSL)`
- `WSL_NOT_INSTALLED_COMPONENT_REQUIRED`
- `EXECUTABLE NOT FOUND`
- `command not found`

AI 反复重试这条死路径，任务一直失败。

## 关联 issue

无关联 issue，本 PR 为直接修复。

## 变更内容

- `miqi/sandbox/manager.py`：`describe_exec_environment` 的 cmd 回退分支新增提示——本机未检测到 Git Bash 时，只用 cmd/powershell 语法，不要直接运行 bash/wsl 命令（PATH 上的 bash 可能是 System32\bash.exe 子系统入口桩，若子系统未启用会报「EXECUTABLE NOT FOUND / 子系统未安装」）。措辞采用条件式，不把 WSL 缺失当事实断言（CodeRabbit 反馈）。
- `tests/sandbox/test_exec_environment_description.py`：新增三条单测——cmd 回退必须带提示；提示不得断言 WSL 未安装；Git Bash 分支不得误带提示。
- `apps/desktop/tests/e2e/no-git-bash-cmd-fallback.spec.ts`：新增 E2E，用 `MIQI_FORCE_CMD_EXEC=1` + 关闭沙箱强制 cmd 回退，`%RANDOM%`（cmd 专属变量）作标记探针，断言 exec 走 cmd 且无 WSL 桩报错。

## 日志/验证证据

```
$ ./.venv/Scripts/python.exe -m pytest tests/sandbox/test_exec_environment_description.py -q
............................................  [100%]
44 passed in 0.36s
```

```
$ npx playwright test --config=playwright.config.ts --project=electron no-git-bash-cmd-fallback.spec.ts
  ok 1 [electron] › no-git-bash-cmd-fallback.spec.ts › exec runs in cmd and no WSL-stub error when Git Bash is absent (24.9s)
  1 passed
```

## 测试情况

- `tests/sandbox/test_exec_environment_description.py` 全绿（44 passed），覆盖 cmd 回退提示、条件式措辞（不误断言 WSL 缺失）、Git Bash 分支反向断言。
- `no-git-bash-cmd-fallback.spec.ts` 本地真 LLM 跑通（1 passed），证明无 Git Bash 时 cmd 回退链路正常、原 WSL 桩报错链消失。
- 打包 exe 等价性：改动属 `miqi` 包，随 PyInstaller 打进 `miqi-bridge.exe`；`find_git_bash()` 纯读宿主机文件系统，不受 frozen 影响。

## 截图

E2E 截图：AI 用 exec 执行 `echo NO_GITBASH_CMD_OK_%RANDOM%`，cmd 展开为 `NO_GITBASH_CMD_OK_27213`，无 `EXECUTABLE NOT FOUND`、无「子系统未安装」。

## 后续计划

无。