### PR TITLE
docs(skills): github-workflow 技能改为少评论、直接更新 PR 描述

### DIFF
--- a/skills/github-workflow/SKILL.md
+++ b/skills/github-workflow/SKILL.md
@@ -15,6 +15,15 @@ agent_created: true
 
 # GitHub Workflow
 
+## PR 沟通原则：少评论，直接更新 PR 描述
+
+> **默认行为：能更新 PR 描述解决的，绝不多发评论。**
+
+- 测试结果、截图、修复说明、进展等证据 → 直接写进 PR 描述（`gh pr edit <N> --body "$(cat body.md)"`），不逐条发评论
+- 图片证据 → 上传后把 `![](url)` 写进 PR 描述的「日志/验证证据」节（见下方 E2E 截图章节）
+- 只有 GitHub 机制要求时才评论：CodeRabbit 触发 re-review（`@coderabbitai review`）、回复 reviewer 的具体评论、dismiss
+- 同步 PR（develop↔main）同理：进展与证据更新 PR 描述，不发通知性评论
+
 ## Issue 模板
 
 ### Feature 请求 (feature_request.yml)
@@ -380,6 +389,7 @@ gh api repos/{owner}/{repo}/pulls/{N}/reviews/{review_id}/dismissals \
 - 新 commit 会触发 re-review，但旧 comments 不会自动 dismiss（需手动 API）
 - `CHANGES_REQUESTED` 阻止 merge，必须 dismiss 或 CodeRabbit 重新 approve
 - nitpick 级别注释不阻止 merge，但建议修复
+- 修复进展/说明直接写进 PR 描述，不逐条回复评论（少评论原则）
 - `@coderabbitai review` PR 评论可手动触发 re-review
 
 ## CI Polling
@@ -407,21 +417,22 @@ gh run rerun <run-id> --repo OWNER/REPO --failed
 gh run view <run-id> --repo OWNER/REPO --log --job=<job-id> | grep "Error:"
 ```
 
-## E2E 截图自动贴到 PR 评论
+## E2E 截图自动贴到 PR 描述
 
 > 完整文档见仓库 `docs/e2e-pr-image-posting.md`。此处为 AI 可主动执行的摘要。
+> **少评论原则：证据一律写进 PR 描述，不贴图片评论**（CI 自动贴图机制仍为评论，AI 手动操作以本节为准）。
 
 ### 何时使用
 
 - 跑过 e2e 且想留证据到 PR → 设 `MIQI_E2E_POST_IMG=1` 跑测试，自动完成
-- 手动上传一张图到评论 → 用下方命令或仓库 `pr-image-post.ts` 的 `uploadImage` 逻辑
+- 手动上传一张图 → 上传后写进 PR 描述（下方命令），不贴评论
 - CI 默认开启；无 PR 上下文时静默跳过
 
 ### 机制（一句话）
 
-图片上传到本仓库固定预发布 `_gh-imgup`（release assets 官方 API，复用创建 + 内容 hash 去重），再以 `![img](url)` 评论到当前 PR。**必须 published 预发布，draft 资产对外 404 会裂图；勿用 user-attachments（无公开 API，有 TOS 风险）。**
+图片上传到本仓库固定预发布 `_gh-imgup`（release assets 官方 API，复用创建 + 内容 hash 去重），再以 `![img](url)` **写进当前 PR 描述的「日志/验证证据」节**。**必须 published 预发布，draft 资产对外 404 会裂图；勿用 user-attachments（无公开 API，有 TOS 风险）。**
 
-### 手动上传一张图并贴评论
+### 手动上传一张图并写进 PR 描述
 
 ```bash
 REPO=14790897/MiQi
@@ -438,22 +449,25 @@ UPLOAD_URL=$(gh api "repos/$REPO/releases/$RID" --jq '.upload_url' | sed 's/{?na
 DL=$(curl -s -X POST "$UPLOAD_URL?name=image-$HASH.png" \
   -H "Authorization: token $(gh auth token)" -H "Content-Type: image/png" \
   --data-binary @image.png | python -c "import json,sys;print(json.load(sys.stdin)['browser_download_url'])")
-# 3) 贴评论
-gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="![img]($DL)"
+# 3) 写进 PR 描述（少评论原则，不贴评论）
+CUR_BODY=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.body')
+gh api "repos/$REPO/pulls/$PR_NUMBER" -X PATCH -f body="$CUR_BODY
+
+![img]($DL)"
 ```
 
 ### 注意
 
-- 预发布 `_gh-imgup` 勿删（历史评论图片会全裂）
+- 预发布 `_gh-imgup` 勿删（历史图片引用会全裂）
 - 上传失败（无 token / 无 PR / 图不存在）静默跳过，不干扰测试
 
-## E2E 截图自动贴 PR 评论
+## E2E 截图自动贴 PR 描述
 
 e2e 验收跑完后把截图上传到仓库固定 `_gh-imgup` 预发布（release assets
-官方 API），并作为 markdown 图片评论到当前 PR。
+官方 API），并以 markdown 图片写进当前 PR 描述（少评论原则，不贴评论）。
 
-**何时调用**：用户要求「贴图到 PR / 上传截图 / e2e 截图评论」，或需要把
-测试证据/图片展示到 PR 评论时。
+**何时调用**：用户要求「贴图到 PR / 上传截图 / e2e 截图」，或需要把
+测试证据/图片展示到 PR 时（写进描述，不发评论）。
 
 **快速使用**：
 
@@ -464,11 +478,11 @@ MIQI_E2E_POST_IMG=1 npx playwright test --config=playwright.config.ts \
 
 # 手动上传一张图（无 shell 依赖的完整实现见 reference）
 # 用 release assets API：复用/创建 _gh-imgup 预发布 → 上传 → 取
-# browser_download_url → 以 ![](url) 评论到 PR
+# browser_download_url → 以 ![](url) 写进 PR 描述（gh pr edit）
 ```
 
 - 完整机制、环境变量、代码接入模式、清理注意：见
   [references/e2e-pr-image-posting.md](references/e2e-pr-image-posting.md)
 - 关键约定：用 **published 预发布**（draft 资产的下载 URL 对匿名 404 会裂图）；
   固定 tag 复用（Releases 列表只多一条）；文件名内容 hash 去重
-- 预发布 `_gh-imgup` **不要删除**（历史评论图片会全部裂掉）
+- 预发布 `_gh-imgup` **不要删除**（历史图片引用会全部裂掉）

--- a/skills/github-workflow/references/e2e-pr-image-posting.md
+++ b/skills/github-workflow/references/e2e-pr-image-posting.md
@@ -1,13 +1,15 @@
-# E2E 截图自动贴到 PR 评论
+# E2E 截图自动贴到 PR 描述
 
 > **给 AI 会话的说明**：本文档描述的能力（`postScreenshotToPr`）可以被任何测试或脚本
 > 主动调用。阅读「何时调用」与「如何在 spec 中接入」后即可使用，无需询问用户。
+> **少评论原则**：AI 手动贴图时把图片写进 PR 描述，不发评论；现有 CI 自动化
+> `postScreenshotToPr` 仍是发评论（若需统一为写描述，需改 helper 实现）。
 
 ## 功能
 
 e2e 测试跑完后，把截图上传到本仓库的固定预发布（release assets 官方 API），
-并以 markdown 图片形式评论到当前 PR。评审者打开 PR 即可看到测试证据，
-无需自己跑测试。
+并以 markdown 图片形式展示到 PR（AI 手动操作为写进 PR 描述，不贴评论）。
+评审者打开 PR 即可看到测试证据，无需自己跑测试。
 
 - 通过：贴成功截图（`✅ E2E 通过：<测试名>`）
 - 失败：贴 Playwright 自动捕获的 `test-failed-1.png`（`❌ E2E 失败：<测试名>`）
@@ -20,13 +22,13 @@ e2e 测试跑完后，把截图上传到本仓库的固定预发布（release as
 | 上传 API | release assets（官方公开 API，token 即可；实测匿名可访问 HTTP 200） |
 | 去重 | 文件名 = `原名-<sha256前8位>.<ext>`；相同内容重复上传返回 422 时自动复用已有资产 |
 | 实现 | 纯 Node `fetch`（无 shell 依赖），见 [tests/e2e/helpers/pr-image-post.ts](../../apps/desktop/tests/e2e/helpers/pr-image-post.ts) |
-| 为何不用 draft release | draft 资产的下载 URL 对外（甚至带 token）都返回 404，评论里会裂图——必须 published 预发布 |
+| 为何不用 draft release | draft 资产的下载 URL 对外（甚至带 token）都返回 404，PR 里会裂图——必须 published 预发布 |
 | 为何不用 user-attachments | 原生贴图端点无公开 API，需驱动真实浏览器且有 TOS 风险（actions-cool/issues-helper 已被封） |
 
 ## 何时调用（给 AI 的决策规则）
 
 1. **跑过 e2e 且希望证据出现在 PR 里** → 设置 `MIQI_E2E_POST_IMG=1` 跑测试，其余自动完成
-2. **手动上传一张图片到评论** → 调用 `uploadImage` 等价逻辑（见下方命令）
+2. **手动上传一张图片** → 调用 `uploadImage` 等价逻辑上传，然后把 `![](url)` 写进 PR 描述（见下方命令），不贴评论
 3. **CI 环境** → 默认已开启（`process.env.CI` 为真），无需额外操作
 4. **无 PR 上下文**（如 develop 分支裸跑）→ 自动静默跳过，无需处理
 
@@ -36,7 +38,7 @@ e2e 测试跑完后，把截图上传到本仓库的固定预发布（release as
 |---|---|---|
 | `MIQI_E2E_POST_IMG` | CI=1 / 本地=0 | 强制开启（`1`）或关闭（`0`）贴图 |
 | `MIQI_IMG_REPO` | `14790897/MiQi` | 目标仓库（fork 测试时覆盖） |
-| `GH_TOKEN` / `GITHUB_TOKEN` | 无 | 上传与评论的鉴权；本地可回退到 `gh auth token` |
+| `GH_TOKEN` / `GITHUB_TOKEN` | 无 | 上传与写描述的鉴权；本地可回退到 `gh auth token` |
 
 ## 如何在 spec 中接入（给 AI 的代码模式）
 
@@ -83,12 +85,12 @@ gh api repos/14790897/MiQi/releases/tags/_gh-imgup --jq '.id' 2>/dev/null ||
     -F tag_name='_gh-imgup' -F name='_gh-imgup' -F prerelease=true \
     -f body='Image assets - do not delete' --jq '.id'
 # 再用 release assets 上传接口（uploads.github.com）传文件，
-# 取 browser_download_url 后以 `![img](url)` 评论到 PR。
+# 取 browser_download_url 后以 `![img](url)` 写进 PR 描述（gh pr edit 更新 body），不发评论。
 # 完整 Node 实现见 pr-image-post.ts 的 uploadImage()。
 ```
 
 ## 清理与注意
 
-- 预发布 `_gh-imgup` **不要删除**（评论里的历史图片会全部裂掉）；body 已写 "do not delete"
+- 预发布 `_gh-imgup` **不要删除**（历史图片引用会全部裂掉）；body 已写 "do not delete"
 - 公开仓库的 release asset 任何人可访问；私有仓库仅成员可见
 - 上传失败（无 token / 无 PR / 图片不存在）一律静默跳过，不干扰测试结果


### PR DESCRIPTION
## 类型

- [x] 📝 文档

## 变更概述

github-workflow 技能改为「尽量少评论，直接更新 PR 描述」的沟通原则。

## 背景/问题

此前技能指导把 E2E 截图、测试证据等以评论形式贴到 PR，导致 PR 评论区消息过多、噪声大。改为默认把结果、证据、进展直接写进 PR 描述，仅在 GitHub 机制要求时（CodeRabbit 触发 re-review、回复 reviewer 的具体评论、dismiss）才发评论。

## 变更内容

- skills/github-workflow/SKILL.md：新增「PR 沟通原则：少评论，直接更新 PR 描述」章节作为默认行为；两处 E2E 截图章节从「贴到 PR 评论」改为「贴到 PR 描述」（上传 _gh-imgup 机制不变，最后一步由发评论改为更新 PR body）；CodeRabbit 处理章节补充「修复进展写进 PR 描述，不逐条回复评论」
- skills/github-workflow/references/e2e-pr-image-posting.md：同步改为写进 PR 描述的决策规则与手动上传流程，并注明 CI 自动贴图 helper postScreenshotToPr 仍为发评论（如需统一需改 helper）

## 日志/验证证据

```
git diff --stat
 skills/github-workflow/SKILL.md                    | 40 +++++++++++++++-------
 .../references/e2e-pr-image-posting.md             | 18 +++++-----
 2 files changed, 37 insertions(+), 21 deletions(-)
```

## 测试情况

- 纯技能文档变更，无代码逻辑改动
- 无需跑测试；CI 校验由 PR template check + title check 触发