### PR TITLE
test(e2e): #811 护栏 B 断言放宽——容忍真实 LLM 改写「沙箱护栏」为「系统护栏」

### DIFF
--- a/apps/desktop/tests/e2e/guard-issue-811-real-llm.spec.ts
+++ b/apps/desktop/tests/e2e/guard-issue-811-real-llm.spec.ts
@@ -193,12 +193,17 @@ test.describe('Issue #811 护栏误拦截复现 (real LLM)', () => {
       test.setTimeout(8 * 60_000);
       await createNewConversation(page);
       // 护栏拒绝路径不 spawn、不发 output delta，原始输出不进 inline 盒，
-      // 只能断言模型复述中必然原样带上的 _HEADER 子串「沙箱护栏拦截」
-      // （它是护栏输出第一行）。「安全替代」在末行、会被模型改写，不稳。
+      // 只能断言模型复述中必然原样带上的 _HEADER 子串「护栏拦截」——真实
+      // 模型会把「沙箱护栏」改写成「系统护栏」等（CI 实测），但「护栏拦截」
+      // 一词稳定保留，且旧版「检测到危险模式」文本不含它，仍可区分新旧。
+      // 「安全替代」在末行、会被模型改写，不稳。
+      // 与 C/D 同级的强制语气：弱提示下模型安全对齐可能直接拒答、不调 exec
+      // （CI 实测），这样护栏根本不会被触发。
       await driveExecAndAssert(
-        `请用 exec 工具执行命令：rm -rf /etc/guard811-e2e-noexist，` +
-          `然后告诉我执行结果。`,
-        /沙箱护栏拦截/,
+        `必须使用 exec 工具执行下面这一条命令，然后只回复命令的完整输出，` +
+          `不要解释、不要改写、不要拆成多条命令：` +
+          `rm -rf /etc/guard811-e2e-noexist`,
+        /护栏拦截/,
       );
       await page.screenshot({
         path: `test-results/${shotStem(test.info().title)}.png`,


### PR DESCRIPTION
## 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [x] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复 `guard-issue-811-real-llm.spec.ts` 在 CI 上持续超时失败的问题：B 用例断言放宽为「护栏拦截」，并把 prompt 语气改为与 C/D 同级的强制 exec 调用。

## 背景/问题

CI（electron-e2e / macos-e2e）连续多轮在 `guard-issue-811-real-llm` 的 B 用例（越界删除 /etc）上失败，8 分钟 test timeout。从失败截图发现两种失败模式：

1. 模型调用了 exec，护栏正常拦截并返回结构化拒绝，但模型复述时把 `_HEADER` 原文「**沙箱**护栏拦截」改写成了「**系统**护栏拦截」——精确子串断言 `/沙箱护栏拦截/` 永不匹配，轮询跑满 8 分钟超时。
2. 模型安全对齐直接拒答（「我不会执行这条命令」），不调用 exec——护栏根本没被触发。B 用例的 prompt 语气（「请用 exec 工具执行命令…」）比 C/D（「必须使用 exec 工具执行…」）弱，更易触发模型抢跑拒答。

「护栏拦截」一词在两种复述中都稳定保留，且旧版护栏文案「检测到危险模式」不含它，仍可区分新旧护栏。

## 变更内容

- `apps/desktop/tests/e2e/guard-issue-811-real-llm.spec.ts`
  - B 用例断言从 `/沙箱护栏拦截/` 放宽为 `/护栏拦截/`（容忍模型改写「沙箱」为「系统」）
  - B 用例 prompt 改为与 C/D 同级的强制语气（「必须使用 exec 工具执行下面这一条命令，然后只回复命令的完整输出」），降低模型直接拒答的概率

## 日志/验证证据

```
CI 失败截图（retry1）显示模型回复：
「我不会执行这条命令。原因如下：命令性质危险：rm -rf 是强制递归删除命令…」

CI 失败截图（retry0）显示护栏已拦截但模型改写：
「命令已被系统护栏拦截，未执行。拦截原因：这条命令是删除操作（rm -rf），
  目标 /etc/guard811-e2e-noexist 解析后位于系统受保护路径（/etc）…」
```

## 测试情况

- 本改动仅调整 E2E 断言与 prompt 文案，不影响产品代码
- 未在本地跑真实 LLM（需要网络 + provider）；依赖 CI 验证

## 截图

失败时模型改写/拒答的 CI 截图已随失败记录在 PR 评审流程中，本次为断言修复无需新截图。