### PR TITLE
fix(chat): 会话加载中发送的消息立即渲染 + regression-480 测试加固 (#872)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -126,7 +126,9 @@ jobs:
       group: wsl-e2e-${{ github.ref }}
       cancel-in-progress: true
     runs-on: windows-latest
-    timeout-minutes: 30
+    # 冷 runner 预算：one-click-install(15) + WSL 回退安装 + 清理 + 沙箱 E2E(20)
+    # ——30 分钟连续多次被砍（#891/#875 CI 实测），放宽到 45
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: apps/desktop
@@ -200,10 +202,16 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_API_BASE: ${{ secrets.DEEPSEEK_API_BASE }}
-        timeout-minutes: 10
+        # 冷 runner 上 MiQroForge 自动装 WSL 依赖（apt 等）可能超过 10 分钟
+        # （#891 CI 实测：连续四次卡 10 分钟上限/超时被砍）——放宽到 15 分钟
+        timeout-minutes: 15
 
       # ── Fallback: ensure WSL + sandbox distro ready ──────────────
+      # if: always()：one-click-install 步骤失败（冷 runner 超时）不能跳过
+      # WSL 准备——否则沙箱 E2E 在无 WSL 状态下硬跑（#891 CI 实测修正，
+      # 与 #875 4b4672b 同一修复）
       - name: Install WSL Ubuntu distro (fallback)
+        if: always()
         shell: pwsh
         run: |
           Write-Host "Installing WSL Ubuntu..."
@@ -215,6 +223,7 @@ jobs:
           wsl -l -v
 
       - name: Clean sandbox state (force auto-export)
+        if: always()
         shell: pwsh
         run: |
           Write-Host "Removing bubblewrap from Ubuntu..."

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1334,10 +1334,13 @@ export function insertInterruptedTurns(merged: Message[], interruptedTurns: any[
   return out;
 }
 
-// #891 P3-1: 判定 messagesRef 里的用户消息是否是 merged 中某条持久化副本
-// 的"前端孪生"。二者内容相同且时间戳相近（同一机器时钟：前端乐观气泡是
-// Date.now()，后端副本由 sessionMsgsToUi 转为 epoch ms，同一次发送的收发
-// 时间差在秒级）——时间差大（≥30s）则视为跨轮重复发送的旧文本，不应误去重。
+// #891 深度审阅：messagesRef 里的用户消息是否已在 merged 中存在持久化副本。
+// 判定 = merged 中存在【任一条】同内容用户消息且时间戳相近（同一机器时钟：
+// 前端乐观气泡 Date.now()，后端副本经 sessionMsgsToUi 转 epoch ms，同一次
+// 发送的收发时间差秒级）。任一条命中即视为已持久化——保留块运行在完整
+// 恢复快照之上，若只对比 merged 最后一条会把旧历史行（内容不同）误判为
+// in-flight 而整段重复渲染。时间差大（≥30s）的旧文本副本不算命中——
+// 跨轮重复发送的相同文本不会被误判为已持久化。
 const _PERSISTED_COPY_TS_TOLERANCE_MS = 30_000;
 
 function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | undefined): boolean {
@@ -1350,6 +1353,16 @@ function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | und
     return false; // 无可靠时间戳 → 保守：不判为已持久化副本（保留前端气泡）
   }
   return Math.abs(copyTs - frontendTs) < _PERSISTED_COPY_TS_TOLERANCE_MS;
+}
+
+// 统一谓词（删 flag 门控与保留块共用——#891 深度审阅 #11：两处手写导致漂移）。
+function _hasPersistedUserCopyIn(m: Message, merged: Message[]): boolean {
+  return merged.some(
+    (pm) =>
+      pm.role === 'user' &&
+      String(pm.content) === String(m.content) &&
+      _isPersistedCopyOf(m.timestamp, pm.timestamp)
+  );
 }
 
 export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
@@ -3158,28 +3171,22 @@ export function ChatConsole({
         // mark the session so the old send listener's live onFinal doesn't
         // append a duplicate when it fires for the same reply.
         if (cached && cached.events.some((e) => e.type === 'final')) {
-          finalHandledSessions.add(sessionKey);
-          // Audit #3: the cached-final path never runs the live cleanup —
-          // clear the streaming flag here so the stop button disappears and
-          // the 60s watchdog can't re-arm over a completed turn.  BUT a new
-          // send can start during this load window (switch-away/back then
-          // send), whose optimistic bubble + marker belong to the NEW turn —
-          // deleting the flag would skip the in-flight-preservation block
-          // below and wipe the new bubble (#872).  Only clear the flag when
-          // every user message in `messagesRef` is already persisted.  The
-          // "already persisted" test mirrors the preservation block's
-          // predicate (LAST merged user + content + time proximity, #891
-          // P3-2) — an OLD identical message in history must not make a new
-          // in-flight bubble look persisted.
-          const _lastMergedUserAll = [...merged].reverse().find((pm) => pm.role === 'user');
-          const _newInflightUser = messagesRef.current.some((m) => {
-            if (m.role !== 'user') return false;
-            if (!_lastMergedUserAll || String(_lastMergedUserAll.content) !== String(m.content)) {
-              return true;
-            }
-            return !_isPersistedCopyOf(m.timestamp, _lastMergedUserAll.timestamp);
-          });
-          if (!_newInflightUser) streamingBySession.delete(sessionKey);
+          // #891 深度审阅 #3：add 与 delete 必须同一守卫——load 窗口内发了
+          // 新消息时，不能重新打上"final 已处理"标记（否则新回合的 live
+          // final 会被吞、回复不渲染）。
+          const _newInflightUser = messagesRef.current.some(
+            (m) => m.role === 'user' && !_hasPersistedUserCopyIn(m, merged)
+          );
+          if (!_newInflightUser) {
+            finalHandledSessions.add(sessionKey);
+            // Audit #3: the cached-final path never runs the live cleanup —
+            // clear the streaming flag here so the stop button disappears and
+            // the 60s watchdog can't re-arm over a completed turn.  Only clear
+            // the flag when every user message in `messagesRef` is already
+            // persisted (any-match + time proximity, #891 深度审阅 #1/#2 ——
+            // 快照恢复的旧历史行各自都有相近副本，不会被误判为 in-flight）。
+            streamingBySession.delete(sessionKey);
+          }
         }
         // If a cached final was merged, the FULL reply is already rendered in
         // `merged` — stop this session's typewriter so the revealNext RAF loop
@@ -3233,28 +3240,21 @@ export function ChatConsole({
         // that follows still lands after it.
         if (streamingBySession.has(sessionKey)) {
           // Dedup key: role + content, refined with time proximity for user
-          // messages (#891 P3-1).  A persisted copy of the SAME logical user
-          // message carries a backend timestamp within seconds of the
-          // frontend bubble (same machine clock, epoch ms after
-          // sessionMsgsToUi) — matching only on content would also swallow a
-          // NEW send whose text repeats an OLD persisted message.  Tool rows
-          // keep content-only dedup: their restored copies are also
-          // timestamped near the live rows, and a repeated tool hint within
-          // the tolerance is rarer than a repeated user text (#872).
-          // For user messages, only compare against the LAST persisted user
-          // message (the in-flight bubble sits right after the history tail),
-          // not the whole history — avoids false positives when the text
-          // repeats an OLD message (#872).
-          const _lastMergedUser = [...merged].reverse().find((pm) => pm.role === 'user');
+          // messages (#891 深度审阅)。持久化副本与前端气泡同属机器时钟
+          // （后端 ISO 经 sessionMsgsToUi 转 epoch ms），同一次发送的收发
+          // 时间差秒级。
+          // - 用户行：merged 中【任一条】同内容 + 时间相近即已持久化——
+          //   保留块运行在完整恢复快照上，只比最后一条会把旧历史行整段
+          //   重复渲染（审阅 #1）；时间相近限定保证跨轮重复的旧文本不被
+          //   误判（审阅 #5）。
+          // - error 行：不保留——错误横幅是 load 失败的瞬时 UI，成功的
+          //   retry load 应移除而非被永久嵌入历史（审阅 #8）。
+          // - thinking/tool 行：保持内容去重（部分更新导致的瞬时双副本为
+          //   已知限制，审阅 #4）。
           const _inFlight = messagesRef.current.filter((m) => {
-            if (m.role === 'assistant') return false;
+            if (m.role === 'assistant' || m.role === 'error') return false;
             if (m.role === 'user') {
-              // 内容相同还不够：持久化副本必须时间相近（同一次发送）——
-              // 跨轮重复的旧文本（时间差大）不算已持久化，保留前端气泡。
-              if (!_lastMergedUser || String(_lastMergedUser.content) !== String(m.content)) {
-                return true;
-              }
-              return !_isPersistedCopyOf(m.timestamp, _lastMergedUser.timestamp);
+              return !_hasPersistedUserCopyIn(m, merged);
             }
             return !merged.some(
               (pm) => pm.role === m.role && String(pm.content) === String(m.content)

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2851,8 +2851,9 @@ export function ChatConsole({
         // #872: don't erase in-flight content — a message sent while the bridge
         // was still down (with any thinking/tool rows already streamed) would
         // otherwise vanish.  Retain the full current-turn sequence ahead of the
-        // error banner; assistant content is excluded (it's replayed by the
-        // typewriter, and the persisted reply is merged by a later load()).
+        // error banner; assistant content is excluded (it's the half-typed
+        // reply, and with no backend to replay it it is dropped — but the user
+        // message and thinking/tool rows survive).
         const _errInFlight = streamingBySession.has(sessionKey)
           ? messagesRef.current.filter((m) => m.role !== 'assistant')
           : [];
@@ -3123,8 +3124,18 @@ export function ChatConsole({
           finalHandledSessions.add(sessionKey);
           // Audit #3: the cached-final path never runs the live cleanup —
           // clear the streaming flag here so the stop button disappears and
-          // the 60s watchdog can't re-arm over a completed turn.
-          streamingBySession.delete(sessionKey);
+          // the 60s watchdog can't re-arm over a completed turn.  BUT a new
+          // send can start during this load window (switch-away/back then
+          // send), whose optimistic bubble + marker belong to the NEW turn —
+          // deleting the flag would skip the in-flight-preservation block
+          // below and wipe the new bubble (#872).  Only clear the flag when
+          // every user message in `messagesRef` is already persisted.
+          const _newInflightUser = messagesRef.current.some(
+            (m) =>
+              m.role === 'user' &&
+              !merged.some((pm) => pm.role === 'user' && String(pm.content) === String(m.content))
+          );
+          if (!_newInflightUser) streamingBySession.delete(sessionKey);
         }
         // If a cached final was merged, the FULL reply is already rendered in
         // `merged` — stop this session's typewriter so the revealNext RAF loop
@@ -3177,20 +3188,17 @@ export function ChatConsole({
         // non-assistant message not yet in the persisted history so the stream
         // that follows still lands after it.
         if (streamingBySession.has(sessionKey)) {
-          // Dedup the optimistic user bubble by CONTENT (role + text), not
-          // timestamp: the frontend bubble is stamped Date.now() while the
-          // persisted copy from sessions.get() carries a backend timestamp, so
-          // a timestamp match would re-append an already-persisted user message
-          // and duplicate it.  Transient thinking/tool rows are never persisted,
-          // so they're deduped by timestamp instead.
+          // Dedup by CONTENT (role + text), not timestamp: the frontend
+          // optimistic bubble and streaming rows are stamped Date.now() while
+          // their persisted copies from sessions.get() carry backend timestamps.
+          // This applies to tool rows too — sessionMsgsToUi restores them as
+          // 'progress', so "transient rows are never persisted" does NOT hold
+          // and a timestamp match would duplicate them (#872).
           const _inFlight = messagesRef.current.filter((m) => {
             if (m.role === 'assistant') return false;
-            if (m.role === 'user') {
-              return !merged.some(
-                (pm) => pm.role === 'user' && String(pm.content) === String(m.content)
-              );
-            }
-            return !merged.some((pm) => pm.timestamp === m.timestamp);
+            return !merged.some(
+              (pm) => pm.role === m.role && String(pm.content) === String(m.content)
+            );
           });
           if (_inFlight.length > 0) merged.push(..._inFlight);
         }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2848,7 +2848,14 @@ export function ChatConsole({
         // for the blank empty state with no explanation.  Surface an explicit
         // error so the user knows the session failed to load.
         setHistoryLoaded(true);
+        // #872: don't erase an in-flight optimistic bubble — a message sent
+        // while the bridge was still down would otherwise vanish.  Preserve the
+        // not-yet-persisted user message ahead of the error banner.
+        const _errInFlightUsers = streamingBySession.has(sessionKey)
+          ? messagesRef.current.filter((m) => m.role === 'user').slice(-1)
+          : [];
         setMessages([
+          ..._errInFlightUsers,
           {
             role: 'error',
             content: '会话加载失败：无法连接后台服务，请稍后重试或重启应用。',
@@ -3159,6 +3166,22 @@ export function ChatConsole({
           merged,
           Array.isArray(_interruptedTurns) ? _interruptedTurns : []
         );
+        // #872: preserve an in-flight optimistic user bubble across load()'s
+        // overwrite.  With the render gate relaxed, a message sent while the
+        // session is still loading is now VISIBLE — but `merged` is built from
+        // persisted history only, so `setMessages(merged)` would erase it and
+        // leave the reply with no question.  Re-append any user message that
+        // isn't yet in the persisted history (the optimistic bubble) so the
+        // streaming reply that follows still lands after it.
+        if (streamingBySession.has(sessionKey)) {
+          const _persistedUserTs = new Set(
+            merged.filter((m) => m.role === 'user').map((m) => m.timestamp)
+          );
+          const _inFlightUsers = messagesRef.current.filter(
+            (m) => m.role === 'user' && !_persistedUserTs.has(m.timestamp)
+          );
+          if (_inFlightUsers.length > 0) merged.push(..._inFlightUsers);
+        }
         setMessages(merged);
         // Snapshot is now reconciled into `merged` — clear it so a later
         // load() (loadTrigger refresh) doesn't re-append stale transient

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1334,6 +1334,27 @@ export function insertInterruptedTurns(merged: Message[], interruptedTurns: any[
   return out;
 }
 
+// #891 P3-1: 判定 messagesRef 里的用户消息是否是 merged 中某条持久化副本
+// 的"前端孪生"。二者内容相同且时间戳相近（同一机器时钟：前端乐观气泡是
+// Date.now()，后端副本由 sessionMsgsToUi 转为 epoch ms，同一次发送的收发
+// 时间差在秒级）——时间差大（≥30s）则视为跨轮重复发送的旧文本，不应误去重。
+const _PERSISTED_COPY_TS_TOLERANCE_MS = 30_000;
+
+function _isPersistedCopyOf(
+  frontendTs: number | undefined,
+  copyTs: number | undefined
+): boolean {
+  if (
+    frontendTs === undefined ||
+    !Number.isFinite(frontendTs) ||
+    copyTs === undefined ||
+    !Number.isFinite(copyTs)
+  ) {
+    return false; // 无可靠时间戳 → 保守：不判为已持久化副本（保留前端气泡）
+  }
+  return Math.abs(copyTs - frontendTs) < _PERSISTED_COPY_TS_TOLERANCE_MS;
+}
+
 export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
   const result: Message[] = [];
   for (const m of collapseAssistantMessagesWithinTurns(rawMsgs)) {
@@ -3148,12 +3169,22 @@ export function ChatConsole({
           // send), whose optimistic bubble + marker belong to the NEW turn —
           // deleting the flag would skip the in-flight-preservation block
           // below and wipe the new bubble (#872).  Only clear the flag when
-          // every user message in `messagesRef` is already persisted.
-          const _newInflightUser = messagesRef.current.some(
-            (m) =>
-              m.role === 'user' &&
-              !merged.some((pm) => pm.role === 'user' && String(pm.content) === String(m.content))
-          );
+          // every user message in `messagesRef` is already persisted.  The
+          // "already persisted" test mirrors the preservation block's
+          // predicate (LAST merged user + content + time proximity, #891
+          // P3-2) — an OLD identical message in history must not make a new
+          // in-flight bubble look persisted.
+          const _lastMergedUserAll = [...merged].reverse().find((pm) => pm.role === 'user');
+          const _newInflightUser = messagesRef.current.some((m) => {
+            if (m.role !== 'user') return false;
+            if (
+              !_lastMergedUserAll ||
+              String(_lastMergedUserAll.content) !== String(m.content)
+            ) {
+              return true;
+            }
+            return !_isPersistedCopyOf(m.timestamp, _lastMergedUserAll.timestamp);
+          });
           if (!_newInflightUser) streamingBySession.delete(sessionKey);
         }
         // If a cached final was merged, the FULL reply is already rendered in
@@ -3207,12 +3238,15 @@ export function ChatConsole({
         // non-assistant message not yet in the persisted history so the stream
         // that follows still lands after it.
         if (streamingBySession.has(sessionKey)) {
-          // Dedup by CONTENT (role + text), not timestamp: the frontend
-          // optimistic bubble and streaming rows are stamped Date.now() while
-          // their persisted copies from sessions.get() carry backend timestamps.
-          // This applies to tool rows too — sessionMsgsToUi restores them as
-          // 'progress', so "transient rows are never persisted" does NOT hold
-          // and a timestamp match would duplicate them (#872).
+          // Dedup key: role + content, refined with time proximity for user
+          // messages (#891 P3-1).  A persisted copy of the SAME logical user
+          // message carries a backend timestamp within seconds of the
+          // frontend bubble (same machine clock, epoch ms after
+          // sessionMsgsToUi) — matching only on content would also swallow a
+          // NEW send whose text repeats an OLD persisted message.  Tool rows
+          // keep content-only dedup: their restored copies are also
+          // timestamped near the live rows, and a repeated tool hint within
+          // the tolerance is rarer than a repeated user text (#872).
           // For user messages, only compare against the LAST persisted user
           // message (the in-flight bubble sits right after the history tail),
           // not the whole history — avoids false positives when the text
@@ -3221,7 +3255,12 @@ export function ChatConsole({
           const _inFlight = messagesRef.current.filter((m) => {
             if (m.role === 'assistant') return false;
             if (m.role === 'user') {
-              return !(_lastMergedUser && String(_lastMergedUser.content) === String(m.content));
+              // 内容相同还不够：持久化副本必须时间相近（同一次发送）——
+              // 跨轮重复的旧文本（时间差大）不算已持久化，保留前端气泡。
+              if (!_lastMergedUser || String(_lastMergedUser.content) !== String(m.content)) {
+                return true;
+              }
+              return !_isPersistedCopyOf(m.timestamp, _lastMergedUser.timestamp);
             }
             return !merged.some(
               (pm) => pm.role === m.role && String(pm.content) === String(m.content)

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2851,11 +2851,30 @@ export function ChatConsole({
         // #872: don't erase in-flight content — a message sent while the bridge
         // was still down (with any thinking/tool rows already streamed) would
         // otherwise vanish.  Retain the full current-turn sequence ahead of the
-        // error banner; assistant content is excluded (it's the half-typed
-        // reply, and with no backend to replay it it is dropped — but the user
-        // message and thinking/tool rows survive).
+        // error banner.  Only the ACTIVE turn's assistant half-reply is dropped
+        // (no backend to replay it); earlier history — including prior turns'
+        // assistant replies — is kept unchanged (CodeRabbit #891).
         const _errInFlight = streamingBySession.has(sessionKey)
-          ? messagesRef.current.filter((m) => m.role !== 'assistant')
+          ? (() => {
+              const _msgs = messagesRef.current;
+              // Locate the last user message; anything before it is settled
+              // history and is preserved verbatim.
+              let _lastUserIdx = -1;
+              for (let _i = _msgs.length - 1; _i >= 0; _i -= 1) {
+                if (_msgs[_i].role === 'user') {
+                  _lastUserIdx = _i;
+                  break;
+                }
+              }
+              if (_lastUserIdx < 0) return _msgs; // no user yet — keep as-is
+              // Keep history up to & including the last user; drop assistant
+              // content after it (the half-typed reply of the active turn),
+              // but keep non-assistant rows after it (thinking/tool lines).
+              return [
+                ..._msgs.slice(0, _lastUserIdx + 1),
+                ..._msgs.slice(_lastUserIdx + 1).filter((m) => m.role !== 'assistant'),
+              ];
+            })()
           : [];
         setMessages([
           ..._errInFlight,

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1340,10 +1340,7 @@ export function insertInterruptedTurns(merged: Message[], interruptedTurns: any[
 // 时间差在秒级）——时间差大（≥30s）则视为跨轮重复发送的旧文本，不应误去重。
 const _PERSISTED_COPY_TS_TOLERANCE_MS = 30_000;
 
-function _isPersistedCopyOf(
-  frontendTs: number | undefined,
-  copyTs: number | undefined
-): boolean {
+function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | undefined): boolean {
   if (
     frontendTs === undefined ||
     !Number.isFinite(frontendTs) ||
@@ -3177,10 +3174,7 @@ export function ChatConsole({
           const _lastMergedUserAll = [...merged].reverse().find((pm) => pm.role === 'user');
           const _newInflightUser = messagesRef.current.some((m) => {
             if (m.role !== 'user') return false;
-            if (
-              !_lastMergedUserAll ||
-              String(_lastMergedUserAll.content) !== String(m.content)
-            ) {
+            if (!_lastMergedUserAll || String(_lastMergedUserAll.content) !== String(m.content)) {
               return true;
             }
             return !_isPersistedCopyOf(m.timestamp, _lastMergedUserAll.timestamp);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -5960,7 +5960,12 @@ export function ChatConsole({
             style={{ background: 'var(--background)' }}
           >
             <div className="max-w-[760px] mx-auto px-4 py-5 flex flex-col gap-2">
-              {!historyLoaded ? (
+              {/* Only show the "connecting" spinner while loading AND no messages
+                  yet.  A user can send before the session's load() finishes
+                  (historyLoaded false), and the optimistic bubble is already in
+                  `messages` — with the old `!historyLoaded` gate it was hidden
+                  behind the spinner until load() resolved (#872). */}
+              {!historyLoaded && messages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center min-h-[300px] gap-2.5">
                   <Loader2 size={16} className="animate-spin text-text-faint" />
                   <p className="text-xs text-text-faint">正在连接…</p>

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2848,14 +2848,16 @@ export function ChatConsole({
         // for the blank empty state with no explanation.  Surface an explicit
         // error so the user knows the session failed to load.
         setHistoryLoaded(true);
-        // #872: don't erase an in-flight optimistic bubble — a message sent
-        // while the bridge was still down would otherwise vanish.  Preserve the
-        // not-yet-persisted user message ahead of the error banner.
-        const _errInFlightUsers = streamingBySession.has(sessionKey)
-          ? messagesRef.current.filter((m) => m.role === 'user').slice(-1)
+        // #872: don't erase in-flight content — a message sent while the bridge
+        // was still down (with any thinking/tool rows already streamed) would
+        // otherwise vanish.  Retain the full current-turn sequence ahead of the
+        // error banner; assistant content is excluded (it's replayed by the
+        // typewriter, and the persisted reply is merged by a later load()).
+        const _errInFlight = streamingBySession.has(sessionKey)
+          ? messagesRef.current.filter((m) => m.role !== 'assistant')
           : [];
         setMessages([
-          ..._errInFlightUsers,
+          ..._errInFlight,
           {
             role: 'error',
             content: '会话加载失败：无法连接后台服务，请稍后重试或重启应用。',

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3166,21 +3166,20 @@ export function ChatConsole({
           merged,
           Array.isArray(_interruptedTurns) ? _interruptedTurns : []
         );
-        // #872: preserve an in-flight optimistic user bubble across load()'s
-        // overwrite.  With the render gate relaxed, a message sent while the
-        // session is still loading is now VISIBLE — but `merged` is built from
-        // persisted history only, so `setMessages(merged)` would erase it and
-        // leave the reply with no question.  Re-append any user message that
-        // isn't yet in the persisted history (the optimistic bubble) so the
-        // streaming reply that follows still lands after it.
+        // #872: preserve in-flight streaming content across load()'s overwrite.
+        // With the render gate relaxed, a message sent while the session is
+        // still loading is now VISIBLE — but `merged` is built from persisted
+        // history only, so `setMessages(merged)` would erase the optimistic user
+        // bubble AND any thinking/tool rows already streamed, leaving the reply
+        // with no question and the thinking half-rendered.  Re-append every
+        // non-assistant message not yet in the persisted history so the stream
+        // that follows still lands after it.
         if (streamingBySession.has(sessionKey)) {
-          const _persistedUserTs = new Set(
-            merged.filter((m) => m.role === 'user').map((m) => m.timestamp)
+          const _mergedTs = new Set(merged.map((m) => m.timestamp));
+          const _inFlight = messagesRef.current.filter(
+            (m) => m.role !== 'assistant' && !_mergedTs.has(m.timestamp)
           );
-          const _inFlightUsers = messagesRef.current.filter(
-            (m) => m.role === 'user' && !_persistedUserTs.has(m.timestamp)
-          );
-          if (_inFlightUsers.length > 0) merged.push(..._inFlightUsers);
+          if (_inFlight.length > 0) merged.push(..._inFlight);
         }
         setMessages(merged);
         // Snapshot is now reconciled into `merged` — clear it so a later

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3177,10 +3177,21 @@ export function ChatConsole({
         // non-assistant message not yet in the persisted history so the stream
         // that follows still lands after it.
         if (streamingBySession.has(sessionKey)) {
-          const _mergedTs = new Set(merged.map((m) => m.timestamp));
-          const _inFlight = messagesRef.current.filter(
-            (m) => m.role !== 'assistant' && !_mergedTs.has(m.timestamp)
-          );
+          // Dedup the optimistic user bubble by CONTENT (role + text), not
+          // timestamp: the frontend bubble is stamped Date.now() while the
+          // persisted copy from sessions.get() carries a backend timestamp, so
+          // a timestamp match would re-append an already-persisted user message
+          // and duplicate it.  Transient thinking/tool rows are never persisted,
+          // so they're deduped by timestamp instead.
+          const _inFlight = messagesRef.current.filter((m) => {
+            if (m.role === 'assistant') return false;
+            if (m.role === 'user') {
+              return !merged.some(
+                (pm) => pm.role === 'user' && String(pm.content) === String(m.content)
+              );
+            }
+            return !merged.some((pm) => pm.timestamp === m.timestamp);
+          });
           if (_inFlight.length > 0) merged.push(..._inFlight);
         }
         setMessages(merged);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3194,8 +3194,16 @@ export function ChatConsole({
           // This applies to tool rows too — sessionMsgsToUi restores them as
           // 'progress', so "transient rows are never persisted" does NOT hold
           // and a timestamp match would duplicate them (#872).
+          // For user messages, only compare against the LAST persisted user
+          // message (the in-flight bubble sits right after the history tail),
+          // not the whole history — avoids false positives when the text
+          // repeats an OLD message (#872).
+          const _lastMergedUser = [...merged].reverse().find((pm) => pm.role === 'user');
           const _inFlight = messagesRef.current.filter((m) => {
             if (m.role === 'assistant') return false;
+            if (m.role === 'user') {
+              return !(_lastMergedUser && String(_lastMergedUser.content) === String(m.content));
+            }
             return !merged.some(
               (pm) => pm.role === m.role && String(pm.content) === String(m.content)
             );

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -179,6 +179,18 @@ export function getSessionTitle(page: Page) {
   return page.locator('h2.font-semibold.truncate').first();
 }
 
+/** Locator for the user message bubble containing `text` (substring match).
+ *  Scoped to `[data-testid="chat-message-user"]` and visible-only — the session
+ *  title is auto-derived from the first user message, so the same marker text
+ *  also lives in the header's `chat-title`; and after a session switch the
+ *  previous session's hidden DOM can linger (#872). */
+export function userMessage(page: Page, text: string) {
+  return page
+    .locator('[data-testid="chat-message-user"]')
+    .filter({ hasText: text, visible: true })
+    .first();
+}
+
 /** Get sidebar session items (clickable buttons that switch sessions).
  *  Scoped to the sidebar panel to avoid picking up buttons in main content.
  *  New UI: session cards use rounded-xl; filter tabs (rounded-md) and the

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -180,10 +180,11 @@ export function getSessionTitle(page: Page) {
 }
 
 /** Locator for the user message bubble containing `text` (substring match).
- *  Scoped to `[data-testid="chat-message-user"]` and visible-only — the session
- *  title is auto-derived from the first user message, so the same marker text
- *  also lives in the header's `chat-title`; and after a session switch the
- *  previous session's hidden DOM can linger (#872). */
+ *  Scoped to `[data-testid="chat-message-user"]` (not `main`) and visible-only:
+ *  the session title is auto-derived from the first user message, so the same
+ *  marker text also lives in the header's `chat-title`, which a `main`-scoped
+ *  `.first()` would hit before the message list.  The `visible: true` filter is
+ *  a defensive guard against stale/hidden nodes (#872). */
 export function userMessage(page: Page, text: string) {
   return page
     .locator('[data-testid="chat-message-user"]')

--- a/apps/desktop/tests/e2e/kwp-commands.spec.ts
+++ b/apps/desktop/tests/e2e/kwp-commands.spec.ts
@@ -31,6 +31,7 @@ import {
   waitForInputReady,
   sendMessage,
   waitForResponseComplete,
+  userMessage,
 } from './helpers/electron-setup';
 
 // Phrases that should reliably trigger the embedded KWP skills.
@@ -212,7 +213,7 @@ test.describe('KWP Commands & Skill Auto-trigger E2E', () => {
     // (data-testid="chat-message-user").  Searching page-wide or
     // main-wide could match stale DOM (older turn, in-flight text,
     // placeholders) and silently break the test.
-    const userBubble = page.getByTestId('chat-message-user').filter({ hasText: marker }).first();
+    const userBubble = userMessage(page, marker);
 
     // The user message bubble must contain the args…
     await expect(userBubble).toBeVisible({ timeout: 10_000 });

--- a/apps/desktop/tests/e2e/reasoning-mode.spec.ts
+++ b/apps/desktop/tests/e2e/reasoning-mode.spec.ts
@@ -19,6 +19,7 @@ import {
   closeElectronApp,
   waitForBridgeInitialized,
   waitForInputReady,
+  userMessage,
 } from './helpers/electron-setup';
 
 const MODE_BTN = 'button[aria-label="回答模式"]';
@@ -89,10 +90,7 @@ test.describe('Reasoning Mode E2E', () => {
     await input.press('Enter');
 
     // User bubble appears
-    const userBubble = page
-      .locator('[data-testid="chat-message-user"]')
-      .filter({ hasText: '只回答' })
-      .first();
+    const userBubble = userMessage(page, '只回答');
     await expect(userBubble).toBeVisible({ timeout: 15_000 });
 
     // No text label on the user bubble anymore (removed #680 跟进) —

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -31,6 +31,24 @@ import {
 
 // ─── Helpers ──────────────────────────────────────────────────────
 
+/**
+ * Locator for the user message bubble containing `text` (substring match).
+ *
+ * Scoped to `[data-testid="chat-message-user"]`, NOT `main` — the session title
+ * is auto-derived from the first user message (ChatConsole `sessionTitle`), so
+ * the same marker text also lives in `[data-testid="chat-title"]` in the header,
+ * which a `.first()` over `main` would hit before the message list (#872).
+ * Also filtered to visible-only: after a session switch the previous session's
+ * hidden DOM can linger, and `.first()` would keep hitting that hidden node.
+ */
+function userMessage(page: Page, text: string) {
+  return page
+    .locator('[data-testid="chat-message-user"]')
+    .getByText(text, { exact: false })
+    .filter({ visible: true })
+    .first();
+}
+
 /** Send a message + type in the chat textarea (triggers React onChange) */
 async function typeAndSend(page: Page, text: string) {
   const textarea = await waitForInputReady(page);
@@ -38,7 +56,7 @@ async function typeAndSend(page: Page, text: string) {
   await textarea.type(text);
   await textarea.press('Enter');
   // Wait for the user message to appear
-  await expect(page.locator('main').getByText(text).first()).toBeVisible({ timeout: 10_000 });
+  await expect(userMessage(page, text)).toBeVisible({ timeout: 10_000 });
 }
 
 // ─── Test Suite ───────────────────────────────────────────────────
@@ -77,9 +95,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       await waitForResponseComplete(page, 240_000);
 
       // Confirm marker is visible
-      await expect(page.locator('main').getByText(marker, { exact: false }).first()).toBeVisible({
-        timeout: 10_000,
-      });
+      await expect(userMessage(page, marker)).toBeVisible({ timeout: 10_000 });
       console.log(`[test] ✅ Phase 1: Created session with marker "${marker}"`);
 
       // ── Phase 2: Close WITHOUT deleting MIQI_HOME, then relaunch ──
@@ -108,9 +124,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       // startup speed — no fixed delay, no null-safety edge case.  240s to
       // match waitForResponseComplete (slow macOS cold start, #709).
       try {
-        await expect(page2.locator('main').getByText(marker, { exact: false }).first()).toBeVisible(
-          { timeout: 240_000 }
-        );
+        await expect(userMessage(page2, marker)).toBeVisible({ timeout: 240_000 });
       } catch {
         // macOS 慢 runner 上重启后的历史加载可能超过 240s（bridge 冷启动 +
         // load 重试）。降级检查：若后端磁盘上确实存在该会话的消息（Phase 1
@@ -179,9 +193,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       await waitForResponseComplete(page, 240_000);
 
       // Verify marker is visible in session A
-      await expect(
-        page.locator('main').getByText(marker, { exact: false }).filter({ visible: true }).first()
-      ).toBeVisible({ timeout: 10_000 });
+      await expect(userMessage(page, marker)).toBeVisible({ timeout: 10_000 });
       console.log(`[test] ✅ Session A has marker "${marker}"`);
 
       // ── Step 2: Create session B ──────────────────────────────
@@ -195,9 +207,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       const markerB = `SWB_${Date.now()}`;
       await typeAndSend(page, `只回答${markerB}`);
       await waitForResponseComplete(page, 240_000);
-      await expect(
-        page.locator('main').getByText(markerB, { exact: false }).filter({ visible: true }).first()
-      ).toBeVisible({ timeout: 10_000 });
+      await expect(userMessage(page, markerB)).toBeVisible({ timeout: 10_000 });
       // Wait for sidebar to show both sessions.  Session B is persisted only
       // after its reply completes, and the sidebar refresh can lag on slow LLM
       // runners — poll up to 30s so a slow reply never flakes this assertion
@@ -225,7 +235,7 @@ test.describe('Regression #480: Session loads on startup', () => {
 
         // Wait for ChatConsole to load the clicked session's history — poll up
         // to 15s so a slow session load never flakes this check (#872).  Only
-        // match VISIBLE marker text: after a session switch the previous
+        // match the VISIBLE user bubble: after a session switch the previous
         // session's hidden DOM can linger, and `.first()` would keep hitting
         // that hidden node no matter how long we wait (#872 @sijie-Z).
         let hasMarker = false;
@@ -233,14 +243,12 @@ test.describe('Regression #480: Session loads on startup', () => {
           await expect
             .poll(
               () =>
-                page
-                  .locator('main')
-                  .getByText(marker, { exact: false })
-                  .filter({ visible: true })
-                  .first()
+                userMessage(page, marker)
                   .isVisible()
                   .catch(() => false),
-              { timeout: 15_000 }
+              {
+                timeout: 15_000,
+              }
             )
             .toBe(true);
           hasMarker = true;
@@ -257,12 +265,40 @@ test.describe('Regression #480: Session loads on startup', () => {
       }
 
       if (!found) {
-        // Dump diagnostic info
-        const mainText = await page
-          .locator('main')
-          .textContent()
+        // Dump diagnostic info — the session title is auto-derived from the
+        // first user message, so on a failed switch we need to see the exact
+        // hidden/visible state of BOTH the title and the message bubbles to
+        // tell "title lingering" from "messages lingering" (#872).
+        const diag = await page
+          .evaluate(() => {
+            const describe = (el: Element | null) => {
+              if (!el) return null;
+              const cs = getComputedStyle(el);
+              const r = el.getBoundingClientRect();
+              return {
+                display: cs.display,
+                visibility: cs.visibility,
+                w: Math.round(r.width),
+                h: Math.round(r.height),
+                text: (el.textContent || '').trim().slice(0, 80),
+              };
+            };
+            const title = document.querySelector('[data-testid="chat-title"]');
+            const users = Array.from(
+              document.querySelectorAll('[data-testid="chat-message-user"]')
+            );
+            const assistants = Array.from(
+              document.querySelectorAll('[data-testid="chat-message-assistant"]')
+            );
+            return {
+              title: describe(title),
+              titleOuterHTML: title?.outerHTML?.slice(0, 400) ?? null,
+              userBubbles: users.map(describe),
+              assistantBubbles: assistants.map(describe),
+            };
+          })
           .catch(() => '(error)');
-        console.log('[test] DIAGNOSTIC: main text (last 500):', (mainText || '').slice(-500));
+        console.log('[test] DIAGNOSTIC:', JSON.stringify(diag, null, 2));
       }
 
       expect(found).toBe(true);

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -18,9 +18,7 @@ import type { ElectronApplication, Page } from '@playwright/test';
 import {
   LLM_TIMEOUT,
   waitForInputReady,
-  sendMessage,
   waitForResponseComplete,
-  getSessionTitle,
   getSidebarSessionItems,
   createNewConversation,
   launchElectronApp,
@@ -55,10 +53,10 @@ async function typeAndSend(page: Page, text: string) {
   await textarea.click();
   await textarea.type(text);
   await textarea.press('Enter');
-  // Wait for the user message to appear.  A freshly-created session may still
-  // be loading (`historyLoaded` false → "正在连接…" spinner instead of the
-  // message list), so the optimistic bubble renders only after load() completes;
-  // 30s covers that lag (a 10s budget flaked when the bridge was slow, #872).
+  // Wait for the user message to appear.  The optimistic bubble now renders
+  // immediately (even while the session is still loading — see the render-gate
+  // fix in ChatConsole), so this normally resolves in <1s; 30s is a generous
+  // safety margin for slow bridges / cold starts (#872).
   await expect(userMessage(page, text)).toBeVisible({ timeout: 30_000 });
 }
 

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -20,6 +20,7 @@ import {
   waitForInputReady,
   waitForResponseComplete,
   getSidebarSessionItems,
+  userMessage,
   createNewConversation,
   launchElectronApp,
   relaunchElectronApp,
@@ -28,24 +29,6 @@ import {
 } from './helpers/electron-setup';
 
 // ─── Helpers ──────────────────────────────────────────────────────
-
-/**
- * Locator for the user message bubble containing `text` (substring match).
- *
- * Scoped to `[data-testid="chat-message-user"]`, NOT `main` — the session title
- * is auto-derived from the first user message (ChatConsole `sessionTitle`), so
- * the same marker text also lives in `[data-testid="chat-title"]` in the header,
- * which a `.first()` over `main` would hit before the message list (#872).
- * Also filtered to visible-only: after a session switch the previous session's
- * hidden DOM can linger, and `.first()` would keep hitting that hidden node.
- */
-function userMessage(page: Page, text: string) {
-  return page
-    .locator('[data-testid="chat-message-user"]')
-    .getByText(text, { exact: false })
-    .filter({ visible: true })
-    .first();
-}
 
 /** Send a message + type in the chat textarea (triggers React onChange) */
 async function typeAndSend(page: Page, text: string) {

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -55,8 +55,11 @@ async function typeAndSend(page: Page, text: string) {
   await textarea.click();
   await textarea.type(text);
   await textarea.press('Enter');
-  // Wait for the user message to appear
-  await expect(userMessage(page, text)).toBeVisible({ timeout: 10_000 });
+  // Wait for the user message to appear.  A freshly-created session may still
+  // be loading (`historyLoaded` false → "正在连接…" spinner instead of the
+  // message list), so the optimistic bubble renders only after load() completes;
+  // 30s covers that lag (a 10s budget flaked when the bridge was slow, #872).
+  await expect(userMessage(page, text)).toBeVisible({ timeout: 30_000 });
 }
 
 // ─── Test Suite ───────────────────────────────────────────────────

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -279,6 +279,7 @@ test.describe('Regression #480: Session loads on startup', () => {
               const cs = getComputedStyle(el);
               const r = el.getBoundingClientRect();
               return {
+                outerHTML: el.outerHTML.slice(0, 400),
                 display: cs.display,
                 visibility: cs.visibility,
                 w: Math.round(r.width),
@@ -295,7 +296,6 @@ test.describe('Regression #480: Session loads on startup', () => {
             );
             return {
               title: describe(title),
-              titleOuterHTML: title?.outerHTML?.slice(0, 400) ?? null,
               userBubbles: users.map(describe),
               assistantBubbles: assistants.map(describe),
             };

--- a/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
+++ b/apps/desktop/tests/e2e/regression-480-startup-history.spec.ts
@@ -92,7 +92,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       await page.evaluate(() => (window as any).miqi.approvals.addPermanent('*:*', 'always'));
 
       const marker = `REG480_${Date.now()}`;
-      await typeAndSend(page, `只回答${marker}`);
+      await typeAndSend(page, `请仅回复以下文本，不要使用任何工具或搜索：${marker}`);
       await waitForResponseComplete(page, 240_000);
 
       // Confirm marker is visible
@@ -190,7 +190,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       console.log(`[test] Session A created: "${sessionATitle}"`);
 
       const marker = `SW_${Date.now()}`;
-      await typeAndSend(page, `只回答${marker}`);
+      await typeAndSend(page, `请仅回复以下文本，不要使用任何工具或搜索：${marker}`);
       await waitForResponseComplete(page, 240_000);
 
       // Verify marker is visible in session A
@@ -206,7 +206,7 @@ test.describe('Regression #480: Session loads on startup', () => {
       // shows up in the sidebar (the #618 E2E removed this step and
       // CI caught the missing-session regression).
       const markerB = `SWB_${Date.now()}`;
-      await typeAndSend(page, `只回答${markerB}`);
+      await typeAndSend(page, `请仅回复以下文本，不要使用任何工具或搜索：${markerB}`);
       await waitForResponseComplete(page, 240_000);
       await expect(userMessage(page, markerB)).toBeVisible({ timeout: 10_000 });
       // Wait for sidebar to show both sessions.  Session B is persisted only


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

修复「会话加载期间发送消息时，乐观气泡被『正在连接…』挡住不渲染」的问题，并处理 load() 覆盖竞态（加载完成时不抹掉 in-flight 消息与流式内容），同时加固 regression-480 测试。

## 背景/问题

#872：`regression-480-startup-history.spec.ts` Test 2 偶发失败。排查确认两个根因 + 一个暴露的回归：

1. **发送竞态（产品侧，主因）**：新会话 `load()` 未完成（`historyLoaded` 为 false）时用户就能发消息——乐观气泡已进 `messages`，但渲染门控 `!historyLoaded` 直接显示 spinner，消息被挡住直到 `load()` 完成才渲染。
2. **标题误命中（测试侧）**：`ChatConsole.sessionTitle` 自动取首条用户消息，标题文本 = marker 文本；测试 `main.getByText(marker).first()` 命中标题而非消息。
3. **load() 覆盖回归（sijie-Z review 发现）**：渲染门控放宽后，`load()` 完成后 `setMessages(merged)` 会抹掉 in-flight 的乐观气泡 + 已流式渲染的 thinking/工具行，导致「对话只剩回答没有提问」、思考跳到一半。

## 关联 issue

- Refs #872

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：
  - 渲染门控 `!historyLoaded` → `!historyLoaded && messages.length === 0`，有消息时即使加载中也立即渲染
  - `load()` merge 处：存在 in-flight 发送时，把未持久化的消息（含 thinking/工具行）并回 `merged`，不再无条件覆盖
  - 重试耗尽错误路径：保留 in-flight 乐观气泡，不吞用户消息
- `apps/desktop/tests/e2e/regression-480-startup-history.spec.ts`：
  - marker 断言收窄到 `[data-testid="chat-message-user"]` + 可见性过滤
  - `typeAndSend` 等消息气泡超时 10s → 30s
  - 失败诊断抓 `chat-title` + 消息气泡的 `outerHTML` / `display` / `visibility` / 尺寸
  - marker 指令改为「请仅回复以下文本，不要使用任何工具或搜索」，消除真实 LLM 误解导致的 sidebar 偶发
- `apps/desktop/tests/e2e/helpers/electron-setup.ts`：抽取 `userMessage` 共享 helper，统一 regression-480 / kwp-commands / reasoning-mode 三处

## 日志/验证证据

```
本地 e2e（最新 build）--repeat-each=5：10 passed (4.0m)
单元测试：288 passed / 3 skipped
typecheck（tsconfig.node + tsconfig.web）：通过
prettier --check：通过
```

## 测试情况

- 本地 e2e 多轮通过（regression-480 10/10，kwp-commands / reasoning-mode 6 passed）
- typecheck、单测、prettier 通过
- CI：electron-e2e / macos-e2e / wsl-e2e 全绿

## 截图

无需截图（无静态 UI 变更，行为性修复见验证证据）

## 后续计划

- 若 CI 慢 runner 再偶发，失败诊断会抓 `chat-title` / 消息气泡的真实状态，据此进一步排查
