### PR TITLE
fix(qraft): 密码登录授权码流程适配 Electron net.fetch manual 302 行为

### DIFF
--- a/apps/desktop/src/main/qraft/ipc.ts
+++ b/apps/desktop/src/main/qraft/ipc.ts
@@ -22,6 +22,8 @@ import {
   buildAuthorizeUrl,
   createQraftClient,
   extractCodeForRedirect,
+  type FetchInitLike,
+  type FetchResponseLike,
   type QraftLogger,
   type ResolvedQraftConfig,
 } from './client';
@@ -31,6 +33,34 @@ import { QraftStore } from './store';
 const { ipcMain, app, net, safeStorage, BrowserWindow, session } = electron;
 
 let service: QraftService | null = null;
+
+/**
+ * electron.net.fetch 的 redirect:'manual' 实现：目标响应为 302 时直接
+ * reject（"Redirect was cancelled"，Chromium 行为），而 OAuth2 授权码
+ * 流程必须读取 302 的 Location（authorize → 登录页 / redirect_uri?code=）。
+ * 遇到该错误时回退 Node 内置 fetch（undici）：其 manual 语义正确返回
+ * 302 响应。其余请求仍走 net.fetch（系统代理支持）。
+ * 登录 cookie 由 QraftClient 显式经 Cookie 头携带（cookie-jar），不依赖
+ * 会话级 cookie store，回退后凭据传递不受影响。
+ */
+async function netFetchWithManualFallback(
+  url: string,
+  init?: FetchInitLike
+): Promise<FetchResponseLike> {
+  try {
+    return await net.fetch(url, init);
+  } catch (err) {
+    if (
+      init?.redirect === 'manual' &&
+      err instanceof Error &&
+      err.message.includes('Redirect was cancelled')
+    ) {
+      console.warn('[qraft] net.fetch manual 302 回退到 undici fetch（Electron 行为差异）');
+      return await globalThis.fetch(url, init);
+    }
+    throw err;
+  }
+}
 
 function getService(): QraftService {
   if (service) return service;
@@ -50,7 +80,7 @@ function getService(): QraftService {
     log
   );
   service = new QraftService({
-    client: createQraftClient({ fetch: (url, init) => net.fetch(url, init) }),
+    client: createQraftClient({ fetch: netFetchWithManualFallback }),
     store,
     log,
     onStatusChanged: (status: QraftStatus) => {

--- a/apps/desktop/tests/e2e/billing-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-live.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Billing 真实链路 E2E（opt-in，需凭据；CI 无凭据自动跳过）：
+ *   真实 OAuth2 登录（设置页 MiQroForge 平台）→ 新会话发消息 → 真实 LLM 调用 write_file
+ *   → 计费闸门在首次工具执行前扣 30 积分 → 聊天区出现扣费提示。
+ *
+ * 运行（会真实消耗测试账号 30 积分）：
+ *   QRAFT_PHONE=… QRAFT_PASSWORD=… npx playwright test  *     --config=playwright.config.ts --project=electron tests/e2e/billing-live.spec.ts
+ * 依赖：真实平台可达、本地 provider 配置（launchElectronApp 复制用户配置）。
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  createNewConversation,
+  launchElectronApp,
+  closeElectronApp,
+  type ElectronFixture,
+} from './helpers/electron-setup';
+
+async function approveLoop(page: Page, timeout = 180_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const btn = page
+      .getByRole('button', { name: '持久允许' })
+      .or(page.getByRole('button', { name: '永久允许' }));
+    if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await btn.click();
+    }
+    const thinking = await page
+      .getByText('Thinking…')
+      .isVisible()
+      .catch(() => false);
+    if (!thinking) break;
+    await page.waitForTimeout(1000);
+  }
+}
+
+const HAS_CREDS = !!process.env.QRAFT_PHONE && !!process.env.QRAFT_PASSWORD;
+
+const describeFn = HAS_CREDS ? test.describe : test.describe.skip;
+
+describeFn('Billing live E2E (opt-in)', () => {
+  let fixture: ElectronFixture;
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    if (electronApp) await closeElectronApp(electronApp, fixture?.miqiHome);
+  });
+
+  test('真实登录 → 对话触发工具 → 扣 30 积分 → 聊天区提示', { timeout: LLM_TIMEOUT }, async () => {
+    // 1. 设置页真实登录（dev userData 可能残留上次运行的登录态，幂等处理）
+    await page.getByText(/^(System Settings|系统设置)$/).click();
+    await page
+      .getByRole('tab')
+      .filter({ hasText: /MiQroForge/ })
+      .first()
+      .click();
+    const loggedInBadge = page.getByText('已登录');
+    if (!(await loggedInBadge.isVisible({ timeout: 5000 }).catch(() => false))) {
+      await page.getByTestId('qraft-phone-input').fill(process.env.QRAFT_PHONE!);
+      await page.getByTestId('qraft-password-input').fill(process.env.QRAFT_PASSWORD!);
+      await page.getByTestId('qraft-login-btn').click();
+    }
+    await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
+    // 登录后余额展示（真实余额查询）
+    await expect(page.getByTestId('qraft-points-value')).toBeVisible({ timeout: 30_000 });
+
+    // 2. 新会话 + 预授权（避免审批卡住工具执行）
+    await createNewConversation(page);
+    await page.evaluate(() => (window as any).miqi.approvals.addPermanent('*:*', 'always'));
+
+    // 3. 发送触发工具调用的消息
+    await sendMessage(
+      page,
+      '使用 write_file 工具创建文件 billing-e2e.txt，内容为 hello billing。完成后只回复 DONE_BILLING'
+    );
+    await approveLoop(page);
+
+    // 4. 计费提示：首次工具执行前扣 30 分（活动行与消息体各渲染一次，取首个）
+    await expect(page.getByText(/已扣 30 积分/).first()).toBeVisible({ timeout: LLM_TIMEOUT });
+
+    // 5. 回合正常收尾（限定 assistant 气泡，避免与用户消息/思考摘要撞词）
+    await waitForResponseComplete(page, LLM_TIMEOUT);
+    await expect(
+      page
+        .getByTestId('chat-message-assistant')
+        .getByText(/DONE_BILLING/)
+        .first()
+    ).toBeVisible({ timeout: 30_000 });
+
+    await page.screenshot({ path: 'test-results/billing-live-e2e.png', fullPage: true });
+  });
+});


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [x] 🧪 测试

## 变更概述

修复密码登录路径在 Electron net.fetch 下无法完成 OAuth2 授权码流程的问题（manual 302 异常），并附上积分扣费真实链路的 opt-in E2E。

## 背景/问题

#915（平台积分计费）合并后做真实扣费 E2E 验证（设置页真实登录 → 对话触发工具 → 扣 30 积分）时发现：**应用内密码登录路径当前不可用**。主进程探测（最小 Electron 脚本）定位根因：

```
OK  200  https://test.forge.miqroera.com/login
ERR Redirect was cancelled | https://test.forge.miqroera.com/api/oauth2/authorize?...
```

electron.net.fetch 对 `redirect:'manual'` 的 302 响应直接 reject（"Redirect was cancelled"，Chromium 行为），而授权码流程必须读取 302 的 Location（authorize → 登录页 / redirect_uri?code=）才能继续。此前 E2E 为零网络依赖设计（预置登录态 + 不可达地址），从未覆盖这条真实链路，因此问题一直未被发现。浏览器登录路径不受影响（webContents 导航，不走 net.fetch）。

## 变更内容

- `apps/desktop/src/main/qraft/ipc.ts`：新增 `netFetchWithManualFallback` —— manual 重定向请求遇到 "Redirect was cancelled" 时回退 Node 内置 fetch（undici，manual 语义正确返回 302 响应），其余请求仍走 net.fetch（系统代理支持）。登录 cookie 由 QraftClient 显式经 Cookie 头携带，回退后凭据传递不受影响
- `apps/desktop/tests/e2e/billing-live.spec.ts`（新）：积分扣费真实链路 E2E —— 真实登录（幂等）→ 新会话 → 真实 LLM 调 write_file → 计费闸门扣 30 分 → 聊天区提示 → 回合完成。凭据经 `QRAFT_PHONE`/`QRAFT_PASSWORD` 环境变量注入，CI 无凭据自动跳过；运行会真实消耗测试账号 30 积分

## 日志/验证证据

```
# net.fetch 行为探测（修复前）
OK  200  https://test.forge.miqroera.com/login
ERR Redirect was cancelled | https://test.forge.miqroera.com/api/oauth2/authorize?...

# 修复后真实扣费 E2E（本地 electron 项目）
$ npx playwright test --config=playwright.config.ts --project=electron tests/e2e/billing-live.spec.ts
ok 1 真实登录 → 对话触发工具 → 扣 30 积分 → 聊天区提示 (21.3s)
1 passed (26.0s)

# 平台余额交叉验证（测试账号）
availablePoints: 850, totalSpent: 150（5 次 × 30 分全部入账一致）
```

## 测试情况

- electron E2E：qraft-login.spec.ts 4 过（含 #917 新增用例，验证修复不破坏零网络路径）；billing-live.spec.ts 真实链路 1 过、无凭据时 1 跳过
- vitest：src/main/qraft 92 过（含 #917 新增用例）；typecheck + prettier 通过
- 本地 build + 真实平台登录/扣费/余额交叉验证通过

## 截图

![设置页 MiQroForge 平台登录卡片与积分区块](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/qraft-fix-settings-e4f4517c.png)

## 后续计划

- 测试账号剩余 850 积分；如需清零重测请联系平台侧重置
- 平台侧 `totalEarned` 未记录发放积分（口径问题，已反馈）

