### PR TITLE
feat(bridge): 后端收口——禁掉自配 provider 凭据写入路径 (#835)

### DIFF
--- a/miqi/providers/factory.py
+++ b/miqi/providers/factory.py
@@ -20,20 +20,11 @@ def make_provider(config: Any) -> Any:
     Raises:
         ValueError: If no API key is configured and the provider is not local.
     """
-    from miqi.providers.custom_provider import CustomProvider
     from miqi.providers.registry import find_by_name
 
     model = config.agents.defaults.model
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
-
-    # Custom: direct OpenAI-compatible endpoint
-    if provider_name == "custom":
-        return CustomProvider(
-            api_key=p.api_key if p else "no-key",
-            api_base=config.get_api_base(model) or "http://localhost:8000/v1",
-            default_model=model,
-        )
 
     spec = find_by_name(provider_name)
     if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_local):

--- a/miqi/providers/registry.py
+++ b/miqi/providers/registry.py
@@ -73,16 +73,6 @@ class ProviderSpec:
 
 PROVIDERS: tuple[ProviderSpec, ...] = (
 
-    # === Custom (direct OpenAI-compatible endpoint, uses CustomProvider) ======
-    ProviderSpec(
-        name="custom",
-        keywords=(),
-        env_key="",
-        display_name="Custom",
-        model_prefix="",
-        is_direct=True,
-    ),
-
     # === Gateways (detected by api_key / api_base, not model name) =========
     # Gateways can route any model, so they win in fallback.
 

--- a/miqi/runtime/config_app_handlers.py
+++ b/miqi/runtime/config_app_handlers.py
@@ -100,6 +100,32 @@ def _validate_dot_path(path: str) -> None:
             )
 
 
+# 后端收口（#835）：providers 下不允许写入的自配凭据字段（snake/camel 两种）。
+_PROVIDER_CREDENTIAL_FIELDS = (
+    "api_key",
+    "api_base",
+    "extra_headers",
+    "apiKey",
+    "apiBase",
+    "extraHeaders",
+)
+
+
+def _reject_provider_credential_path(path: str) -> None:
+    """拒绝 batchWrite 写入 providers 的凭据字段。
+
+    dot-path 形如 "providers.deepseek.apiKey"，第三段是字段名。
+    """
+    if not path.startswith("providers."):
+        return
+    segments = path.split(".")
+    if len(segments) >= 3 and segments[2] in _PROVIDER_CREDENTIAL_FIELDS:
+        raise AppServerError(
+            f"自定义 Provider 凭据（{path}）已禁用，请使用内置激活码",
+            code="NOT_SUPPORTED",
+        )
+
+
 def _apply_edit(target: dict, edit: dict) -> None:
     """Apply a single edit dict to *target* in-place.
 
@@ -109,6 +135,7 @@ def _apply_edit(target: dict, edit: dict) -> None:
     op = edit.get("op", "set")
     path = edit.get("path", "")
     _validate_dot_path(path)
+    _reject_provider_credential_path(path)  # 后端收口（#835）
 
     segments = path.split(".")
     if op in ("set", None):

--- a/miqi/runtime/config_handlers.py
+++ b/miqi/runtime/config_handlers.py
@@ -18,6 +18,38 @@ from loguru import logger
 from miqi.runtime.app_server import AppServerError, get_bridge_state
 from miqi.runtime.core_request_models import validate_core_params
 
+# 后端收口（#835）：providers 下不允许写入的自配凭据字段（snake/camel 两种）。
+_PROVIDER_CREDENTIAL_FIELDS = (
+    "api_key",
+    "api_base",
+    "extra_headers",
+    "apiKey",
+    "apiBase",
+    "extraHeaders",
+)
+
+
+def _reject_provider_credentials(updates: Any) -> None:
+    """拒绝经 config.update 写入 providers 的自配凭据。
+
+    仅拦截 providers.* 的凭据字段；agents.defaults.model 等其它字段不受影响。
+    """
+    if not isinstance(updates, dict):
+        return
+    providers = updates.get("providers")
+    if not isinstance(providers, dict):
+        return
+    for provider_name, pconfig in providers.items():
+        if not isinstance(pconfig, dict):
+            continue
+        for field in _PROVIDER_CREDENTIAL_FIELDS:
+            if pconfig.get(field):
+                raise AppServerError(
+                    f"自定义 Provider 凭据（providers.{provider_name}.{field}）已禁用，"
+                    "请使用内置激活码",
+                    code="NOT_SUPPORTED",
+                )
+
 
 def _apply_runtime_approval_bypass(runtime: Any, config: Any) -> None:
     services = getattr(runtime, "services", None)
@@ -193,6 +225,8 @@ async def config_update_handler(
     """
     typed = validate_core_params("config.update", params)
     updates = typed.config
+
+    _reject_provider_credentials(updates)  # 后端收口（#835）
 
     from miqi.config.schema import Config
     from miqi.config.loader import save_config

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -216,6 +216,12 @@ async def providers_test_handler(
     api_base = params.get("api_base") or None
     requested_model = str(params.get("model") or "").strip()
 
+    # 后端收口（#835）：不再接受自配凭据，仅支持测试已保存的内置 key。
+    if api_key:
+        raise AppServerError("自定义 API Key 已禁用，仅支持内置密钥", code="NOT_SUPPORTED")
+    if api_base:
+        raise AppServerError("自定义 API Base 已禁用", code="NOT_SUPPORTED")
+
     if not provider_name:
         raise AppServerError("provider_name is required", code="INVALID_PARAMS")
 
@@ -334,10 +340,9 @@ async def providers_update_handler(
     session_id: str | None,
     registry: Any,
 ) -> dict[str, Any]:
-    """Update a single provider's api_key / api_base / extra_headers / model."""
+    """Update the default model only（自配凭据已禁用，#835 后端收口）。"""
     from miqi.config.loader import save_config
-    from miqi.config.schema import ProviderConfig, ProvidersConfig
-    from miqi.providers.registry import find_by_name
+    from miqi.config.schema import ProvidersConfig
 
     provider_name = params.get("provider_name", "").strip()
     if not provider_name:
@@ -348,7 +353,6 @@ async def providers_update_handler(
         raise AppServerError(
             f"Unknown provider: {provider_name}", code="INVALID_PARAMS",
         )
-    spec = find_by_name(provider_name)
 
     state = get_bridge_state(registry)
     config = state.load_config()
@@ -360,75 +364,23 @@ async def providers_update_handler(
             f"Provider config not found: {provider_name}", code="NOT_FOUND",
         )
 
-    update: dict[str, Any] = {}
-    if "api_key" in params:
-        update["api_key"] = str(params["api_key"])
-    if "api_base" in params:
-        v = params["api_base"]
-        update["api_base"] = str(v) if v else (spec.default_api_base if spec else None)
-    if "extra_headers" in params:
-        v = params["extra_headers"]
-        update["extra_headers"] = dict(v) if v else None
+    # 后端收口（#835）：拒绝自配凭据（api_key / api_base / extra_headers），
+    # 只允许更新默认模型（agents.defaults.model）。
+    if params.get("api_key"):
+        raise AppServerError("自定义 API Key 已禁用，请使用内置激活码", code="NOT_SUPPORTED")
+    if params.get("api_base"):
+        raise AppServerError("自定义 API Base 已禁用", code="NOT_SUPPORTED")
+    if params.get("extra_headers"):
+        raise AppServerError("自定义 Extra Headers 已禁用", code="NOT_SUPPORTED")
 
     model_override: str | None = None
     if "model" in params and params["model"]:
         model_override = str(params["model"]).strip()
 
-    if update.get("api_key") and "api_base" not in update and not getattr(pc, "api_base", None):
-        default_api_base = spec.default_api_base if spec else ""
-        if default_api_base:
-            update["api_base"] = default_api_base
-
-    if not update and not model_override:
+    if not model_override:
         raise AppServerError("No fields to update", code="INVALID_PARAMS")
 
-    if update:
-        current_dict = pc.model_dump(by_alias=False)
-        current_dict.update(update)
-        new_pc = ProviderConfig.model_validate(current_dict)
-        setattr(config.providers, provider_name, new_pc)
-        _set_provider_verification(
-            config,
-            provider_name,
-            "unverified",
-            _provider_fingerprint(new_pc, config.agents.defaults.model),
-            "Provider settings changed; test again to verify",
-        )
-        # When user explicitly provides an API key (including empty to clear
-        # built-in activation), clear the built-in activation flag so the UI
-        # defaults to "own key" next time.
-        if "api_key" in update:
-            activation_store = _provider_activation_store(config)
-            activation_store.pop(provider_name, None)
-
-    if model_override:
-        config.agents.defaults.model = model_override
-    elif ("api_key" in update and update.get("api_key")) or (
-        "api_base" in update and update.get("api_base")
-    ):
-        # User saved a provider key/base without picking a model. If the
-        # current default model belongs to a provider that is NOT usable,
-        # switch the default to this provider's model — otherwise chat keeps
-        # sending e.g. "anthropic/claude-opus-4-5" to the DeepSeek API and
-        # gets 400 invalid_request_error (#602).
-        from miqi.providers.registry import find_by_model
-
-        current = config.agents.defaults.model
-        current_spec = find_by_model(current)
-        # Only auto-switch when the current model belongs to a KNOWN
-        # standard provider that is not usable. If the model matches
-        # nothing (e.g. a local vllm/ollama model that find_by_model skips),
-        # leave the default untouched — switching would clobber a valid
-        # local setup.
-        if current_spec is not None:
-            cur_pc = getattr(config.providers, current_spec.name, None)
-            cur_configured = _provider_usable(cur_pc, current_spec)
-        else:
-            cur_configured = True  # unknown model — do not switch
-        if not cur_configured:
-            fallback_model = PROVIDER_TEST_MODELS.get(provider_name)
-            if fallback_model:
-                config.agents.defaults.model = fallback_model
+    config.agents.defaults.model = model_override
 
     save_config(config)
     state.config = config

--- a/tests/runtime/test_config_app_handlers.py
+++ b/tests/runtime/test_config_app_handlers.py
@@ -162,23 +162,37 @@ async def test_config_batch_write_delete_removes_optional_value():
     registry = ClientSessionRegistry()
     server = _setup_server(registry, model="anthropic/claude-opus-4-5")
 
-    # Set an optional provider field so we can delete it
+    # 使用非凭据字段（providers.* 凭据字段已收口禁用，见 #835）
     await server.dispatch(
         "1", "config/batchWrite",
-        {"edits": [{"path": "providers.anthropic.apiBase", "value": "https://api.example.com/v1"}]},
+        {"edits": [{"path": "agents.defaults.workspace", "value": "/tmp/foo"}]},
         "client-1", None,
     )
     state = registry.bridge_context["state"]
-    assert state.config.providers.anthropic.api_base == "https://api.example.com/v1"
+    assert state.config.agents.defaults.workspace == "/tmp/foo"
 
-    # Now delete that optional field
+    # Now delete that field
     response = await server.dispatch(
         "2", "config/batchWrite",
-        {"edits": [{"op": "delete", "path": "providers.anthropic.apiBase"}]},
+        {"edits": [{"op": "delete", "path": "agents.defaults.workspace"}]},
         "client-1", None,
     )
     assert response["result"]["saved"] is True
-    assert state.config.providers.anthropic.api_base is None
+    assert state.config.agents.defaults.workspace == "~/.miqi/workspace"
+
+
+@pytest.mark.asyncio
+async def test_config_batch_write_rejects_provider_credentials():
+    """后端收口（#835）：batchWrite 拒绝写入 providers 凭据字段。"""
+    registry = ClientSessionRegistry()
+    server = _setup_server(registry, model="anthropic/claude-opus-4-5")
+
+    response = await server.dispatch(
+        "1", "config/batchWrite",
+        {"edits": [{"path": "providers.deepseek.apiKey", "value": "sk-custom"}]},
+        "client-1", None,
+    )
+    assert response.get("code") == "NOT_SUPPORTED"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -78,6 +78,23 @@ async def test_config_update_saves_and_propagates(fake_config, fake_provider, tm
 
 
 @pytest.mark.asyncio
+async def test_config_update_rejects_provider_credentials(fake_config, fake_provider, tmp_path):
+    """后端收口（#835）：config.update 拒绝写入 providers 凭据字段。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"providers": {"deepseek": {"api_key": "sk-custom"}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "NOT_SUPPORTED"
+
+
+@pytest.mark.asyncio
 async def test_config_update_rejects_empty_config(fake_config, fake_provider, tmp_path):
     """config.update rejects empty config param."""
     from miqi.runtime.app_server import AppServerError

--- a/tests/runtime/test_error_sanitization.py
+++ b/tests/runtime/test_error_sanitization.py
@@ -107,7 +107,7 @@ async def test_providers_test_error_is_sanitized():
     try:
         await providers_test_handler(
             "req-1",
-            {"provider_name": "nonexistent-provider-xyz", "api_key": "sk-fake-key-for-test"},
+            {"provider_name": "nonexistent-provider-xyz"},
             "client-1", None, registry,
         )
     except AppServerError as exc:
@@ -115,6 +115,21 @@ async def test_providers_test_error_is_sanitized():
         assert exc.code == "NOT_FOUND"
         assert_error_is_sanitized(exc, "providers_test")
         # Message must NOT contain the fake API key (but provider name is fine)
+
+
+@pytest.mark.asyncio
+async def test_providers_test_rejects_custom_api_key():
+    """后端收口（#835）：providers.test 拒绝非空自配 api_key。"""
+    from miqi.runtime.provider_handlers import providers_test_handler
+
+    registry = ClientSessionRegistry()
+    with pytest.raises(AppServerError) as exc:
+        await providers_test_handler(
+            "req-1",
+            {"provider_name": "deepseek", "api_key": "sk-fake-key-for-test"},
+            "client-1", None, registry,
+        )
+    assert exc.value.code == "NOT_SUPPORTED"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_handlers_regression.py
+++ b/tests/runtime/test_provider_handlers_regression.py
@@ -1,16 +1,15 @@
-"""Provider handler regression tests — #602 deepseek model mismatch.
+"""Provider handler tests — #602 list 标注 + #835 后端收口.
 
-Reproduces the bug where saving a DeepSeek API key left the global default
-model at "anthropic/claude-opus-4-5", so the DeepSeek API was called with a
-Claude model name and rejected with 400 invalid_request_error. Also covers
-providers.list mislabeling the global model as DeepSeek's configured model.
+#602 的「写自定义 key 自动切模型」用例已删除:后端收口(#835)移除了
+providers.update 的自定义凭据写入路径,该行为不再存在。替换为收口回归测试,
+断言自配凭据被拒绝、model-only 覆盖仍可用。
 """
 
 from __future__ import annotations
 
 import pytest
 
-from miqi.runtime.app_server import ClientSessionRegistry
+from miqi.runtime.app_server import AppServerError, ClientSessionRegistry
 from miqi.runtime.provider_handlers import (
     providers_list_handler,
     providers_update_handler,
@@ -40,6 +39,9 @@ def _make_registry(model: str, **provider_keys) -> ClientSessionRegistry:
     return registry
 
 
+# ── providers.list（保留）─────────────────────────────────────────────────
+
+
 @pytest.mark.asyncio
 async def test_providers_list_does_not_mislabel_global_model_as_deepseek_model():
     """providers.list must not report the claude default as deepseek's configured_model."""
@@ -50,7 +52,6 @@ async def test_providers_list_does_not_mislabel_global_model_as_deepseek_model()
 
     deepseek = providers["deepseek"]
     assert deepseek["configured"] is True
-    # The default model belongs to anthropic — deepseek must NOT claim it.
     assert deepseek["configured_model"] is None
     assert result["result"]["active_model"] == "anthropic/claude-opus-4-5"
     assert result["result"]["active_provider"] == "anthropic"
@@ -68,170 +69,51 @@ async def test_providers_list_reports_model_when_it_belongs_to_provider():
     assert deepseek["configured_model"] == "deepseek-v4-flash"
 
 
-@pytest.mark.asyncio
-async def test_providers_update_switches_default_model_to_saved_provider():
-    """Saving a DeepSeek key while the default model is unusable (no key) must
-    switch the default model to DeepSeek's — otherwise chat calls the DeepSeek
-    API with a Claude model name (#602)."""
-    from unittest import mock
-
-    registry = _make_registry("anthropic/claude-opus-4-5", deepseek="sk-ds-1234567890")
-    state = registry.bridge_context["state"]
-
-    # save_config is imported inside the handler from miqi.config.loader
-    with mock.patch("miqi.config.loader.save_config"):
-        result = await providers_update_handler(
-            "r1",
-            {"provider_name": "deepseek", "api_key": "sk-ds-9876543210"},
-            "client-1", None, registry,
-        )
-
-    assert result["result"]["saved"] is True
-    # Default model must now be a DeepSeek model, not the claude default.
-    assert state.config.agents.defaults.model == "deepseek-v4-flash"
+# ── 后端收口（#835）：providers.update 拒绝自配凭据 ─────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_providers_update_keeps_model_when_provider_still_configured():
-    """If the current default provider still has a key, saving another provider's
-    key must NOT change the default model."""
-    registry = _make_registry(
-        "anthropic/claude-opus-4-5",
-        anthropic="sk-ant-api03-1234567890abcdef",
-        deepseek="sk-ds-1234567890",
-    )
-    state = registry.bridge_context["state"]
+async def test_providers_update_rejects_custom_api_key():
+    """后端收口：providers.update 拒绝非空 api_key。"""
+    registry = _make_registry("deepseek/deepseek-v4-flash")
 
-    from unittest import mock
-
-    with mock.patch("miqi.config.loader.save_config"):
+    with pytest.raises(AppServerError) as exc:
         await providers_update_handler(
             "r1",
-            {"provider_name": "deepseek", "api_key": "sk-ds-9876543210"},
+            {"provider_name": "deepseek", "api_key": "sk-ds-custom"},
             "client-1", None, registry,
         )
-
-    # anthropic still configured — default model must stay untouched.
-    assert state.config.agents.defaults.model == "anthropic/claude-opus-4-5"
+    assert exc.value.code == "NOT_SUPPORTED"
 
 
 @pytest.mark.asyncio
-async def test_providers_update_explicit_model_override_wins():
-    """An explicit model param overrides the auto-switch behavior."""
-    registry = _make_registry("anthropic/claude-opus-4-5")
-    state = registry.bridge_context["state"]
+async def test_providers_update_rejects_custom_api_base():
+    """后端收口：providers.update 拒绝非空 api_base。"""
+    registry = _make_registry("deepseek/deepseek-v4-flash")
 
-    from unittest import mock
-
-    with mock.patch("miqi.config.loader.save_config"):
+    with pytest.raises(AppServerError) as exc:
         await providers_update_handler(
             "r1",
-            {"provider_name": "deepseek", "api_key": "sk-ds-9876543210", "model": "deepseek-v4-pro"},
+            {"provider_name": "deepseek", "api_base": "https://evil.example.com/v1"},
             "client-1", None, registry,
         )
-
-    assert state.config.agents.defaults.model == "deepseek-v4-pro"
+    assert exc.value.code == "NOT_SUPPORTED"
 
 
 @pytest.mark.asyncio
-async def test_providers_update_api_base_also_triggers_auto_switch():
-    """Saving a local provider's api_base (no key) must also trigger the
-    auto-switch when the current default model's provider is unusable."""
-    from unittest.mock import MagicMock
-
-    from miqi.config.schema import Config
-
-    cfg = Config()
-    cfg.agents.defaults.model = "anthropic/claude-opus-4-5"
-    # vllm is a local provider — configured via api_base only
-    cfg.providers.vllm.api_base = "http://localhost:8000/v1"
-
-    state = MagicMock()
-    state.load_config.return_value = cfg
-    state.config = cfg
-
-    registry = ClientSessionRegistry()
-    registry.bridge_context["state"] = state
-
+async def test_providers_update_model_only_still_works():
+    """后端收口：providers.update 仍支持 model 覆盖（内置激活流程用）。"""
     from unittest import mock
+
+    registry = _make_registry("deepseek/deepseek-v4-flash")
+    state = registry.bridge_context["state"]
 
     with mock.patch("miqi.config.loader.save_config"):
         result = await providers_update_handler(
             "r1",
-            {"provider_name": "vllm", "api_base": "http://localhost:9000/v1"},
+            {"provider_name": "deepseek", "model": "deepseek/deepseek-v4-flash"},
             "client-1", None, registry,
         )
 
     assert result["result"]["saved"] is True
-    # Default model was claude (unusable — no anthropic key); saving the
-    # local provider's base must switch to its test model.
-    assert state.config.agents.defaults.model == "meta-llama/Llama-3.1-8B-Instruct"
-
-
-@pytest.mark.asyncio
-async def test_providers_update_local_provider_api_key_counts_configured():
-    """A local provider with only an api_key set is still usable — the
-    auto-switch must NOT fire when it holds the current default model."""
-    from unittest.mock import MagicMock
-
-    from miqi.config.schema import Config
-
-    cfg = Config()
-    cfg.agents.defaults.model = "meta-llama/Llama-3.1-8B-Instruct"
-    cfg.providers.vllm.api_key = "local-key"
-
-    state = MagicMock()
-    state.load_config.return_value = cfg
-    state.config = cfg
-
-    registry = ClientSessionRegistry()
-    registry.bridge_context["state"] = state
-
-    from unittest import mock
-
-    with mock.patch("miqi.config.loader.save_config"):
-        await providers_update_handler(
-            "r1",
-            {"provider_name": "deepseek", "api_key": "sk-ds-9876543210"},
-            "client-1", None, registry,
-        )
-
-    # vllm (local, api_key-only) holds the default model — it is
-    # usable, so the model must stay untouched.
-    assert state.config.agents.defaults.model == "meta-llama/Llama-3.1-8B-Instruct"
-
-
-@pytest.mark.asyncio
-async def test_default_api_base_without_key_is_not_usable():
-    """A standard provider with only the auto-filled default api_base (no
-    api_key — key saved then cleared) must NOT count as configured. The
-    auto-switch must fire when the current default model belongs to it."""
-    from unittest.mock import MagicMock
-
-    from miqi.config.schema import Config
-
-    cfg = Config()
-    cfg.agents.defaults.model = "anthropic/claude-opus-4-5"
-    # Simulate: key was saved (auto-filling default api_base), then cleared
-    cfg.providers.anthropic.api_base = "https://api.anthropic.com"
-    cfg.providers.anthropic.api_key = ""
-
-    state = MagicMock()
-    state.load_config.return_value = cfg
-    state.config = cfg
-
-    registry = ClientSessionRegistry()
-    registry.bridge_context["state"] = state
-
-    from unittest import mock
-
-    with mock.patch("miqi.config.loader.save_config"):
-        await providers_update_handler(
-            "r1",
-            {"provider_name": "deepseek", "api_key": "sk-ds-9876543210"},
-            "client-1", None, registry,
-        )
-
-    # anthropic has no key — only a default endpoint — so the default
-    # model must switch to deepseek's.
-    assert state.config.agents.defaults.model == "deepseek-v4-flash"
+    assert state.config.agents.defaults.model == "deepseek/deepseek-v4-flash"


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

后端收口：禁掉自配 provider 凭据（api_key / api_base / extra_headers）的后端写入路径，配合 #907 前端收口完成「移除自定义模型运行能力」。

## 背景/问题

前端收口（#907）已删除「自配 provider/model」的 UI 入口，但后端仍能自配凭据，残留接口可被绕过（issue #835 备选方案明确点名：仅前端移除入口、后端保留能力，需后端一并收口）。

本 PR 收紧后端写入路径，让 `config.providers.*.api_key` 只能由「内置激活码」（`providers.activate`）写入：
1. `providers.update` / `providers.test` 拒绝自配凭据；
2. `config.update` / `config.batchWrite` 拦截 providers 凭据字段（堵两个绕过后门）；
3. 移除 `custom` provider（任意 OpenAI-compatible 端点）。

「执行路径改为从登录态/平台获取凭据」属后续（Level 2，等平台接口），本次不做。

## 关联 issue

- #835 模型选择收口（后端部分）
- #893 功能描述 4（执行路径改造——本次仅收口「自配凭据写入」，「从登录态获取凭据」待平台接口）

## 变更内容

- `miqi/runtime/provider_handlers.py`：`providers_test_handler` / `providers_update_handler` 拒绝非空 api_key / api_base / extra_headers，只保留 model 覆盖（内置激活流程用）
- `miqi/runtime/config_handlers.py`：`config.update` 深合并前拦截 providers 凭据字段（`_reject_provider_credentials`）
- `miqi/runtime/config_app_handlers.py`：`batchWrite` dot-path 拦截 providers 凭据字段（`_reject_provider_credential_path`）
- `miqi/providers/registry.py` + `factory.py`：移除 `custom` provider spec 与工厂分支
- `tests/`：删除「写自定义 key 自动切模型」旧用例，新增收口回归测试

## 日志/验证证据

```
$ .venv/Scripts/python.exe -m pytest tests/runtime/ tests/providers/ -q
1337 passed, 1 skipped
```

## 测试情况

- 全量 `tests/runtime/` + `tests/providers/`：1337 passed, 1 skipped
- 新增收口回归测试：providers.update/test 拒绝自配凭据、config.update/batchWrite 拒绝 providers 凭据字段
- 同步更新 4 个测试文件（删旧「自动切模型」用例） 
<img width="2316" height="253" alt="image" src="https://github.com/user-attachments/assets/5103c22f-662f-4437-84cf-3d55b6a55380" />


## 截图

<img width="1257" height="835" alt="image" src="https://github.com/user-attachments/assets/50c034d6-7680-45f5-9d35-2e73a90c07fb" />
<img width="1256" height="854" alt="image" src="https://github.com/user-attachments/assets/49478609-e19f-4798-ab71-360445690b6b" />


## 后续计划

- #893 执行路径改为从登录态/平台获取凭据（Level 2，等平台接口）
- #893 平台模型清单动态拉取（功能描述 1/2/3，等接口文档）
