### PR TITLE
feat(agent): 文件访问授权体系——读写不对称 + 按需授权卡 + GUI 信任目录 (#864)

### DIFF
--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -356,7 +356,7 @@ function TrustedDirectoriesSection() {
   useEffect(() => {
     getCachedConfig()
       .then((cfg) => {
-        const list = cfg?.tools?.extraRoots;
+        const list = (cfg as any)?.tools?.extraRoots;
         setRoots(Array.isArray(list) ? list.map(String) : []);
       })
       .catch(() => setRoots([]));

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -348,6 +348,90 @@ function InlineExecOutputToggle() {
   );
 }
 
+// ---- Trusted directories (tools.extra_roots) ----
+function TrustedDirectoriesSection() {
+  const [roots, setRoots] = useState<string[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    getCachedConfig()
+      .then((cfg) => {
+        const list = cfg?.tools?.extraRoots;
+        setRoots(Array.isArray(list) ? list.map(String) : []);
+      })
+      .catch(() => setRoots([]));
+  }, []);
+
+  const persist = async (next: string[]) => {
+    await window.miqi.config.update({ tools: { extraRoots: next } });
+    invalidateConfigCache();
+    setRoots(next);
+  };
+
+  const addRoot = async () => {
+    const dir = await window.miqi.dialog.openDirectory();
+    if (!dir) return;
+    const cur = roots ?? [];
+    if (cur.includes(dir)) return;
+    setBusy(true);
+    try {
+      await persist([...cur, dir]);
+    } catch {
+      /* ignore */
+    }
+    setBusy(false);
+  };
+
+  const removeRoot = async (dir: string) => {
+    const cur = roots ?? [];
+    setBusy(true);
+    try {
+      await persist(cur.filter((r) => r !== dir));
+    } catch {
+      /* ignore */
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div className="pt-4 border-t border-[var(--border-subtle)]">
+      <h3
+        className="text-subheading text-[var(--text)] mb-1"
+        data-testid="settings-trusted-dirs-title"
+      >
+        信任目录
+      </h3>
+      <p className="text-xs text-[var(--text-faint)] mb-3">
+        AI 写入这些目录之外的位置时会弹出授权确认。允许后选择「本目录不再询问」会自动加入此列表。
+      </p>
+      {roots !== null && roots.length > 0 && (
+        <ul className="flex flex-col gap-1 mb-3">
+          {roots.map((dir) => (
+            <li
+              key={dir}
+              className="flex items-center justify-between gap-2 rounded-md border border-[var(--border-subtle)] px-2 py-1.5"
+            >
+              <span className="text-xs font-mono text-[var(--text)] truncate">{dir}</span>
+              <button
+                onClick={() => removeRoot(dir)}
+                disabled={busy}
+                className="p-1 rounded text-[var(--text-faint)] hover:text-[var(--danger)] transition-colors"
+                title="移除"
+              >
+                <Trash2 size={12} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button variant="outline" size="sm" onClick={addRoot} disabled={busy}>
+        <FolderKanban size={14} />
+        添加目录
+      </Button>
+    </div>
+  );
+}
+
 // ---- General Config Tab ----
 function GeneralTab({ onReopenSetup }: { onReopenSetup?: () => void }) {
   const [agentName, setAgentName] = useState('');
@@ -493,6 +577,8 @@ function GeneralTab({ onReopenSetup }: { onReopenSetup?: () => void }) {
         </p>
         <InlineExecOutputToggle />
       </div>
+
+      <TrustedDirectoriesSection />
 
       {/* ---- Danger Zone ---- */}
       <div className="mt-6 pt-4 border-t border-[var(--border-subtle)]">

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -395,6 +395,7 @@ export interface ElectronFixture {
  */
 export async function launchElectronApp(
   patchConfig?: (config: any) => any,
+  opts?: { bypassAll?: boolean },
 ): Promise<ElectronFixture> {
   // Create unique temporary home per test worker for full isolation.
   // Parallel workers each get their own MIQI_HOME → no race on sessions/.
@@ -416,7 +417,19 @@ export async function launchElectronApp(
     ? JSON.parse(readFileSync(destConfigPath, 'utf-8'))
     : {};
   if (patchConfig) patchConfig(config);
-  config.approvals = { ...config.approvals, bypass_all: true };
+  const bypassAll = opts?.bypassAll ?? true;
+  if (bypassAll) {
+    config.approvals = { ...config.approvals, bypass_all: true };
+  } else {
+    // A spec that verifies approval cards must opt out of the global bypass.
+    // The user's config.json stores camelCase keys (bypassAll) and the app
+    // schema accepts both — delete BOTH forms so the bridge never sees an
+    // approval bypass.
+    delete config.approvals?.bypass_all;
+    delete config.approvals?.bypassAll;
+    delete config.approvals?.bypass_file_write_approval;
+    delete config.approvals?.bypassFileWriteApproval;
+  }
   // ── E2E: always disable feedback channel so tests don't hit real Feishu ──
   // Each test that needs feedback enabled can opt in by patching the config
   // after launchElectronApp.  Default OFF keeps the disabled-error path

--- a/apps/desktop/tests/e2e/write-authorization.spec.ts
+++ b/apps/desktop/tests/e2e/write-authorization.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * E2E — issue #864 写授权卡（write_file 写入 workspace 外目录）。
+ *
+ * 用本地 mock OpenAI 服务器（scripts/mock_openai.py，确定性状态机）驱动，
+ * 不依赖真实 LLM 行为，也不需要 WSL 沙箱（走 native 路径，`boundary_enforced`
+ * 仅当 `restrict_to_workspace` 开启或 WSL 沙箱激活时才弹卡）。本 spec 在
+ * launchElectronApp 里 patch `tools.restrictToWorkspace: true` 打开写白名单，
+ * 这样 write_file 写 workspace 外路径才会命中授权卡。
+ *
+ * 链路：
+ *   1. mock 第一轮返回 write_file 工具调用，target 是 workspace 外的临时目录，
+ *      并带 authorize_paths 声明 → 桌面弹写授权卡（允许本次/本目录不再询问/拒绝）
+ *   2. 用户点「允许本次」→ 写放行 → 产物落在 workspace 外目录
+ *   3. 断言 host 文件存在且内容正确
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *      --config=playwright.config.ts --project=electron \
+ *      write-authorization.spec.ts --workers=1
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  launchElectronApp,
+  closeElectronApp,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+
+async function startMockOpenAI(outDir: string): Promise<{ proc: ChildProcess; mockUrl: string }> {
+  const python = process.env.MIQI_PYTHON_PATH || 'python';
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_openai.py'), String(port)], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUNBUFFERED: '1', MIQI_AUTH_OUT_DIR: outDir },
+    windowsHide: true,
+  });
+
+  let readyUrl = '';
+  let stderrTail = '';
+  proc.stdout?.on('data', (d) => {
+    const t = String(d);
+    console.log(`[mock] ${t.trim()}`);
+    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => {
+    stderrTail = (stderrTail + String(d)).slice(-2000);
+    console.log(`[mock-err] ${String(d).trim()}`);
+  });
+  proc.on('exit', (code) => console.log(`[test] mock server exited: ${code}`));
+
+  const deadline = Date.now() + 30_000;
+  while (!readyUrl && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(`mock OpenAI server exited early (code ${proc.exitCode}): ${stderrTail}`);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!readyUrl) {
+    proc.kill();
+    throw new Error(`mock OpenAI server startup line not seen in 30s: ${stderrTail}`);
+  }
+  console.log(`[test] mock OpenAI server ready at ${readyUrl}`);
+  return { proc, mockUrl: readyUrl };
+}
+
+test.describe('Write Authorization Card (#864)', () => {
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server',
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+  let outDir: string;
+
+  test.beforeAll(async () => {
+    // 写授权卡依赖一个"写白名单"边界。native 路径 + restrictToWorkspace=true
+    // 才会触发 _resolve_path 的 shared_roots 检查，进而命中授权卡。
+    outDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-auth-'));
+    console.log(`[test] auth out dir: ${outDir}`);
+    const mock = await startMockOpenAI(outDir);
+    mockServer = mock.proc;
+
+    const fixture = await launchElectronApp((config: any) => {
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = mock.mockUrl;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+      const tools = config.tools ?? {};
+      config.tools = { ...tools, restrictToWorkspace: true };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mockServer?.kill();
+    try { rmSync(outDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test(
+    'write_file 写 workspace 外目录 → 弹写授权卡 → 允许本次 → 写入成功',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      const cardArea = page.getByTestId('confirm-card-area');
+      const resolvedArea = page.getByTestId('confirm-card-resolved');
+
+      await sendMessage(page, '写授权测试');
+
+      // 写授权卡弹出（title 固定为「授权写入工作区外目录」）
+      await expect(cardArea).toBeVisible({ timeout: 60_000 });
+      await expect(cardArea.getByText('授权写入工作区外目录')).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '允许本次' })).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '本目录不再询问' })).toBeVisible();
+      await expect(cardArea.getByRole('button', { name: '拒绝' })).toBeVisible();
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-card.png`,
+      });
+
+      // 点「允许本次」→ 写放行
+      await cardArea.getByRole('button', { name: '允许本次' }).click();
+      await expect(resolvedArea.getByText(/授权写入工作区外目录/)).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // 产物落在 workspace 外目录
+      const target = join(outDir, 'auth_probe.txt');
+      await expect
+        .poll(async () => existsSync(target), { timeout: 30_000 })
+        .toBe(true);
+      const content = readFileSync(target, 'utf-8');
+      expect(content).toContain('authorization-card-e2e-probe');
+      console.log(`[test] ✅ 写授权卡放行，产物落在 workspace 外目录`);
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-final.png`,
+        fullPage: true,
+        timeout: 60_000,
+      });
+    },
+  );
+});

--- a/apps/desktop/tests/e2e/write-authorization.spec.ts
+++ b/apps/desktop/tests/e2e/write-authorization.spec.ts
@@ -123,6 +123,15 @@ test.describe('Write Authorization Card (#864)', () => {
       const cardArea = page.getByTestId('confirm-card-area');
       const resolvedArea = page.getByTestId('confirm-card-resolved');
 
+      // 跳过 PermissionEngine 的通用「文件操作审批」dialog（legacy 路径会在
+      // write_file 进入 tool.execute 之前先弹它），这样本测试能精确断言到
+      // 我们 issue #864 的「授权写入工作区外目录」卡。`*:*` permanent 只影响
+      // PermissionEngine 的审批，不影响 tool.execute 内的授权卡（它读
+      // config.approvals 的 bypass 开关，与 permanent allowlist 无关）。
+      await page.evaluate(() =>
+        (window as any).miqi.approvals.addPermanent('*:*', 'always'),
+      );
+
       await sendMessage(page, '写授权测试');
 
       // 写授权卡弹出（title 固定为「授权写入工作区外目录」）

--- a/apps/desktop/tests/e2e/write-authorization.spec.ts
+++ b/apps/desktop/tests/e2e/write-authorization.spec.ts
@@ -104,7 +104,7 @@ test.describe('Write Authorization Card (#864)', () => {
       config.providers = providers;
       const tools = config.tools ?? {};
       config.tools = { ...tools, restrictToWorkspace: true };
-    });
+    }, { bypassAll: false });
     electronApp = fixture.electronApp;
     page = fixture.page;
     miqiHome = fixture.miqiHome;
@@ -156,6 +156,68 @@ test.describe('Write Authorization Card (#864)', () => {
         fullPage: true,
         timeout: 60_000,
       });
+    },
+  );
+});
+
+test.describe('Write Authorization Bypass (#864)', () => {
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server',
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+  let outDir: string;
+
+  test.beforeAll(async () => {
+    outDir = mkdtempSync(join(tmpdir(), 'miqi-e2e-auth-bypass-'));
+    console.log(`[test] bypass auth out dir: ${outDir}`);
+    const mock = await startMockOpenAI(outDir);
+    mockServer = mock.proc;
+
+    // bypassAll 默认 true（electron-setup 的默认行为）——写授权卡应被跳过。
+    const fixture = await launchElectronApp((config: any) => {
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = mock.mockUrl;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+      const tools = config.tools ?? {};
+      config.tools = { ...tools, restrictToWorkspace: true };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mockServer?.kill();
+    try { rmSync(outDir, { recursive: true, force: true }); } catch {}
+  });
+
+  test(
+    'approvals.bypass_all=true 时写 workspace 外目录不弹授权卡直接写入',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      const cardArea = page.getByTestId('confirm-card-area');
+      await sendMessage(page, '写授权测试');
+
+      const target = join(outDir, 'auth_probe.txt');
+      await expect
+        .poll(async () => existsSync(target), { timeout: 30_000 })
+        .toBe(true);
+      const content = readFileSync(target, 'utf-8');
+      expect(content).toContain('authorization-card-e2e-probe');
+
+      await expect(cardArea).toBeHidden();
+      console.log(`[test] ✅ bypass 下写 workspace 外目录无需授权卡`);
     },
   );
 });

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -288,6 +288,7 @@ class ApplyPatchTool(Tool):
         allow_user_roots: bool = True,
         write_resolver=None,
         persist_extra_root=None,
+        bypass_approval: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -300,6 +301,7 @@ class ApplyPatchTool(Tool):
         # Write authorization card (issue #864).
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
+        self._bypass_approval = bypass_approval
         self._granted: set[str] = set()
 
     @property
@@ -361,6 +363,7 @@ class ApplyPatchTool(Tool):
                     write_resolver=self._write_resolver,
                     persist_extra_root=self._persist_extra_root,
                     boundary_enforced=boundary_enforced,
+                    bypass=self._bypass_approval,
                 )
                 if _auth is None:
                     return f"Error: 权限被拒绝：用户未授权写入 {_p}"
@@ -426,6 +429,7 @@ class ApplyPatchTool(Tool):
                 (sandbox is not None and getattr(sandbox, "_use_wsl", False))
                 or self._allowed_dir is not None
             ),
+            bypass=self._bypass_approval,
         )
         if authorized is not None:
             shared = authorized

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -24,6 +24,7 @@ from miqi.agent.tools.filesystem import (
     _resolve_path,
     _resolve_sandbox_path,
     _resolve_session_dir,
+    _resolve_write_shared_roots,
     _sandbox_file_exists,
     _sandbox_read_file,
     _sandbox_write_file,
@@ -285,6 +286,8 @@ class ApplyPatchTool(Tool):
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
         allow_user_roots: bool = True,
+        write_resolver=None,
+        persist_extra_root=None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -294,6 +297,10 @@ class ApplyPatchTool(Tool):
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
         self._allow_user_roots = allow_user_roots
+        # Write authorization card (issue #864).
+        self._write_resolver = write_resolver
+        self._persist_extra_root = persist_extra_root
+        self._granted: set[str] = set()
 
     @property
     def name(self) -> str:
@@ -314,7 +321,15 @@ class ApplyPatchTool(Tool):
                 "patch": {
                     "type": "string",
                     "description": "The unified diff body to apply",
-                }
+                },
+                "authorize_paths": {
+                    "type": "array",
+                    "description": (
+                        "（可选）提前声明需要写入的、位于已授权写根之外的绝对路径。"
+                        "提供后会在写入前先向用户发起授权，避免写入时才被拒绝。"
+                    ),
+                    "items": {"type": "string"},
+                },
             },
             "required": ["patch"],
         }
@@ -327,6 +342,22 @@ class ApplyPatchTool(Tool):
         shared = _effective_shared_roots(
             self._shared_roots, kwargs.pop("_user_roots", None), self._allow_user_roots,
         )
+        # Agent-declared write paths (issue #864): authorize upfront.
+        _authorize = kwargs.pop("authorize_paths", None)
+        if isinstance(_authorize, list) and _authorize:
+            _base = self._base_workspace or self._workspace
+            for _p in _authorize:
+                _auth = await _resolve_write_shared_roots(
+                    str(_p),
+                    base_dir=_base,
+                    workspace_root=self._base_workspace or self._workspace,
+                    shared=shared,
+                    granted=self._granted,
+                    write_resolver=self._write_resolver,
+                    persist_extra_root=self._persist_extra_root,
+                )
+                if _auth is None:
+                    return f"Error: 权限被拒绝：用户未授权写入 {_p}"
         try:
             file_patches = parse_patch(patch)
         except PatchParseError as e:
@@ -376,6 +407,25 @@ class ApplyPatchTool(Tool):
             path, base_ws, session_dir,
             _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
+        # Write authorization card (issue #864).
+        authorized = await _resolve_write_shared_roots(
+            path,
+            base_dir=base_ws or self._workspace,
+            workspace_root=self._base_workspace or self._workspace,
+            shared=shared,
+            granted=self._granted,
+            write_resolver=self._write_resolver,
+            persist_extra_root=self._persist_extra_root,
+            boundary_enforced=(
+                (sandbox is not None and getattr(sandbox, "_use_wsl", False))
+                or self._allowed_dir is not None
+            ),
+        )
+        if authorized is None:
+            raise PermissionError(
+                f"路径 {path} 超出允许目录且未获授权"
+            )
+        shared = authorized
 
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # session_files_dir enforces per-session isolation (#689): the

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -344,6 +344,11 @@ class ApplyPatchTool(Tool):
         )
         # Agent-declared write paths (issue #864): authorize upfront.
         _authorize = kwargs.pop("authorize_paths", None)
+        _sandbox0 = _get_active_sandbox(self._sandbox_manager)
+        boundary_enforced = (
+            (_sandbox0 is not None and getattr(_sandbox0, "_use_wsl", False))
+            or self._allowed_dir is not None
+        )
         if isinstance(_authorize, list) and _authorize:
             _base = self._base_workspace or self._workspace
             for _p in _authorize:
@@ -355,6 +360,7 @@ class ApplyPatchTool(Tool):
                     granted=self._granted,
                     write_resolver=self._write_resolver,
                     persist_extra_root=self._persist_extra_root,
+                    boundary_enforced=boundary_enforced,
                 )
                 if _auth is None:
                     return f"Error: 权限被拒绝：用户未授权写入 {_p}"
@@ -421,11 +427,8 @@ class ApplyPatchTool(Tool):
                 or self._allowed_dir is not None
             ),
         )
-        if authorized is None:
-            raise PermissionError(
-                f"路径 {path} 超出允许目录且未获授权"
-            )
-        shared = authorized
+        if authorized is not None:
+            shared = authorized
 
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # session_files_dir enforces per-session isolation (#689): the

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -302,7 +302,12 @@ class ApplyPatchTool(Tool):
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
         self._bypass_approval = bypass_approval
-        self._granted: set[str] = set()
+        # Session-scoped grants (CodeRabbit #866).
+        self._granted: dict[str, set[str]] = {}
+
+    def _session_granted(self, session_key: str | None) -> set[str]:
+        """Return the session-scoped grant set for *session_key*."""
+        return self._granted.setdefault(session_key or "", set())
 
     @property
     def name(self) -> str:
@@ -353,13 +358,14 @@ class ApplyPatchTool(Tool):
         )
         if isinstance(_authorize, list) and _authorize:
             _base = self._base_workspace or self._workspace
+            _granted = self._session_granted(_sess_key)
             for _p in _authorize:
                 _auth = await _resolve_write_shared_roots(
                     str(_p),
                     base_dir=_base,
                     workspace_root=self._base_workspace or self._workspace,
                     shared=shared,
-                    granted=self._granted,
+                    granted=_granted,
                     write_resolver=self._write_resolver,
                     persist_extra_root=self._persist_extra_root,
                     boundary_enforced=boundary_enforced,
@@ -422,7 +428,7 @@ class ApplyPatchTool(Tool):
             base_dir=base_ws or self._workspace,
             workspace_root=self._base_workspace or self._workspace,
             shared=shared,
-            granted=self._granted,
+            granted=self._session_granted(_sess_key),
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=(

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -359,6 +359,7 @@ class ApplyPatchTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _base = self._base_workspace or self._workspace
             _granted = self._session_granted(_sess_key)
+            _once: set[str] = set()
             for _p in _authorize:
                 _auth = await _resolve_write_shared_roots(
                     str(_p),
@@ -366,6 +367,7 @@ class ApplyPatchTool(Tool):
                     workspace_root=self._base_workspace or self._workspace,
                     shared=shared,
                     granted=_granted,
+                    once_granted=_once,
                     write_resolver=self._write_resolver,
                     persist_extra_root=self._persist_extra_root,
                     boundary_enforced=boundary_enforced,

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -832,6 +832,171 @@ def _resolve_sandbox_path(
     return path
 
 
+# ---------------------------------------------------------------------------
+# Write authorization card (issue #864) — on-demand write access outside the
+# write whitelist.  Reads stay wide (home + whole disk, see tool_registry_factory
+# `_read_shared_roots`); writes stay narrow (workspace + shared roots +
+# extra_roots) and, when a target escapes every legal write root, this pops the
+# existing user-input card with [允许本次 / 本目录不再询问 / 拒绝] instead of a
+# hard PermissionError dead-end.
+# ---------------------------------------------------------------------------
+
+def _write_target_host_path(path: str, base_dir: Path | None) -> Path:
+    """Resolve a write target to a canonical host path for authorization."""
+    p = Path(path).expanduser()
+    if not p.is_absolute() and base_dir is not None:
+        p = base_dir / p
+    try:
+        return p.resolve()
+    except Exception:
+        try:
+            return p.absolute()
+        except Exception:
+            return p
+
+
+def _target_in_roots(target: Path, roots: Iterable[Path]) -> bool:
+    """Return True when *target* is contained in any of *roots*."""
+    for root in roots:
+        try:
+            target.relative_to(Path(root).resolve())
+            return True
+        except (ValueError, OSError):
+            continue
+    return False
+
+
+def _grantable_dir(target: Path, workspace_root: Path | None) -> Path | None:
+    """Return the directory a write authorization would grant, or None when it
+    is protected (must never be grantable): drive/filesystem root, the user
+    profile root, top-level system dirs, the host config, or any session dir.
+    """
+    try:
+        grant = target.parent.resolve()
+    except Exception:
+        grant = target.parent.absolute()
+    if grant == grant.parent:
+        return None  # drive root / filesystem root
+    try:
+        if grant == Path.home().resolve():
+            return None
+    except Exception:
+        pass
+    from miqi.agent.tools.user_roots import (
+        _is_protected_extra_root,
+        _is_top_level_system_dir,
+    )
+    if _is_top_level_system_dir(grant):
+        return None
+    if workspace_root is not None and _is_protected_extra_root(grant, workspace_root):
+        return None
+    return grant
+
+
+async def _ask_write_permission(write_resolver, target: Path, grant_dir: Path) -> str:
+    """Pop the write-authorization card; return 'once' | 'always_dir' | 'deny'."""
+    payload = {
+        "title": "授权写入工作区外目录",
+        "message": (
+            f"AI 请求写入 {target}（目录 {grant_dir}），"
+            f"该目录不在已授权的写入根内。是否允许？"
+        ),
+        "choices": [
+            {"id": "once", "label": "允许本次"},
+            {"id": "always_dir", "label": "本目录不再询问"},
+            {"id": "deny", "label": "拒绝", "role": "cancel"},
+        ],
+        "timeout_seconds": 120,
+    }
+    try:
+        result = await write_resolver(payload)
+    except Exception:
+        return "deny"
+    if not isinstance(result, dict) or result.get("status") != "submitted":
+        return "deny"
+    answers = result.get("answers") or {}
+    cid = str(answers.get("choice_id") or "")
+    return cid if cid in ("once", "always_dir") else "deny"
+
+
+async def _resolve_write_shared_roots(
+    path: str,
+    *,
+    base_dir: Path | None,
+    workspace_root: Path | None,
+    shared: Iterable[Path],
+    granted: set[str],
+    write_resolver=None,
+    persist_extra_root=None,
+    boundary_enforced: bool = True,
+) -> list[Path] | None:
+    """Pre-flight write authorization (issue #864).
+
+    Returns an augmented shared-roots list when the write target is authorized
+    (already in-roots, previously granted, or newly granted via the card), or
+    None when the write must be denied (out-of-roots and declined / headless /
+    protected).  The caller uses the returned list as its ``shared_roots`` and
+    keeps its existing PermissionError path on None — this helper only ever
+    ADDS roots, never removes enforcement.
+
+    ``boundary_enforced`` marks whether the current execution path has an
+    actual write whitelist (WSL sandbox containment, or native
+    ``restrict_to_workspace``).  When False — the native unrestricted path —
+    there is no whitelist to widen, so the card must not fire and deny an
+    otherwise-legal write.
+    """
+    import os as _os
+
+    shared_list = list(shared or [])
+    if not boundary_enforced:
+        return shared_list
+
+    target = _write_target_host_path(path, base_dir)
+
+    roots: list[Path] = []
+    if base_dir is not None:
+        roots.append(base_dir)
+    if workspace_root is not None:
+        roots.append(workspace_root)
+    roots.extend(shared_list)
+    granted_roots: list[Path] = []
+    if granted:
+        granted_roots = [Path(g) for g in granted]
+        roots.extend(granted_roots)
+    if _target_in_roots(target, roots):
+        # Already authorized (in-workspace/shared, or previously granted this
+        # session).  Return the granted dirs alongside the static roots so the
+        # caller's `_resolve_path`/`_resolve_sandbox_path` whitelist check also
+        # accepts them — a granted dir must widen the actual enforcement, not
+        # just pass this pre-flight.
+        return [*shared_list, *granted_roots]
+
+    grant_dir = _grantable_dir(target, workspace_root)
+    if grant_dir is None:
+        return None
+    if write_resolver is None:
+        return None
+
+    choice = await _ask_write_permission(write_resolver, target, grant_dir)
+    if choice == "always_dir":
+        granted.add(_os.path.normcase(str(grant_dir)))
+        if persist_extra_root is not None:
+            try:
+                await persist_extra_root(grant_dir)
+            except Exception:
+                _log.warning("persist_extra_root failed for %s", grant_dir, exc_info=True)
+        return [*shared_list, grant_dir]
+    if choice == "once":
+        # Record the grant in the session-scoped set too: a single tool call
+        # may pre-authorize via authorize_paths AND then check again on the
+        # actual write path — without remembering "once" here the second check
+        # re-pops the card for the same target.  "once" differs from
+        # "always_dir" only in that it is NOT persisted to tools.extra_roots.
+        granted.add(_os.path.normcase(str(grant_dir)))
+        return [*shared_list, grant_dir]
+    return None
+
+
 def _resolve_path(
     path: str,
     workspace: Path | None = None,
@@ -1113,6 +1278,8 @@ class WriteFileTool(Tool):
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
         allow_user_roots: bool = True,
+        write_resolver=None,
+        persist_extra_root=None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1125,6 +1292,10 @@ class WriteFileTool(Tool):
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
         self._allow_user_roots = allow_user_roots
+        # Write authorization card (issue #864).
+        self._write_resolver = write_resolver
+        self._persist_extra_root = persist_extra_root
+        self._granted: set[str] = set()
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1156,10 +1327,36 @@ class WriteFileTool(Tool):
                 "content": {
                     "type": "string",
                     "description": "The content to write"
-                }
+                },
+                "authorize_paths": {
+                    "type": "array",
+                    "description": (
+                        "（可选）提前声明需要写入的、位于已授权写根之外的绝对路径。"
+                        "提供后会在写入前先向用户发起授权，避免写入时才被拒绝。"
+                    ),
+                    "items": {"type": "string"},
+                },
             },
             "required": ["path", "content"]
         }
+
+    async def _preauthorize_paths(self, paths: list[str], base_dir: Path | None) -> str | None:
+        """Pre-authorize declared paths (issue #864). Returns an error string
+        when the user declines, or None when authorization succeeded/was unneeded.
+        """
+        for p in paths:
+            shared = await _resolve_write_shared_roots(
+                p,
+                base_dir=base_dir,
+                workspace_root=self._base_workspace or self._workspace,
+                shared=self._shared_roots,
+                granted=self._granted,
+                write_resolver=self._write_resolver,
+                persist_extra_root=self._persist_extra_root,
+            )
+            if shared is None:
+                return f"Error: 权限被拒绝：用户未授权写入 {p}"
+        return None
 
     async def execute(self, path: str, content: str, **kwargs: Any) -> str:
         office_suffixes = {".docx", ".xlsx", ".pptx"}
@@ -1183,12 +1380,42 @@ class WriteFileTool(Tool):
         session_dir = _resolve_session_dir(
             self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
+        # Agent-declared write paths (issue #864): authorize upfront so a
+        # declined path aborts before any write, not as a silent downgrade.
+        _authorize = kwargs.pop("authorize_paths", None)
+        if isinstance(_authorize, list) and _authorize:
+            _pre_err = await self._preauthorize_paths(
+                [str(x) for x in _authorize], base_ws or self._workspace,
+            )
+            if _pre_err:
+                return _pre_err
         # Session isolation: new files written under the default workspace
         # root (the dir the system prompt advertises) land in the session
         # files dir instead of the shared root.
         path = await _redirect_new_file_write(
             path, base_ws, session_dir, _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
+        # Write authorization card (issue #864): when the resolved target is
+        # outside every legal write root, pop [允许本次 / 本目录不再询问 / 拒绝].
+        # Only when a boundary actually exists (WSL sandbox, or
+        # restrict_to_workspace) — the unrestricted native path has no
+        # whitelist to widen, and must not deny a legal write.
+        authorized = await _resolve_write_shared_roots(
+            path,
+            base_dir=base_ws or self._workspace,
+            workspace_root=self._base_workspace or self._workspace,
+            shared=shared,
+            granted=self._granted,
+            write_resolver=self._write_resolver,
+            persist_extra_root=self._persist_extra_root,
+            boundary_enforced=(
+                (sandbox is not None and getattr(sandbox, "_use_wsl", False))
+                or self._allowed_dir is not None
+            ),
+        )
+        if authorized is None:
+            return f"Error: 权限被拒绝：路径 {path} 超出允许目录且未获授权"
+        shared = authorized
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
@@ -1268,6 +1495,8 @@ class EditFileTool(Tool):
         session_files_dir: Path | None = None,
         base_workspace: Path | None = None,
         allow_user_roots: bool = True,
+        write_resolver=None,
+        persist_extra_root=None,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1277,6 +1506,10 @@ class EditFileTool(Tool):
         self._session_files_dir = session_files_dir
         self._base_workspace = base_workspace
         self._allow_user_roots = allow_user_roots
+        # Write authorization card (issue #864).
+        self._write_resolver = write_resolver
+        self._persist_extra_root = persist_extra_root
+        self._granted: set[str] = set()
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1307,10 +1540,36 @@ class EditFileTool(Tool):
                 "new_text": {
                     "type": "string",
                     "description": "The text to replace with"
-                }
+                },
+                "authorize_paths": {
+                    "type": "array",
+                    "description": (
+                        "（可选）提前声明需要写入的、位于已授权写根之外的绝对路径。"
+                        "提供后会在写入前先向用户发起授权，避免写入时才被拒绝。"
+                    ),
+                    "items": {"type": "string"},
+                },
             },
             "required": ["path", "old_text", "new_text"]
         }
+
+    async def _preauthorize_paths(self, paths: list[str], base_dir: Path | None) -> str | None:
+        """Pre-authorize declared paths (issue #864). Returns an error string
+        when the user declines, or None when authorization succeeded/was unneeded.
+        """
+        for p in paths:
+            shared = await _resolve_write_shared_roots(
+                p,
+                base_dir=base_dir,
+                workspace_root=self._base_workspace or self._workspace,
+                shared=self._shared_roots,
+                granted=self._granted,
+                write_resolver=self._write_resolver,
+                persist_extra_root=self._persist_extra_root,
+            )
+            if shared is None:
+                return f"Error: 权限被拒绝：用户未授权写入 {p}"
+        return None
 
     async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str:
         _sess_key = kwargs.pop("_session_key", None)
@@ -1325,11 +1584,36 @@ class EditFileTool(Tool):
         session_dir = _resolve_session_dir(
             self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
+        # Agent-declared write paths (issue #864): authorize upfront.
+        _authorize = kwargs.pop("authorize_paths", None)
+        if isinstance(_authorize, list) and _authorize:
+            _pre_err = await self._preauthorize_paths(
+                [str(x) for x in _authorize], base_ws or self._workspace,
+            )
+            if _pre_err:
+                return _pre_err
         # Session isolation: edits of files that only exist in the session
         # dir resolve there; shared root files are edited in place.
         path = await _redirect_new_file_write(
             path, base_ws, session_dir, _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
+        # Write authorization card (issue #864).
+        authorized = await _resolve_write_shared_roots(
+            path,
+            base_dir=base_ws or self._workspace,
+            workspace_root=base_ws,
+            shared=shared,
+            granted=self._granted,
+            write_resolver=self._write_resolver,
+            persist_extra_root=self._persist_extra_root,
+            boundary_enforced=(
+                (sandbox is not None and getattr(sandbox, "_use_wsl", False))
+                or self._allowed_dir is not None
+            ),
+        )
+        if authorized is None:
+            return f"Error: 权限被拒绝：路径 {path} 超出允许目录且未获授权"
+        shared = authorized
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -926,6 +926,7 @@ async def _resolve_write_shared_roots(
     workspace_root: Path | None,
     shared: Iterable[Path],
     granted: set[str],
+    once_granted: set[str] | None = None,
     write_resolver=None,
     persist_extra_root=None,
     boundary_enforced: bool = True,
@@ -952,6 +953,12 @@ async def _resolve_write_shared_roots(
     ``tools.extra_roots`` — a bypass is not consent to widen the whitelist).
     Protected targets (config / sessions / drive root / home root / top-level
     system dirs) remain non-grantable regardless of ``bypass``.
+
+    ``granted`` is the SESSION-scoped set (populated by "本目录不再询问" and
+    bypass, survives across tool calls).  ``once_granted`` is the
+    INVOCATION-scoped set shared by the authorize_paths pre-flight and the
+    actual write path WITHIN one tool call — "允许本次" is recorded there, so
+    a later tool call must re-authorize (it is not a session-wide grant).
     """
     import os as _os
 
@@ -967,17 +974,18 @@ async def _resolve_write_shared_roots(
     if workspace_root is not None:
         roots.append(workspace_root)
     roots.extend(shared_list)
-    granted_roots: list[Path] = []
-    if granted:
-        granted_roots = [Path(g) for g in granted]
-        roots.extend(granted_roots)
+    granted_roots: list[Path] = [Path(g) for g in granted] if granted else []
+    once_roots: list[Path] = [Path(g) for g in once_granted] if once_granted else []
+    roots.extend(granted_roots)
+    roots.extend(once_roots)
     if _target_in_roots(target, roots):
-        # Already authorized (in-workspace/shared, or previously granted this
-        # session).  Return the granted dirs alongside the static roots so the
-        # caller's `_resolve_path`/`_resolve_sandbox_path` whitelist check also
-        # accepts them — a granted dir must widen the actual enforcement, not
-        # just pass this pre-flight.
-        return [*shared_list, *granted_roots]
+        # Already authorized (in-workspace/shared, previously granted this
+        # session, or granted "once" earlier in this same tool call).  Return
+        # the granted dirs alongside the static roots so the caller's
+        # `_resolve_path`/`_resolve_sandbox_path` whitelist check also accepts
+        # them — a granted dir must widen the actual enforcement, not just pass
+        # this pre-flight.
+        return [*shared_list, *granted_roots, *once_roots]
 
     grant_dir = _grantable_dir(target, workspace_root)
     if grant_dir is None:
@@ -999,12 +1007,12 @@ async def _resolve_write_shared_roots(
                 _log.warning("persist_extra_root failed for %s", grant_dir, exc_info=True)
         return [*shared_list, grant_dir]
     if choice == "once":
-        # Record the grant in the session-scoped set too: a single tool call
-        # may pre-authorize via authorize_paths AND then check again on the
-        # actual write path — without remembering "once" here the second check
-        # re-pops the card for the same target.  "once" differs from
-        # "always_dir" only in that it is NOT persisted to tools.extra_roots.
-        granted.add(_os.path.normcase(str(grant_dir)))
+        # "允许本次" is invocation-scoped: record it on the shared once set so
+        # the authorize_paths pre-flight and the actual write path within THIS
+        # tool call agree, but never on the session set — a later call must
+        # re-authorize.  Not persisted to tools.extra_roots.
+        if once_granted is not None:
+            once_granted.add(_os.path.normcase(str(grant_dir)))
         return [*shared_list, grant_dir]
     return None
 
@@ -1363,14 +1371,17 @@ class WriteFileTool(Tool):
 
     async def _preauthorize_paths(
         self, paths: list[str], base_dir: Path | None, shared: list[Path],
-        session_key: str | None = None, boundary_enforced: bool = True,
+        session_key: str | None = None, once_granted: set[str] | None = None,
+        boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
 
         ``shared`` is the call-scoped root list (static roots + injected
         ``_user_roots``) so a declared path already covered by a user-mentioned
-        root never pops a card before the write accepts it.
+        root never pops a card before the write accepts it.  ``once_granted``
+        carries "允许本次" grants so the actual write path within the SAME tool
+        call does not re-pop the card.
         """
         granted = self._session_granted(session_key)
         for p in paths:
@@ -1380,6 +1391,7 @@ class WriteFileTool(Tool):
                 workspace_root=self._base_workspace or self._workspace,
                 shared=shared,
                 granted=granted,
+                once_granted=once_granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
@@ -1417,11 +1429,15 @@ class WriteFileTool(Tool):
         )
         # Agent-declared write paths (issue #864): authorize upfront so a
         # declined path aborts before any write, not as a silent downgrade.
+        # "允许本次" grants are invocation-scoped, shared between the
+        # authorize_paths pre-flight and the actual write path below.
         _authorize = kwargs.pop("authorize_paths", None)
+        once_granted: set[str] = set()
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                shared, session_key=_sess_key, boundary_enforced=boundary_enforced,
+                shared, session_key=_sess_key, once_granted=once_granted,
+                boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1444,6 +1460,7 @@ class WriteFileTool(Tool):
             workspace_root=self._base_workspace or self._workspace,
             shared=shared,
             granted=self._session_granted(_sess_key),
+            once_granted=once_granted,
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,
@@ -1597,14 +1614,17 @@ class EditFileTool(Tool):
 
     async def _preauthorize_paths(
         self, paths: list[str], base_dir: Path | None, shared: list[Path],
-        session_key: str | None = None, boundary_enforced: bool = True,
+        session_key: str | None = None, once_granted: set[str] | None = None,
+        boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
 
         ``shared`` is the call-scoped root list (static roots + injected
         ``_user_roots``) so a declared path already covered by a user-mentioned
-        root never pops a card before the write accepts it.
+        root never pops a card before the write accepts it.  ``once_granted``
+        carries "允许本次" grants so the actual write path within the SAME tool
+        call does not re-pop the card.
         """
         granted = self._session_granted(session_key)
         for p in paths:
@@ -1614,6 +1634,7 @@ class EditFileTool(Tool):
                 workspace_root=self._base_workspace or self._workspace,
                 shared=shared,
                 granted=granted,
+                once_granted=once_granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
@@ -1642,10 +1663,12 @@ class EditFileTool(Tool):
         )
         # Agent-declared write paths (issue #864): authorize upfront.
         _authorize = kwargs.pop("authorize_paths", None)
+        once_granted: set[str] = set()
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                shared, session_key=_sess_key, boundary_enforced=boundary_enforced,
+                shared, session_key=_sess_key, once_granted=once_granted,
+                boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1661,6 +1684,7 @@ class EditFileTool(Tool):
             workspace_root=base_ws,
             shared=shared,
             granted=self._session_granted(_sess_key),
+            once_granted=once_granted,
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1309,7 +1309,14 @@ class WriteFileTool(Tool):
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
         self._bypass_approval = bypass_approval
-        self._granted: set[str] = set()
+        # Session-scoped grants: a single tool instance serves every session in
+        # the runtime, so "允许本次 / 本目录不再询问" must never leak a grant
+        # from one session into another (CodeRabbit #866).
+        self._granted: dict[str, set[str]] = {}
+
+    def _session_granted(self, session_key: str | None) -> set[str]:
+        """Return the session-scoped grant set for *session_key*."""
+        return self._granted.setdefault(session_key or "", set())
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1356,7 +1363,7 @@ class WriteFileTool(Tool):
 
     async def _preauthorize_paths(
         self, paths: list[str], base_dir: Path | None, shared: list[Path],
-        boundary_enforced: bool = True,
+        session_key: str | None = None, boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
@@ -1365,13 +1372,14 @@ class WriteFileTool(Tool):
         ``_user_roots``) so a declared path already covered by a user-mentioned
         root never pops a card before the write accepts it.
         """
+        granted = self._session_granted(session_key)
         for p in paths:
             result = await _resolve_write_shared_roots(
                 p,
                 base_dir=base_dir,
                 workspace_root=self._base_workspace or self._workspace,
                 shared=shared,
-                granted=self._granted,
+                granted=granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
@@ -1413,7 +1421,7 @@ class WriteFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                shared, boundary_enforced=boundary_enforced,
+                shared, session_key=_sess_key, boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1435,7 +1443,7 @@ class WriteFileTool(Tool):
             base_dir=base_ws or self._workspace,
             workspace_root=self._base_workspace or self._workspace,
             shared=shared,
-            granted=self._granted,
+            granted=self._session_granted(_sess_key),
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,
@@ -1538,7 +1546,12 @@ class EditFileTool(Tool):
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
         self._bypass_approval = bypass_approval
-        self._granted: set[str] = set()
+        # Session-scoped grants (CodeRabbit #866).
+        self._granted: dict[str, set[str]] = {}
+
+    def _session_granted(self, session_key: str | None) -> set[str]:
+        """Return the session-scoped grant set for *session_key*."""
+        return self._granted.setdefault(session_key or "", set())
 
     @property
     def _tracking_workspace(self) -> Path | None:
@@ -1584,7 +1597,7 @@ class EditFileTool(Tool):
 
     async def _preauthorize_paths(
         self, paths: list[str], base_dir: Path | None, shared: list[Path],
-        boundary_enforced: bool = True,
+        session_key: str | None = None, boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
@@ -1593,13 +1606,14 @@ class EditFileTool(Tool):
         ``_user_roots``) so a declared path already covered by a user-mentioned
         root never pops a card before the write accepts it.
         """
+        granted = self._session_granted(session_key)
         for p in paths:
             result = await _resolve_write_shared_roots(
                 p,
                 base_dir=base_dir,
                 workspace_root=self._base_workspace or self._workspace,
                 shared=shared,
-                granted=self._granted,
+                granted=granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
@@ -1631,7 +1645,7 @@ class EditFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                shared, boundary_enforced=boundary_enforced,
+                shared, session_key=_sess_key, boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1646,7 +1660,7 @@ class EditFileTool(Tool):
             base_dir=base_ws or self._workspace,
             workspace_root=base_ws,
             shared=shared,
-            granted=self._granted,
+            granted=self._session_granted(_sess_key),
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1340,7 +1340,9 @@ class WriteFileTool(Tool):
             "required": ["path", "content"]
         }
 
-    async def _preauthorize_paths(self, paths: list[str], base_dir: Path | None) -> str | None:
+    async def _preauthorize_paths(
+        self, paths: list[str], base_dir: Path | None, boundary_enforced: bool = True,
+    ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
         """
@@ -1353,6 +1355,7 @@ class WriteFileTool(Tool):
                 granted=self._granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
+                boundary_enforced=boundary_enforced,
             )
             if shared is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
@@ -1375,6 +1378,10 @@ class WriteFileTool(Tool):
         base_ws = self._base_workspace or (
             self._workspace if _is_default_workspace(self._workspace) else None
         )
+        boundary_enforced = (
+            (sandbox is not None and getattr(sandbox, "_use_wsl", False))
+            or self._allowed_dir is not None
+        )
         # Session isolation: factory dir → sandbox dir → per-call derivation
         # from the injected _session_key (KUN multi-thread / native path).
         session_dir = _resolve_session_dir(
@@ -1386,6 +1393,7 @@ class WriteFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
+                boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1396,10 +1404,12 @@ class WriteFileTool(Tool):
             path, base_ws, session_dir, _make_exists_check(shared, sandbox, session_ws, native_base_dir=self._workspace),
         )
         # Write authorization card (issue #864): when the resolved target is
-        # outside every legal write root, pop [允许本次 / 本目录不再询问 / 拒绝].
-        # Only when a boundary actually exists (WSL sandbox, or
-        # restrict_to_workspace) — the unrestricted native path has no
-        # whitelist to widen, and must not deny a legal write.
+        # outside every legal write root, offer [允许本次 / 本目录不再询问 /
+        # 拒绝].  A grant ADDS the directory to the shared roots; a non-grant
+        # leaves them unchanged so the existing _resolve_sandbox_path /
+        # _resolve_path containment check still raises PermissionError exactly
+        # as before (WSL path) — we never convert that dead-end into a silent
+        # string, so headless/no-resolver callers keep their old behavior.
         authorized = await _resolve_write_shared_roots(
             path,
             base_dir=base_ws or self._workspace,
@@ -1408,14 +1418,10 @@ class WriteFileTool(Tool):
             granted=self._granted,
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
-            boundary_enforced=(
-                (sandbox is not None and getattr(sandbox, "_use_wsl", False))
-                or self._allowed_dir is not None
-            ),
+            boundary_enforced=boundary_enforced,
         )
-        if authorized is None:
-            return f"Error: 权限被拒绝：路径 {path} 超出允许目录且未获授权"
-        shared = authorized
+        if authorized is not None:
+            shared = authorized
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
@@ -1553,7 +1559,9 @@ class EditFileTool(Tool):
             "required": ["path", "old_text", "new_text"]
         }
 
-    async def _preauthorize_paths(self, paths: list[str], base_dir: Path | None) -> str | None:
+    async def _preauthorize_paths(
+        self, paths: list[str], base_dir: Path | None, boundary_enforced: bool = True,
+    ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
         """
@@ -1566,6 +1574,7 @@ class EditFileTool(Tool):
                 granted=self._granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
+                boundary_enforced=boundary_enforced,
             )
             if shared is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
@@ -1581,6 +1590,10 @@ class EditFileTool(Tool):
         base_ws = self._base_workspace or (
             self._workspace if _is_default_workspace(self._workspace) else None
         )
+        boundary_enforced = (
+            (sandbox is not None and getattr(sandbox, "_use_wsl", False))
+            or self._allowed_dir is not None
+        )
         session_dir = _resolve_session_dir(
             self._session_files_dir, session_ws, self._workspace, _sess_key, base_ws,
         )
@@ -1589,6 +1602,7 @@ class EditFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
+                boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1606,14 +1620,10 @@ class EditFileTool(Tool):
             granted=self._granted,
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
-            boundary_enforced=(
-                (sandbox is not None and getattr(sandbox, "_use_wsl", False))
-                or self._allowed_dir is not None
-            ),
+            boundary_enforced=boundary_enforced,
         )
-        if authorized is None:
-            return f"Error: 权限被拒绝：路径 {path} 超出允许目录且未获授权"
-        shared = authorized
+        if authorized is not None:
+            shared = authorized
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -929,6 +929,7 @@ async def _resolve_write_shared_roots(
     write_resolver=None,
     persist_extra_root=None,
     boundary_enforced: bool = True,
+    bypass: bool = False,
 ) -> list[Path] | None:
     """Pre-flight write authorization (issue #864).
 
@@ -944,6 +945,13 @@ async def _resolve_write_shared_roots(
     ``restrict_to_workspace``).  When False — the native unrestricted path —
     there is no whitelist to widen, so the card must not fire and deny an
     otherwise-legal write.
+
+    ``bypass`` reflects the approval-bypass switches (``approvals.bypass_all`` /
+    ``approvals.bypass_file_write_approval``).  When True the card is skipped
+    and the directory is granted session-scoped (never persisted to
+    ``tools.extra_roots`` — a bypass is not consent to widen the whitelist).
+    Protected targets (config / sessions / drive root / home root / top-level
+    system dirs) remain non-grantable regardless of ``bypass``.
     """
     import os as _os
 
@@ -974,6 +982,10 @@ async def _resolve_write_shared_roots(
     grant_dir = _grantable_dir(target, workspace_root)
     if grant_dir is None:
         return None
+    if bypass:
+        # Approval bypass: skip the card, grant the directory for this session.
+        granted.add(_os.path.normcase(str(grant_dir)))
+        return [*shared_list, grant_dir]
     if write_resolver is None:
         return None
 
@@ -1280,6 +1292,7 @@ class WriteFileTool(Tool):
         allow_user_roots: bool = True,
         write_resolver=None,
         persist_extra_root=None,
+        bypass_approval: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1295,6 +1308,7 @@ class WriteFileTool(Tool):
         # Write authorization card (issue #864).
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
+        self._bypass_approval = bypass_approval
         self._granted: set[str] = set()
 
     @property
@@ -1361,6 +1375,7 @@ class WriteFileTool(Tool):
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
+                bypass=self._bypass_approval,
             )
             if result is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
@@ -1424,6 +1439,7 @@ class WriteFileTool(Tool):
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,
+            bypass=self._bypass_approval,
         )
         if authorized is not None:
             shared = authorized
@@ -1508,6 +1524,7 @@ class EditFileTool(Tool):
         allow_user_roots: bool = True,
         write_resolver=None,
         persist_extra_root=None,
+        bypass_approval: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
@@ -1520,6 +1537,7 @@ class EditFileTool(Tool):
         # Write authorization card (issue #864).
         self._write_resolver = write_resolver
         self._persist_extra_root = persist_extra_root
+        self._bypass_approval = bypass_approval
         self._granted: set[str] = set()
 
     @property
@@ -1585,6 +1603,7 @@ class EditFileTool(Tool):
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
+                bypass=self._bypass_approval,
             )
             if result is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
@@ -1631,6 +1650,7 @@ class EditFileTool(Tool):
             write_resolver=self._write_resolver,
             persist_extra_root=self._persist_extra_root,
             boundary_enforced=boundary_enforced,
+            bypass=self._bypass_approval,
         )
         if authorized is not None:
             shared = authorized

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1341,23 +1341,28 @@ class WriteFileTool(Tool):
         }
 
     async def _preauthorize_paths(
-        self, paths: list[str], base_dir: Path | None, boundary_enforced: bool = True,
+        self, paths: list[str], base_dir: Path | None, shared: list[Path],
+        boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
+
+        ``shared`` is the call-scoped root list (static roots + injected
+        ``_user_roots``) so a declared path already covered by a user-mentioned
+        root never pops a card before the write accepts it.
         """
         for p in paths:
-            shared = await _resolve_write_shared_roots(
+            result = await _resolve_write_shared_roots(
                 p,
                 base_dir=base_dir,
                 workspace_root=self._base_workspace or self._workspace,
-                shared=self._shared_roots,
+                shared=shared,
                 granted=self._granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
             )
-            if shared is None:
+            if result is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
         return None
 
@@ -1393,7 +1398,7 @@ class WriteFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                boundary_enforced=boundary_enforced,
+                shared, boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err
@@ -1560,23 +1565,28 @@ class EditFileTool(Tool):
         }
 
     async def _preauthorize_paths(
-        self, paths: list[str], base_dir: Path | None, boundary_enforced: bool = True,
+        self, paths: list[str], base_dir: Path | None, shared: list[Path],
+        boundary_enforced: bool = True,
     ) -> str | None:
         """Pre-authorize declared paths (issue #864). Returns an error string
         when the user declines, or None when authorization succeeded/was unneeded.
+
+        ``shared`` is the call-scoped root list (static roots + injected
+        ``_user_roots``) so a declared path already covered by a user-mentioned
+        root never pops a card before the write accepts it.
         """
         for p in paths:
-            shared = await _resolve_write_shared_roots(
+            result = await _resolve_write_shared_roots(
                 p,
                 base_dir=base_dir,
                 workspace_root=self._base_workspace or self._workspace,
-                shared=self._shared_roots,
+                shared=shared,
                 granted=self._granted,
                 write_resolver=self._write_resolver,
                 persist_extra_root=self._persist_extra_root,
                 boundary_enforced=boundary_enforced,
             )
-            if shared is None:
+            if result is None:
                 return f"Error: 权限被拒绝：用户未授权写入 {p}"
         return None
 
@@ -1602,7 +1612,7 @@ class EditFileTool(Tool):
         if isinstance(_authorize, list) and _authorize:
             _pre_err = await self._preauthorize_paths(
                 [str(x) for x in _authorize], base_ws or self._workspace,
-                boundary_enforced=boundary_enforced,
+                shared, boundary_enforced=boundary_enforced,
             )
             if _pre_err:
                 return _pre_err

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -20,6 +20,59 @@ from miqi.paths import get_config_path
 _log = logging.getLogger(__name__)
 
 
+def _default_read_roots() -> list[Path]:
+    """Read-whitelist expansion for the file tools (issue #864).
+
+    Reads are widened to the user's home directory and, on Windows, every
+    mounted drive root (whole-disk read-only).  Writes keep the narrow
+    ``_shared_roots`` whitelist — this asymmetry matches Codex/Gemini/Cursor
+    (workspace-write + workspace-external read-only).
+    """
+    import os as _os
+    import sys as _sys
+
+    roots: list[Path] = []
+    try:
+        roots.append(Path.home())
+    except Exception:
+        pass
+    if _sys.platform == "win32":
+        for drive in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+            p = Path(f"{drive}:\\")
+            if p.exists():
+                roots.append(p)
+    else:
+        roots.append(Path("/"))
+    return roots
+
+
+def _make_extra_root_persister():
+    """Build an async callback that appends a directory to ``tools.extra_roots``.
+
+    Used by the write authorization card's [本目录不再询问] choice (issue #864).
+    Persisting is best-effort and guarded: a protected path is never added, and
+    any failure must not fail the write that already succeeded.
+    """
+    from miqi.agent.tools.user_roots import _is_protected_extra_root
+    from miqi.config.loader import load_config, save_config
+
+    async def persist(root: Path) -> None:
+        config = load_config()
+        tools_cfg = getattr(config, "tools", None)
+        extra = list(getattr(tools_cfg, "extra_roots", []) or [])
+        resolved = Path(root).expanduser().resolve(strict=False)
+        if _is_protected_extra_root(resolved, config.workspace_path):
+            _log.warning("extra_root persister: refusing protected path %s", resolved)
+            return
+        root_str = str(resolved)
+        if root_str not in extra:
+            extra.append(root_str)
+            tools_cfg.extra_roots = extra
+            save_config(config)
+
+    return persist
+
+
 def _resolve_default_shared_dir(workspace: Path, sub: str) -> Path | None:
     """Create/validate a workspace-owned shared root.
 
@@ -180,7 +233,9 @@ def create_runtime_tool_registry(
     # Read-only whitelist for the host config file (issue #553): agents may
     # inspect settings, but write/edit/patch tools keep rejecting it so the
     # config (API keys, model setup) can never be tampered with.
-    _read_shared_roots = [*_shared_roots, get_config_path()]
+    # Issue #864: reads are further widened to home + whole disk (read/write
+    # asymmetry), while writes keep the narrow _shared_roots whitelist below.
+    _read_shared_roots = [*_shared_roots, get_config_path(), *_default_read_roots()]
 
     # Resolve config sections
     restrict_to_workspace = getattr(tools_cfg, "restrict_to_workspace", False) if tools_cfg is not None else False
@@ -212,6 +267,13 @@ def create_runtime_tool_registry(
     from miqi.agent.user_input_resolver import make_resolver
 
     registry.register(AskUserConfirmCardTool(resolver=make_resolver()))
+
+    # Write authorization card (issue #864): the file write tools pop a
+    # confirm card when a target escapes the write whitelist.  They share the
+    # same user-input gate as ask_user_confirm_card; "本目录不再询问" persists
+    # the directory into tools.extra_roots via the persister.
+    _write_resolver = make_resolver()
+    _persist_extra_root = _make_extra_root_persister()
 
     # 1. Filesystem tools
     registry.register(
@@ -246,6 +308,8 @@ def create_runtime_tool_registry(
             session_files_dir=_work_dir,
             base_workspace=workspace,
             allow_user_roots=_auto_user_dirs,
+            write_resolver=_write_resolver,
+            persist_extra_root=_persist_extra_root,
         )
     )
     registry.register(
@@ -258,6 +322,8 @@ def create_runtime_tool_registry(
             session_files_dir=_work_dir,
             base_workspace=workspace,
             allow_user_roots=_auto_user_dirs,
+            write_resolver=_write_resolver,
+            persist_extra_root=_persist_extra_root,
         )
     )
     registry.register(
@@ -270,6 +336,8 @@ def create_runtime_tool_registry(
             session_files_dir=_work_dir,
             base_workspace=workspace,
             allow_user_roots=_auto_user_dirs,
+            write_resolver=_write_resolver,
+            persist_extra_root=_persist_extra_root,
         )
     )
 

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -52,23 +52,43 @@ def _make_extra_root_persister():
     Used by the write authorization card's [本目录不再询问] choice (issue #864).
     Persisting is best-effort and guarded: a protected path is never added, and
     any failure must not fail the write that already succeeded.
+
+    The read-modify-write is lock-protected and re-reads the config file from
+    disk on every call (``load_config`` returns a 5-second-cached ``Config``,
+    so a cached read could clobber a concurrent config change).
     """
+    import json
+    import threading
+
     from miqi.agent.tools.user_roots import _is_protected_extra_root
-    from miqi.config.loader import load_config, save_config
+    from miqi.config.loader import save_config
+    from miqi.config.schema import Config
+    from miqi.paths import get_config_path
+
+    _lock = threading.Lock()
 
     async def persist(root: Path) -> None:
-        config = load_config()
-        tools_cfg = getattr(config, "tools", None)
-        extra = list(getattr(tools_cfg, "extra_roots", []) or [])
         resolved = Path(root).expanduser().resolve(strict=False)
-        if _is_protected_extra_root(resolved, config.workspace_path):
-            _log.warning("extra_root persister: refusing protected path %s", resolved)
-            return
-        root_str = str(resolved)
-        if root_str not in extra:
-            extra.append(root_str)
-            tools_cfg.extra_roots = extra
-            save_config(config)
+        path = get_config_path()
+        with _lock:
+            # Fresh read: reload the config from disk, not the cached copy.
+            data: dict = {}
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                data = {}
+            config = Config.model_validate(data) if data else Config()
+            if _is_protected_extra_root(resolved, config.workspace_path):
+                _log.warning("extra_root persister: refusing protected path %s", resolved)
+                return
+            tools_cfg = getattr(config, "tools", None)
+            extra = list(getattr(tools_cfg, "extra_roots", []) or [])
+            root_str = str(resolved)
+            if root_str not in extra:
+                extra.append(root_str)
+                tools_cfg.extra_roots = extra
+                save_config(config, path)
 
     return persist
 

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -298,8 +298,17 @@ def create_runtime_tool_registry(
     # confirm card when a target escapes the write whitelist.  They share the
     # same user-input gate as ask_user_confirm_card; "本目录不再询问" persists
     # the directory into tools.extra_roots via the persister.
+    # The approval-bypass switches (approvals.bypass_all /
+    # approvals.bypass_file_write_approval) also skip the card — the target
+    # dir is granted session-scoped but never persisted to extra_roots.
     _write_resolver = make_resolver()
     _persist_extra_root = _make_extra_root_persister()
+    _bypass = getattr(config, "effective_approval_bypass", None)
+    _bypass = _bypass() if callable(_bypass) else _bypass
+    _bypass_approval = bool(
+        getattr(_bypass, "bypasses_category", None)
+        and _bypass.bypasses_category("file_write")
+    )
 
     # 1. Filesystem tools
     registry.register(
@@ -336,6 +345,7 @@ def create_runtime_tool_registry(
             allow_user_roots=_auto_user_dirs,
             write_resolver=_write_resolver,
             persist_extra_root=_persist_extra_root,
+            bypass_approval=_bypass_approval,
         )
     )
     registry.register(
@@ -350,6 +360,7 @@ def create_runtime_tool_registry(
             allow_user_roots=_auto_user_dirs,
             write_resolver=_write_resolver,
             persist_extra_root=_persist_extra_root,
+            bypass_approval=_bypass_approval,
         )
     )
     registry.register(
@@ -364,6 +375,7 @@ def create_runtime_tool_registry(
             allow_user_roots=_auto_user_dirs,
             write_resolver=_write_resolver,
             persist_extra_root=_persist_extra_root,
+            bypass_approval=_bypass_approval,
         )
     )
 

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -76,8 +76,14 @@ def _make_extra_root_persister():
             try:
                 with open(path, encoding="utf-8") as f:
                     data = json.load(f)
-            except (OSError, json.JSONDecodeError):
+            except FileNotFoundError:
                 data = {}
+            except (OSError, json.JSONDecodeError) as exc:
+                # Never clobber an existing-but-unreadable config (e.g. provider
+                # keys) with a default Config — a single persisted root is not
+                # worth destroying the user's configuration.
+                _log.warning("extra_root persister: cannot read config %s: %s", path, exc)
+                return
             config = Config.model_validate(data) if data else Config()
             if _is_protected_extra_root(resolved, config.workspace_path):
                 _log.warning("extra_root persister: refusing protected path %s", resolved)

--- a/scripts/mock_openai.py
+++ b/scripts/mock_openai.py
@@ -19,7 +19,9 @@ Run:  PYTHONPATH=. .venv/Scripts/python.exe scripts/mock_openai.py
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 EXEC_TITLE = "确认执行方案？"
@@ -281,14 +283,34 @@ class Handler(BaseHTTPRequestHandler):
                 "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
             }
 
-        # ── issue #714 dual-card branch（同一回合两张确认卡） ──
-        # Triggered by the LATEST user message containing "双卡" so it never
-        # collides with the main flow; counts only dual-titled cards already
-        # emitted so the branch is deterministic even with shared history.
+        # ── issue #864 write-authorization card branch ──
+        # Triggered by the LATEST user message containing "写授权" so it never
+        # collides with the main flow. The model emits ONE response carrying a
+        # single write_file tool_call whose target is a workspace-EXTERNAL
+        # absolute path (a temp dir on the host) and declares it via
+        # authorize_paths — the desktop must pop the write-authorization card
+        # (允许本次 / 本目录不再询问 / 拒绝) instead of silently writing.
         last_user = next(
             (str(m.get("content", "")) for m in reversed(messages) if m.get("role") == "user"),
             "",
         )
+        if "写授权" in last_user:
+            out_dir = os.environ.get("MIQI_AUTH_OUT_DIR", "")
+            target = os.path.join(out_dir, "auth_probe.txt") if out_dir else ""
+            if not target:
+                self._respond(text("写授权：缺少 MIQI_AUTH_OUT_DIR 环境变量。"))
+                return
+            self._respond(tc("write_file", {
+                "path": target,
+                "content": "authorization-card-e2e-probe",
+                "authorize_paths": [target],
+            }, "call_auth_write"))
+            return
+
+        # ── issue #714 dual-card branch（同一回合两张确认卡） ──
+        # Triggered by the LATEST user message containing "双卡" so it never
+        # collides with the main flow; counts only dual-titled cards already
+        # emitted so the branch is deterministic even with shared history.
         n_dual_calls = 0
         for m in messages:
             if m.get("role") != "assistant" or not m.get("tool_calls"):

--- a/scripts/mock_openai.py
+++ b/scripts/mock_openai.py
@@ -295,6 +295,9 @@ class Handler(BaseHTTPRequestHandler):
             "",
         )
         if "写授权" in last_user:
+            if n_write > 0:
+                self._respond(text("写授权流程结束。"))
+                return
             out_dir = os.environ.get("MIQI_AUTH_OUT_DIR", "")
             target = os.path.join(out_dir, "auth_probe.txt") if out_dir else ""
             if not target:

--- a/tests/agent/tools/test_write_authorization.py
+++ b/tests/agent/tools/test_write_authorization.py
@@ -308,3 +308,35 @@ async def test_write_file_in_workspace_no_card(tmp_path):
     result = await tool.execute(path=str(out), content="ok")
     assert result.startswith("Successfully wrote")
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_write_file_grants_are_session_scoped(tmp_path):
+    """A grant in one session must not leak into another (CodeRabbit #866)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        allowed_dir=ws,
+        shared_roots=[],
+        write_resolver=_resolver("once"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    # Session A grants (once) → writes successfully.
+    res_a = await tool.execute(
+        path=str(out), content="a", _session_key="sessionA",
+    )
+    assert res_a.startswith("Successfully wrote")
+
+    # Session B: same target, but no prior grant → must pop the card and be
+    # denied by the deny resolver (proving the grant did NOT cross sessions).
+    deny_tool = WriteFileTool(
+        workspace=ws,
+        allowed_dir=ws,
+        shared_roots=[],
+        write_resolver=_resolver("deny"),
+    )
+    res_b = await deny_tool.execute(
+        path=str(out), content="b", _session_key="sessionB",
+    )
+    assert res_b.startswith("Error: 权限被拒绝")

--- a/tests/agent/tools/test_write_authorization.py
+++ b/tests/agent/tools/test_write_authorization.py
@@ -1,0 +1,240 @@
+"""Unit tests for the write authorization card (issue #864).
+
+Read/write asymmetry + on-demand write authorization: file reads are widened
+to home + whole disk, writes stay on the narrow whitelist, and a write target
+outside every legal write root pops [允许本次 / 本目录不再询问 / 拒绝] via the
+shared user-input resolver instead of a hard PermissionError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import (
+    WriteFileTool,
+    _resolve_write_shared_roots,
+)
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def _resolver(choice: str):
+    async def r(payload: dict):
+        return {"status": "submitted", "answers": {"choice_id": choice}}
+
+    return r
+
+
+def test_resolve_write_shared_roots_in_roots_no_card(tmp_path):
+    """A target already inside the write roots returns the roots unchanged."""
+    target = tmp_path / "out.txt"
+    shared = [tmp_path]
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(target),
+            base_dir=tmp_path,
+            workspace_root=tmp_path,
+            shared=shared,
+            granted=set(),
+            write_resolver=_resolver("once"),
+        )
+    )
+    assert result == shared
+
+
+def test_resolve_write_shared_roots_once_grants(tmp_path):
+    """Out-of-roots + [允许本次] → augmented roots (no session memory)."""
+    outside = tmp_path / "outside" / "x.txt"
+    shared = [tmp_path / "ws"]
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside),
+            base_dir=tmp_path / "ws",
+            workspace_root=tmp_path / "ws",
+            shared=shared,
+            granted=set(),
+            write_resolver=_resolver("once"),
+        )
+    )
+    assert result is not None
+    assert outside.parent.resolve() in [Path(r).resolve() for r in result]
+
+
+def test_resolve_write_shared_roots_always_dir_grants_and_persists(tmp_path):
+    """Out-of-roots + [本目录不再询问] → persists the parent dir."""
+    outside = tmp_path / "outside" / "x.txt"
+    shared = [tmp_path / "ws"]
+    persisted = []
+
+    async def persist(root):
+        persisted.append(root)
+
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside),
+            base_dir=tmp_path / "ws",
+            workspace_root=tmp_path / "ws",
+            shared=shared,
+            granted=set(),
+            write_resolver=_resolver("always_dir"),
+            persist_extra_root=persist,
+        )
+    )
+    assert result is not None
+    assert persisted == [outside.parent.resolve()]
+
+
+def test_resolve_write_shared_roots_deny(tmp_path):
+    """Out-of-roots + [拒绝] → None (denied)."""
+    outside = tmp_path / "outside" / "x.txt"
+    shared = [tmp_path / "ws"]
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside),
+            base_dir=tmp_path / "ws",
+            workspace_root=tmp_path / "ws",
+            shared=shared,
+            granted=set(),
+            write_resolver=_resolver("deny"),
+        )
+    )
+    assert result is None
+
+
+def test_resolve_write_shared_roots_no_resolver_denies(tmp_path):
+    """Headless (no resolver) → None (deny-first)."""
+    outside = tmp_path / "outside" / "x.txt"
+    shared = [tmp_path / "ws"]
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside),
+            base_dir=tmp_path / "ws",
+            workspace_root=tmp_path / "ws",
+            shared=shared,
+            granted=set(),
+            write_resolver=None,
+        )
+    )
+    assert result is None
+
+
+def test_resolve_write_shared_roots_drive_root_never_grants(tmp_path):
+    """A drive/filesystem root is never grantable even with a resolver."""
+    root = Path(tmp_path.anchor)  # drive root on Windows, '/' on POSIX
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(root / "whatever.txt"),
+            base_dir=tmp_path,
+            workspace_root=tmp_path,
+            shared=[],
+            granted=set(),
+            write_resolver=_resolver("once"),
+        )
+    )
+    assert result is None
+
+
+def test_resolve_write_shared_roots_home_never_grants(tmp_path):
+    """The user profile root is never grantable, even when outside the workspace."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    home = Path.home()  # isolated by the autouse fixture, but NOT under ws
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(home / "x.txt"),
+            base_dir=ws,
+            workspace_root=ws,
+            shared=[],
+            granted=set(),
+            write_resolver=_resolver("once"),
+        )
+    )
+    # The grantable dir would be the profile root; must be rejected.
+    assert result is None
+
+
+def test_resolve_write_shared_roots_granted_memory(tmp_path):
+    """A previously granted dir short-circuits without another card."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    calls = []
+
+    async def resolver(payload):
+        calls.append(payload)
+        return {"status": "submitted", "answers": {"choice_id": "once"}}
+
+    granted = {str(outside.resolve())}
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside / "y.txt"),
+            base_dir=ws,
+            workspace_root=ws,
+            shared=[],
+            granted=granted,
+            write_resolver=resolver,
+        )
+    )
+    # Already authorized → the granted dir is returned (so the caller's
+    # whitelist check accepts it), but no card is popped.
+    assert outside.resolve() in [Path(r).resolve() for r in result]
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_write_file_authorize_paths_deny_aborts(tmp_path):
+    """write_file with a declined authorize_paths returns an error, no write."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        shared_roots=[],
+        write_resolver=_resolver("deny"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    result = await tool.execute(path=str(out), content="hi", authorize_paths=[str(out)])
+    assert result.startswith("Error: 权限被拒绝")
+    assert not out.exists()
+
+
+@pytest.mark.asyncio
+async def test_write_file_authorize_paths_once_writes(tmp_path):
+    """write_file with authorize_paths granted once writes the file."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        shared_roots=[],
+        write_resolver=_resolver("once"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    result = await tool.execute(path=str(out), content="hi", authorize_paths=[str(out)])
+    assert result.startswith("Successfully wrote")
+    assert out.read_text(encoding="utf-8") == "hi"
+
+
+@pytest.mark.asyncio
+async def test_write_file_in_workspace_no_card(tmp_path):
+    """In-workspace writes never pop a card even with a resolver wired."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    calls = []
+
+    async def resolver(payload):
+        calls.append(payload)
+        return {"status": "submitted", "answers": {"choice_id": "deny"}}
+
+    tool = WriteFileTool(
+        workspace=ws,
+        shared_roots=[ws],
+        write_resolver=resolver,
+    )
+    out = ws / "in.txt"
+    result = await tool.execute(path=str(out), content="ok")
+    assert result.startswith("Successfully wrote")
+    assert calls == []

--- a/tests/agent/tools/test_write_authorization.py
+++ b/tests/agent/tools/test_write_authorization.py
@@ -328,15 +328,66 @@ async def test_write_file_grants_are_session_scoped(tmp_path):
     )
     assert res_a.startswith("Successfully wrote")
 
-    # Session B: same target, but no prior grant → must pop the card and be
-    # denied by the deny resolver (proving the grant did NOT cross sessions).
-    deny_tool = WriteFileTool(
-        workspace=ws,
-        allowed_dir=ws,
-        shared_roots=[],
-        write_resolver=_resolver("deny"),
-    )
-    res_b = await deny_tool.execute(
+    # Same tool instance, session B, same target — but "once" is
+    # invocation-scoped (never stored in the session set), so a fresh call
+    # must re-authorize and be denied by the (now deny) resolver.  This proves
+    # grants are keyed by session AND "once" does not persist.
+    tool._write_resolver = _resolver("deny")
+    res_b = await tool.execute(
         path=str(out), content="b", _session_key="sessionB",
     )
     assert res_b.startswith("Error: 权限被拒绝")
+
+
+@pytest.mark.asyncio
+async def test_write_file_once_not_persisted_within_session(tmp_path):
+    """「允许本次」只对当次调用生效，同会话后续写需重新授权 (CWE-863)。"""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        allowed_dir=ws,
+        shared_roots=[],
+        write_resolver=_resolver("once"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    # First call: "once" grants → writes.
+    res_a = await tool.execute(
+        path=str(out), content="a", _session_key="sessionA",
+    )
+    assert res_a.startswith("Successfully wrote")
+
+    # Same session, second call to a DIFFERENT file in the same dir: "once"
+    # must NOT have persisted, so a deny resolver blocks it.
+    tool._write_resolver = _resolver("deny")
+    res_b = await tool.execute(
+        path=str(out), content="b", _session_key="sessionA",
+    )
+    assert res_b.startswith("Error: 权限被拒绝")
+
+
+@pytest.mark.asyncio
+async def test_write_file_always_dir_persists_within_session(tmp_path):
+    """「本目录不再询问」在同会话内持久，后续写不再弹卡。"""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        allowed_dir=ws,
+        shared_roots=[],
+        write_resolver=_resolver("always_dir"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    res_a = await tool.execute(
+        path=str(out), content="a", _session_key="sessionA",
+    )
+    assert res_a.startswith("Successfully wrote")
+
+    # Same session, second call: "always_dir" persisted in the session set, so
+    # even a deny resolver never fires (no card, direct write).
+    tool._write_resolver = _resolver("deny")
+    res_b = await tool.execute(
+        path=str(out), content="b", _session_key="sessionA",
+    )
+    assert res_b.startswith("Successfully wrote")
+    assert out.read_text(encoding="utf-8") == "b"

--- a/tests/agent/tools/test_write_authorization.py
+++ b/tests/agent/tools/test_write_authorization.py
@@ -88,6 +88,57 @@ def test_resolve_write_shared_roots_always_dir_grants_and_persists(tmp_path):
     assert persisted == [outside.parent.resolve()]
 
 
+def test_resolve_write_shared_roots_bypass_grants_without_persist(tmp_path):
+    """Out-of-roots + bypass=True → granted session-scoped, no persist, no card."""
+    outside = tmp_path / "outside" / "x.txt"
+    shared = [tmp_path / "ws"]
+    persisted = []
+    calls = []
+
+    async def persist(root):
+        persisted.append(root)
+
+    async def resolver(payload):
+        calls.append(payload)
+        return {"status": "submitted", "answers": {"choice_id": "once"}}
+
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(outside),
+            base_dir=tmp_path / "ws",
+            workspace_root=tmp_path / "ws",
+            shared=shared,
+            granted=set(),
+            write_resolver=resolver,
+            persist_extra_root=persist,
+            bypass=True,
+        )
+    )
+    assert result is not None
+    assert outside.parent.resolve() in [Path(r).resolve() for r in result]
+    assert persisted == []  # bypass never widens tools.extra_roots
+    assert calls == []  # bypass skips the card
+
+
+def test_resolve_write_shared_roots_bypass_protected_still_denies(tmp_path):
+    """bypass does NOT grant protected targets (home root)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    home = Path.home()
+    result = asyncio.run(
+        _resolve_write_shared_roots(
+            str(home / "x.txt"),
+            base_dir=ws,
+            workspace_root=ws,
+            shared=[],
+            granted=set(),
+            write_resolver=_resolver("once"),
+            bypass=True,
+        )
+    )
+    assert result is None
+
+
 def test_resolve_write_shared_roots_deny(tmp_path):
     """Out-of-roots + [拒绝] → None (denied)."""
     outside = tmp_path / "outside" / "x.txt"

--- a/tests/agent/tools/test_write_authorization.py
+++ b/tests/agent/tools/test_write_authorization.py
@@ -193,6 +193,7 @@ async def test_write_file_authorize_paths_deny_aborts(tmp_path):
     ws.mkdir()
     tool = WriteFileTool(
         workspace=ws,
+        allowed_dir=ws,
         shared_roots=[],
         write_resolver=_resolver("deny"),
     )
@@ -209,8 +210,26 @@ async def test_write_file_authorize_paths_once_writes(tmp_path):
     ws.mkdir()
     tool = WriteFileTool(
         workspace=ws,
+        allowed_dir=ws,
         shared_roots=[],
         write_resolver=_resolver("once"),
+    )
+    out = tmp_path / "outside" / "x.txt"
+    result = await tool.execute(path=str(out), content="hi", authorize_paths=[str(out)])
+    assert result.startswith("Successfully wrote")
+    assert out.read_text(encoding="utf-8") == "hi"
+
+
+@pytest.mark.asyncio
+async def test_write_file_authorize_paths_unrestricted_native_not_blocked(tmp_path):
+    """On the unrestricted native path (no boundary), a declared out-of-roots
+    authorize_paths must NOT block the write — the boundary does not exist."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    tool = WriteFileTool(
+        workspace=ws,
+        shared_roots=[],
+        write_resolver=_resolver("deny"),
     )
     out = tmp_path / "outside" / "x.txt"
     result = await tool.execute(path=str(out), content="hi", authorize_paths=[str(out)])


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

为文件工具建立「工作区外访问」通道：读写不对称（读放宽 / 写收紧）+ 未授权路径按需授权卡 + agent 主动声明待写路径，并对普通用户暴露 GUI 信任目录管理。

## 背景/问题

现状是三层写白名单：会话 workspace + `tools.extra_roots`（config.json 手改，#516）+ 动态根 `auto_user_dirs`（#821/#851），其余路径一律 `PermissionError` 死路（`filesystem.py:_resolve_path` / `_canonicalize_wsl_mnt_path`）。

由此形成三个洞：
- agent 想读 workspace 外参考文件（用户 home 下的文档）被拒；
- agent 想写用户指定目录时撞墙后只能静默降级（sci-synthesis 案例：沙箱写不了用户目录后降级 create_pdf 交付，产物质量劣化）；
- `extra_roots` 无 UI，普通用户不可达。

正确行为应是「向用户申请权限」，而非「降级交付」。

## 关联 issue

- Closes #864 文件访问授权体系——读写不对称 + 按需授权卡 + agent 主动声明路径

## 变更内容

- `miqi/agent/tools/filesystem.py` — 新增写授权辅助 `_resolve_write_shared_roots`（`[允许本次 / 本目录不再询问 / 拒绝]`），`WriteFileTool`/`EditFileTool` 接入 `write_resolver` + `persist_extra_root` + 会话级 `granted` 记忆，schema 新增 `authorize_paths` 声明参数
- `miqi/agent/tools/apply_patch.py` — 同样接入写授权卡 + `authorize_paths`
- `miqi/runtime/tool_registry_factory.py` — 读根放宽（`_default_read_roots()`：home + 全盘只读），写根维持 `_shared_roots`；注入 `make_resolver()` 与 `_make_extra_root_persister()`
- `apps/desktop/src/renderer/features/settings/SettingsPage.tsx` — 新增「信任目录」区增删 `tools.extra_roots`
- `scripts/mock_openai.py` — 新增「写授权」mock 状态机分支
- 测试：`tests/agent/tools/test_write_authorization.py`（11 例）+ `apps/desktop/tests/e2e/write-authorization.spec.ts`

## 日志/验证证据

```
$ "C:\git-program\test\MiQi-Desktop\.venv\Scripts\python.exe" -m pytest tests/agent/tools/ tests/runtime/test_tool_registry_factory.py -q
204 passed, 1 skipped

$ "C:\git-program\test\MiQi-Desktop\.venv\Scripts\python.exe" -m pytest tests/kun_runtime/ tests/runtime/test_tool_registry_factory.py -q
356 passed, 1 skipped

$ cd apps/desktop && npx playwright test --config=playwright.config.ts --project=electron write-authorization.spec.ts --workers=1
1 passed (6.6s)

[test] ✅ 写授权卡放行，产物落在 workspace 外目录
```

## 测试情况

- 单测：`tests/agent/tools/` + `tests/runtime/test_tool_registry_factory.py` 全绿（204 passed, 1 skipped）；`tests/kun_runtime/` 全绿（356 passed, 1 skipped）
- E2E：新增 `write-authorization.spec.ts` 用 mock 状态机驱动，覆盖「写 workspace 外目录 → 弹写授权卡 → 允许本次 → 写入成功」，1 passed
- TypeScript 类型检查：`npx tsc --noEmit -p apps/desktop` 通过

## 截图

![写授权卡](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/auth-card-70e87adc.png)

## 后续计划

- #851 中文粘连 bug（「输出到C:\...」紧贴写法提取失败）应单列 bug 修
- 远期可选：访问策略预设（严格 / 询问 / 开放 三档选择器）