### PR TITLE
fix(agent): 云平台上传必须走 dataUpload 接口，禁止用 message 工具冒充上传

### DIFF
--- a/miqi/agent/tools/message.py
+++ b/miqi/agent/tools/message.py
@@ -42,7 +42,14 @@ class MessageTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Send a message to the user. Use this when you want to communicate something."
+        return (
+            "Send a chat message to the user (optionally with file attachments). "
+            "This is for chatting/notifying only — it is NOT an upload API for any "
+            "cloud platform or website. To upload a file or plan to an external "
+            "platform (e.g. the MiQroForge/Qraft platform), use that platform's "
+            "dedicated upload interface (the qraft-workflowspec-export skill's "
+            "upload_run.py dataUpload), never this tool."
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -64,7 +71,10 @@ class MessageTool(Tool):
                 "media": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Optional: list of file paths to attach (images, audio, documents)"
+                    "description": (
+                        "Optional: file paths to send as CHAT attachments only. "
+                        "Attachments go to the chat, not to any platform — this is not an upload."
+                    )
                 }
             },
             "required": ["content"]

--- a/miqi/skills/qraft-workflowspec-export/SKILL.md
+++ b/miqi/skills/qraft-workflowspec-export/SKILL.md
@@ -4,17 +4,35 @@ description: >
   Export a WorkflowRun JSON (per workflowspec.schema.json) that organizes the
   scattered outputs of an agent problem-solving session — files, numbers,
   evidence, and conclusions — into a structured, schema-validated run record,
-  then confirm the plan with the user and upload it to the MiQroForge platform via
-  the dataUpload API (#674). Use when a session that invoked other skills has
-  finished and the user wants its products organized, archived, or unified
-  (e.g. "整理这次会话的产物", "把结果归档成 JSON", "export the workflow run",
-  "上传方案到 MiQroForge", "upload the workflow"). Also use when an existing
-  WorkflowRun needs to be updated with additional artifacts or conclusions.
-  Trigger on post-task archiving regardless of which skills produced the
-  outputs.
+  then confirm the plan with the user and upload it to the MiQroForge cloud
+  platform via its dataUpload API (#674). Use when a session that invoked other
+  skills has finished and the user wants its products organized, archived, or
+  unified (e.g. "整理这次会话的产物", "把结果归档成 JSON", "export the workflow run",
+  "上传方案到 MiQroForge", "上传到 MiQroForge 云平台", "把方案上传到平台",
+  "upload the workflow"). Also use when an existing WorkflowRun needs to be
+  updated with additional artifacts or conclusions. Trigger on post-task
+  archiving regardless of which skills produced the outputs. IMPORTANT: the
+  MiQroForge platform is an EXTERNAL cloud website, not yourself — "upload to
+  MiQroForge" means uploading via the dataUpload API (scripts/upload_run.py),
+  never sending a message/attachment to the miqroforge channel.
 ---
 
 # qraft-workflowspec-export
+
+## ⚠️ 上传红线（必读，先于一切步骤）
+
+**MiQroForge 平台（Qraft 平台）是外部云平台网站，不是你自己。**
+
+- 你（桌面 AI 助手）恰好也叫 MiQroForge，但用户说「上传到 MiQroForge / MiQroForge 云平台 / Qraft 平台」时，
+  指的是外部平台网站（测试环境 `https://test.forge.miqroera.com`），**不是**「给你自己发消息」。
+- **上传的唯一通道是平台的 dataUpload 接口**：`python <skill_dir>/scripts/upload_run.py <json> --json`（Step 8）。
+  只有该脚本返回 `ok:true` 才算「已上传到平台」。
+- **严禁用 `message` 工具冒充上传**：`message(channel="miqroforge"/"desktop", media=[...])` 只是把文件作为
+  聊天附件发给当前会话（等于发给自己）。文件不会进入平台，平台上看不到任何东西；
+  「Message sent to ...」返回 ≠ 上传成功，二者没有任何等价性。
+- 平台只接受 **JSON 文件**（`document_kind` = `workflow_definition` / `workflow_run`，≤5MB）。
+  Word/PDF 等附件不能直接上传——把方案内容组织成 workflow_definition JSON 后走 dataUpload。
+  如需把 Word 文档交给用户，可另外用 `message` 发给用户本地留档；但「上传到平台」这一步必须走 dataUpload。
 
 把一次 agent 问题解决会话的产物整理为 **WorkflowDefinition（上传目标）** 或 **WorkflowRun（归档记录）**：按 `references/workflowspec.schema.json` 定义的结构构建 JSON，完成 schema + 语义校验后，渲染方案视图经用户确认，上传到 MiQroForge 平台（dataUpload 接口）。上传目标默认是 `workflow_definition`（官方 OAuth2 文档 8.4 节），仅当用户明确要求归档运行记录时才导出 `workflow_run`。
 
@@ -225,6 +243,8 @@ python <skill_dir>/scripts/validate_run.py <落盘文件> --schema <权威版或
 - `cancelled`（超时/取消）→ 停止，不上传，告知用户可随时重来。
 
 ### Step 8: 凭据检查 + 上传
+
+自检：上传只能通过 `upload_run.py`（dataUpload）完成——`message` 工具发附件只是聊天附件，不是上传，不得替代本步骤。
 
 ```bash
 # 1) 检查登录态（只输出 {ok, source, expiresAt}，不含 token —— 防止完整凭据进入


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修正 AI 把「上传到 MiQroForge 云平台」误执行为 message 工具发附件的问题：上传必须走平台 dataUpload 接口，在提示词层面双重堵漏。

## 背景/问题

- 现象：用户要求「生成方案并上传至 MiQroForge 云平台」，AI 用 `message(channel="miqroforge", media=[docx])` 把文件作为聊天附件发给当前桌面会话（等于发给自己），并报告「上传成功」；文件实际未进入平台。
- 根因：助手自身名为 MiQroForge，与外部 MiQroForge 云平台（test.forge.miqroera.com）同名，AI 将「上传到 MiQroForge」理解为「给自己发消息」；上传技能提示词未明确区分二者、未禁止用 message 冒充上传。
- 影响：用户以为方案已上传，平台侧查不到任何产物。

## 变更内容

- `miqi/skills/qraft-workflowspec-export/SKILL.md`
  - 新增「⚠️ 上传红线」段（正文最顶部）：MiQroForge 平台是外部云平台网站而非助手自身；上传唯一通道为 dataUpload（`upload_run.py` 返回 `ok:true` 才算成功）；严禁用 message 发附件冒充上传；平台只收 JSON（document_kind 为 workflow_definition / workflow_run，≤5MB）
  - frontmatter 强化触发词：「上传到 MiQroForge 云平台」「把方案上传到平台」等，并加 NOTE 声明上传必须走 dataUpload
  - Step 8 增加自检行：message 发附件不是上传，不得替代 upload_run.py
- `miqi/agent/tools/message.py`
  - 工具 description 声明仅用于聊天/通知，不是任何云平台的上传接口；上传 MiQroForge/Qraft 平台须走 qraft-workflowspec-export 技能的 dataUpload
  - `media` 参数描述改为「仅作为聊天附件发送，不会上传到任何平台」

## 日志/验证证据

```
$ python -m py_compile miqi/agent/tools/message.py
SYNTAX OK

$ uv run pytest tests/skills/test_qraft_workflowspec.py -q
.......................................                                  [100%]
39 passed in 3.02s
```

## 测试情况

- `uv run pytest tests/skills/test_qraft_workflowspec.py -q`：39 passed
- `python -m py_compile miqi/agent/tools/message.py`：通过
- 已确认无测试断言 message 工具旧文案，无回归风险

## 截图

无需截图
