### PR TITLE
fix(bridge): loguru 日志 % 占位符修复 + reasoning 流式日志降噪

### DIFF
--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1231,6 +1231,8 @@ class BridgeRuntimeLoop:
             return True
 
         heartbeat_task: asyncio.Task | None = None
+        reasoning_chunks = 0
+        reasoning_chars = 0
 
         try:
             from dataclasses import asdict, is_dataclass
@@ -1373,10 +1375,13 @@ class BridgeRuntimeLoop:
                 # streaming thinking block (DeepSeek-R1 / Kimi thinking
                 # models). Issue #539.
                 if isinstance(event, AgentReasoningEvent):
-                    logger.info(
-                        "forwarding reasoning_delta (len={}) for turn={}",
-                        len(event.content), event.turn_id,
-                    )
+                    reasoning_chunks += 1
+                    reasoning_chars += len(event.content)
+                    if reasoning_chunks % 10 == 0:
+                        logger.info(
+                            "forwarding reasoning_delta #{} (len={}) for turn={}",
+                            reasoning_chunks, len(event.content), event.turn_id,
+                        )
                     await _emit("progress", {
                         "stream": "reasoning",
                         "delta": event.content,
@@ -1449,6 +1454,12 @@ class BridgeRuntimeLoop:
             })
         finally:
             # Stop the heartbeat — the turn is done (or the drain died).
+            if reasoning_chunks:
+                logger.info(
+                    "chat.send drain done: forwarded {} reasoning chunks "
+                    "({} chars) for session={}",
+                    reasoning_chunks, reasoning_chars, session_id,
+                )
             if heartbeat_task is not None:
                 heartbeat_task.cancel()
             # Unwire THIS session's user-input emitter and thread mapping so

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -945,7 +945,7 @@ class BridgeRuntimeLoop:
                 try:
                     raw = _b64.b64decode(data_b64)
                 except Exception as exc:
-                    logger.warning("chat.send: base64 decode failed for %s: %s", name, exc)
+                    logger.warning("chat.send: base64 decode failed for {}: {}", name, exc)
                     return None
 
                 safe_name = _re.sub(r'[<>:"/\\\\|?*]', '_', name)
@@ -976,7 +976,7 @@ class BridgeRuntimeLoop:
                         )
                         return (name, text)
                 except Exception as exc:
-                    logger.warning("chat.send: parse failed for %s: %s", name, exc)
+                    logger.warning("chat.send: parse failed for {}: {}", name, exc)
                 return (name, "")
 
             tasks = [_decode_and_parse(att) for att in attachments_raw]

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -111,25 +111,25 @@ def _normalize_tool_args(
                 if "file_path" not in kwargs:
                     kwargs["file_path"] = kwargs.pop(alias)
                     logger.debug(
-                        "Tool %s: normalised arg %r → %r", tool_name, alias, "file_path",
+                        "Tool {}: normalised arg {!r} → {!r}", tool_name, alias, "file_path",
                     )
                 else:
                     dropped = kwargs.pop(alias)
                     logger.debug(
-                        "Tool %s: dropped alias arg %r=%r (canonical %r already set)",
+                        "Tool {}: dropped alias arg {!r}={!r} (canonical {!r} already set)",
                         tool_name, alias, dropped, "file_path",
                     )
             continue
         if canonical not in kwargs:
             kwargs[canonical] = kwargs.pop(alias)
             logger.debug(
-                "Tool %s: normalised arg %r → %r", tool_name, alias, canonical,
+                "Tool {}: normalised arg {!r} → {!r}", tool_name, alias, canonical,
             )
         else:
             # Canonical already present — drop the alias to avoid ambiguity
             dropped = kwargs.pop(alias)
             logger.debug(
-                "Tool %s: dropped alias arg %r=%r (canonical %r already set)",
+                "Tool {}: dropped alias arg {!r}={!r} (canonical {!r} already set)",
                 tool_name, alias, dropped, canonical,
             )
     return kwargs
@@ -737,7 +737,7 @@ class ToolOrchestrator:
             _save_permanent_allowlist()
         except Exception as exc:
             logger.warning(
-                "Failed to sync permanent approval to global allowlist: %s", exc,
+                "Failed to sync permanent approval to global allowlist: {}", exc,
             )
 
     def _record_session_approval(self, meta: dict[str, Any]) -> None:

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -114,10 +114,10 @@ def _normalize_tool_args(
                         "Tool {}: normalised arg {!r} → {!r}", tool_name, alias, "file_path",
                     )
                 else:
-                    dropped = kwargs.pop(alias)
+                    kwargs.pop(alias)
                     logger.debug(
-                        "Tool {}: dropped alias arg {!r}={!r} (canonical {!r} already set)",
-                        tool_name, alias, dropped, "file_path",
+                        "Tool {}: dropped alias arg {!r} (canonical {!r} already set)",
+                        tool_name, alias, "file_path",
                     )
             continue
         if canonical not in kwargs:
@@ -127,10 +127,10 @@ def _normalize_tool_args(
             )
         else:
             # Canonical already present — drop the alias to avoid ambiguity
-            dropped = kwargs.pop(alias)
+            kwargs.pop(alias)
             logger.debug(
-                "Tool {}: dropped alias arg {!r}={!r} (canonical {!r} already set)",
-                tool_name, alias, dropped, canonical,
+                "Tool {}: dropped alias arg {!r} (canonical {!r} already set)",
+                tool_name, alias, canonical,
             )
     return kwargs
 

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -440,6 +440,7 @@ class OpenAIProvider(LLMProvider):
 
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
+        reasoning_chunks = 0
         # Accumulate tool calls incrementally (OpenAI sends index + fragments)
         tool_call_accum: dict[int, dict[str, Any]] = {}
         finish_reason: str | None = None
@@ -516,10 +517,12 @@ class OpenAIProvider(LLMProvider):
             reasoning_text = getattr(delta, "reasoning_content", None) or ""
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
-                logger.info(
-                    "stream_chat: got reasoning delta len={} for model={}",
-                    len(reasoning_text), resolved,
-                )
+                reasoning_chunks += 1
+                if reasoning_chunks % 10 == 0:
+                    logger.info(
+                        "stream_chat: got reasoning delta #{} len={} for model={}",
+                        reasoning_chunks, len(reasoning_text), resolved,
+                    )
                 yield LLMStreamEvent(kind="reasoning_delta", delta=reasoning_text)
 
             # Tool calls — incremental accumulation
@@ -547,6 +550,11 @@ class OpenAIProvider(LLMProvider):
         # Build final response
         full_content = "".join(content_parts) or None
         full_reasoning = "".join(reasoning_parts) or None
+        if reasoning_parts:
+            logger.info(
+                "stream_chat: reasoning complete chunks={} chars={} for model={}",
+                reasoning_chunks, len(full_reasoning or ""), resolved,
+            )
 
         # Parse accumulated tool calls
         parsed_tool_calls: list[ToolCallRequest] = []

--- a/miqi/providers/openai_provider.py
+++ b/miqi/providers/openai_provider.py
@@ -313,7 +313,7 @@ class OpenAIProvider(LLMProvider):
         reasoning_content = getattr(message, "reasoning_content", None) or None
         if reasoning_content:
             logger.info(
-                "chat: got reasoning len=%d",
+                "chat: got reasoning len={}",
                 len(reasoning_content),
             )
         else:
@@ -456,7 +456,7 @@ class OpenAIProvider(LLMProvider):
                 break
             except asyncio.TimeoutError:
                 if is_first:
-                    logger.warning("LLM first-token timeout for model %s (%.0fs)", resolved, timeout)
+                    logger.warning("LLM first-token timeout for model {} ({:.0f}s)", resolved, timeout)
                     yield LLMStreamEvent(
                         kind="completed",
                         response=LLMResponse(
@@ -466,7 +466,7 @@ class OpenAIProvider(LLMProvider):
                         ),
                     )
                 else:
-                    logger.warning("LLM stream idle timeout for model %s", resolved)
+                    logger.warning("LLM stream idle timeout for model {}", resolved)
                     yield LLMStreamEvent(
                         kind="completed",
                         response=LLMResponse(
@@ -477,7 +477,7 @@ class OpenAIProvider(LLMProvider):
                     )
                 return
             except Exception as e:
-                logger.exception("LLM streaming error for model %s", resolved)
+                logger.exception("LLM streaming error for model {}", resolved)
                 kind = resilience.classify_error(e)
                 yield LLMStreamEvent(
                     kind="completed",
@@ -517,7 +517,7 @@ class OpenAIProvider(LLMProvider):
             if reasoning_text:
                 reasoning_parts.append(reasoning_text)
                 logger.info(
-                    "stream_chat: got reasoning delta len=%d for model=%s",
+                    "stream_chat: got reasoning delta len={} for model={}",
                     len(reasoning_text), resolved,
                 )
                 yield LLMStreamEvent(kind="reasoning_delta", delta=reasoning_text)

--- a/miqi/runtime/history_runtime.py
+++ b/miqi/runtime/history_runtime.py
@@ -224,7 +224,7 @@ class HistoryRuntime:
             tools_used = json.loads(row["tools_used_json"])
         except (json.JSONDecodeError, TypeError) as exc:
             logger.warning(
-                "Corrupted tools_used_json for turn %s, degrading to []: %s",
+                "Corrupted tools_used_json for turn {}, degrading to []: {}",
                 turn_id, exc,
             )
             tools_used = []
@@ -234,7 +234,7 @@ class HistoryRuntime:
             token_usage = json.loads(row["token_usage_json"])
         except (json.JSONDecodeError, TypeError) as exc:
             logger.warning(
-                "Corrupted token_usage_json for turn %s, degrading to {}: %s",
+                "Corrupted token_usage_json for turn {}, degrading to {{}}: {}",
                 turn_id, exc,
             )
             token_usage = {}
@@ -311,7 +311,7 @@ class HistoryRuntime:
                 payload = json.loads(row["payload_json"])
             except (json.JSONDecodeError, TypeError) as exc:
                 logger.warning(
-                    "Skipping corrupted payload_json for item %s in thread %s: %s",
+                    "Skipping corrupted payload_json for item {} in thread {}: {}",
                     row["item_id"], thread_id, exc,
                 )
                 payload = {}

--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -538,7 +538,7 @@ class RuntimeSession:
                             pass
                         except Exception:
                             _session_logger.exception(
-                                "RuntimeSession: unhandled exception in auxiliary task %s",
+                                "RuntimeSession: unhandled exception in auxiliary task {}",
                                 d.get_name() if hasattr(d, "get_name") else "?",
                             )
                             from miqi.protocol.events import ErrorEvent as _ErrEvt2

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -165,7 +165,7 @@ async def _load_interrupted_turns(
             finally:
                 await hr.close()
     except Exception as exc:
-        logger.warning("interrupted-turn lookup failed for %s: %s", sid, exc)
+        logger.warning("interrupted-turn lookup failed for {}: {}", sid, exc)
     return []
 
 
@@ -220,7 +220,7 @@ async def sessions_get_handler(
         else:
             raise AppServerError(exc.args[0], code=exc.code) from exc
     except Exception as exc:
-        logger.warning("Failed to load session %s: %s", session_key, exc)
+        logger.warning("Failed to load session {}: {}", session_key, exc)
         raise AppServerError("Failed to get session", code="INTERNAL") from exc
 
     ws_result = metadata.get("workspace")

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -350,6 +350,7 @@ class TurnRunner:
             response: Any = None
             content_parts: list[str] = []
             reasoning_parts: list[str] = []
+            reasoning_chunks = 0
             async for stream_event in self._provider.stream_chat(
                 messages=messages,
                 tools=tools,
@@ -398,15 +399,17 @@ class TurnRunner:
                             (time.perf_counter() - _turn_started) * 1000, turn.turn_id,
                         )
                     reasoning_parts.append(stream_event.delta)
+                    reasoning_chunks += 1
                     if snapshot_buffer is not None:
                         snapshot_buffer.reasoning.append(stream_event.delta)
                         if snapshot_buffer.due(self._history):
                             await snapshot_buffer.flush(self._history, turn, status="running")
                     from miqi.protocol.events import AgentReasoningEvent
-                    logger.info(
-                        "turn_runner: got reasoning_delta len={} for turn={}",
-                        len(stream_event.delta), turn.turn_id,
-                    )
+                    if reasoning_chunks % 10 == 0:
+                        logger.info(
+                            "turn_runner: got reasoning_delta #{} len={} for turn={}",
+                            reasoning_chunks, len(stream_event.delta), turn.turn_id,
+                        )
                     await self._events.emit(AgentReasoningEvent(
                         turn_id=turn.turn_id,
                         content=stream_event.delta,
@@ -421,6 +424,12 @@ class TurnRunner:
                         )
                 elif stream_event.kind == "completed":
                     response = stream_event.response
+
+            if reasoning_parts:
+                logger.info(
+                    "turn_runner: reasoning complete chunks={} chars={} for turn={}",
+                    reasoning_chunks, len("".join(reasoning_parts)), turn.turn_id,
+                )
 
             # Safety net: if the stream never yielded a completed event,
             # synthesize one from the accumulated content parts.

--- a/miqi/runtime/workbench_process_runtime.py
+++ b/miqi/runtime/workbench_process_runtime.py
@@ -557,7 +557,7 @@ class WorkbenchProcessRuntime:
                     except Exception:
                         logger.exception(
                             "WorkbenchProcessRuntime: on_exit callback failed "
-                            "for handle %s", handle_id,
+                            "for handle {}", handle_id,
                         )
             finally:
                 async with self._lock:
@@ -625,7 +625,7 @@ class WorkbenchProcessRuntime:
                                 except Exception:
                                     logger.exception(
                                         "WorkbenchProcessRuntime: on_chunk failed "
-                                        "for handle %s", handle.handle_id,
+                                        "for handle {}", handle.handle_id,
                                     )
                         else:
                             # Buffer already exactly at cap — emit an
@@ -642,7 +642,7 @@ class WorkbenchProcessRuntime:
                                 except Exception:
                                     logger.exception(
                                         "WorkbenchProcessRuntime: on_chunk failed "
-                                        "for handle %s", handle.handle_id,
+                                        "for handle {}", handle.handle_id,
                                     )
                         continue
                     # Chunk fits entirely — emit normally
@@ -657,13 +657,13 @@ class WorkbenchProcessRuntime:
                         except Exception:
                             logger.exception(
                                 "WorkbenchProcessRuntime: on_chunk failed "
-                                "for handle %s", handle.handle_id,
+                                "for handle {}", handle.handle_id,
                             )
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.exception(
-                    "WorkbenchProcessRuntime: error reading %s for handle %s",
+                    "WorkbenchProcessRuntime: error reading {} for handle {}",
                     stream_name, handle.handle_id,
                 )
             return cap_reached
@@ -685,7 +685,7 @@ class WorkbenchProcessRuntime:
                     await asyncio.sleep(timeout_ms / 1000.0)
                     if proc.returncode is None:
                         logger.warning(
-                            "WorkbenchProcessRuntime: timeout %dms reached for %s, killing",
+                            "WorkbenchProcessRuntime: timeout {}ms reached for {}, killing",
                             timeout_ms, handle.handle_id,
                         )
                         handle.termination_reason = "timeout"
@@ -783,7 +783,7 @@ class WorkbenchProcessRuntime:
             pass
         except Exception:
             logger.exception(
-                "WorkbenchProcessRuntime: error killing process pid=%s",
+                "WorkbenchProcessRuntime: error killing process pid={}",
                 proc.pid,
             )
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [x] ♻️ 重构

## 变更概述

1. 修复 loguru 日志调用误用 printf 风格占位符（%d/%s/%r）导致参数不生效、占位符原样输出的问题，统一改为 loguru 的 {} 风格。
2. reasoning 流式日志降噪：delta 级日志从「每块一条」改为「每 10 块采样」，流结束时输出总长度汇总。

## 背景/问题

**占位符问题**：loguru 使用 str.format 风格的 {} 占位符，不认识 %d/%s/%r。代码中 7 个文件共 25 处日志调用误用 printf 风格：

- 传入的格式化参数被静默丢弃（str.format 忽略多余参数），日志拿不到实际值
- 占位符原样出现在日志中，例如 `stream_chat: got reasoning delta len=%d for model=%s`
- history_runtime.py 中 `degrading to {}` 的字面大括号会被 loguru 当作占位符，吞掉第一个参数 turn_id

**日志噪声**：deepseek/kimi 把 thinking 内容切成 1-3 字符的小块流式下发（一次对话 24-29 块），provider → turn_runner → bridge 三层组件对每个 delta 各打一行 INFO，一次对话产生 ~72 行几乎重复的日志。改为每 10 块采样一次，流结束时各层输出一条汇总（chunks 数 + 总字符数），噪声降低约 7 倍，且排障时仍能定位「模型没给 reasoning / turn 层丢块 / 转发断流」。

## 变更内容

| 文件 | 处数 | 说明 |
|------|------|------|
| miqi/providers/openai_provider.py | 5 | reasoning len、first-token timeout（%.0f→{:.0f}）、idle timeout、streaming error、reasoning delta；流结束输出 `reasoning complete chunks=N chars=M` |
| miqi/execution/orchestrator.py | 5 | alias 归一化 debug 日志（%r→{!r} 保留 repr 语义）、allowlist 同步告警；dropped-alias 日志不输出参数值（CodeRabbit：cmd 可能含凭据） |
| miqi/bridge/loop.py | 2 | chat.send 附件 base64 解码/解析失败告警；drain 结束时输出 `forwarded N reasoning chunks (M chars)` 汇总 |
| miqi/runtime/history_runtime.py | 3 | 损坏 JSON 降级告警；token_usage 消息中字面 {} 转义为 {{}} |
| miqi/runtime/session.py | 1 | auxiliary task 未处理异常日志 |
| miqi/runtime/session_handlers.py | 2 | interrupted-turn 查询、session 加载失败告警 |
| miqi/runtime/workbench_process_runtime.py | 7 | on_exit/on_chunk 回调失败、流读取错误、超时杀进程、kill 失败 |
| miqi/runtime/turn_runner.py | 3 | reasoning delta 采样 + 完成汇总 |

使用 stdlib logging 的文件（command_approval.py、search_orchestrator.py、otel.py）保持 % 风格不变——那是 logging 模块的正确用法。

## 日志/验证证据

```
修复前：
[bridge] miqi.providers.openai_provider:stream_chat:519 | stream_chat: got reasoning delta len=%d for model=%s
（每块 delta 一条，一次对话 24 块 × 3 层 = 72 行）

修复后（本地 E2E 实机运行 deepseek-v4-flash，29 个 chunk）：
stream_chat: got reasoning delta #10 len=2 for model=deepseek-v4-flash
turn_runner: got reasoning_delta #10 len=2 for turn=afece5af-970
forwarding reasoning_delta #10 (len=2) for turn=afece5af-970
stream_chat: got reasoning delta #20 len=2 for model=deepseek-v4-flash
turn_runner: got reasoning_delta #20 len=2 for turn=afece5af-970
forwarding reasoning_delta #20 (len=2) for turn=afece5af-970
stream_chat: reasoning complete chunks=29 chars=47 for model=deepseek-v4-flash
turn_runner: reasoning complete chunks=29 chars=47 for turn=afece5af-970
chat.send drain done: forwarded 29 reasoning chunks (47 chars) for session=miqi-desktop:desktop:default
```

## 测试情况

- python -m py_compile 对全部修改文件通过
- 全仓库扫描确认 loguru 日志调用中不再存在 % 风格占位符（stdlib logging 文件除外）
- 使用真实 loguru 渲染修复后的消息模板，占位符替换与 {{}} 转义均正确
- 本地 E2E（reasoning-mode.spec.ts fast-mode send，真实 LLM deepseek-v4-flash）通过：采样与汇总日志符合预期，前端流式渲染正常

## 截图

本次为日志修复与降噪，无界面变更，无需截图。
