### PR TITLE
fix(release): update repository URL to MiqroForge-Desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Release tooling for MiqroForge Desktop",
   "repository": {
     "type": "git",
-    "url": "https://github.com/14790897/MiQi.git"
+    "url": "https://github.com/14790897/MiqroForge-Desktop.git"
   },
   "scripts": {
     "commit": "cz",


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复仓库改名后 semantic-release 发版失败（EMISMATCHGITHUBURL）。

## 背景/问题

仓库从 MiQi 更名为 MiqroForge-Desktop 后，root package.json 的 repository.url 仍是旧名，semantic-release verifyConditions 校验 git URL 与 GitHub URL 不匹配，导致 8-28 两次发版 CI 全部失败。

## 变更内容

- package.json: repository.url 从 https://github.com/14790897/MiQi.git 改为 https://github.com/14790897/MiqroForge-Desktop.git

## 日志/验证证据

```
[1:39:38 AM] [semantic-release] › ✘  Failed step "verifyConditions" of plugin "@semantic-release/github"
[1:39:39 AM] [semantic-release] › ✘  EMISMATCHGITHUBURL The git repository URL mismatches the GitHub URL.
```

## 测试情况

- 合并后重跑 Release and Build 验证发版恢复