### PR TITLE
fix(theme): 外观设置 5 个主题选项网格布局,修复右边界溢出(#828)

### DIFF
--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -1286,7 +1286,7 @@ function AppearanceTab() {
       <h3 className="text-subheading text-[var(--text)]">外观</h3>
       <div className="flex flex-col gap-1.5">
         <label className="text-size-sm font-medium text-[var(--text-muted)]">主题</label>
-        <div className="flex items-stretch gap-0.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)]/50 p-1">
+        <div className="grid grid-cols-5 gap-1 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-muted)]/50 p-1">
           {modes.map(({ value, label, icon, preview }) => (
             <button
               key={value}
@@ -1301,7 +1301,7 @@ function AppearanceTab() {
               aria-pressed={theme === value}
               title={label}
               className={cn(
-                'flex-1 flex flex-col items-center gap-1.5 rounded-xl px-2 py-2.5 transition duration-200',
+                'flex flex-col items-center gap-1 rounded-lg px-1 py-2 transition duration-200',
                 theme === value
                   ? 'bg-[var(--accent-soft)] ring-1 ring-[var(--accent)]/50'
                   : 'hover:bg-[var(--surface)]/60 hover:ring-1 hover:ring-[var(--border-subtle)]'
@@ -1309,7 +1309,7 @@ function AppearanceTab() {
             >
               {/* 线框图预览卡片:侧栏条+主区+占位条(参考图式) */}
               <span
-                className="relative w-[76px] h-11 rounded-lg overflow-hidden ring-1 ring-[var(--border-subtle)] shrink-0"
+                className="relative w-full h-10 rounded-lg overflow-hidden ring-1 ring-[var(--border-subtle)] shrink-0"
                 aria-hidden="true"
               >
                 {/* 侧栏条 */}


### PR DESCRIPTION
## 类型
- [x] 🐛 Bug 修复

## 变更概述
PR #849 合并后遗留:外观设置主题切换 5 个选项(浅色/柔和/冰蓝/深色/跟随系统)在 flex 一行布局下右侧溢出。

## 背景/问题
#849 合并时最后一个 commit(22f1a2c8)未包含在合并 head 中,溢出问题遗留到 develop。

## 变更内容
- 主题选项容器 flex → grid grid-cols-5
- 预览卡 w-[76px] → w-full 自适应列宽,按钮 padding 收紧
- 实测:容器右边界 919px < 窗口 1264px,不再溢出

## 日志/验证证据
```
overflow check: {"left":513,"right":919,"docW":1264,"over":false}
```

## 测试情况
tsc 0 错 / build 通过 / 实机截图验证无溢出

## 截图
![外观设置](https://raw.githubusercontent.com/14790897/MiQi/feature/828-theme-overflow-fix/docs/pr-828/appearance-settings.png)

## 后续计划
无