### PR TITLE
feat(desktop): 隐私确认门停留倒计时——滚到底后同意按钮显示 3s 递减倒计时 (#837 增强)

### DIFF
--- a/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
+++ b/apps/desktop/src/renderer/features/setup/PrivacyConsentGate.tsx
@@ -12,7 +12,9 @@ import {
 /** 距底部多少像素内视为「已滚动到底」。 */
 const BOTTOM_THRESHOLD_PX = 8;
 /** 到底后需停留的时长（毫秒），期间滚离底部则重新计时。 */
-const HOLD_AT_BOTTOM_MS = 1000;
+const HOLD_AT_BOTTOM_MS = 3000;
+/** 停留倒计时的刷新间隔（毫秒）。 */
+const COUNTDOWN_TICK_MS = 100;
 
 /**
  * 首次启动的隐私协议确认门 (#837)。
@@ -22,25 +24,36 @@ const HOLD_AT_BOTTOM_MS = 1000;
  * 会再次要求确认。拒绝则退出应用。
  *
  * 同意前置条件（下拉到底并停留确认）：协议文本需滚动到底部并在底部
- * 停留满 HOLD_AT_BOTTOM_MS 后「同意并继续」才启用；文本不足一屏
- * （无溢出）时视为已完整展示，直接放行；切换语言后重新确认。
+ * 停留满 HOLD_AT_BOTTOM_MS 后「同意并继续」才启用，停留期间同意按钮
+ * 上显示剩余时间倒计时；文本不足一屏（无溢出）时视为已完整展示，直接
+ * 放行；切换语言后重新确认。
  */
 export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
   const [language, setLanguage] = useState<PrivacyLanguage>(() => detectPrivacyLanguage());
   const scrollRef = useRef<HTMLDivElement>(null);
   const holdTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const holdTick = useRef<ReturnType<typeof setInterval> | null>(null);
   // 一旦满足条件即启用（滚离底部不重新禁用），语言切换时整体重置
   const satisfiedRef = useRef(false);
   const [reachedBottom, setReachedBottom] = useState(false);
   const [holdElapsed, setHoldElapsed] = useState(false);
+  // 停留倒计时剩余毫秒数；null 表示当前无倒计时（未到底或已放行）
+  const [holdRemainingMs, setHoldRemainingMs] = useState<number | null>(null);
 
   const canAgree = holdElapsed;
+  // 停留倒计时剩余秒数（1 位小数），无倒计时时为 null
+  const countdownSeconds = holdRemainingMs === null ? null : (holdRemainingMs / 1000).toFixed(1);
 
   const clearHold = () => {
     if (holdTimer.current !== null) {
       clearTimeout(holdTimer.current);
       holdTimer.current = null;
     }
+    if (holdTick.current !== null) {
+      clearInterval(holdTick.current);
+      holdTick.current = null;
+    }
+    setHoldRemainingMs(null);
   };
 
   useEffect(() => clearHold, []);
@@ -55,8 +68,15 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
     setReachedBottom(atBottom);
     if (atBottom) {
       if (holdTimer.current === null) {
+        // 停留期间在同意按钮上显示剩余时间倒计时
+        setHoldRemainingMs(HOLD_AT_BOTTOM_MS);
+        holdTick.current = setInterval(() => {
+          setHoldRemainingMs((prev) =>
+            prev === null ? prev : Math.max(0, prev - COUNTDOWN_TICK_MS)
+          );
+        }, COUNTDOWN_TICK_MS);
         holdTimer.current = setTimeout(() => {
-          holdTimer.current = null;
+          clearHold();
           // timer 与 scroll 回调无跨源顺序保证：到期时重新检查几何位置，
           // 用户已滚离底部则不启用（CodeRabbit 评审场景）
           const elNow = scrollRef.current;
@@ -222,6 +242,9 @@ export function PrivacyConsentGate({ onAgree }: { onAgree: () => void }) {
             >
               <Check size={14} />
               {language === 'zh-CN' ? '同意并继续' : 'Agree and Continue'}
+              {countdownSeconds !== null && (
+                <span className="ml-1 tabular-nums">({countdownSeconds}s)</span>
+              )}
             </Button>
           </div>
         </div>

--- a/apps/desktop/tests/e2e/privacy-consent.spec.ts
+++ b/apps/desktop/tests/e2e/privacy-consent.spec.ts
@@ -103,19 +103,31 @@ test.describe.serial('Privacy consent gate (#837)', () => {
     await scrollBox.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
+    // 倒计时：滚到底后按钮显示剩余时间倒计时（如 "…(3.0s)"）并保持禁用
+    await expect(agreeBtn).toContainText(/\(\d+\.\ds\)/);
+    await expect(agreeBtn).toBeDisabled();
+    // 倒计时显示中的截图（PR 证据）
+    await page.screenshot({
+      path: `test-results/${test.info().title.replace(/\s+/g, '-')}-consent-countdown.png`,
+      fullPage: true,
+    });
     await scrollBox.evaluate((el) => {
       el.style.maxHeight = '40vh'; // 缩小容器 → 溢出增多，此前「到底」失效
     });
-    // 等过原停留时长（1s）——计时已被 resize 清除，按钮保持禁用
-    await page.waitForTimeout(1300);
+    // 计时与倒计时一同被 resize 清除，按钮回到无倒计时的禁用态
+    await expect(agreeBtn).not.toContainText('(');
+    // 等过停留时长（3s）——计时已被 resize 清除，按钮保持禁用
+    await page.waitForTimeout(3300);
     await expect(agreeBtn).toBeDisabled();
 
     // 恢复容器尺寸：scrollTop 被浏览器钳制回底部（不产生 scroll 事件），
-    // 组件在尺寸变化回调里重新评估并重启停留计时 → 自动启用
+    // 组件在尺寸变化回调里重新评估并重启停留计时 → 倒计时走完自动启用
     await scrollBox.evaluate((el) => {
       el.style.maxHeight = '';
     });
     await expect(agreeBtn).toBeEnabled({ timeout: 10_000 });
+    // 倒计时归零后按钮恢复原文案
+    await expect(agreeBtn).not.toContainText('(');
 
     // 确认门本身的截图（滚动到底、按钮已启用）
     await page.screenshot({


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

隐私确认门「下拉到底并停留确认」增加可见倒计时：停留时长从 1s 延长到 3s，滚到底部后「同意并继续」按钮显示 3.0s 递减倒计时，归零后恢复原文案并启用。

## 背景/问题

#896 实现滚到底停留 1s 才可同意的确认门，但等待过程对用户完全无感知——仅一句提示文字，按钮静默启用，缺少进度反馈，1s 停留几乎不可察觉。在同意按钮上显示递减倒计时，让等待过程可见、可预期，同时延长停留时长强化合规观感。

## 变更内容

- `features/setup/PrivacyConsentGate.tsx`：
  - `HOLD_AT_BOTTOM_MS` 1000 → 3000，新增 `COUNTDOWN_TICK_MS = 100`
  - 新增 `holdTick` 间隔计时与 `holdRemainingMs` 状态：滚到底后从 3.0s 起每 100ms 递减，按钮文案显示「同意并继续 (3.0s)」（`tabular-nums` 防数字跳动），归零即启用并恢复原文案
  - 倒计时与停留计时同生共死：滚离底部 / resize / 切换语言均清除计时并重置，重滚到底后从 3.0s 重新倒计时；一旦启用不回退（沿用 #896 语义）
- `tests/e2e/privacy-consent.spec.ts`：
  - 新增倒计时断言：滚到底 → 按钮显示倒计时且禁用 → 停留中缩小容器 → 倒计时消失、等过 3s 仍禁用（证明 resize 真清除计时）→ 恢复尺寸 → 重新倒计时归零后启用且倒计时消失
  - 新增倒计时状态截图

## 日志/验证证据

```
Running 4 tests using 1 worker
  ok 1 [electron] › tests\e2e\privacy-consent.spec.ts:48:7 › Privacy consent gate (#837) › 拒绝并退出：应用直接退出 (1.0s)
  ok 2 [electron] › tests\e2e\privacy-consent.spec.ts:76:7 › Privacy consent gate (#837) › 同意并继续：主界面加载 (13.1s)
  ok 3 [electron] › tests\e2e\privacy-consent.spec.ts:150:7 › Privacy consent gate (#837) › 同意持久化：重挂载后不再展示确认门 (11.9s)
  ok 4 [electron] › tests\e2e\privacy-consent.spec.ts:159:7 › Privacy consent gate (#837) › 设置页可随时查阅隐私协议 (570ms)

  4 passed (27.4s)
```

## 测试情况

- E2E `privacy-consent.spec.ts` 4/4 通过（含新增倒计时断言与 resize 回归场景）
- `npx vitest run` 320 passed / 3 skipped
- `npm run typecheck`、`npm run format:check` 通过

## 截图

倒计时显示中（3.0s，按钮禁用态）：

![consent-countdown](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/consent-countdown-cb449d97.png)

倒计时归零启用后（经 resize 回归场景重新倒计时走完）：

![consent-gate-enabled](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/consent-gate-a45dfd0a.png)
