### PR TITLE
fix(bridge): 堵住 providers 整对象替换与空值写入的收口绕过 (#835)

### DIFF
--- a/miqi/runtime/config_app_handlers.py
+++ b/miqi/runtime/config_app_handlers.py
@@ -100,28 +100,15 @@ def _validate_dot_path(path: str) -> None:
             )
 
 
-# 后端收口（#835）：providers 下不允许写入的自配凭据字段（snake/camel 两种）。
-_PROVIDER_CREDENTIAL_FIELDS = (
-    "api_key",
-    "api_base",
-    "extra_headers",
-    "apiKey",
-    "apiBase",
-    "extraHeaders",
-)
-
-
 def _reject_provider_credential_path(path: str) -> None:
-    """拒绝 batchWrite 写入 providers 的凭据字段。
+    """拒绝 batchWrite 写入 providers 子树（整个 providers 都是凭据领域）。
 
-    dot-path 形如 "providers.deepseek.apiKey"，第三段是字段名。
+    拦截 "providers" 及 "providers.*" 任意层级，防止整对象替换
+    （如 path="providers.deepseek"）绕过字段级拦截（CodeRabbit #912 review）。
     """
-    if not path.startswith("providers."):
-        return
-    segments = path.split(".")
-    if len(segments) >= 3 and segments[2] in _PROVIDER_CREDENTIAL_FIELDS:
+    if path == "providers" or path.startswith("providers."):
         raise AppServerError(
-            f"自定义 Provider 凭据（{path}）已禁用，请使用内置激活码",
+            f"Provider 配置（{path}）已禁用写入，请使用内置激活码",
             code="NOT_SUPPORTED",
         )
 

--- a/miqi/runtime/config_handlers.py
+++ b/miqi/runtime/config_handlers.py
@@ -18,37 +18,17 @@ from loguru import logger
 from miqi.runtime.app_server import AppServerError, get_bridge_state
 from miqi.runtime.core_request_models import validate_core_params
 
-# 后端收口（#835）：providers 下不允许写入的自配凭据字段（snake/camel 两种）。
-_PROVIDER_CREDENTIAL_FIELDS = (
-    "api_key",
-    "api_base",
-    "extra_headers",
-    "apiKey",
-    "apiBase",
-    "extraHeaders",
-)
-
-
 def _reject_provider_credentials(updates: Any) -> None:
-    """拒绝经 config.update 写入 providers 的自配凭据。
+    """拒绝经 config.update 写入 providers（整个 providers 子树都是凭据领域）。
 
-    仅拦截 providers.* 的凭据字段；agents.defaults.model 等其它字段不受影响。
+    providers 下只有 api_key / api_base / extra_headers 等凭据字段，无合法可写项；
+    拦整个子树可同时堵住整对象替换与空值/null 写入（CodeRabbit #912 review）。
     """
-    if not isinstance(updates, dict):
-        return
-    providers = updates.get("providers")
-    if not isinstance(providers, dict):
-        return
-    for provider_name, pconfig in providers.items():
-        if not isinstance(pconfig, dict):
-            continue
-        for field in _PROVIDER_CREDENTIAL_FIELDS:
-            if pconfig.get(field):
-                raise AppServerError(
-                    f"自定义 Provider 凭据（providers.{provider_name}.{field}）已禁用，"
-                    "请使用内置激活码",
-                    code="NOT_SUPPORTED",
-                )
+    if isinstance(updates, dict) and "providers" in updates:
+        raise AppServerError(
+            "Provider 配置（providers）已禁用写入，请使用内置激活码",
+            code="NOT_SUPPORTED",
+        )
 
 
 def _apply_runtime_approval_bypass(runtime: Any, config: Any) -> None:

--- a/tests/runtime/test_config_app_handlers.py
+++ b/tests/runtime/test_config_app_handlers.py
@@ -196,6 +196,20 @@ async def test_config_batch_write_rejects_provider_credentials():
 
 
 @pytest.mark.asyncio
+async def test_config_batch_write_rejects_whole_provider_object():
+    """后端收口（#835）：batchWrite 拒绝整对象替换 provider（绕过字段级拦截）。"""
+    registry = ClientSessionRegistry()
+    server = _setup_server(registry, model="anthropic/claude-opus-4-5")
+
+    response = await server.dispatch(
+        "1", "config/batchWrite",
+        {"edits": [{"path": "providers.deepseek", "value": {"apiKey": "sk-custom"}}]},
+        "client-1", None,
+    )
+    assert response.get("code") == "NOT_SUPPORTED"
+
+
+@pytest.mark.asyncio
 async def test_config_batch_write_delete_requires_existing_key():
     """Delete of a non-existent key must return INVALID_PARAMS."""
     registry = ClientSessionRegistry()

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -95,6 +95,23 @@ async def test_config_update_rejects_provider_credentials(fake_config, fake_prov
 
 
 @pytest.mark.asyncio
+async def test_config_update_rejects_empty_provider_credential(fake_config, fake_provider, tmp_path):
+    """后端收口（#835）：config.update 连空值/null 凭据也拒绝。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"providers": {"deepseek": {"api_key": ""}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "NOT_SUPPORTED"
+
+
+@pytest.mark.asyncio
 async def test_config_update_rejects_empty_config(fake_config, fake_provider, tmp_path):
     """config.update rejects empty config param."""
     from miqi.runtime.app_server import AppServerError


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

堵住 #912 后端收口遗漏的两个绕过漏洞：batchWrite 整对象替换 provider、config.update 空值/null 凭据写入。

## 背景/问题

#912 的后端收口只拦截了「字段级 + 非空」的凭据写入，但 CodeRabbit 指出仍有两个绕过路径：

1. `config/batchWrite` 用整对象路径（如 `providers.deepseek`）可替换整个 provider 对象塞入任意凭据，字段级拦截被绕过；
2. `config.update` 用空值/null（如 `api_key: ""`）仍被放行。

本 PR 把拦截升级为「整个 providers 子树一律禁写」，彻底堵住这两个路径。

## 关联 issue

- #835 模型选择收口（后端收口 follow-up 修复）

## 变更内容

- `miqi/runtime/config_handlers.py`：`_reject_provider_credentials` 改为拦截任何含 `providers` key 的更新
- `miqi/runtime/config_app_handlers.py`：`_reject_provider_credential_path` 改为拦截 `providers` 及 `providers.*` 任意层级
- `tests/runtime/test_config_handlers.py`：新增空值凭据拒绝测试
- `tests/runtime/test_config_app_handlers.py`：新增整对象替换拒绝测试

## 日志/验证证据

```
修复前（#912 原实现，字段级 + 非空拦截）：
- config/batchWrite path="providers.deepseek"（整对象）→ 字段级拦截不命中 → 放行，可整对象替换塞任意凭据
- config.update 写 providers.deepseek.api_key=""（空值）→ 非空检查不命中 → 放行

修复后（本 PR，整子树拦截）：
- config/batchWrite path="providers" 或 "providers.*" → NOT_SUPPORTED 拒绝
- config.update 含 providers key → NOT_SUPPORTED 拒绝

$ .venv/Scripts/python.exe -m pytest tests/runtime/ tests/providers/ -q
1335 passed, 5 skipped
```
<img width="2341" height="227" alt="image" src="https://github.com/user-attachments/assets/5bd5cc8d-91df-4dfb-9d12-6f52897db031" />

## 测试情况

- 全量 `tests/runtime/` + `tests/providers/`：1335 passed, 5 skipped, 0 failed
- 新增 2 个绕过场景回归测试（整对象替换、空值凭据）

## 截图

无需截图（后端改动，无 UI 变更）

## 后续计划

- #893 执行路径改为从登录态/平台获取凭据（Level 2，等平台接口）
