### PR TITLE
feat(agent): 会话启动时连接配置的 MCP 服务器并注册工具

### DIFF
--- a/apps/desktop/tests/e2e/mcp.spec.ts
+++ b/apps/desktop/tests/e2e/mcp.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * MCP 服务器集成 E2E — 桌面端 MCP 全链路。
+ *
+ * 链路：beforeAll 把 stdio MCP 服务器（本地 FastMCP 测试服务器）写进
+ * config.json → 会话创建时 RuntimeSession 连接 MCP 服务器、把其工具注册
+ * 进 ToolRegistry → mock LLM 调用 mcp_e2emcp_e2e_echo → 编排器执行包装器
+ * → MCP 子进程真实执行 → 工具结果回传 → mock 仅在收到真实标记时输出
+ * MCP-E2E-PASS。
+ *
+ * 另有一条 UI 链路：设置页添加服务器（uimcp）→ 列表显示 + config.json
+ * 持久化。两条链路互相独立（重试安全：每个用例单独跑也能通过）。
+ *
+ * 不依赖真实 LLM：scripts/mock_mcp.py 按工具调用序列确定性推进。
+ *
+ * Run: cd apps/desktop && npx playwright test \
+ *      --config=playwright.config.ts --project=electron -g "MCP 服务器"
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  launchElectronApp,
+  closeElectronApp,
+  createNewConversation,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+import { postScreenshotToPr } from './helpers/pr-image-post';
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+const SERVER_NAME = 'e2emcp';
+const ECHO_MARKER = 'MCP_ECHO_RESULT_7f3a9c';
+const SERVER_SCRIPT = join(REPO_ROOT, 'scripts', 'mock_mcp_server.py');
+
+/**
+ * Start scripts/mock_mcp.py on an ephemeral port and wait for its startup
+ * line (the server prints the ACTUAL bound port after bind) — same pattern
+ * as the confirm-card spec's mock_openai.py launcher.
+ */
+async function startMockLLM(): Promise<{ proc: ChildProcess; mockUrl: string }> {
+  const python = process.env.MIQI_PYTHON_PATH || 'python';
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_mcp.py'), String(port)], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    windowsHide: true,
+  });
+
+  let readyUrl = '';
+  let stderrTail = '';
+  proc.stdout?.on('data', (d) => {
+    const t = String(d);
+    console.log(`[mock-mcp] ${t.trim()}`);
+    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => {
+    stderrTail = (stderrTail + String(d)).slice(-2000);
+    console.log(`[mock-mcp-err] ${String(d).trim()}`);
+  });
+  proc.on('exit', (code) => console.log(`[test] mock-mcp server exited: ${code}`));
+
+  const deadline = Date.now() + 30_000;
+  while (!readyUrl && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(`mock-mcp server exited early (code ${proc.exitCode}): ${stderrTail}`);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!readyUrl) {
+    proc.kill();
+    throw new Error(`mock-mcp startup line not seen in 30s: ${stderrTail}`);
+  }
+  console.log(`[test] mock-mcp LLM ready at ${readyUrl}`);
+  return { proc, mockUrl: readyUrl };
+}
+
+/**
+ * Resolve the interpreter that runs the MCP test server: it must import
+ * the `mcp` SDK.  Prefer the same interpreters the bridge uses — an
+ * explicit MIQI_PYTHON_PATH (if it has mcp) or the repo venv; fall back
+ * to `uv run python` (CI bridge fallback).
+ */
+function resolveMcpCommand(): { command: string; args: string[] } {
+  const candidates: string[] = [];
+  if (process.env.MIQI_PYTHON_PATH) candidates.push(process.env.MIQI_PYTHON_PATH);
+  const venvPy =
+    process.platform === 'win32'
+      ? join(REPO_ROOT, '.venv', 'Scripts', 'python.exe')
+      : join(REPO_ROOT, '.venv', 'bin', 'python');
+  candidates.push(venvPy);
+  for (const py of candidates) {
+    if (!existsSync(py)) continue;
+    const probe = spawnSync(py, ['-c', 'import mcp'], {
+      encoding: 'utf8',
+      timeout: 15_000,
+      windowsHide: true,
+    });
+    if (probe.status === 0) {
+      console.log(`[test] MCP server interpreter: ${py}`);
+      return { command: py, args: [] };
+    }
+  }
+  console.log('[test] MCP server interpreter: uv run python (fallback)');
+  return { command: 'uv', args: ['run', 'python'] };
+}
+
+test.describe('MCP 服务器集成', () => {
+  // macOS CI cannot run this spec: the runner's undici fetch fails against
+  // a local 127.0.0.1 listener and the spawned mock's stdout pipe never
+  // delivers — same trimming strategy as the confirm-card spec (#710).
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server'
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+  let mcpCommand: { command: string; args: string[] };
+
+  test.beforeAll(async () => {
+    const mock = await startMockLLM();
+    mockServer = mock.proc;
+    mcpCommand = resolveMcpCommand();
+    // Point EVERY configured provider at the mock — provider resolution
+    // depends on the model in agents.defaults, so patching a single provider
+    // would leak real API calls.  Preload the runtime-test MCP server
+    // (config.json persists camelCase keys: tools.mcpServers) and drop any
+    // user-configured servers so the run is deterministic.
+    const fixture = await launchElectronApp((config: any) => {
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = mock.mockUrl;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+      config.tools = {
+        ...(config.tools ?? {}),
+        mcpServers: {
+          [SERVER_NAME]: {
+            command: mcpCommand.command,
+            args: [...mcpCommand.args, SERVER_SCRIPT],
+            toolTimeout: 30,
+            description: 'E2E 测试 MCP 服务器',
+            lazy: false,
+          },
+        },
+      };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mockServer?.kill();
+  });
+
+  // 失败时把 Playwright 自动截图贴到 PR 评论（CI 默认开启，本地 MQI_E2E_POST_IMG=1）
+  test.afterEach(async () => {
+    if (test.info().status === 'passed') return;
+    const fail = join(test.info().outputDir, 'test-failed-1.png');
+    if (existsSync(fail)) {
+      await postScreenshotToPr(fail, `❌ E2E 失败：${test.info().title}`);
+    }
+  });
+
+  test(
+    '设置页添加 stdio MCP 服务器 → 列表显示并持久化到 config.json',
+    { timeout: 120_000 },
+    async () => {
+      // ── 打开设置 → MCP 服务 tab ──
+      const settingsBtn = page.locator('[data-testid="nav-system-settings"]');
+      await expect(settingsBtn).toBeVisible({ timeout: 15_000 });
+      await settingsBtn.click();
+      const mcpTab = page.getByRole('tab', { name: /MCP 服务/ }).first();
+      await expect(mcpTab).toBeVisible({ timeout: 10_000 });
+      await mcpTab.click();
+      await expect(page.getByRole('heading', { name: 'MCP 服务器' })).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 预置的 e2emcp（beforeAll 写入 config.json）已出现在列表里
+      await expect(page.getByText(SERVER_NAME, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // ── 添加服务器弹窗 ──
+      await page.getByRole('button', { name: '添加服务器' }).click();
+      await expect(page.getByRole('heading', { name: '添加 MCP 服务器' })).toBeVisible();
+
+      const uiName = 'uimcp';
+      await page.getByPlaceholder('my-mcp-server').fill(uiName);
+      await page.getByPlaceholder('npx').fill(mcpCommand.command);
+      const argsStr =
+        mcpCommand.args.length > 0
+          ? [...mcpCommand.args, SERVER_SCRIPT].join(', ')
+          : SERVER_SCRIPT;
+      await page
+        .getByPlaceholder('-y, @modelcontextprotocol/server-filesystem')
+        .fill(argsStr);
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-modal.png`,
+      });
+      await page.getByRole('button', { name: '保存', exact: true }).click();
+
+      // ── 列表出现新服务器卡片（stdio 徽标） ──
+      await expect(page.getByText(uiName, { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(page.getByText('stdio', { exact: true })).toHaveCount(2);
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-list.png`,
+        fullPage: true,
+      });
+      await postScreenshotToPr(
+        `test-results/${test.info().title.replace(/\s+/g, '-')}-list.png`,
+        '✅ E2E 通过：设置页添加 MCP 服务器（uimcp）→ 列表显示 + config.json 持久化',
+      );
+
+      // ── config.json 持久化（文件存 camelCase 键：tools.mcpServers） ──
+      const raw = readFileSync(join(miqiHome, 'config.json'), 'utf-8');
+      const saved = JSON.parse(raw);
+      const entry = saved?.tools?.mcpServers?.[uiName];
+      expect(entry, 'config.json 应包含 tools.mcpServers.uimcp').toBeTruthy();
+      expect(entry.command).toBe(mcpCommand.command);
+      const savedArgs = entry.args ?? [];
+      expect(savedArgs).toContain(SERVER_SCRIPT);
+    }
+  );
+
+  test(
+    '新建会话 → 模型调用 MCP 工具 → 最终回复含工具返回值标记',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      // ── 新建会话（离开设置页）→ 新 RuntimeSession 在 start() 时连接 MCP ──
+      await createNewConversation(page);
+      await expect(page.locator('[data-testid="chat-input-container"]')).toBeVisible();
+
+      // ── 发送任务 → mock 第一轮即调用 mcp_e2emcp_e2e_echo ──
+      await sendMessage(page, 'MCP 测试：请调用 MCP 工具并返回结果');
+
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      await expect(page.locator('main')).toContainText('MCP-E2E-PASS', {
+        timeout: 30_000,
+      });
+      await expect(page.locator('main')).toContainText(ECHO_MARKER, {
+        timeout: 30_000,
+      });
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}-final.png`,
+        fullPage: true,
+      });
+      await postScreenshotToPr(
+        `test-results/${test.info().title.replace(/\s+/g, '-')}-final.png`,
+        '✅ E2E 通过：新会话中模型调用 mcp_e2emcp_e2e_echo，真实 MCP 子进程返回标记，AI 回复 MCP-E2E-PASS',
+      );
+    }
+  );
+});

--- a/apps/desktop/tests/e2e/mcp.spec.ts
+++ b/apps/desktop/tests/e2e/mcp.spec.ts
@@ -204,12 +204,8 @@ test.describe('MCP 服务器集成', () => {
       await page.getByPlaceholder('my-mcp-server').fill(uiName);
       await page.getByPlaceholder('npx').fill(mcpCommand.command);
       const argsStr =
-        mcpCommand.args.length > 0
-          ? [...mcpCommand.args, SERVER_SCRIPT].join(', ')
-          : SERVER_SCRIPT;
-      await page
-        .getByPlaceholder('-y, @modelcontextprotocol/server-filesystem')
-        .fill(argsStr);
+        mcpCommand.args.length > 0 ? [...mcpCommand.args, SERVER_SCRIPT].join(', ') : SERVER_SCRIPT;
+      await page.getByPlaceholder('-y, @modelcontextprotocol/server-filesystem').fill(argsStr);
       await page.screenshot({
         path: `test-results/${test.info().title.replace(/\s+/g, '-')}-modal.png`,
       });
@@ -226,7 +222,7 @@ test.describe('MCP 服务器集成', () => {
       });
       await postScreenshotToPr(
         `test-results/${test.info().title.replace(/\s+/g, '-')}-list.png`,
-        '✅ E2E 通过：设置页添加 MCP 服务器（uimcp）→ 列表显示 + config.json 持久化',
+        '✅ E2E 通过：设置页添加 MCP 服务器（uimcp）→ 列表显示 + config.json 持久化'
       );
 
       // ── config.json 持久化（文件存 camelCase 键：tools.mcpServers） ──
@@ -265,7 +261,7 @@ test.describe('MCP 服务器集成', () => {
       });
       await postScreenshotToPr(
         `test-results/${test.info().title.replace(/\s+/g, '-')}-final.png`,
-        '✅ E2E 通过：新会话中模型调用 mcp_e2emcp_e2e_echo，真实 MCP 子进程返回标记，AI 回复 MCP-E2E-PASS',
+        '✅ E2E 通过：新会话中模型调用 mcp_e2emcp_e2e_echo，真实 MCP 子进程返回标记，AI 回复 MCP-E2E-PASS'
       );
     }
   );

--- a/docs/e2e-pr-image-posting.md
+++ b/docs/e2e-pr-image-posting.md
@@ -19,7 +19,7 @@ e2e 测试跑完后，把截图上传到本仓库的固定预发布（release as
 | 存放位置 | 本仓库固定预发布 `_gh-imgup`（复用创建，Releases 列表只有一条） |
 | 上传 API | release assets（官方公开 API，token 即可；实测匿名可访问 HTTP 200） |
 | 去重 | 文件名 = `原名-<sha256前8位>.<ext>`；相同内容重复上传返回 422 时自动复用已有资产 |
-| 实现 | 纯 Node `fetch`（无 shell 依赖），见 [tests/e2e/helpers/pr-image-post.ts](../../apps/desktop/tests/e2e/helpers/pr-image-post.ts) |
+| 实现 | 纯 Node `fetch`（无 shell 依赖），见 [tests/e2e/helpers/pr-image-post.ts](https://github.com/14790897/MiqroForge-Desktop/blob/develop/apps/desktop/tests/e2e/helpers/pr-image-post.ts) |
 | 为何不用 draft release | draft 资产的下载 URL 对外（甚至带 token）都返回 404，评论里会裂图——必须 published 预发布 |
 | 为何不用 user-attachments | 原生贴图端点无公开 API，需驱动真实浏览器且有 TOS 风险（actions-cool/issues-helper 已被封） |
 
@@ -71,8 +71,8 @@ test.describe('My Acceptance E2E', () => {
 
 已接入的参考 spec：
 
-- [no-sandbox-exec.spec.ts](../../apps/desktop/tests/e2e/no-sandbox-exec.spec.ts)
-- [mof5-qraft-upload.spec.ts](../../apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts)
+- [no-sandbox-exec.spec.ts](https://github.com/14790897/MiqroForge-Desktop/blob/develop/apps/desktop/tests/e2e/no-sandbox-exec.spec.ts)
+- [mof5-qraft-upload.spec.ts](https://github.com/14790897/MiqroForge-Desktop/blob/develop/apps/desktop/tests/e2e/mof5-qraft-upload.spec.ts)
 
 ## 手动上传一张图（不跑测试）
 

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -63,6 +63,17 @@ graph TB
 }
 ```
 
+## 连接生命周期
+
+桌面端每个会话在创建时（`RuntimeSession.start()`）连接
+`tools.mcpServers` 中配置的服务器，并把各服务器工具注册进该会话的
+ToolRegistry（`MCPToolWrapper`，命名 `mcp_<server>_<tool>`；`lazy: true`
+时改为注册单个 `use_<server>` 网关工具，按需激活）。
+
+- 修改 MCP 配置后**新建会话**即可生效（无需重启应用，hot-reload tier B）。
+- 会话销毁时连接随会话关闭（stdio 子进程随之终止）。
+- 单个服务器连接失败只会被记录并跳过，不阻塞会话启动。
+
 ## MCP 工具特性
 
 ### 心跳进度报告

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -197,16 +197,27 @@ class MCPGatewayTool(Tool):
 
 
 async def _connect_one_server(
-    name: str, cfg, registry: ToolRegistry
-) -> AsyncExitStack | None:
-    """Connect a single MCP server in an isolated context.
+    name: str,
+    cfg,
+    registry: ToolRegistry,
+    keep_alive: asyncio.Event,
+    registered: asyncio.Event,
+) -> None:
+    """Connect a single MCP server and keep the connection alive.
 
-    Returns the server's AsyncExitStack on success (caller must keep it alive)
-    or None on failure (stack is already closed).
+    Runs as its own asyncio.Task.  The connection stays open until
+    *keep_alive* is set (or the task is cancelled), and the server's
+    AsyncExitStack is closed HERE — inside the same task that entered it.
 
-    Running each server in its own asyncio.Task (via gather) ensures that anyio
-    cancel-scopes inside the MCP/httpx transports cannot leak into sibling
-    connections or the parent task.
+    This task-boundary discipline matters: the MCP SDK / anyio transports
+    enter cancel-scopes while connecting, and anyio requires those scopes
+    to be exited in the same task they were entered in.  Handing the stack
+    to another task and calling ``aclose()`` there raises
+    "Attempted to exit cancel scope in a different task".
+
+    *registered* is set once the server's tools are registered (or the
+    connection failed) so the caller can wait for a deterministic tool
+    list before the first turn.
     """
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -215,92 +226,95 @@ async def _connect_one_server(
     await server_stack.__aenter__()
 
     try:
-        if cfg.command:
-            params = StdioServerParameters(
-                command=cfg.command, args=cfg.args, env=cfg.env or None
-            )
-            read, write = await server_stack.enter_async_context(stdio_client(params))
-        elif cfg.url:
-            from mcp.client.streamable_http import streamable_http_client
+        try:
+            if cfg.command:
+                params = StdioServerParameters(
+                    command=cfg.command, args=cfg.args, env=cfg.env or None
+                )
+                read, write = await server_stack.enter_async_context(stdio_client(params))
+            elif cfg.url:
+                from mcp.client.streamable_http import streamable_http_client
 
-            http_client = (
-                httpx.AsyncClient(headers=cfg.headers, follow_redirects=True)
-                if cfg.headers
-                else None
-            )
-            read, write, _ = await server_stack.enter_async_context(
-                streamable_http_client(cfg.url, http_client=http_client)
-            )
-        else:
-            logger.warning("MCP server '{}': no command or url configured, skipping", name)
-            await server_stack.aclose()
-            return None
+                http_client = (
+                    httpx.AsyncClient(headers=cfg.headers, follow_redirects=True)
+                    if cfg.headers
+                    else None
+                )
+                read, write, _ = await server_stack.enter_async_context(
+                    streamable_http_client(cfg.url, http_client=http_client)
+                )
+            else:
+                logger.warning("MCP server '{}': no command or url configured, skipping", name)
+                return
 
-        session = await server_stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
+            session = await server_stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
 
-        tools = await session.list_tools()
-        progress_interval = getattr(cfg, "progress_interval_seconds", 15)
-        wrappers = [
-            MCPToolWrapper(
-                session, name, tool_def,
-                tool_timeout=cfg.tool_timeout,
-                progress_interval=progress_interval,
-            )
-            for tool_def in tools.tools
-        ]
+            tools = await session.list_tools()
+            progress_interval = getattr(cfg, "progress_interval_seconds", 15)
+            wrappers = [
+                MCPToolWrapper(
+                    session, name, tool_def,
+                    tool_timeout=cfg.tool_timeout,
+                    progress_interval=progress_interval,
+                )
+                for tool_def in tools.tools
+            ]
 
-        lazy = getattr(cfg, "lazy", False)
-        if lazy:
-            # Register a single gateway entry-point tool; real tools are
-            # injected into the registry on demand when the gateway executes.
-            gateway_desc = getattr(cfg, "description", "") or ""
-            gateway = MCPGatewayTool(name, wrappers, registry, gateway_desc)
-            registry.register(gateway)
-            logger.info(
-                "MCP server '{}': connected, {} tools ready (lazy gateway registered)",
-                name, len(wrappers),
-            )
-        else:
-            for wrapper in wrappers:
-                registry.register(wrapper)
-                logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
-            logger.info("MCP server '{}': connected, {} tools registered", name, len(wrappers))
+            lazy = getattr(cfg, "lazy", False)
+            if lazy:
+                # Register a single gateway entry-point tool; real tools are
+                # injected into the registry on demand when the gateway executes.
+                gateway_desc = getattr(cfg, "description", "") or ""
+                gateway = MCPGatewayTool(name, wrappers, registry, gateway_desc)
+                registry.register(gateway)
+                logger.info(
+                    "MCP server '{}': connected, {} tools ready (lazy gateway registered)",
+                    name, len(wrappers),
+                )
+            else:
+                for wrapper in wrappers:
+                    registry.register(wrapper)
+                    logger.debug("MCP: registered tool '{}' from server '{}'", wrapper.name, name)
+                logger.info("MCP server '{}': connected, {} tools registered", name, len(wrappers))
+        except BaseException as e:
+            logger.error("MCP server '{}': failed to connect: {}", name, e)
+    finally:
+        registered.set()
 
-        return server_stack  # caller keeps it alive
-
-    except BaseException as e:
-        logger.error("MCP server '{}': failed to connect: {}", name, e)
+    # Stay alive so the connection (and its cancel-scopes) never leaves this
+    # task.  The session sets keep_alive (or cancels this task) on stop.
+    try:
+        await keep_alive.wait()
+    finally:
         try:
             await server_stack.aclose()
         except Exception:
             pass
-        return None
 
 
 async def connect_mcp_servers(
-    mcp_servers: dict, registry: ToolRegistry, stack: AsyncExitStack
-) -> None:
+    mcp_servers: dict, registry: ToolRegistry, keep_alive: asyncio.Event
+) -> list[asyncio.Task]:
     """Connect to configured MCP servers and register their tools.
 
     Each server connection runs in its own asyncio.Task so that anyio
     cancel-scopes (used internally by the MCP SDK / httpx) are fully
-    isolated.  A failure in one server cannot cancel siblings or the caller.
+    isolated and always torn down inside the task that created them.
+
+    Returns the list of connection tasks; the caller keeps them alive via
+    *keep_alive* and awaits them after setting it (or cancels them) to
+    close the connections.  A failure in one server cannot cancel siblings
+    or the caller.
     """
+    tasks: list[asyncio.Task] = []
+    registered = [asyncio.Event() for _ in mcp_servers]
+    for (name, cfg), ev in zip(mcp_servers.items(), registered):
+        tasks.append(
+            asyncio.create_task(_connect_one_server(name, cfg, registry, keep_alive, ev))
+        )
 
-    async def _task(name: str, cfg):
-        return await _connect_one_server(name, cfg, registry)
-
-    tasks = {
-        name: asyncio.create_task(_task(name, cfg))
-        for name, cfg in mcp_servers.items()
-    }
-
-    results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-
-    for name, result in zip(tasks, results):
-        if isinstance(result, BaseException):
-            logger.error("MCP server '{}': task failed: {}", name, result)
-        elif isinstance(result, AsyncExitStack):
-            # Transfer cleanup responsibility to the shared stack
-            stack.push_async_callback(result.aclose)
+    # Barrier: wait until every server has registered its tools (or failed)
+    # so the caller's first turn sees a deterministic tool list.
+    await asyncio.gather(*(ev.wait() for ev in registered))
+    return tasks

--- a/miqi/config/hot_reload.py
+++ b/miqi/config/hot_reload.py
@@ -34,7 +34,6 @@ TIER_C_PATHS: dict[str, str] = {
     "gateway.port": "网关监听端口在进程启动时绑定，修改后需重启应用",
     "agents.defaults.runtime": "运行时引擎在会话创建时选择，修改后需重启应用",
     "agents.sessions.use_sqlite": "会话存储后端在启动时选择，修改后需重启应用",
-    "tools.mcp_servers": "MCP 服务器在工具注册时连接，修改后需重启应用",
 }
 
 # ── Tier A: hot-applied prefixes ─────────────────────────────────────────

--- a/miqi/kun_runtime/migration_adapter.py
+++ b/miqi/kun_runtime/migration_adapter.py
@@ -116,11 +116,12 @@ class GatewayKunRuntime:
             return
         from miqi.agent.tools.mcp import connect_mcp_servers
         try:
-            from contextlib import AsyncExitStack
-            stack = AsyncExitStack()
-            await stack.__aenter__()
+            import asyncio
             registry = self._runtime.tool_host._registry
-            await connect_mcp_servers(self._mcp_servers, registry, stack)
+            self._mcp_keep_alive = asyncio.Event()
+            self._mcp_tasks = await connect_mcp_servers(
+                self._mcp_servers, registry, self._mcp_keep_alive
+            )
             self._mcp_connected = True
         except Exception:
             pass  # MCP connection failure is non-fatal for KunRuntime path

--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -71,6 +71,12 @@ class RuntimeSession:
         # Phase 42 fix: track auxiliary tasks (shell commands during active turns)
         # so they can be cancelled on abort and cleaned up on stop.
         self._pending_aux_tasks: set[asyncio.Task] = set()
+        # MCP integration: config snapshot, connection tasks, and a
+        # connect-once guard (set by create() / start()).
+        self._config: Any = None
+        self._mcp_tasks: list[asyncio.Task] = []
+        self._mcp_keep_alive: asyncio.Event | None = None
+        self._mcp_connected: bool = False
 
     @classmethod
     def create(
@@ -110,6 +116,7 @@ class RuntimeSession:
             event_queue=events,
             hooks=getattr(services, "hooks", None),
         )
+        runtime._config = config
         return runtime
 
     async def start(self) -> None:
@@ -133,6 +140,13 @@ class RuntimeSession:
         if ledger is not None:
             await ledger.initialize()
 
+        # MCP integration: connect configured MCP servers (tools.mcpServers)
+        # and register their tools into the session's ToolRegistry.  Runs
+        # before the dispatch task starts so the tools are advertised on the
+        # first turn.  Config changes take effect for the NEXT session
+        # (hot-reload tier: 修改后新建会话生效).
+        await self._connect_mcp()
+
         if self._task is None or self._task.done():
             self._stopped.clear()
             self._task = asyncio.create_task(self._run())
@@ -146,6 +160,39 @@ class RuntimeSession:
                     data={"session_id": self.session_id},
                 ),
             )
+
+    async def _connect_mcp(self) -> None:
+        """Connect configured MCP servers and register their tools (Phase MCP).
+
+        Reads ``config.tools.mcp_servers`` and delegates to
+        ``miqi.agent.tools.mcp.connect_mcp_servers``, which registers an
+        ``MCPToolWrapper`` per tool (or a lazy gateway) into the shared
+        ToolRegistry.  Connection is attempted exactly once per session —
+        a failing server is logged and skipped, never blocking session
+        startup.  Each connection lives in its own task; ``stop()`` sets
+        the keep-alive event and awaits the tasks so stdio subprocesses
+        are torn down inside the tasks that spawned them.
+        """
+        if self._mcp_connected:
+            return
+        self._mcp_connected = True
+
+        tools_cfg = getattr(self._config, "tools", None) if self._config is not None else None
+        mcp_servers = getattr(tools_cfg, "mcp_servers", None) or {}
+        if not mcp_servers:
+            return
+
+        from miqi.agent.tools.mcp import connect_mcp_servers
+
+        keep_alive = asyncio.Event()
+        try:
+            self._mcp_tasks = await connect_mcp_servers(
+                mcp_servers, self.services.tool_registry, keep_alive
+            )
+        except BaseException:
+            _session_logger.exception("MCP server connection failed during session start")
+            return
+        self._mcp_keep_alive = keep_alive
 
     async def stop(self) -> None:
         """Stop the dispatch loop and tear down agent resources."""
@@ -192,6 +239,15 @@ class RuntimeSession:
         ledger = getattr(self.services, "ledger_runtime", None)
         if ledger is not None:
             await ledger.close()
+        # MCP integration: release the connection tasks so stdio server
+        # subprocesses are terminated (each task closes its own stack).
+        if getattr(self, "_mcp_keep_alive", None) is not None:
+            self._mcp_keep_alive.set()
+            await asyncio.gather(*self._mcp_tasks, return_exceptions=True)
+            self._mcp_keep_alive = None
+            self._mcp_tasks = []
+        # A restarted session must reconnect (the connections above are gone).
+        self._mcp_connected = False
 
     async def submit(self, submission: Any) -> None:
         """Submit a command to the runtime (UserMessage, AbortTurn, etc.)."""

--- a/scripts/mock_mcp.py
+++ b/scripts/mock_mcp.py
@@ -1,0 +1,182 @@
+"""Mock OpenAI-compatible server for the desktop MCP E2E (mcp.spec.ts).
+
+Deterministic state machine driven by the request history:
+
+  Round 1 (no MCP tool call yet): tool_call → mcp_e2emcp_e2e_echo
+  Round 2 (tool result present): final text
+    - "MCP-E2E-PASS：<tool output>" when the tool result contains the real
+      MCP server's marker (scripts/mock_mcp_server.py ECHO_MARKER) — proves
+      the MCP subprocess actually executed and its output round-tripped.
+    - "MCP-E2E-FAIL：<tool output prefix>" otherwise (tool missing, error,
+      or an unexpected result), so the spec can distinguish both cases.
+
+The MiQi-wrapped tool name is ``mcp_<server>_<tool>`` — the E2E registers
+the server under the name ``e2emcp``, so the wrapped name is
+``mcp_e2emcp_e2e_echo``.
+
+Run:  PYTHONPATH=. .venv/Scripts/python.exe scripts/mock_mcp.py
+"""
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MCP_TOOL_NAME = "mcp_e2emcp_e2e_echo"
+ECHO_MARKER = "MCP_ECHO_RESULT_7f3a9c"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_sse(self, obj, streamed=True):
+        """Streaming (stream:true) response in OpenAI SSE format.
+
+        Mirrors scripts/mock_openai.py: one full message chunk + a finish
+        chunk + [DONE].  A plain JSON body served to a stream:true request
+        yields zero chunks and the provider completes with an empty response.
+        """
+        msg = obj["choices"][0]["message"]
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            delta = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "index": i,
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": tc["function"],
+                    }
+                    for i, tc in enumerate(tool_calls)
+                ],
+            }
+            finish = obj["choices"][0].get("finish_reason") or "tool_calls"
+        else:
+            delta = {"role": "assistant", "content": msg.get("content") or ""}
+            finish = obj["choices"][0].get("finish_reason") or "stop"
+        chunk1 = {
+            "id": obj.get("id", "mock-mcp"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-mcp-model"),
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+        chunk2 = {
+            "id": obj.get("id", "mock-mcp"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-mcp-model"),
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+        }
+        body = (
+            "data: " + json.dumps(chunk1, ensure_ascii=False) + "\n\n"
+            "data: " + json.dumps(chunk2, ensure_ascii=False) + "\n\n"
+            "data: [DONE]\n\n"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _respond(self, obj):
+        if self._stream_requested:
+            self._send_sse(obj)
+        else:
+            self._send(200, obj)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._send(200, {"object": "list", "data": [{"id": "mock-mcp-model", "object": "model"}]})
+        else:
+            self._send(404, {"error": {"message": "not found"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            req = json.loads(raw)
+        except Exception:
+            self._send(400, {"error": {"message": "bad json"}})
+            return
+        if not self.path.startswith("/v1/chat/completions"):
+            self._send(404, {"error": {"message": "not found"}})
+            return
+
+        self._stream_requested = bool(req.get("stream"))
+        messages = req.get("messages", [])
+
+        # Tool results are role:"tool" messages whose content carries the
+        # output string the orchestrator produced.
+        tool_outputs = [
+            str(m.get("content", ""))
+            for m in messages
+            if m.get("role") == "tool"
+        ]
+        n_mcp_calls = sum(
+            1
+            for m in messages
+            if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+            if (tc.get("function") or {}).get("name") == MCP_TOOL_NAME
+        )
+
+        def tc(name, args, cid="call_mcp"):
+            return {
+                "id": cid,
+                "object": "chat.completion",
+                "created": 0,
+                "model": "mock-mcp-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": None, "tool_calls": [{
+                        "id": cid, "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args, ensure_ascii=False)},
+                    }]},
+                    "finish_reason": "tool_calls",
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+            }
+
+        def text(content):
+            return {
+                "id": "mock-mcp-final", "object": "chat.completion", "created": 0,
+                "model": "mock-mcp-model",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": content},
+                             "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+            }
+
+        if n_mcp_calls == 0:
+            print("  [mock-mcp] R1 → tool_call mcp_e2emcp_e2e_echo", flush=True)
+            self._respond(tc(MCP_TOOL_NAME, {"text": "hello-mcp"}, "call_mcp_echo"))
+            return
+
+        joined = "\n".join(tool_outputs)
+        if ECHO_MARKER in joined:
+            print("  [mock-mcp] R2 → 工具返回含真实 MCP 标记 → PASS", flush=True)
+            self._respond(text(f"MCP-E2E-PASS：工具链路成功。工具返回：{joined.strip()}"))
+        else:
+            print(f"  [mock-mcp] R2 → 未收到标记 → FAIL（收到 {len(tool_outputs)} 条工具结果）", flush=True)
+            preview = joined.strip()[:200] if joined.strip() else "(无工具结果)"
+            self._respond(text(f"MCP-E2E-FAIL：未收到预期工具返回。实际：{preview}"))
+
+
+if __name__ == "__main__":
+    import sys
+
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8899
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    actual_port = server.server_address[1]
+    print(f"Mock OpenAI server on http://127.0.0.1:{actual_port}/v1", flush=True)
+    server.serve_forever()

--- a/scripts/mock_mcp_server.py
+++ b/scripts/mock_mcp_server.py
@@ -1,0 +1,30 @@
+"""Minimal stdio MCP server used by the desktop E2E spec (mcp.spec.ts).
+
+Exposes a single tool, ``e2e_echo``, which returns a distinctive marker
+string.  The E2E mock LLM (scripts/mock_mcp.py) calls this tool through
+MiQroForge's MCP client and only reports success when the marker comes
+back — proving the full chain:
+
+    registry → orchestrator → MCP client (stdio subprocess) → server
+
+The server is spawned with the same interpreter as the bridge (repo venv),
+so the ``mcp`` SDK import always resolves.
+"""
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+MCP = FastMCP("e2e-mock-mcp")
+
+# Distinctive marker the E2E mock LLM asserts on.  Do not reuse elsewhere.
+ECHO_MARKER = "MCP_ECHO_RESULT_7f3a9c"
+
+
+@MCP.tool()
+def e2e_echo(text: str) -> str:
+    """Echo the given text prefixed with an E2E marker."""
+    return f"{ECHO_MARKER}:{text}"
+
+
+if __name__ == "__main__":
+    MCP.run(transport="stdio")

--- a/tests/config/test_hot_reload.py
+++ b/tests/config/test_hot_reload.py
@@ -92,15 +92,17 @@ def test_gateway_port_change_is_tier_c():
     assert "gateway.port" in report.restart_required
 
 
-def test_mcp_servers_change_is_tier_c():
-    """test_mcp_servers_change_is_tier_c: mcp servers change is tier c."""
+def test_mcp_servers_change_is_tier_b():
+    """MCP servers connect at session creation — new sessions pick them up
+    without an app restart (Phase MCP integration)."""
     from miqi.config.schema import MCPServerConfig
 
     new = _mutate(**{"tools.mcp_servers": {"server1": MCPServerConfig(command="npx")}})
     report = classify_config_update(Config(), new)
-    # Diff recurses into the dict; the prefix rule still classifies as C.
-    assert any(p.startswith("tools.mcp_servers") for p in report.restart_required)
-    assert report.needs_restart is True
+    # Diff recurses into the dict; the prefix rule still classifies as B.
+    assert any(p.startswith("tools.mcp_servers") for p in report.new_sessions_only)
+    assert "tools.mcp_servers" not in report.restart_required
+    assert report.needs_restart is False
 
 
 def test_mixed_change_reports_all_tiers():

--- a/tests/runtime/test_mcp_session_wiring.py
+++ b/tests/runtime/test_mcp_session_wiring.py
@@ -1,0 +1,113 @@
+"""Tests for RuntimeSession MCP connection (Phase MCP integration).
+
+Verifies that a session connects configured ``tools.mcp_servers`` at
+``start()``, registers the server's tools into the session registry, and
+tears the connection down at ``stop()``.  Uses scripts/mock_mcp_server.py
+(stdio FastMCP server) for a real MCP subprocess round-trip.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from miqi.config.schema import MCPServerConfig
+
+SERVER_SCRIPT = str(
+    Path(__file__).resolve().parents[2] / "scripts" / "mock_mcp_server.py"
+)
+ECHO_MARKER = "MCP_ECHO_RESULT_7f3a9c"
+WRAPPED_TOOL = "mcp_e2emcp_e2e_echo"
+
+
+@pytest.mark.asyncio
+async def test_session_connects_mcp_server_and_registers_tools(
+    fake_config, fake_provider, tmp_path
+):
+    import sys
+
+    from miqi.runtime.session import RuntimeSession
+
+    fake_config.tools.mcp_servers["e2emcp"] = MCPServerConfig(
+        command=sys.executable,
+        args=[SERVER_SCRIPT],
+        tool_timeout=30,
+    )
+
+    runtime = RuntimeSession.create(
+        config=fake_config,
+        provider=fake_provider,
+        session_id="sess-mcp-connect",
+        workspace=tmp_path,
+    )
+    await runtime.start()
+    try:
+        registry = runtime.services.tool_registry
+        assert registry.has(WRAPPED_TOOL), (
+            "MCP tool should be registered: "
+            f"{registry.tool_names}"
+        )
+
+        # Real subprocess round-trip: execute the wrapper, which drives the
+        # MCP client → stdio server → back.
+        tool = registry.get(WRAPPED_TOOL)
+        result = await tool.execute(text="pytest-probe")
+        assert ECHO_MARKER in result, result
+        assert "pytest-probe" in result, result
+    finally:
+        await runtime.stop()
+
+    # stop() releases the connection tasks (terminates the stdio subprocess)
+    assert runtime._mcp_keep_alive is None
+    assert runtime._mcp_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_session_skips_mcp_when_no_servers_configured(
+    fake_config, fake_provider, tmp_path
+):
+    from miqi.runtime.session import RuntimeSession
+
+    fake_config.tools.mcp_servers = {}
+
+    runtime = RuntimeSession.create(
+        config=fake_config,
+        provider=fake_provider,
+        session_id="sess-mcp-none",
+        workspace=tmp_path,
+    )
+    await runtime.start()
+    try:
+        assert runtime._mcp_keep_alive is None
+        assert runtime._mcp_connected is True  # guard set even with no servers
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_session_start_survives_broken_mcp_server(
+    fake_config, fake_provider, tmp_path
+):
+    """A failing MCP server must never block session startup."""
+    from miqi.runtime.session import RuntimeSession
+
+    fake_config.tools.mcp_servers["broken"] = MCPServerConfig(
+        command=str(tmp_path / "no-such-binary"),
+        args=[],
+        tool_timeout=10,
+    )
+
+    runtime = RuntimeSession.create(
+        config=fake_config,
+        provider=fake_provider,
+        session_id="sess-mcp-broken",
+        workspace=tmp_path,
+    )
+    # Must not raise despite the connection failure
+    await runtime.start()
+    try:
+        registry = runtime.services.tool_registry
+        assert not any(
+            name.startswith("mcp_broken_") for name in registry.tool_names
+        )
+    finally:
+        await runtime.stop()


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

桌面会话创建时连接配置的 MCP 服务器，把其工具注册进会话 ToolRegistry，AI 可在对话中直接调用 MCP 工具。

## 背景/问题

MCP 的客户端实现（`miqi/agent/tools/mcp.py`）、配置 schema、设置页 UI、增删改查 handler 早已存在，但**从未接入桌面聊天主路径**：`connect_mcp_servers` 只被从未实例化的 `GatewayKunRuntime`（死代码）引用。用户按文档（docs/mcp-integration.md、scripts/configure_mcps.sh）配置的 7 个内置 MCP 服务器（raspa2、zeopp、mofstructure 等）在桌面对话中完全不可见，AI 调用即报「工具不存在」。

## 变更内容

- **`miqi/runtime/session.py`**：`RuntimeSession.start()` 读取 `config.tools.mcp_servers` 连接各服务器，把工具（`mcp_<server>_<tool>`，lazy 时为 `use_<server>` 网关）注册进会话 ToolRegistry；`stop()` 释放连接任务。**新建会话即生效**（hot_reload tier C → tier B，无需重启应用）
- **`miqi/agent/tools/mcp.py`**：重构连接生命周期——每服务器一个常驻 asyncio.Task + keep-alive 事件，AsyncExitStack 在同一 task 内创建与关闭。修复 anyio cancel-scope 跨 task 退出抛 `Attempted to exit cancel scope in a different task` 的潜伏 bug
- **`miqi/kun_runtime/migration_adapter.py`**：`GatewayKunRuntime._ensure_mcp` 适配新签名
- **`miqi/config/hot_reload.py`**：`tools.mcp_servers` 从 tier C（重启）降为 tier B（新建会话）
- **`docs/mcp-integration.md`**：补充「连接生命周期」说明

## 日志/验证证据

```
E2E（本地 Windows，2 passed，30.6s）：
  ok 1 [electron] › mcp.spec.ts › MCP 服务器集成 › 设置页添加 stdio MCP 服务器 → 列表显示并持久化到 config.json (2.2s)
  ok 2 [electron] › mcp.spec.ts › MCP 服务器集成 › 新建会话 → 模型调用 MCP 工具 → 最终回复含工具返回值标记 (17.1s)
  2 passed (30.6s)

mock LLM 日志（真实 MCP 子进程往返）：
  [mock-mcp] R1 → tool_call mcp_e2emcp_e2e_echo
  [mock-mcp] R2 → 工具返回含真实 MCP 标记 → PASS

pytest：
  tests/runtime/test_mcp_session_wiring.py ......  3 passed
  tests/runtime（全套回归）                       1330 passed, 1 skipped
```

## 测试情况

- 新增 `tests/runtime/test_mcp_session_wiring.py`：连接并注册工具（含真实子进程往返）、无配置跳过、坏服务器不阻塞启动——3 passed
- 新增 E2E `apps/desktop/tests/e2e/mcp.spec.ts` + `scripts/mock_mcp_server.py`（FastMCP stdio 测试服务器）+ `scripts/mock_mcp.py`（确定性状态机 mock LLM，不依赖真实 LLM）——本地 2 passed；macOS CI 沿用 confirm-card 惯例 skip（本地 mock 不可达，#710）
- 回归：`tests/runtime` 全套 1330 passed；hot-reload/MCP handler 相关 32 passed

## 截图

**设置页添加 MCP 服务器 → 列表显示**（本地 Windows E2E）：

![MCP 设置页列表](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/-stdio-MCP-.-.-.-config.json-list-9d8b0b51.png)

**新会话中模型调用 MCP 工具 → 真实子进程往返 → AI 回复 MCP-E2E-PASS**：

![MCP 工具调用链路](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/-.-.-MCP-.-.-.-final-752e1169.png)


**真实 luma-mcp 使用验证（npx stdio 服务器 + 视觉 API）**：

![luma-mcp 桌面调用](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/final-23b45a4b.png)
