### PR TITLE
feat(sandbox): 沙箱默认共享宿主网络（share_net 默认开启）

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -160,7 +160,7 @@ apps/desktop/src/
   "tools": {
     "sandbox": {
       "enabled": true,
-      "share_net": false,
+      "share_net": true,
       "allow_system_installs": false,
       "max_sandboxes": 10,
       "auto_cleanup": true,
@@ -175,7 +175,7 @@ apps/desktop/src/
 | 字段 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `enabled` | bool | true | 启用沙箱隔离 |
-| `share_net` | bool | false | 共享宿主机网络（true=容器可联网） |
+| `share_net` | bool | true | 共享宿主机网络（默认开启，沙箱内可直接联网、`pip install` 等；设为 false 则隔离网络命名空间 `--unshare-net`，沙箱内无外网） |
 | `allow_system_installs` | bool | false | 将系统包安装命令（`sudo apt-get install ...` 等）路由到 WSL 发行版以 root 执行。沙箱内无 root 且 `/usr` 等系统目录只读，apt 永远无法在沙箱内安装；开启后安装命令会改为在 WSL 发行版中执行，**安装一次、跨会话持久**，并立即通过沙箱对发行版系统目录的 ro-bind 在沙箱内可见（如 `xelatex`）。默认关闭：在 WSL 发行版中执行 root 命令属于主动让渡的权限，需用户显式开启。仅 Windows + WSL 生效（#759） |
 | `max_sandboxes` | int | 10 | 最大并发沙箱数 |
 | `auto_cleanup` | bool | true | 会话结束时自动清理沙箱 |

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1883,7 +1883,7 @@ class BridgeRuntimeLoop:
             sb_cfg = getattr(config.tools, "sandbox", None)
             new_mgr = SandboxManager(
                 workspace=config.workspace_path,
-                share_net=getattr(sb_cfg, "share_net", False),
+                share_net=getattr(sb_cfg, "share_net", True),
                 enabled=True,
                 max_sandboxes=getattr(sb_cfg, "max_sandboxes", 10),
                 auto_cleanup=getattr(sb_cfg, "auto_cleanup", True),

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -241,7 +241,7 @@ class BridgeState:
 
         self._sandbox_manager = SandboxManager(
             workspace=config.workspace_path,
-            share_net=getattr(sb_cfg, "share_net", False),
+            share_net=getattr(sb_cfg, "share_net", True),
             # Start with enabled=False so tools run locally during
             # background install.  _init_sandbox_manager() in loop.py
             # auto-enables after initialize() succeeds and persists

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -448,7 +448,7 @@ class SandboxConfig(Base):
     """Sandbox isolation configuration for per-session environments."""
 
     enabled: bool = True
-    share_net: bool = False  # Allow network access inside sandbox (disabled by default for security)
+    share_net: bool = True  # Share host network with sandbox (enabled by default so pip/apt inside the sandbox can reach the network; set false for full network isolation)
     # Route system package installs (apt-get/apt/dnf/... install) to the WSL
     # distro as root instead of failing inside the unprivileged read-only
     # bwrap sandbox.  Installs persist across sessions and are immediately

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -8,7 +8,7 @@ Each conversation gets its own mount namespace with:
 - A writable overlay (tmpfs) for /tmp, /home/miqi/workspace
 - Read-only bind mounts for /usr, /lib, /bin, etc.
 - A per-session home directory with its own copy of the workspace
-- Network isolation (unshare-net) by default
+- Network shared with host by default (unshare-net only when share_net=False)
 - PID namespace isolation (unshare-pid)
 
 Usage:
@@ -298,7 +298,7 @@ class BwrapSandbox:
         session_key: str,
         workspace: Path | str,
         sandbox_base_dir: Path | str | None = None,
-        share_net: bool = False,
+        share_net: bool = True,
         extra_ro_binds: list[str] | None = None,
         extra_rw_binds: list[str] | None = None,
         hostname: str = "miqi-sandbox",

--- a/miqi/sandbox/manager.py
+++ b/miqi/sandbox/manager.py
@@ -385,7 +385,7 @@ class SandboxManager:
         self,
         workspace: Path,
         sandbox_base_dir: Path | None = None,
-        share_net: bool = False,
+        share_net: bool = True,
         enabled: bool = True,
         max_sandboxes: int = 10,
         auto_cleanup: bool = True,


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [x] 🔧 其他

## 变更概述

将沙箱网络共享配置 `tools.sandbox.share_net` 的默认值由 `false` 改为 `true`，沙箱默认共享宿主网络、可直接联网。

## 背景/问题

原默认 `share_net=false` 会在 bwrap 命令中追加 `--unshare-net`，把沙箱隔离进独立的网络命名空间——里面只有 loopback、没有对外网卡，导致沙箱内 DNS 解析失败、`pip install` 无法联网、直传类工具（dataUpload）不可用。对比实验实锤：

| bwrap 模式 | 结果 |
|---|---|
| `--unshare-net`（share_net=false，原默认） | NO_NET，DNS 失败 ❌ |
| 不带该参数（share_net=true） | HAS_NET，HTTPS 请求返回 200 ✅ |

用户期望默认不需要断网：agent 在沙箱内执行 `pip install httpx`、访问外网是常见需求，默认断网造成大量困惑与误报（WSL 网络问题排查了半天，根因其实是沙箱自身隔了网）。因此翻转默认值。

安全权衡：`--unshare-net` 曾是刻意的安全默认（沙箱内任意代码无法访问外网/内网）。翻转后网络隔离变为 opt-in——需要完全断网的场景把 `share_net` 显式设为 `false` 即可恢复 `--unshare-net`。

## 变更内容

| 文件 | 改动 |
|------|------|
| `miqi/config/schema.py` | `SandboxConfig.share_net` 默认 `False` → `True`，注释同步 |
| `miqi/sandbox/manager.py` | `SandboxManager.__init__` 的 `share_net` 参数默认值 → `True` |
| `miqi/sandbox/bwrap.py` | `BwrapSandbox.__init__` 的 `share_net` 参数默认值 → `True`；模块 docstring 改为「默认共享宿主网络，`--unshare-net` 仅在 `share_net=False` 时追加」 |
| `miqi/bridge/server.py`、`miqi/bridge/loop.py` | 两处 `getattr(sb_cfg, "share_net", ...)` 兜底默认值 → `True`（兼容旧配置缺字段） |
| `docs/developer-guide.md` | 配置示例与字段表默认值改为 `true`，补充 `false` 时的隔离语义 |

bwrap 参数构建逻辑（`if not self.share_net: args.append("--unshare-net")`）无需改动，翻转默认后未显式配置的用户直接走共享网络分支。

注意：pydantic 默认值只在字段缺失时生效——已把 `"shareNet": false` 显式写入 config.json 的存量用户行为不变，需手动改值或删除该字段。

## 日志/验证证据

```
$ uv run pytest tests/sandbox -q
........................................................................ [ 34%]
........................................................................ [ 69%]
............................s..s................................         [100%]
206 passed, 2 skipped in 22.54s

$ uv run pytest tests/sandbox/test_system_install_routing.py tests/sandbox/test_workspace_bind_mount.py tests/sandbox/test_bwrap_auto_install.py tests/config/test_hot_reload.py -q
122 passed in 18.90s
```

## 测试情况

- `tests/sandbox` 全量：206 passed，2 skipped（WSL 环境相关用例跳过）
- 无测试断言 `--unshare-net` 默认存在，翻转默认值不破坏现有用例
- 纯后端配置默认值改动，前端无变更

## 截图

无需截图（纯后端配置默认值改动，无 UI 变更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
