### PR TITLE
fix(chat): 手动停止后重试保留被中断轮次——regenerate/重试不再截断，重载按时间序插入中断卡(#886)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1136,6 +1136,69 @@ function collapseAssistantMessagesWithinTurns(rawMsgs: any[]): any[] {
  *  into the hint instead of a concise call summary (issue #532). */
 const HINT_VALUE_KEYS = ['path', 'file_path', 'filename', 'outPath', 'command', 'url', 'query'];
 
+/** #886: whether the user round starting at *userIdx* was manually stopped.
+ *  A stopped round carries the frontend's "已停止。" progress marker between
+ *  the user message and the next user message.  When the user regenerates or
+ *  retries such a round, the interrupted half-reply must be preserved in the
+ *  timeline (the new attempt appends after it) instead of being rewound away.
+ */
+export function wasTurnStopped(messages: Message[], userIdx: number): boolean {
+  let end = messages.length;
+  for (let i = userIdx + 1; i < messages.length; i += 1) {
+    if (messages[i].role === 'user') {
+      end = i;
+      break;
+    }
+  }
+  for (let i = userIdx + 1; i < end; i += 1) {
+    const m = messages[i];
+    if (m.role === 'progress' && String(m.content ?? '').includes('已停止')) return true;
+  }
+  return false;
+}
+
+/** #886: convert backend interrupted-turn snapshots into resumable cards and
+ *  insert each at its chronological position (right after its own user
+ *  message, before the later successful turns) instead of appending at the
+ *  end — the old push put the 中断卡 after the retry's answer, leaving a
+ *  duplicate "ghost" user message and a visual discontinuity. */
+export function insertInterruptedTurns(merged: Message[], interruptedTurns: any[]): Message[] {
+  const cards: Message[] = [];
+  for (const _it of interruptedTurns) {
+    const _halfContent = String(_it.assistant_content ?? '');
+    cards.push({
+      role: 'assistant',
+      content: _halfContent,
+      reasoning: String(_it.reasoning_content ?? '') || undefined,
+      interrupted: true,
+      interruptedMeta: {
+        turnId: String(_it.turn_id ?? ''),
+        status: String(_it.status ?? 'interrupted'),
+        assistantContent: _halfContent,
+        reasoningContent: String(_it.reasoning_content ?? ''),
+        updatedAt: Number(_it.updated_at ?? 0) * 1000,
+        tokenEstimate: _halfContent ? Math.round(_halfContent.length / 4) : 0,
+      },
+      timestamp: Number(_it.updated_at ?? Date.now() / 1000) * 1000,
+    });
+  }
+  if (cards.length === 0) return merged;
+  // Oldest first so each card lands in its own slot in order.
+  cards.sort((a, b) => a.timestamp - b.timestamp);
+  const out = merged.slice();
+  for (const card of cards) {
+    let ins = out.length;
+    for (let i = 0; i < out.length; i += 1) {
+      if (out[i].timestamp > card.timestamp) {
+        ins = i;
+        break;
+      }
+    }
+    out.splice(ins, 0, card);
+  }
+  return out;
+}
+
 export function sessionMsgsToUi(rawMsgs: any[]): Message[] {
   const result: Message[] = [];
   for (const m of collapseAssistantMessagesWithinTurns(rawMsgs)) {
@@ -2823,30 +2886,17 @@ export function ChatConsole({
             setStreaming(false);
           }
         }
-        // #740: append interrupted-turn snapshots — half-generated replies
-        // the user saw before an interruption (process exit / abort) — as
-        // resumable assistant bubbles with the 中断卡 + 继续执行/重新开始 actions.
+        // #740/#886: interrupted-turn snapshots — half-generated replies the
+        // user saw before an interruption (process exit / abort) — render as
+        // resumable assistant bubbles (中断卡 + 继续执行/重新开始).  Insert each
+        // at its chronological position (after its own user message) so a
+        // later successful retry appends AFTER the interrupted round instead of
+        // the card landing at the end of history.
         const _interruptedTurns = (detail as any)?.interrupted_turns ?? [];
-        if (Array.isArray(_interruptedTurns) && _interruptedTurns.length > 0) {
-          for (const _it of _interruptedTurns) {
-            const _halfContent = String(_it.assistant_content ?? '');
-            merged.push({
-              role: 'assistant',
-              content: _halfContent,
-              reasoning: String(_it.reasoning_content ?? '') || undefined,
-              interrupted: true,
-              interruptedMeta: {
-                turnId: String(_it.turn_id ?? ''),
-                status: String(_it.status ?? 'interrupted'),
-                assistantContent: _halfContent,
-                reasoningContent: String(_it.reasoning_content ?? ''),
-                updatedAt: Number(_it.updated_at ?? 0) * 1000,
-                tokenEstimate: _halfContent ? Math.round(_halfContent.length / 4) : 0,
-              },
-              timestamp: Number(_it.updated_at ?? Date.now() / 1000) * 1000,
-            });
-          }
-        }
+        merged = insertInterruptedTurns(
+          merged,
+          Array.isArray(_interruptedTurns) ? _interruptedTurns : []
+        );
         setMessages(merged);
         // Snapshot is now reconciled into `merged` — clear it so a later
         // load() (loadTrigger refresh) doesn't re-append stale transient
@@ -5007,7 +5057,12 @@ export function ChatConsole({
       if (streaming) return;
       cleanupListeners();
       const idx = messagesRef.current.indexOf(msg);
-      if (idx >= 0) setMessages((prev) => prev.slice(0, idx));
+      if (idx >= 0) {
+        // #886: a stopped round keeps its interrupted half-reply in the
+        // timeline — the retried attempt appends after it instead of
+        // rewinding and dropping the "已停止" context.
+        setMessages((prev) => (wasTurnStopped(prev, idx) ? prev : prev.slice(0, idx)));
+      }
       setInput(msg.content);
       setAttachments(msg.attachments ?? []);
     },
@@ -5034,7 +5089,10 @@ export function ChatConsole({
         attachments: userMsg.attachments ?? [],
         retry: true,
       };
-      setMessages((prev) => prev.slice(0, userIdx)); // handleSend re-appends the user message
+      // #886: regenerating a manually-stopped turn must not rewind and drop
+      // the interrupted round — keep it and let handleSend append the new
+      // attempt after it.  Only a completed answer is replaced in place.
+      setMessages((prev) => (wasTurnStopped(prev, userIdx) ? prev : prev.slice(0, userIdx)));
       setInput(userMsg.content);
       setAttachments(userMsg.attachments ?? []);
       requestAnimationFrame(() => handleSendRef.current());

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -6,6 +6,8 @@ import {
   getTaskShareDownloadName,
   appendReasoningDelta,
   insertStandaloneReasoning,
+  insertInterruptedTurns,
+  wasTurnStopped,
   sessionMsgsToUi,
   formatToolCallHint,
 } from '../src/renderer/features/chat/ChatConsole';
@@ -287,5 +289,102 @@ describe('task share helpers', () => {
     const name = getTaskShareDownloadName('修复: 顶部/侧边 文件?', 1783993200000);
 
     expect(name).toBe('修复-顶部-侧边-文件-2026-07-14T01-40-00-000Z.md');
+  });
+});
+
+// ── #886: interrupted-turn preservation ────────────────────────────────────
+
+const user = (content: string, ts: number) => ({ role: 'user', content, timestamp: ts });
+const assistant = (content: string, ts: number) => ({ role: 'assistant', content, timestamp: ts });
+const stopped = (ts: number) => ({ role: 'progress', content: '已停止。', timestamp: ts });
+
+describe('wasTurnStopped', () => {
+  it('returns true when the round carries the 已停止 marker', () => {
+    const msgs = [user('长任务', 1), assistant('半截', 2), stopped(3)];
+    expect(wasTurnStopped(msgs, 0)).toBe(true);
+  });
+
+  it('returns false for a completed round without the marker', () => {
+    const msgs = [user('问题', 1), assistant('完整回答', 2)];
+    expect(wasTurnStopped(msgs, 0)).toBe(false);
+  });
+
+  it('scopes to the current round only (not a later stopped round)', () => {
+    const msgs = [
+      user('问题A', 1),
+      assistant('回答A', 2),
+      user('问题B', 3),
+      assistant('半截B', 4),
+      stopped(5),
+    ];
+    expect(wasTurnStopped(msgs, 0)).toBe(false);
+    expect(wasTurnStopped(msgs, 2)).toBe(true);
+  });
+
+  it('ignores a 已停止 marker that appears before the user message', () => {
+    const msgs = [stopped(0), user('问题A', 1), assistant('回答A', 2)];
+    expect(wasTurnStopped(msgs, 1)).toBe(false);
+  });
+});
+
+describe('insertInterruptedTurns', () => {
+  // timestamps are epoch-ms for messages; snapshot `updated_at` is epoch
+  // seconds (the helper converts ×1000), so both land in the same domain.
+  it('inserts the interrupted card after its own user message, before the retry', () => {
+    const merged = [
+      user('长任务', 100_000),
+      user('长任务', 300_000),
+      assistant('重试成功', 400_000),
+    ];
+    const snap = [
+      {
+        turn_id: 't1',
+        status: 'interrupted',
+        assistant_content: '半截回答',
+        updated_at: 200, // → 200_000 ms, between user#1 (100k) and retry user#2 (300k)
+      },
+    ];
+    const out = insertInterruptedTurns(merged, snap);
+    expect(out.map((m) => (m.interrupted ? 'CARD' : m.role))).toEqual([
+      'user',
+      'CARD',
+      'user',
+      'assistant',
+    ]);
+    const card = out.find((m) => m.interrupted);
+    expect(card?.content).toBe('半截回答');
+    expect(card?.interruptedMeta?.turnId).toBe('t1');
+  });
+
+  it('appends at the end when the interrupted round is the latest', () => {
+    const merged = [user('长任务', 100_000)];
+    const snap = [
+      { turn_id: 't1', status: 'interrupted', assistant_content: '半截', updated_at: 200 },
+    ];
+    const out = insertInterruptedTurns(merged, snap);
+    expect(out.map((m) => (m.interrupted ? 'CARD' : m.role))).toEqual(['user', 'CARD']);
+  });
+
+  it('returns merged unchanged when there are no interrupted turns', () => {
+    const merged = [user('a', 1), assistant('b', 2)];
+    expect(insertInterruptedTurns(merged, [])).toBe(merged);
+  });
+
+  it('keeps multiple interrupted cards in chronological order', () => {
+    const merged = [user('一', 100_000), user('二', 400_000), assistant('答', 500_000)];
+    const snaps = [
+      { turn_id: 't2', status: 'interrupted', assistant_content: '半截B', updated_at: 450 },
+      { turn_id: 't1', status: 'interrupted', assistant_content: '半截A', updated_at: 200 },
+    ];
+    const out = insertInterruptedTurns(merged, snaps);
+    const cards = out.filter((m) => m.interrupted);
+    expect(cards.map((c) => c.interruptedMeta?.turnId)).toEqual(['t1', 't2']);
+    expect(out.map((m) => (m.interrupted ? 'CARD' : m.role))).toEqual([
+      'user',
+      'CARD',
+      'user',
+      'CARD',
+      'assistant',
+    ]);
   });
 });

--- a/tests/runtime/test_issue_886_interrupted_turn_retry.py
+++ b/tests/runtime/test_issue_886_interrupted_turn_retry.py
@@ -1,0 +1,178 @@
+"""Reproduction for #886: after manual stop + fresh retry succeeds, does the
+interrupted turn's snapshot survive in the backend history?
+
+Scenario (desktop chat.send flow, driven at the RuntimeSession level):
+1. submit a UserMessage (turn T1) — user message persisted, turn streams
+2. submit AbortTurn (user clicks 停止生成) — turn cancelled, execution snapshot saved
+3. submit the SAME content again as a fresh turn T2 (用户点击重新生成),
+   with NO resume_turn_id
+4. T2 completes successfully
+5. Read history_runtime snapshots + history items + SessionManager messages
+   (the same stores sessions.get reads) — check the interrupted round survived
+
+Expected per issue: the interrupted round's node must REMAIN in history
+(snapshot kept, user message kept).
+"""
+
+import asyncio
+
+import pytest
+
+
+class StreamProvider:
+    """Streams deltas then completes after a short delay.
+
+    T1 is aborted while streaming (before completion); the retry T2 runs the
+    same provider to completion.
+    """
+
+    def __init__(self, delay_s: float = 0.5):
+        self.delay_s = delay_s
+        self.calls = 0
+
+    def get_default_model(self):
+        return "test-model"
+
+    async def stream_chat(self, **kwargs):
+        from miqi.providers.base import LLMResponse, LLMStreamEvent
+
+        self.calls += 1
+        yield LLMStreamEvent(kind="content_delta", delta="部分回答内容")
+        await asyncio.sleep(self.delay_s)
+        yield LLMStreamEvent(kind="content_delta", delta="，继续输出")
+        await asyncio.sleep(self.delay_s)
+        yield LLMStreamEvent(kind="completed", response=LLMResponse(
+            content="部分回答内容，继续输出重试成功", finish_reason="stop",
+        ))
+
+
+async def _drain_until(runtime, ev_name: str, *, timeout_s: float = 8.0) -> list:
+    """Drain runtime events until one of class *ev_name* is seen, or timeout."""
+    seen: list = []
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        ev = await runtime.next_event(timeout=0.5)
+        if ev is None:
+            continue
+        seen.append(ev)
+        if ev.__class__.__name__ == ev_name:
+            return seen
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_interrupted_turn_survives_fresh_retry(tmp_path, fake_config):
+    from miqi.protocol.commands import AbortTurn, UserMessage
+    from miqi.runtime.session import RuntimeSession
+
+    provider = StreamProvider(delay_s=0.5)
+    runtime = RuntimeSession.create(
+        config=fake_config,
+        provider=provider,
+        session_id="c1:s1",
+        workspace=fake_config.workspace_path,
+    )
+    await runtime.start()
+    hr = runtime.services.history_runtime
+    assert hr is not None
+
+    thread_id = "thread-886"
+    content = "请生成长时间运行的任务"
+
+    try:
+        # ── Turn T1: long task ──────────────────────────────────────────
+        await runtime.submit(UserMessage(content=content, thread_id=thread_id, mode="edit"))
+
+        # Wait until the model stream actually starts (turn_runner.run is
+        # inside the stream loop) — mirrors a user letting the task run.
+        t1_events = await _drain_until(runtime, "AgentMessageDeltaEvent")
+        assert t1_events and t1_events[-1].__class__.__name__ == "AgentMessageDeltaEvent", (
+            "T1 never started streaming"
+        )
+
+        # ── Stop: user clicks 停止生成 ──────────────────────────────────
+        await runtime.submit(AbortTurn(thread_id=thread_id))
+
+        t1_settle = await _drain_until(runtime, "TurnAbortedEvent")
+        assert t1_settle and t1_settle[-1].__class__.__name__ == "TurnAbortedEvent", (
+            f"T1 never emitted TurnAbortedEvent: {[e.__class__.__name__ for e in t1_settle]}"
+        )
+
+        # The interrupted snapshot MUST exist now.
+        interrupted_after_abort = await hr.get_interrupted_snapshots()
+        assert len(interrupted_after_abort) == 1, (
+            f"T1 snapshot missing after abort: {interrupted_after_abort}"
+        )
+
+        # ── Retry: user clicks 重新生成 (fresh turn, no resume_turn_id) ─
+        await runtime.submit(UserMessage(content=content, thread_id=thread_id, mode="edit"))
+
+        # Wait for the retry turn to complete (TurnCompleteEvent).
+        t2_events = await _drain_until(runtime, "TurnCompleteEvent")
+        assert t2_events and t2_events[-1].__class__.__name__ == "TurnCompleteEvent", (
+            f"retry turn never completed: {[e.__class__.__name__ for e in t2_events]}"
+        )
+
+        # ── Verify history state (what sessions.get would return) ───────
+        snapshots = await hr.get_interrupted_snapshots()
+        assert len(snapshots) == 1, (
+            "#886: interrupted snapshot vanished after fresh retry succeeded. "
+            f"interrupted_turns={snapshots}"
+        )
+
+        items = await hr.load_items(thread_id)
+        roles = [i.role for i in items]
+        assert roles.count("user") == 2, (
+            f"expected user msg from BOTH the interrupted round and the retry, got {roles}"
+        )
+        assert roles.count("assistant") == 1, (
+            f"retry's assistant answer missing: {roles}"
+        )
+
+        # sessions.get reads messages from SessionManager JSONL — verify the
+        # interrupted round's user message survived there too.
+        from miqi.session.manager import SessionManager
+
+        sm = SessionManager(fake_config.workspace_path)
+        sess = sm.get_or_create("s1")
+        jsonl_roles = [m.get("role") for m in sess.messages]
+        assert jsonl_roles.count("user") == 2, (
+            f"JSONL user msgs missing (interrupted round lost): {jsonl_roles}"
+        )
+        assert jsonl_roles.count("assistant") == 1, (
+            f"JSONL assistant msg missing: {jsonl_roles}"
+        )
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_resume_completing_deletes_only_that_snapshot(tmp_path, fake_config):
+    """Regression guard: deleting a snapshot on resume-completion must not
+    wipe unrelated interrupted snapshots in the same session (#886 class)."""
+    from miqi.runtime.session import RuntimeSession
+
+    provider = StreamProvider(delay_s=0.1)
+    runtime = RuntimeSession.create(
+        config=fake_config,
+        provider=provider,
+        session_id="c1:s1",
+        workspace=fake_config.workspace_path,
+    )
+    await runtime.start()
+    hr = runtime.services.history_runtime
+
+    try:
+        await hr.upsert_snapshot("turn-other-1", "thread-886", status="interrupted",
+                                 assistant_content="半截A")
+        await hr.upsert_snapshot("turn-other-2", "thread-886", status="interrupted",
+                                 assistant_content="半截B")
+        await hr.upsert_snapshot("turn-resume", "thread-886", status="interrupted",
+                                 assistant_content="半截C")
+        await hr.delete_snapshot("turn-resume")
+
+        snapshots = await hr.get_interrupted_snapshots()
+        ids = sorted(s["turn_id"] for s in snapshots)
+        assert ids == ["turn-other-1", "turn-other-2"], ids
+    finally:
+        await runtime.stop()


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

手动停止 Agent 后重试成功，被中断的那一轮 Message Node 现在保留在会话历史中（标记为已停止/中断），新的成功记录追加其后。

## 背景/问题

**现象**：发送长任务 → 执行中手动点「停止生成」→ 前端显示"已停止" → 点击重试/重新生成 → 任务成功完成后，被中断的一轮从会话历史消失，仅剩最后一次成功交互；刷新/重载后也只看到最后一次成功消息，历史上下文丢失，UI 出现视觉断层。

**根因**：后端其实完整保留了中断轮（execution_snapshots 快照 + JSONL/SQLite 双存储的用户消息），问题在前端两处：
1. 停止后点「重新生成/重试」时，`handleRegenerate`/`handleRetry` 用 `slice(0, userIdx)` 把中断轮（用户消息 + 半截回答 + "已停止。"标记）整体截掉，重试成功后实时会话只剩最后一次成功交互；
2. 重载时 load 路径用 `merged.push()` 把中断卡追加到**历史末尾**，落在重试回答之后，且中断轮的用户消息变成无回答的"幽灵"重复，形成视觉断层。

**影响**：中断的任务上下文丢失，用户无法从历史看出"先试了一次（被打断）、又试了一次（成功）"的完整过程，也失去了对中断轮继续执行/重新开始的操作入口（重载后中断卡位置错乱）。

## 关联 issue

- Closes #886 手动暂停/停止 Agent 后重试成功，被中断的对话历史 Message Node 从会话历史消失

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 新增 `wasTurnStopped()`：检测某轮是否被手动停止（该轮内是否含"已停止。"标记）
  - 新增 `insertInterruptedTurns()`：把中断卡按时间戳插到**自己的用户消息之后**（重试之前），而非追加到历史末尾
  - `handleRegenerate` / `handleRetry`：目标轮若已停止则**保留**该轮，新回合追加其后；已完成回答仍原地替换，不改变原有语义
- `apps/desktop/tests/chatConsoleMessages.test.ts`：新增 `wasTurnStopped` / `insertInterruptedTurns` 8 个单元测试
- `tests/runtime/test_issue_886_interrupted_turn_retry.py`（新增）：后端回归测试，锁定"停止→全新重试成功后，interrupted 快照 + 两条用户消息 + assistant 消息在 JSONL/SQLite 双存储均保留"

## 日志/验证证据

```
后端回归测试（新增，证明后端数据保留，根因在前端）：
$ .venv/Scripts/python.exe -m pytest tests/runtime/test_issue_886_interrupted_turn_retry.py -q
..                                                                       [100%]
2 passed in 2.34s

前端单元测试（新增用例覆盖修复逻辑）：
$ npx vitest run tests/chatConsoleMessages.test.ts
✓ tests/chatConsoleMessages.test.ts (22 tests) 9ms
Test Files  1 passed (1)
Tests       22 passed (22)
```

## 测试情况

- [x] `npm run typecheck`（tsconfig.node + tsconfig.web）通过
- [x] `npx vitest run` 全部 296 通过 / 3 跳过（含新增 8 个用例）
- [x] prettier 格式检查通过（`.github/workflows/format-check.yml` 会强制）
- [x] 后端 `tests/runtime/test_issue_886_interrupted_turn_retry.py` + 相关中断 turn 测试 23 个通过
- [ ] 完整 Electron UI 实测需真实 LLM provider 驱动「长时间任务→停止→重试」流程，未在本次运行

## 截图
修复前
<img width="699" height="432" alt="image" src="https://github.com/user-attachments/assets/3433cdc4-ab78-43d6-8823-ee8fce0f1d3e" />

修复后的
<img width="722" height="667" alt="image" src="https://github.com/user-attachments/assets/3f0c8c0b-15ea-412b-9321-9036ed94e6c9" />

## 后续计划

- 用 Playwright e2e 覆盖「停止→重新生成→重载后中断卡保留且顺序正确」的完整用户路径（需真实 LLM provider，独立于本 PR）