### PR TITLE
fix(desktop): dev server 固定绑定 127.0.0.1,修复 Electron 启动 ERR_CONNECTION_TIMED_OUT

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
   },
   renderer: {
     root: resolve(__dirname, 'src/renderer'),
+    // 固定 IPv4 回环：Windows 网络过滤组件（WFP 过滤器）可能劫持 IPv6 回环 ::1，
+    // 而 Node 25 把 localhost 解析为 ::1，Vite 默认只绑 ::1，Electron 加载 dev
+    // server 就会 ERR_CONNECTION_TIMED_OUT。
+    server: {
+      host: '127.0.0.1',
+    },
     define: {
       __APP_VERSION__: JSON.stringify(pkg.version),
     },


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

dev server 固定绑定 127.0.0.1,规避 IPv6 回环被网络过滤组件拦截导致的 Electron 启动超时。

## 背景/问题

Windows 网络过滤组件(WFP 过滤器)会拦截 IPv6 回环流量:对监听中的 [::1] socket 发起连接报 EACCES 或被黑洞。Node 25 的 dns.lookup 把 localhost 解析为 ::1,Vite dev server 因此只绑定 [::1]:5173,Electron 加载 http://localhost:5173/ 时连接被拦截,报 ERR_CONNECTION_TIMED_OUT (-118),开发窗口无法加载。实测 IPv4 回环(127.0.0.1)不受影响。

## 变更内容

- `apps/desktop/electron.vite.config.ts`:renderer 增加 `server.host: '127.0.0.1'`,electron-vite 自动把 ELECTRON_RENDERER_URL 改为 http://127.0.0.1:5173,固定走 IPv4 回环,避开被拦截的 ::1

## 日志/验证证据

```
修复前（必现）：
[main] did-fail-load: code=-118 desc=ERR_CONNECTION_TIMED_OUT url=http://localhost:5173/
(node:10840) electron: Failed to load URL: http://localhost:5173/ with error: ERR_CONNECTION_TIMED_OUT

修复后（网络环境不变，npx electron-vite dev 实测）：
dev server running for the electron renderer process at:

  ➜  Local:   http://127.0.0.1:5173/

start electron app...
（主进程 + GPU + 渲染进程共 4 个 electron.exe 正常存活，无任何 did-fail-load/ERR_ 报错）
```

## 测试情况

- 网络环境不变的情况下实测 `npx electron-vite dev`:dev server 绑定 127.0.0.1:5173,Electron 窗口正常加载,无加载报错
- 根因排查对照实验:[::1]:5173 起监听时 curl/Node fetch 均连接失败(EACCES),同端口 127.0.0.1 监听 curl 可达,确认根因在 IPv6 回环被拦截而非代码

## 截图

无需截图(纯配置文件改动,无 UI 变更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
