### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Release tooling for MiqroForge Desktop",
   "repository": {
     "type": "git",
-    "url": "https://github.com/14790897/MiQi.git"
+    "url": "https://github.com/14790897/MiqroForge-Desktop.git"
   },
   "scripts": {
     "commit": "cz",


### PR DESCRIPTION
## 类型

- [ ] 🔧 其他

## 变更概述

合并 develop 到 main，包含发版 URL 修复，准备下一次发布。

## 背景/问题

develop 分支包含 1 个尚未合入 main 的提交，需要定期同步到 main 以发布新版本。其中 fix(release): update repository URL 修复了仓库改名导致的发版 CI 失败。

## 变更内容

本次 develop → main 合并包含以下提交：

- `0a2a0256` fix(release): update repository URL to MiqroForge-Desktop (#871)

## 日志/验证证据

```
$ git log --oneline origin/main..origin/develop --no-merges
0a2a0256 fix(release): update repository URL to MiqroForge-Desktop (#871)
```

## 测试情况

- 所有 1 个提交已在 develop 通过各自 PR 评审并合并
- 自动化测试在各自原 PR 中已通过
- 本次为 release 合并，CI 将由 PR template check + title check 触发