### PR TITLE
chore(providers): rotate built-in DeepSeek API key

### DIFF
--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -463,7 +463,7 @@ _BUILTIN_PROVIDERS = {"deepseek"}
 
 # Encrypted API key for DeepSeek internal testing.
 # Token generated via Fernet with activation-code-derived key.
-_BUILTIN_KEYS: dict[str, str] = {"deepseek": "gAAAAABqcAKIbwGAo4su3S7LbqrXcazQI39QTE-Flr5B_NF8jo2feHUT4tMy7KK0C-Ieh7waUArthTYrBqcSvSNVsGZIPUFV9yFugT7_Lp_eHeTjL53VXi2drCLQ8_019316D__pjnMl"}  # provider_name → encrypted_key
+_BUILTIN_KEYS: dict[str, str] = {"deepseek": "gAAAAABqmSpZGjsRS0YDYm8ZvtPLtFG1sQOtIbT3TsKBn9WQP_YkHqmr3x2-Wx16sq9VR84jmmmguoBx-mqIPTN9uOmpdyY2vees1-bhE54fvxFZyrXEkGkyUbIP-LwxuFA_v6vWJw8V"}  # provider_name → encrypted_key
 
 # Default activation code — the company name / internal code
 _DEFAULT_ACTIVATION_CODE = "weiguanjiyuan5g"


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

轮换内置 DeepSeek API key（更换为企业提供的新 key）。

## 背景/问题

Desktop 内置的企业共享 DeepSeek 凭证需要更新为新 key。凭证以 Fernet 密文形式内嵌在 `_BUILTIN_KEYS` 中，密钥由激活码派生；本次只替换密文，激活码与解密逻辑均不变。

## 变更内容

- `miqi/runtime/provider_handlers.py`：`_BUILTIN_KEYS["deepseek"]` 的 Fernet 密文替换为新 key 的密文（同一派生密钥重加密）。

## 日志/验证证据

```
$ python round-trip verify
round-trip decrypt OK: True
decrypted value: sk-b186...7a3a
length: 35
```

验证方式：按 `_get_fernet()` 相同逻辑（SHA-256(激活码) → Fernet key）对文件中的新密文解密，结果与新 key 一致。

## 测试情况

- 无相关单元测试（`tests/` 中无引用 activate 流程的用例）。
- 手动验证：旧密文可解出旧 key（确认派生方案正确）；新密文 round-trip 解密结果与目标 key 一致。

## 截图

无需截图