### PR TITLE
fix(sandbox): 幂等确保 WSL 默认用户为 root，避免外部改 wsl.conf 后卡 sudo 密码

### DIFF
--- a/miqi/runtime/ledger_runtime.py
+++ b/miqi/runtime/ledger_runtime.py
@@ -51,7 +51,12 @@ class LedgerRuntime:
 
     async def initialize(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._db = await aiosqlite.connect(str(self.db_path))
+        # Same busy timeout as HistoryRuntime/StoredRuntime: all runtime
+        # stores open independent connections on the same DB file, and a
+        # cancelled turn's in-flight write can hold the file lock while a
+        # retry turn's mirror write waits. The default 5s is too short and
+        # surfaces as "database is locked" (flaky test_issue_886).
+        self._db = await aiosqlite.connect(str(self.db_path), timeout=30)
         await self._db.execute("""
             CREATE TABLE IF NOT EXISTS runtime_ledger_items (
                 item_id TEXT PRIMARY KEY,

--- a/miqi/runtime/thread_runtime.py
+++ b/miqi/runtime/thread_runtime.py
@@ -58,7 +58,9 @@ class ThreadRuntime:
     async def initialize(self) -> None:
         """Open persistent connection and create tables."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._db = await aiosqlite.connect(str(self.db_path))
+        # Same busy timeout as HistoryRuntime/StoredRuntime — see
+        # LedgerRuntime.initialize for the cross-connection contention note.
+        self._db = await aiosqlite.connect(str(self.db_path), timeout=30)
         self._db.row_factory = aiosqlite.Row
         await self._db.execute("""
             CREATE TABLE IF NOT EXISTS runtime_threads (

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -106,6 +106,27 @@ makes the second caller wait for the first install, then re-check with
 a quick readiness probe that succeeds immediately.
 """
 
+#: Idempotent check that the distro's WSL default user is root. Prints
+#: ``ROOT_OK`` when /etc/wsl.conf already declares ``default=root``, or
+#: ``ROOT_FIXED`` after correcting it (so the caller knows to terminate
+#: the distro to apply the change). Run as root (``-u root``) so it has
+#: write access to /etc/wsl.conf regardless of the current default user.
+_WSL_ENSURE_ROOT_CMD = (
+    "if [ \"$(id -un)\" != \"root\" ]; then echo NOT_ROOT; exit 1; fi; "
+    "if grep -qF 'default=root' /etc/wsl.conf 2>/dev/null; then "
+    "echo ROOT_OK; "
+    "else "
+    "if grep -qF 'default=' /etc/wsl.conf 2>/dev/null; then "
+    "sed -i 's/^default=.*/default=root/' /etc/wsl.conf; "
+    "elif grep -qF '[user]' /etc/wsl.conf 2>/dev/null; then "
+    "sed -i '/^\\[user\\]/a default=root' /etc/wsl.conf; "
+    "else "
+    "printf '\\n[user]\\ndefault=root\\n' >> /etc/wsl.conf; "
+    "fi; "
+    "echo ROOT_FIXED; "
+    "fi"
+)
+
 
 class BwrapCommandHandle:
     """Handle to a running command inside the bwrap sandbox.
@@ -772,6 +793,60 @@ class BwrapSandbox:
         except (asyncio.TimeoutError, OSError, ValueError):
             return None
     @staticmethod
+    async def _ensure_root_default_user(distro: str) -> bool:
+        """Ensure the distro's WSL default user is root (idempotent).
+
+        miqi's sandbox relies on the distro running as root so apt-get
+        and bwrap never hit a sudo password prompt. The distro's
+        /etc/wsl.conf may have been edited externally (or the distro
+        created outside miqi) to a non-root default user, which breaks
+        that assumption and makes every sandbox invocation stall on a
+        password. This corrects it and terminates the distro so the
+        change takes effect.
+
+        Returns True if a change was made (default user flipped to
+        root), False if it was already root or could not be verified.
+        """
+        try:
+            proc = await _create_subprocess_exec(
+                "wsl.exe", "-d", distro, "-u", "root", "--",
+                "bash", "-c", _WSL_ENSURE_ROOT_CMD,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_data, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=15.0,
+            )
+        except (asyncio.TimeoutError, OSError):
+            return False
+
+        output = stdout_data.decode("utf-8", errors="replace") if stdout_data else ""
+        if proc.returncode != 0:
+            logger.warning(
+                "Failed to ensure root default user for '{}': {}",
+                distro, output.strip()[:200],
+            )
+            return False
+
+        if "ROOT_FIXED" not in output:
+            return False  # ROOT_OK (already root) or no action needed
+
+        # Terminate so wsl.conf takes effect on the next launch
+        try:
+            term = await _create_subprocess_exec(
+                "wsl.exe", "--terminate", distro,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await asyncio.wait_for(term.communicate(), timeout=10.0)
+        except (asyncio.TimeoutError, OSError):
+            pass
+        logger.info(
+            "Sandbox distro '{}' default user set to root", distro,
+        )
+        return True
+
+    @staticmethod
     async def _ensure_sandbox_distro(target_name: str = "AIShadowSandbox") -> bool:
         """Create a dedicated sandbox WSL distro if it does not exist.
 
@@ -795,6 +870,11 @@ class BwrapSandbox:
                 logger.info(
                     "Sandbox distro '{}' already exists", target_name,
                 )
+                # The distro may exist but with a non-root default user
+                # (e.g. /etc/wsl.conf edited externally), which would
+                # make apt-get/bwrap stall on a sudo password prompt.
+                # Enforce root even on the already-exists path.
+                await BwrapSandbox._ensure_root_default_user(target_name)
                 return True
         except (asyncio.TimeoutError, OSError):
             pass
@@ -871,29 +951,11 @@ class BwrapSandbox:
                 )
                 return False
 
-            # Set default user to root so apt-get never needs a password
-            try:
-                set_root = await _create_subprocess_exec(
-                    "wsl.exe", "-d", target_name, "-u", "root", "--",
-                    "bash", "-c",
-                    "echo -e '[user]\\ndefault=root' > /etc/wsl.conf",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                await asyncio.wait_for(
-                    set_root.communicate(), timeout=10.0,
-                )
-                # Terminate so wsl.conf takes effect on next launch
-                term = await _create_subprocess_exec(
-                    "wsl.exe", "--terminate", target_name,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                await asyncio.wait_for(
-                    term.communicate(), timeout=10.0,
-                )
-            except (asyncio.TimeoutError, OSError):
-                pass  # best-effort, not fatal
+            # Set default user to root so apt-get never needs a password.
+            # Reuse the idempotent helper so the just-imported distro's
+            # wsl.conf is normalized the same way as the already-exists
+            # path above (keeps any extra [boot]/[network] sections intact).
+            await BwrapSandbox._ensure_root_default_user(target_name)
 
             logger.info(
                 "Sandbox distro '{}' created (installed at {})",


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

1. 沙箱 distro 已存在但默认用户被外部改为非 root 时，自动幂等修复 wsl.conf 为 `default=root`，避免每次沙箱调用卡在 sudo 密码提示。
2. 对齐 runtime DB 连接的 busy timeout 为 30s，修复 CI 上 `test_issue_886` 偶发的 `database is locked` 失败（与沙箱改动无关的既有 flake，在 main 与多个无关分支上同样复现）。

## 背景/问题

**沙箱 root 修复**：miqi 沙箱依赖 distro 以 root 运行（apt-get/bwrap 不弹 sudo 密码）。原有逻辑只在「首次创建 distro」路径写入 wsl.conf，且用 `echo > /etc/wsl.conf` 整体覆盖文件：

1. **已存在路径不检查**：distro 在 miqi 外创建、或 /etc/wsl.conf 被外部编辑成非 root 默认用户时，`_ensure_sandbox_distro` 走 already-exists 分支直接返回，不修复 → 之后每次沙箱调用都卡在 sudo 密码提示。
2. **整体覆盖丢配置**：新建路径用 `echo` 覆盖 wsl.conf，会丢失 `[boot]`/`[network]` 等外部配置的 section。

**runtime busy timeout 对齐**：`LedgerRuntime`/`HistoryRuntime`/`ThreadRuntime` 各自独立连接打开同一个 runtime_db 文件；取消中的轮次写与重试轮次的镜像写在跨连接竞争文件锁。`LedgerRuntime` 与 `ThreadRuntime` 用 aiosqlite 默认 5s busy timeout（其余 store 均为 30s），竞争超时即抛 `OperationalError: database is locked`，导致本 PR CI 的 `test (ubuntu-latest)` 连续失败。

## 变更内容

- `miqi/sandbox/bwrap.py`
  - 新增幂等 helper `_ensure_root_default_user()`：以 `-u root` 运行，检查 wsl.conf 是否已声明 `default=root`（`ROOT_OK`），否则按三种情况就地修正（改已有 default= 行 / 在 [user] 段后插入 / 追加新 [user] 段），保留其他 section 不动，修正后 terminate distro 使配置生效（`ROOT_FIXED`）。
  - already-exists 路径新增强制检查调用。
  - 新建路径删除旧的 echo 覆盖逻辑，复用同一 helper。
- `miqi/runtime/ledger_runtime.py`、`miqi/runtime/thread_runtime.py`
  - `aiosqlite.connect(..., timeout=30)`，与 `history_runtime.py`/`stored_runtime.py` 等既有约定一致。

## 日志/验证证据

```
$ git apply --check --stat sandbox-root-fix.patch
 miqi/sandbox/bwrap.py | 108 +++++++++++++++++++++++++++++++++++++++----------
 1 file changed, 85 insertions(+), 23 deletions(-)

$ python -m py_compile miqi/sandbox/bwrap.py miqi/runtime/ledger_runtime.py miqi/runtime/thread_runtime.py
# COMPILE_OK
```

`database is locked` flake 证据（同一测试 `test_issue_886_interrupted_turn_retry.py::test_interrupted_turn_survives_fresh_retry`，同一错误，均非本分支改动所致）：

```
$ gh run view 33470337439 --log   # main（develop→main 发布合并）
FAILED tests/runtime/test_issue_886_interrupted_turn_retry.py::test_interrupted_turn_survives_fresh_retry
E   sqlite3.OperationalError: database is locked

$ gh run view 33464925805 --log   # fix/bridge-loopback-lan-fallback（#898 分支）
FAILED tests/runtime/test_issue_886_interrupted_turn_retry.py::test_interrupted_turn_survives_fresh_retry
E   sqlite3.OperationalError: database is locked

# develop 最新 run 33486588706 则 3405 passed 全绿 → 时序相关，非确定性挂
```

## 测试情况

- 语法检查：`python -m py_compile` 三个改动文件全部通过
- busy timeout 修复已在 CI `test (ubuntu-latest)` 验证（修复前连续 3 次挂同一测试，修复后见 CI 状态）
- 未跑 WSL E2E（需要真实 WSL distro 环境）；幂等逻辑通过 shell 命令静态推演覆盖三条分支（已有 default=root / 已有其他 default= / 无 [user] 段）

## 截图

无需截图（无 UI 变更）