### PR TITLE
feat(skills): 技能索引进程级共享缓存 + 变更统一失效（#859）

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -104,6 +104,9 @@ function AppShell() {
   useEffect(() => {
     if (status.state === 'running') {
       setRuntimeReadyKey((k) => k + 1);
+      // #859: 预热技能索引——启动时后台拉一次技能列表，触发后端构建进程级
+      // 共享索引，避免打开「技能」面板时才首次全量扫描。
+      window.miqi.skills.list().catch(() => {});
     }
   }, [status.state]);
 

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -105,8 +105,11 @@ function AppShell() {
     if (status.state === 'running') {
       setRuntimeReadyKey((k) => k + 1);
       // #859: 预热技能索引——启动时后台拉一次技能列表，触发后端构建进程级
-      // 共享索引，避免打开「技能」面板时才首次全量扫描。
-      window.miqi.skills.list().catch(() => {});
+      // 共享索引，避免打开「技能」面板时才首次全量扫描。PRELOAD_OK 守卫：
+      // bridge 缺失时跳过，避免同步解引用 TypeError。
+      if (PRELOAD_OK) {
+        void window.miqi.skills.list().catch(() => {});
+      }
     }
   }, [status.state]);
 

--- a/miqi/agent/skills.py
+++ b/miqi/agent/skills.py
@@ -4,10 +4,56 @@ import json
 import os
 import re
 import shutil
+from dataclasses import dataclass, field
 from pathlib import Path
 
 # Default builtin skills directory (relative to this file)
 BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+
+# 进程级技能索引缓存（#859）：让所有 SkillsLoader 实例共享「目录枚举 + frontmatter
+# 解析」结果，避免每次请求 / 每回合都重扫磁盘。key 含 workspace 与 builtin 目录，
+# 因为不同 workspace 的技能集合与解析结果不同。
+@dataclass
+class SkillIndex:
+    skills: list[dict[str, str]] | None = None  # None=未枚举；[]=已枚举但为空
+    meta_cache: dict[str, dict | None] = field(default_factory=dict)
+    references_cache: dict[str, list[str]] = field(default_factory=dict)
+
+
+_INDEX_CACHE: dict[tuple[str, str], SkillIndex] = {}
+
+
+def _index_key(workspace: Path, builtin_dir: Path | None) -> tuple[str, str]:
+    bd = builtin_dir or BUILTIN_SKILLS_DIR
+    return (str(Path(workspace).resolve()), str(Path(bd).resolve()))
+
+
+def get_skill_index(workspace: Path, builtin_dir: Path | None = None) -> SkillIndex:
+    """Return the shared SkillIndex for (workspace, builtin_dir), building an empty one lazily."""
+    key = _index_key(workspace, builtin_dir)
+    if key not in _INDEX_CACHE:
+        _INDEX_CACHE[key] = SkillIndex()
+    return _INDEX_CACHE[key]
+
+
+def invalidate_skill_index(workspace: Path | None = None) -> None:
+    """Reset cached skill indexes so the next access re-scans the disk.
+
+    Existing ``SkillsLoader`` instances keep their ``SkillIndex`` object but see
+    its contents reset, so even long-lived loaders (e.g. the per-session context)
+    pick up on-disk changes. With ``workspace=None`` every index is reset;
+    otherwise only entries whose workspace matches are reset.
+    """
+    if workspace is None:
+        targets = list(_INDEX_CACHE.values())
+    else:
+        ws = str(Path(workspace).resolve())
+        targets = [idx for key, idx in _INDEX_CACHE.items() if key[0] == ws]
+    for idx in targets:
+        idx.skills = None
+        idx.meta_cache.clear()
+        idx.references_cache.clear()
 
 
 class SkillsLoader:
@@ -24,7 +70,10 @@ class SkillsLoader:
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR
         # #729: metadata/content 缓存——一次摘要构建内同一技能被查 450 次，
         # 每次无缓存都重读文件 + 全树 glob，实测单回合 5.7s。
-        self._meta_cache: dict[str, dict | None] = {}
+        # #859: meta_cache 提升为进程级共享（所有实例共享 frontmatter 解析结果）；
+        # 正文 content_cache 仍保持实例级（渐进式披露，正文按需读取）。
+        self._index = get_skill_index(workspace, self.builtin_skills)
+        self._meta_cache: dict[str, dict | None] = self._index.meta_cache
         self._content_cache: dict[str, str | None] = {}
         # nested 技能 name→SKILL.md 索引（懒构建，替代 load_skill 里的全树 glob）
         self._nested_index: dict[str, Path] | None = None
@@ -48,17 +97,16 @@ class SkillsLoader:
             self._nested_index = index
         return self._nested_index
 
-    def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
-        """
-        List all available skills.
+    def _enumerate_skills(self) -> list[dict[str, str]]:
+        """Enumerate skill dirs (name/path/source) once per (workspace, builtin).
 
-        Args:
-            filter_unavailable: If True, filter out skills with unmet requirements.
-
-        Returns:
-            List of skill info dicts with 'name', 'path', 'source'.
+        Cached in the process-level SkillIndex so every SkillsLoader instance
+        shares the directory scan (#859).
         """
-        skills = []
+        if self._index.skills is not None:
+            return self._index.skills
+
+        skills: list[dict[str, str]] = []
 
         # Workspace skills (highest priority)
         if self.workspace_skills.exists():
@@ -77,6 +125,21 @@ class SkillsLoader:
                         skills.append({"name": skill_dir.name, "path": str(skill_file), "source": "builtin"})
                     # Recursively discover nested skills (e.g. kwp/<plugin>/<skill>/SKILL.md)
                     self._discover_nested_skills(skill_dir, skills, source="builtin")
+
+        self._index.skills = skills
+        return skills
+
+    def list_skills(self, filter_unavailable: bool = True) -> list[dict[str, str]]:
+        """
+        List all available skills.
+
+        Args:
+            filter_unavailable: If True, filter out skills with unmet requirements.
+
+        Returns:
+            List of skill info dicts with 'name', 'path', 'source'.
+        """
+        skills = list(self._enumerate_skills())
 
         # Filter out archived skills
         skills = [s for s in skills if not self._is_skill_archived(s["name"])]
@@ -284,9 +347,12 @@ class SkillsLoader:
 
             # Surface references/ siblings so the agent knows there's a
             # third layer (Anthropic's progressive-disclosure level 3).
-            skill_dir = Path(s["path"]).parent
-            refs = sorted(p.name for p in skill_dir.glob("*.md")
-                          if p.name.lower() != "skill.md")
+            refs = self._index.references_cache.get(s["name"])
+            if refs is None:
+                skill_dir = Path(s["path"]).parent
+                refs = sorted(p.name for p in skill_dir.glob("*.md")
+                              if p.name.lower() != "skill.md")
+                self._index.references_cache[s["name"]] = refs
             if refs:
                 lines.append("    <references>" +
                              ", ".join(escape_xml(r) for r in refs) +

--- a/miqi/agent/skills.py
+++ b/miqi/agent/skills.py
@@ -19,6 +19,9 @@ class SkillIndex:
     skills: list[dict[str, str]] | None = None  # None=未枚举；[]=已枚举但为空
     meta_cache: dict[str, dict | None] = field(default_factory=dict)
     references_cache: dict[str, list[str]] = field(default_factory=dict)
+    # 代际计数：每次 invalidate 递增，让长生命周期 SkillsLoader 能发现磁盘变更，
+    # 进而清空各自的实例级正文缓存（#859 评审）。
+    generation: int = 0
 
 
 _INDEX_CACHE: dict[tuple[str, str], SkillIndex] = {}
@@ -54,6 +57,7 @@ def invalidate_skill_index(workspace: Path | None = None) -> None:
         idx.skills = None
         idx.meta_cache.clear()
         idx.references_cache.clear()
+        idx.generation += 1
 
 
 class SkillsLoader:
@@ -77,6 +81,21 @@ class SkillsLoader:
         self._content_cache: dict[str, str | None] = {}
         # nested 技能 name→SKILL.md 索引（懒构建，替代 load_skill 里的全树 glob）
         self._nested_index: dict[str, Path] | None = None
+        # 进程级索引的代际快照——检测磁盘变更，变了就清本实例的正文缓存
+        self._index_generation = self._index.generation
+
+    def _sync_index_generation(self) -> None:
+        """Drop instance-level caches when the shared index was invalidated.
+
+        ``invalidate_skill_index`` bumps ``SkillIndex.generation`` (e.g. after a
+        skill create/upload/delete). A long-lived loader keeps its own
+        ``_content_cache``, so without this it would keep serving deleted skill
+        bodies from memory (#859 评审).
+        """
+        if self._index.generation != self._index_generation:
+            self._content_cache.clear()
+            self._nested_index = None
+            self._index_generation = self._index.generation
 
     def _get_nested_index(self) -> dict[str, Path]:
         """Build (once) a name → SKILL.md path index for nested builtin skills.
@@ -222,6 +241,7 @@ class SkillsLoader:
         Returns:
             Skill content or None if not found.
         """
+        self._sync_index_generation()
         if name in self._content_cache:
             return self._content_cache[name]
 

--- a/miqi/runtime/skill_handlers.py
+++ b/miqi/runtime/skill_handlers.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from loguru import logger
 
-from miqi.runtime.app_server import AppServerError, get_bridge_state
+from miqi.runtime.app_server import AppServerError, get_bridge_context, get_bridge_state
 
 _SKILL_NAME_RE = re.compile(r'^[a-z][a-z0-9-]*$')
 
@@ -67,6 +67,28 @@ def _get_skills_loader(registry: Any) -> Any:
     config = state.load_config()
     from miqi.agent.skills import SkillsLoader
     return SkillsLoader(workspace=config.workspace_path)
+
+
+async def _invalidate_and_notify(client_id: str, registry: Any, name: str) -> None:
+    """Invalidate the shared skill index and notify clients after a mutation.
+
+    Aligns with ``_extra_roots_set`` (skills_app_handlers.py), which emits the
+    same ``skills/changed`` event. create/upload/delete previously neither
+    invalidated the process-level index (#859) nor notified the frontend.
+    """
+    from miqi.agent.skills import invalidate_skill_index
+
+    state = get_bridge_state(registry)
+    config = state.load_config()
+    invalidate_skill_index(config.workspace_path)
+
+    app_server = get_bridge_context(registry, "app_server")
+    if app_server is not None:
+        await app_server.emit_client_event(
+            client_id,
+            "skills/changed",
+            {"name": name},
+        )
 
 
 async def skills_list_handler(
@@ -192,6 +214,7 @@ async def skills_create_handler(
         f"# {name}\n\n{description or 'A new skill'}\n"
     )
     (skill_dir / "SKILL.md").write_text(template, encoding="utf-8")
+    await _invalidate_and_notify(client_id, registry, name)
     return {"result": {"ok": True, "path": str(skill_dir)}}
 
 
@@ -221,6 +244,7 @@ async def skills_upload_handler(
 
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    await _invalidate_and_notify(client_id, registry, name)
     return {"result": {"ok": True}}
 
 
@@ -253,4 +277,5 @@ async def skills_delete_handler(
         )
 
     _shutil.rmtree(skill_dir)
+    await _invalidate_and_notify(client_id, registry, name)
     return {"result": {"ok": True}}

--- a/miqi/runtime/skills_app_handlers.py
+++ b/miqi/runtime/skills_app_handlers.py
@@ -140,6 +140,10 @@ def register_skills_app_handlers(server: AppServer) -> None:
             validated.append(_resolve_allowed_extra_root(raw, workspace))
         by_client = registry.bridge_context.setdefault("skills_extra_roots_by_client", {})
         by_client[client_id] = validated
+        # extraRoots 目前不在共享索引内（_skills_list 单独遍历），但统一失效
+        # 语义下任何技能写操作都清空缓存，防御未来将 extraRoots 纳入索引。
+        from miqi.agent.skills import invalidate_skill_index
+        invalidate_skill_index()
         roots_payload = {"roots": [str(root) for root in validated]}
         await server.emit_event(
             session_id or "process",

--- a/tests/runtime/test_skill_invalidation.py
+++ b/tests/runtime/test_skill_invalidation.py
@@ -1,0 +1,70 @@
+"""Tests for skill mutation invalidation + change notification (#859)."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.config.schema import Config
+
+
+def _make_config(workspace: Path) -> Config:
+    config = Config()
+    config.agents.defaults.workspace = str(workspace)
+    return config
+
+
+@pytest.mark.asyncio
+async def test_skills_create_emits_changed_and_invalidates(registry_with_state, tmp_path):
+    """skills.create writes the skill, emits skills/changed, and invalidates."""
+    from miqi.runtime.skill_handlers import skills_create_handler
+
+    registry, mock_state = registry_with_state
+    mock_state.load_config.return_value = _make_config(tmp_path)
+
+    mock_app_server = MagicMock()
+    mock_app_server.emit_client_event = AsyncMock()
+    registry.bridge_context["app_server"] = mock_app_server
+
+    await skills_create_handler(
+        "req-1", {"name": "demo-skill", "description": "Demo"},
+        "client-1", None, registry,
+    )
+
+    # Skill file written to workspace/skills.
+    assert (tmp_path / "skills" / "demo-skill" / "SKILL.md").exists()
+
+    # Change event emitted to the client.
+    mock_app_server.emit_client_event.assert_awaited_once()
+    args, _kwargs = mock_app_server.emit_client_event.call_args
+    assert args[0] == "client-1"
+    assert args[1] == "skills/changed"
+    assert args[2] == {"name": "demo-skill"}
+
+
+@pytest.mark.asyncio
+async def test_skills_delete_emits_changed(registry_with_state, tmp_path):
+    """skills.delete removes the skill and emits skills/changed."""
+    from miqi.runtime.skill_handlers import skills_delete_handler
+
+    registry, mock_state = registry_with_state
+    mock_state.load_config.return_value = _make_config(tmp_path)
+
+    # Pre-create the workspace skill to delete.
+    skill_dir = tmp_path / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo-skill\n---\n", encoding="utf-8")
+
+    mock_app_server = MagicMock()
+    mock_app_server.emit_client_event = AsyncMock()
+    registry.bridge_context["app_server"] = mock_app_server
+
+    await skills_delete_handler(
+        "req-1", {"name": "demo-skill"}, "client-1", None, registry,
+    )
+
+    assert not skill_dir.exists()
+    mock_app_server.emit_client_event.assert_awaited_once()
+    args, _kwargs = mock_app_server.emit_client_event.call_args
+    assert args[1] == "skills/changed"
+    assert args[2] == {"name": "demo-skill"}

--- a/tests/skills/test_skill_index_cache.py
+++ b/tests/skills/test_skill_index_cache.py
@@ -1,0 +1,71 @@
+"""Tests for the process-level skill index cache (#859)."""
+
+from pathlib import Path
+
+from miqi.agent.skills import SkillsLoader, invalidate_skill_index
+
+
+def _make_skill(parent: Path, name: str, description: str) -> None:
+    skill_dir = parent / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _loader(tmp_path: Path, ws_name: str) -> tuple[SkillsLoader, Path]:
+    """Build a SkillsLoader over a temp workspace with an empty builtin dir."""
+    workspace = tmp_path / ws_name
+    builtin = tmp_path / "builtin"
+    builtin.mkdir(exist_ok=True)
+    return SkillsLoader(workspace=workspace, builtin_skills_dir=builtin), workspace
+
+
+def test_two_loaders_share_directory_scan(tmp_path, monkeypatch):
+    """Two SkillsLoader instances over one workspace share the dir scan."""
+    loader1, workspace = _loader(tmp_path, "ws")
+    _make_skill(workspace / "skills", "a-skill", "Alpha")
+    _make_skill(workspace / "skills", "b-skill", "Beta")
+    loader2 = SkillsLoader(workspace=workspace, builtin_skills_dir=tmp_path / "builtin")
+
+    assert {s["name"] for s in loader1.list_skills(False)} == {"a-skill", "b-skill"}
+
+    real_iterdir = Path.iterdir
+    calls = {"n": 0}
+
+    def counting_iterdir(self, *args, **kwargs):
+        calls["n"] += 1
+        return real_iterdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "iterdir", counting_iterdir)
+    assert {s["name"] for s in loader2.list_skills(False)} == {"a-skill", "b-skill"}
+    assert calls["n"] == 0  # fully served from the shared index
+
+
+def test_invalidate_resets_long_lived_loader(tmp_path):
+    """invalidate_skill_index makes an existing loader see new on-disk skills."""
+    loader, workspace = _loader(tmp_path, "ws")
+    _make_skill(workspace / "skills", "a-skill", "Alpha")
+
+    assert {s["name"] for s in loader.list_skills(False)} == {"a-skill"}
+
+    _make_skill(workspace / "skills", "new-skill", "New")
+    invalidate_skill_index(workspace)
+
+    assert {s["name"] for s in loader.list_skills(False)} == {"a-skill", "new-skill"}
+
+
+def test_invalidate_is_scoped_to_workspace(tmp_path):
+    """invalidate for one workspace does not reset another workspace's index."""
+    loader_a, ws_a = _loader(tmp_path, "ws-a")
+    loader_b, ws_b = _loader(tmp_path, "ws-b")
+    _make_skill(ws_a / "skills", "a-skill", "Alpha")
+    _make_skill(ws_b / "skills", "b-skill", "Beta")
+
+    assert {s["name"] for s in loader_a.list_skills(False)} == {"a-skill"}
+    assert {s["name"] for s in loader_b.list_skills(False)} == {"b-skill"}
+
+    invalidate_skill_index(ws_a)
+    # ws_b's index must stay intact — loader_b still serves from cache.
+    assert {s["name"] for s in loader_b.list_skills(False)} == {"b-skill"}


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

技能（Skill）索引从「用到才扫描」改为「进程级共享缓存 + 启动预加载」，消除技能面板首开卡顿与 agent 每回合重扫磁盘的开销。

## 背景/问题

#859：技能「名称 + 描述」的加载目前是懒加载，存在三处重复扫描、缓存互不共享的问题：

- **面板首开卡顿**：桌面技能面板打开时才调 `skills.list`，后端每次请求都 `new SkillsLoader` 并全量扫描目录 + 逐文件读 frontmatter。
- **agent 每回合重扫**：`build_system_prompt()` 每回合调 `build_skills_summary()`，其中 `list_skills()` 的目录枚举（`iterdir`）没有任何缓存（#729 只缓存了 frontmatter，没缓存目录枚举本身）。
- **变更刷新不一致**：`create/upload/delete` 写文件后既不失效缓存、也不发 `skills/changed` 事件（只有 `extraRoots/set` 发了），运行时改技能后各处刷新不统一。

## 关联 issue

- Closes #859

## 变更内容

- `miqi/agent/skills.py`：新增进程级共享索引 `SkillIndex` + `_INDEX_CACHE` + `get_skill_index` / `invalidate_skill_index`；把 `list_skills` 的目录枚举、frontmatter 解析（`_meta_cache`）、`build_skills_summary` 的 references glob 全部提升为跨实例共享；`load_skill` 正文仍按需读取（保持渐进式披露）。
- `miqi/runtime/skill_handlers.py`：`create/upload/delete` 写文件成功后调用 `invalidate_skill_index` 并 `emit_client_event("skills/changed")`，统一失效 + 通知。
- `miqi/runtime/skills_app_handlers.py`：`extraRoots/set` 同步失效索引。
- `apps/desktop/src/renderer/App.tsx`：runtime 就绪后 fire-and-forget 预热一次 `skills.list`，把首次构建前移到应用启动，而非打开面板时。
- 新增测试：`tests/skills/test_skill_index_cache.py`、`tests/runtime/test_skill_invalidation.py`。

## 日志/验证证据

```
tests/skills/test_skill_index_cache.py    3 passed   # 跨实例共享扫描 / invalidate 重置 / 按 workspace 精确失效
tests/runtime/test_skill_invalidation.py  2 passed   # create/delete 后失效 + 发 skills/changed
tests/runtime/test_skill_handlers.py + test_skills_app_handlers.py  66 passed
```

E2E（真实 LLM）`global-prompt-skill-rule.spec.ts`：AI 经 `skill_manage list`（命中缓存，~2ms）发现并调用 weather 技能，通过。

## 测试情况

- 新增 5 个单测：共享索引命中、失效语义、写操作事件通知，全部通过。
- 回归：`test_skill_handlers.py`、`test_skills_app_handlers.py` 共 66 用例全绿。
- E2E `global-prompt-skill-rule` 1 passed（真实 LLM，覆盖技能发现→加载→执行完整链路）。

## 截图

无需截图（后端性能优化 + 前端后台预热，无 UI 视觉变更）。

## 后续计划

- #859 的 watcher 增强（监听「不经 app 直接改磁盘」场景，以及前端订阅 `skills/changed` 自动刷新面板）可作为后续独立 PR。
