### PR TITLE
feat(desktop): 隐私确认门下拉到底并停留确认——滚至底部停留 1s 才可同意 (#837 增强)

### DIFF
--- a/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
+++ b/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
@@ -45,7 +45,9 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
 
   useEffect(() => clearHold, []);
 
-  const handleScroll = () => {
+  // 统一评估「是否到底」：在底部则启动停留计时（已在计时则保持），
+  // 不在底部则清除计时。scroll 事件与尺寸变化共用此路径。
+  const evaluateBottom = () => {
     if (satisfiedRef.current) return;
     const el = scrollRef.current;
     if (!el) return;
@@ -64,6 +66,10 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
     }
   };
 
+  const handleScroll = () => {
+    evaluateBottom();
+  };
+
   // 内容不足一屏（无滚动空间）时视为已完整展示，直接放行；窗口/字体
   // 尺寸变化导致高度改变时重新评估。仍有溢出时重置停留状态——resize
   // 可能让此前「到底」失效（内容变多），不能靠旧计时放行同意。
@@ -80,10 +86,11 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
         setHoldElapsed(true);
         return;
       }
-      // 仍有溢出：尺寸变化后重新要求滚到底并停留（防止 resize 绕过确认）。
+      // 仍有溢出：重置后重新评估——尺寸对称恢复时 scrollTop 会被浏览器
+      // 钳制回底部，但不会产生 scroll 事件，需在此重启停留计时。
       clearHold();
-      setReachedBottom(false);
       setHoldElapsed(false);
+      evaluateBottom();
     };
     checkOverflow();
     const observer = new ResizeObserver(checkOverflow);

--- a/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
+++ b/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
@@ -56,6 +56,17 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
     if (atBottom) {
       if (holdTimer.current === null) {
         holdTimer.current = setTimeout(() => {
+          holdTimer.current = null;
+          // timer 与 scroll 回调无跨源顺序保证：到期时重新检查几何位置，
+          // 用户已滚离底部则不启用（CodeRabbit 评审场景）
+          const elNow = scrollRef.current;
+          if (!elNow) return;
+          const stillAtBottom =
+            elNow.scrollTop + elNow.clientHeight >= elNow.scrollHeight - BOTTOM_THRESHOLD_PX;
+          if (!stillAtBottom) {
+            setReachedBottom(false);
+            return;
+          }
           satisfiedRef.current = true;
           setHoldElapsed(true);
         }, HOLD_AT_BOTTOM_MS);

--- a/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
+++ b/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
@@ -65,7 +65,9 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
   };
 
   // 内容不足一屏（无滚动空间）时视为已完整展示，直接放行；窗口/字体
-  // 尺寸变化导致高度改变时重新评估。语言切换后重新检测。
+  // 尺寸变化导致高度改变时重新评估。仍有溢出时重置停留状态——resize
+  // 可能让此前「到底」失效（内容变多），不能靠旧计时放行同意。
+  // 语言切换后重新检测。
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -73,13 +75,22 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
       if (satisfiedRef.current) return;
       if (el.scrollHeight - el.clientHeight <= 1) {
         satisfiedRef.current = true;
+        clearHold();
         setReachedBottom(true);
         setHoldElapsed(true);
+        return;
       }
+      // 仍有溢出：尺寸变化后重新要求滚到底并停留（防止 resize 绕过确认）。
+      clearHold();
+      setReachedBottom(false);
+      setHoldElapsed(false);
     };
     checkOverflow();
     const observer = new ResizeObserver(checkOverflow);
     observer.observe(el);
+    // 文本自身高度变化（字体加载、内容换行）同样影响溢出量
+    const textEl = el.querySelector('pre');
+    if (textEl) observer.observe(textEl);
     return () => observer.disconnect();
   }, [language]);
 

--- a/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
+++ b/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Check, Languages, X } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { cn } from '../../lib/utils';
@@ -9,15 +9,88 @@ import {
   type PrivacyLanguage,
 } from '../../lib/privacy';
 
+/** 距底部多少像素内视为「已滚动到底」。 */
+const BOTTOM_THRESHOLD_PX = 8;
+/** 到底后需停留的时长（毫秒），期间滚离底部则重新计时。 */
+const HOLD_AT_BOTTOM_MS = 1000;
+
 /**
  * 首次启动的隐私协议确认门 (#837)。
  *
  * 无安装向导的分发形式（portable/zip）与升级用户在应用内看到本页；
  * 同意状态写入 localStorage，协议版本更新时（PRIVACY_VERSION 递增）
- * 会再次要求确认。拒绝则关闭窗口退出应用。
+ * 会再次要求确认。拒绝则退出应用。
+ *
+ * 同意前置条件（下拉到底并停留确认）：协议文本需滚动到底部并在底部
+ * 停留满 HOLD_AT_BOTTOM_MS 后「同意并继续」才启用；文本不足一屏
+ * （无溢出）时视为已完整展示，直接放行；切换语言后重新确认。
  */
 export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
   const [language, setLanguage] = useState<PrivacyLanguage>(() => detectPrivacyLanguage());
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const holdTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 一旦满足条件即启用（滚离底部不重新禁用），语言切换时整体重置
+  const satisfiedRef = useRef(false);
+  const [reachedBottom, setReachedBottom] = useState(false);
+  const [holdElapsed, setHoldElapsed] = useState(false);
+
+  const canAgree = holdElapsed;
+
+  const clearHold = () => {
+    if (holdTimer.current !== null) {
+      clearTimeout(holdTimer.current);
+      holdTimer.current = null;
+    }
+  };
+
+  useEffect(() => clearHold, []);
+
+  const handleScroll = () => {
+    if (satisfiedRef.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD_PX;
+    setReachedBottom(atBottom);
+    if (atBottom) {
+      if (holdTimer.current === null) {
+        holdTimer.current = setTimeout(() => {
+          satisfiedRef.current = true;
+          setHoldElapsed(true);
+        }, HOLD_AT_BOTTOM_MS);
+      }
+    } else {
+      clearHold();
+      setHoldElapsed(false);
+    }
+  };
+
+  // 内容不足一屏（无滚动空间）时视为已完整展示，直接放行；窗口/字体
+  // 尺寸变化导致高度改变时重新评估。语言切换后重新检测。
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const checkOverflow = () => {
+      if (satisfiedRef.current) return;
+      if (el.scrollHeight - el.clientHeight <= 1) {
+        satisfiedRef.current = true;
+        setReachedBottom(true);
+        setHoldElapsed(true);
+      }
+    };
+    checkOverflow();
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [language]);
+
+  const switchLanguage = (lang: PrivacyLanguage) => {
+    if (lang === language) return;
+    setLanguage(lang);
+    clearHold();
+    satisfiedRef.current = false;
+    setReachedBottom(false);
+    setHoldElapsed(false);
+  };
 
   const decline = () => {
     // 走主进程 app.quit()——macOS 上 window.close() 不终止应用（#837 评审）。
@@ -53,7 +126,7 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
             {(['zh-CN', 'en-US'] as const).map((lang) => (
               <button
                 key={lang}
-                onClick={() => setLanguage(lang)}
+                onClick={() => switchLanguage(lang)}
                 aria-pressed={language === lang}
                 className={cn(
                   'rounded-md px-2 py-1 text-xs font-medium transition-colors',
@@ -70,7 +143,12 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
         </div>
 
         {/* Scrollable agreement text */}
-        <div className="max-h-[52vh] overflow-y-auto px-6 py-4">
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="max-h-[52vh] overflow-y-auto px-6 py-4"
+          data-testid="privacy-consent-scroll"
+        >
           <pre
             className="whitespace-pre-wrap break-words font-sans text-[13px] leading-relaxed text-[var(--text)]"
             data-testid="privacy-consent-text"
@@ -81,10 +159,21 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
 
         {/* Footer */}
         <div className="flex items-center justify-between gap-3 border-t border-[var(--border-subtle)] bg-[var(--surface-muted)]/40 px-6 py-4">
-          <p className="min-w-0 text-xs text-[var(--text-faint)]">
-            {language === 'zh-CN'
-              ? '同意状态保存在本机，协议更新时需重新确认。'
-              : 'Consent is stored locally; re-confirmation is required when the agreement is updated.'}
+          <p
+            className="min-w-0 text-xs text-[var(--text-faint)]"
+            data-testid="privacy-consent-hint"
+          >
+            {canAgree
+              ? language === 'zh-CN'
+                ? '同意状态保存在本机，协议更新时需重新确认。'
+                : 'Consent is stored locally; re-confirmation is required when the agreement is updated.'
+              : language === 'zh-CN'
+                ? reachedBottom
+                  ? '请停留在协议底部片刻后继续。'
+                  : '请滚动阅读完整协议后继续。'
+                : reachedBottom
+                  ? 'Please hold at the bottom of the agreement to continue.'
+                  : 'Please scroll through the full agreement to continue.'}
           </p>
           <div className="flex shrink-0 items-center gap-2">
             <Button
@@ -96,7 +185,12 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
               <X size={14} />
               {language === 'zh-CN' ? '拒绝并退出' : 'Decline and Exit'}
             </Button>
-            <Button size="sm" onClick={onAgree} data-testid="privacy-consent-agree">
+            <Button
+              size="sm"
+              onClick={onAgree}
+              disabled={!canAgree}
+              data-testid="privacy-consent-agree"
+            >
               <Check size={14} />
               {language === 'zh-CN' ? '同意并继续' : 'Agree and Continue'}
             </Button>

--- a/apps/desktop/tests/e2e/privacy-consent.spec.ts
+++ b/apps/desktop/tests/e2e/privacy-consent.spec.ts
@@ -93,12 +93,34 @@ test.describe.serial('Privacy consent gate (#837)', () => {
 
     // 下拉到底并停留确认：滚动到底部前「同意并继续」必须禁用
     const agreeBtn = page.getByTestId('privacy-consent-agree');
+    const scrollBox = page.getByTestId('privacy-consent-scroll');
     await expect(agreeBtn).toBeDisabled();
-    // 滚到底（触发 scroll 事件）→ 底部停留满 1s 后启用
-    await page.getByTestId('privacy-consent-scroll').evaluate((el) => {
+
+    // 回归：停留计时中 resize（窗口变矮 → 内容溢出更多）应重置到底状态，
+    // 不能靠旧计时放行同意（CodeRabbit 评审场景）
+    await scrollBox.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const win =
+        BrowserWindow.getAllWindows().find((w) => w.getTitle() === 'MiqroForge Desktop') ??
+        BrowserWindow.getAllWindows()[0];
+      win.setSize(1280, 760); // minHeight=760，缩小 100px 使溢出增多
+    });
+    // 等过原停留时长（1s）——计时已被 resize 清除，按钮保持禁用
+    await page.waitForTimeout(1300);
+    await expect(agreeBtn).toBeDisabled();
+
+    // 再次滚到底（触发 scroll 事件）→ 底部停留满 1s 后启用
+    await scrollBox.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
     await expect(agreeBtn).toBeEnabled({ timeout: 10_000 });
+
+    // 恢复窗口尺寸，不影响后续测试；已满足条件后 resize 不再重置
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].setSize(1280, 860);
+    });
 
     // 确认门本身的截图（滚动到底、按钮已启用）
     await page.screenshot({

--- a/apps/desktop/tests/e2e/privacy-consent.spec.ts
+++ b/apps/desktop/tests/e2e/privacy-consent.spec.ts
@@ -96,31 +96,26 @@ test.describe.serial('Privacy consent gate (#837)', () => {
     const scrollBox = page.getByTestId('privacy-consent-scroll');
     await expect(agreeBtn).toBeDisabled();
 
-    // 回归：停留计时中 resize（窗口变矮 → 内容溢出更多）应重置到底状态，
-    // 不能靠旧计时放行同意（CodeRabbit 评审场景）
+    // 回归：停留计时中滚动容器尺寸变化（窗口缩放/内容重排经 ResizeObserver
+    // 触发 checkOverflow）应重置到底状态，不能靠旧计时放行同意
+    // （CodeRabbit 评审场景）。直接缩小容器模拟——窗口级 resize 在 macOS CI
+    // 上受屏幕分辨率钳制不可靠，而容器是 ResizeObserver 的直接观察对象。
     await scrollBox.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
-    await electronApp.evaluate(({ BrowserWindow }) => {
-      const win =
-        BrowserWindow.getAllWindows().find((w) => w.getTitle() === 'MiqroForge Desktop') ??
-        BrowserWindow.getAllWindows()[0];
-      win.setSize(1280, 760); // minHeight=760，缩小 100px 使溢出增多
+    await scrollBox.evaluate((el) => {
+      el.style.maxHeight = '40vh'; // 缩小容器 → 溢出增多，此前「到底」失效
     });
     // 等过原停留时长（1s）——计时已被 resize 清除，按钮保持禁用
     await page.waitForTimeout(1300);
     await expect(agreeBtn).toBeDisabled();
 
-    // 再次滚到底（触发 scroll 事件）→ 底部停留满 1s 后启用
+    // 恢复容器尺寸：scrollTop 被浏览器钳制回底部（不产生 scroll 事件），
+    // 组件在尺寸变化回调里重新评估并重启停留计时 → 自动启用
     await scrollBox.evaluate((el) => {
-      el.scrollTop = el.scrollHeight;
+      el.style.maxHeight = '';
     });
     await expect(agreeBtn).toBeEnabled({ timeout: 10_000 });
-
-    // 恢复窗口尺寸，不影响后续测试；已满足条件后 resize 不再重置
-    await electronApp.evaluate(({ BrowserWindow }) => {
-      BrowserWindow.getAllWindows()[0].setSize(1280, 860);
-    });
 
     // 确认门本身的截图（滚动到底、按钮已启用）
     await page.screenshot({

--- a/apps/desktop/tests/e2e/privacy-consent.spec.ts
+++ b/apps/desktop/tests/e2e/privacy-consent.spec.ts
@@ -4,7 +4,7 @@
  * 覆盖四条路径（全部禁用 MIQI_E2E 绕过，走真实确认门）：
  *  1. 拒绝并退出：首次启动展示协议 → 点「拒绝并退出」→ 应用退出；
  *  2. 同意进入：重启（同一 MIQI_HOME，同意未持久化）→ 门再次出现 →
- *     点「同意并继续」→ 主界面加载；
+ *     滚到底部并停留 → 「同意并继续」启用 → 点击 → 主界面加载；
  *  3. 同意持久化：page.reload() 重挂载 AppShell → 门不再出现（同
  *     readStoredConsent/门判定路径；不重启进程——CI 上 close 后
  *     relaunch 存在桥接端口残留，主界面长期不加载）；
@@ -91,13 +91,22 @@ test.describe.serial('Privacy consent gate (#837)', () => {
 
     await expect(page.getByTestId('privacy-consent-gate')).toBeVisible({ timeout: 60_000 });
 
-    // 确认门本身的截图（点同意前）
+    // 下拉到底并停留确认：滚动到底部前「同意并继续」必须禁用
+    const agreeBtn = page.getByTestId('privacy-consent-agree');
+    await expect(agreeBtn).toBeDisabled();
+    // 滚到底（触发 scroll 事件）→ 底部停留满 1s 后启用
+    await page.getByTestId('privacy-consent-scroll').evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    await expect(agreeBtn).toBeEnabled({ timeout: 10_000 });
+
+    // 确认门本身的截图（滚动到底、按钮已启用）
     await page.screenshot({
       path: `test-results/${test.info().title.replace(/\s+/g, '-')}-consent-gate.png`,
       fullPage: true,
     });
 
-    await page.getByTestId('privacy-consent-agree').click();
+    await agreeBtn.click();
 
     // CI 冷启动（bridge + python.check）较慢，给足时间
     await expect(page.getByTestId('app-title')).toBeVisible({ timeout: 120_000 });


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

隐私协议首次启动确认门增加「下拉到底并停留确认」：协议文本需滚动到底部并停留 1 秒后，「同意并继续」按钮才启用。

## 背景/问题

#837 的确认门允许用户不阅读协议直接点击同意，合规性不足（用户可跳过阅读直接进入应用）。业界通行做法（如主流 EULA 确认页）要求滚动至协议底部后才可同意。

## 变更内容

- `features/setup/PrivacyConsentGate.tsx`：
  - 文本区监听滚动，距底部 8px 内视为到底；到底后停留满 1s 才启用「同意并继续」，滚离底部则重新计时，一旦启用不回退
  - 内容不足一屏（无溢出）时视为已完整展示，直接放行；窗口/字体尺寸变化经 ResizeObserver 重新评估，避免超大窗口下永远无法同意
  - 切换语言重置确认状态（不同语言文本长度不同，需重新阅读）
  - 未启用期间 footer 提示语随状态切换：「请滚动阅读完整协议后继续」→「请停留在协议底部片刻后继续」（英文同步）
- `tests/e2e/privacy-consent.spec.ts`：同意流程更新为「断言按钮禁用 → 滚动到底 → 等待启用 → 点击同意」
- 拒绝按钮保持始终可点（用户无需阅读即可拒绝退出）
- 设置页协议页为查阅入口、无同意动作，不涉及此机制；NSIS 安装器协议页为原生行为，不在本次范围

## 日志/验证证据

```
Running 4 tests using 1 worker
  ok 1 [electron] › tests\e2e\privacy-consent.spec.ts:48:7 › Privacy consent gate (#837) › 拒绝并退出：应用直接退出
  ok 2 [electron] › tests\e2e\privacy-consent.spec.ts:76:7 › Privacy consent gate (#837) › 同意并继续：主界面加载
  ok 3 [electron] › tests\e2e\privacy-consent.spec.ts:121:7 › Privacy consent gate (#837) › 同意持久化：重挂载后不再展示确认门
  ok 4 [electron] › tests\e2e\privacy-consent.spec.ts:130:7 › Privacy consent gate (#837) › 设置页可随时查阅隐私协议
  4 passed (11.9s)
```

## 截图

滚动到底、停留满 1s、同意按钮已启用（此前为禁用态）：

![consent-gate-scrolled](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/consent-gate-scrolled-a45dfd0a.png)

## 测试情况

- E2E：`privacy-consent.spec.ts` 4 条全过（含新增的禁用→滚动→启用→同意断言）
- `npx vitest run` 305 passed / 3 skipped
- `npm run typecheck`、`npm run format:check` 通过
- 依赖 #888（已合并）的确认门与 E2E 基础设施
- macos-e2e 修复轮（b9ef0f09）：回归场景的窗口级 setSize 在 macOS CI 受屏幕分辨率钳制不可靠，改为直接缩小滚动容器；并修复组件缺陷——容器尺寸对称恢复时 scrollTop 被浏览器钳制回底部但不产生 scroll 事件，停留计时永不启动，现在尺寸变化回调重置后会重新评估并自动重启计时。本地连续两遍 4/4


