### PR TITLE
fix(bridge): 打包版不把 miqi-bridge.exe 自身当 Python 解释器推荐给 AI

### DIFF
--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -63,6 +63,39 @@ def sandbox_is_active(sandbox_manager: Any) -> bool:
 _git_bash_checked = False
 _git_bash_path: str | None = None
 
+_host_python_checked = False
+_host_python_path: str | None = None
+
+
+def _find_host_python() -> str | None:
+    """Find a real Python interpreter on the host, skipping store stubs.
+
+    Packaged (frozen) builds only — there sys.executable is the bridge
+    binary itself, not an interpreter. On Windows the PATH scan must skip
+    %LOCALAPPDATA%\\Microsoft\\WindowsApps\\python.exe: that is a store
+    stub which opens the Microsoft Store and hangs instead of running.
+    Result is cached because the per-turn environment description calls
+    this on every turn.
+    """
+    global _host_python_checked, _host_python_path
+    if _host_python_checked:
+        return _host_python_path
+    _host_python_checked = True
+    if os.name == "nt":
+        for entry in os.environ.get("PATH", "").split(os.pathsep):
+            if not entry:
+                continue
+            cand = os.path.join(entry, "python.exe")
+            if not os.path.isfile(cand):
+                continue
+            if "windowsapps" in cand.lower():
+                continue
+            _host_python_path = cand
+            break
+    else:
+        _host_python_path = shutil.which("python3") or shutil.which("python")
+    return _host_python_path
+
 
 def _is_cygwin_bash(path: str) -> bool:
     r"""True when *path* is a Cygwin bash.exe (e.g. C:\cygwin64\bin\bash.exe).
@@ -186,6 +219,16 @@ def _skills_dirs_note(workspace: str | Path | None, style: str) -> str:
     return "技能定位：" + "、".join(parts) + "。"
 
 
+def _host_python_note(exe: str, style: str) -> str:
+    if style == "msys":
+        exe = windows_path_to_msys(exe)
+    return (
+        f"推荐 Python 解释器：{exe}。"
+        "运行 python 脚本请直接用这个完整路径，避免 PATH 上其他 "
+        "python 启动卡顿（如商店占位程序）。"
+    )
+
+
 def _python_note(style: str) -> str:
     """One sentence disclosing the bridge's REAL python interpreter.
 
@@ -196,16 +239,24 @@ def _python_note(style: str) -> str:
     path in the exec environment's path style
     (msys = /c/..., native = as-is).
     """
+    if getattr(sys, "frozen", False):
+        # Packaged (PyInstaller) build: sys.executable is miqi-bridge.exe
+        # itself, NOT a python interpreter — recommending it would make
+        # the AI launch a second bridge instead of running the script.
+        # The embedded runtime is private to the bridge, so fall back to a
+        # real host interpreter when one exists.
+        host_py = _find_host_python()
+        if host_py:
+            return _host_python_note(host_py, style)
+        return (
+            "本机未检测到可用的独立 Python（打包版自带的运行时仅供 bridge "
+            "内部使用，不能用来执行脚本）。运行 Python 脚本请让用户安装 "
+            "Python 3.11+，或启用沙箱后在沙箱内使用 python3。"
+        )
     exe = str(getattr(sys, "executable", ""))
     if not exe:
         return ""
-    if style == "msys":
-        exe = windows_path_to_msys(exe)
-    return (
-        f"推荐 Python 解释器：{exe}。"
-        "运行 python 脚本请直接用这个完整路径，避免 PATH 上其他 "
-        "python 启动卡顿（如商店占位程序）。"
-    )
+    return _host_python_note(exe, style)
 
 
 def _sandbox_python_note(sandbox_manager: Any) -> str:

--- a/tests/sandbox/test_exec_environment_description.py
+++ b/tests/sandbox/test_exec_environment_description.py
@@ -151,6 +151,12 @@ class _FakeOsPath:
     def exists(self, path: str) -> bool:
         return path in self._existing
 
+    def isfile(self, path: str) -> bool:
+        return path in self._existing
+
+    def join(self, a: str, b: str) -> str:
+        return a + "\\" + b
+
     def expandvars(self, path: str) -> str:
         return self._expandvars_result if self._expandvars_result is not None else path
 
@@ -169,9 +175,12 @@ class _FakeOs:
         existing: tuple[str, ...] = (),
         expandvars_result: str | None = None,
         name: str = "nt",
+        env_path: str = "",
     ):
         self.name = name
         self.path = _FakeOsPath(existing, expandvars_result)
+        self.pathsep = ";"
+        self.environ = {"PATH": env_path}
 
 
 def test_find_git_bash_from_common_location(monkeypatch, tmp_path):
@@ -476,3 +485,96 @@ def test_exec_direct_runs_through_git_bash_on_windows(tmp_path):
     assert "A" in result.output and "B" in result.output and "C" in result.output
     # cmd would have echoed the command text verbatim; bash executed it
     assert "echo" not in result.output
+
+
+def _reset_host_python_cache(monkeypatch):
+    monkeypatch.setattr("miqi.sandbox.manager._host_python_checked", False)
+    monkeypatch.setattr("miqi.sandbox.manager._host_python_path", None)
+
+
+def test_find_host_python_skips_windowsapps_store_stub(monkeypatch):
+    """The PATH scan must skip the WindowsApps python.exe store stub
+    (opens the Microsoft Store, hangs) and pick the real interpreter."""
+    from miqi.sandbox.manager import _find_host_python
+
+    _reset_host_python_cache(monkeypatch)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.os",
+        _FakeOs(
+            existing=(r"C:\WindowsApps\python.exe", r"C:\Python313\python.exe"),
+            env_path=r"C:\WindowsApps;C:\Python313",
+        ),
+        raising=False,
+    )
+    assert _find_host_python() == r"C:\Python313\python.exe"
+
+
+def test_find_host_python_none_when_only_store_stub(monkeypatch):
+    """All-PATH-stub machines (no real Python) must yield None, not the
+    store stub — the AI then gets the 'ask the user to install' note."""
+    from miqi.sandbox.manager import _find_host_python
+
+    _reset_host_python_cache(monkeypatch)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.os",
+        _FakeOs(
+            existing=(r"C:\WindowsApps\python.exe",),
+            env_path=r"C:\WindowsApps",
+        ),
+        raising=False,
+    )
+    assert _find_host_python() is None
+
+
+def test_find_host_python_none_on_empty_path(monkeypatch):
+    from miqi.sandbox.manager import _find_host_python
+
+    _reset_host_python_cache(monkeypatch)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.os", _FakeOs(env_path=""), raising=False,
+    )
+    assert _find_host_python() is None
+
+
+def test_describe_exec_environment_frozen_no_host_python(monkeypatch):
+    """Packaged build, no host Python: sys.executable is the bridge exe
+    itself and must NEVER be recommended as an interpreter (running it
+    would launch a second bridge). The AI is told to have the user
+    install Python or enable the sandbox instead."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr("miqi.sandbox.manager.find_git_bash", lambda: None)
+    monkeypatch.setattr("miqi.sandbox.manager._find_host_python", lambda: None)
+
+    class _FrozenSys:
+        frozen = True
+        executable = r"C:\Program Files\MiqroForge\miqi-bridge.exe"
+
+    monkeypatch.setattr("miqi.sandbox.manager.sys", _FrozenSys(), raising=False)
+    text = describe_exec_environment(None)
+    assert "miqi-bridge.exe" not in text
+    assert "推荐 Python 解释器" not in text
+    assert "让用户安装" in text
+    assert "沙箱" in text
+
+
+def test_describe_exec_environment_frozen_uses_host_python(monkeypatch):
+    """Packaged build with a real Python on PATH: recommend the host
+    interpreter (msys path form under Git Bash), never the bridge exe."""
+    monkeypatch.setattr("miqi.sandbox.manager.os", _FakeOs(), raising=False)
+    monkeypatch.setattr(
+        "miqi.sandbox.manager.find_git_bash",
+        lambda: r"C:\Program Files\Git\bin\bash.exe",
+    )
+    monkeypatch.setattr(
+        "miqi.sandbox.manager._find_host_python",
+        lambda: r"D:\Python313\python.exe",
+    )
+
+    class _FrozenSys:
+        frozen = True
+        executable = r"C:\Program Files\MiqroForge\miqi-bridge.exe"
+
+    monkeypatch.setattr("miqi.sandbox.manager.sys", _FrozenSys(), raising=False)
+    text = describe_exec_environment(None, workspace=r"C:\Users\demo\ws")
+    assert "/d/Python313/python.exe" in text
+    assert "miqi-bridge.exe" not in text


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复打包版（PyInstaller frozen）下系统提示词把 `miqi-bridge.exe` 自身当 Python 解释器推荐给 AI 的问题：frozen 时改推荐宿主机器上的真实 Python，找不到则明确提示安装或启用沙箱。

## 背景/问题

`_python_note()` 用 `sys.executable` 向 AI 推荐本机 Python 解释器（避免 AI 用 PATH 上的 WindowsApps 商店占位程序卡死）。但在 PyInstaller frozen 环境下 `sys.executable` 是 `miqi-bridge.exe` 自身，**不是解释器**——AI 若照提示用 `miqi-bridge.exe script.py` 跑脚本，参数会变成 sys.argv，结果是拉起第二个 bridge 实例而不是执行脚本。

打包版用户的机器通常没有安装 Python，AI 在 PATH 上也找不到可用解释器。即：**打包版 + 未开沙箱 + 用户机器无 Python = 智能体没有可用的 Python，且提示词会给它指一条死路**。目前代码里没有任何 frozen 检测来处理这种情况。

## 变更内容

- `miqi/sandbox/manager.py`：
  - 新增 `_find_host_python()`：frozen 时扫描宿主 PATH 上的真实 `python.exe`，跳过 `WindowsApps` 商店占位 stub（运行会弹商店并卡死）；非 Windows 用 `shutil.which`；结果模块级缓存（环境描述每回合调用，避免重复扫描）
  - `_python_note()` 增加 frozen 分支：检测到 frozen 且找到宿主 Python → 推荐宿主解释器；找不到 → 明确告知"打包版自带运行时仅供 bridge 内部使用，不能执行脚本；请让用户安装 Python 3.11+ 或启用沙箱后在沙箱内使用 python3"
  - 提取 `_host_python_note()` helper 消除推荐文案重复
- `tests/sandbox/test_exec_environment_description.py`：新增 6 个用例（frozen 无宿主 Python 不推荐 exe、frozen 有宿主 Python 推荐宿主解释器、PATH 扫描跳过商店 stub、全是 stub 返回 None、空 PATH 返回 None 等）

## 日志/验证证据

```
# tests/sandbox 全套
206 passed, 2 skipped in 27.75s

# 真实环境 frozen 模拟（monkeypatch sys.frozen=True 后真实调用）
host python on this machine: C:\Users\Intership003\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe
...推荐 Python 解释器：/c/Users/Intership003/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe。
```

## 测试情况

- `tests/sandbox/test_exec_environment_description.py`：49 passed（含新增 6 个 frozen 用例）
- `tests/sandbox` 全套：206 passed, 2 skipped
- 真实环境 frozen 模拟：`_find_host_python()` 正确跳过 WindowsApps stub 并命中 PATH 上第一个真实 python；`describe_exec_environment` 输出推荐路径正确（msys 形式）

## 截图

无需截图（本次为提示词生成逻辑修复，无 UI 变更）
