### PR TITLE
fix(desktop): 修复 #929 收口审查问题——模型门控改为可解析且凭据可用 + 内置密钥聊天端点收口

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -2077,11 +2077,11 @@ for m in ("pydantic", "httpx", "loguru"):
   });
 
   ipcMain.handle(IPC.CONFIG_WRITE_INITIAL, (_event, payload: unknown) => {
-    const { provider_name, api_key, api_base, model, workspace } = payload as {
-      provider_name?: string | null;
-      api_key?: string | null;
-      api_base?: string | null;
-      model?: string | null;
+    // #835 收口：provider 凭据与默认模型只允许经后端收口接口写入
+    //（providers.activate / config.update）。此通道原先可绕过全部校验
+    // 直写 provider_name/api_key/api_base/model 到 config.json（#929
+    // review），现在只保留 workspace 初始化。
+    const { workspace } = payload as {
       workspace?: string | null;
     };
     const configDir = getConfigDir();
@@ -2096,21 +2096,10 @@ for m in ("pydantic", "httpx", "loguru"):
       // Start fresh
     }
 
-    if (provider_name) {
-      const providers = (existing['providers'] as Record<string, unknown> | undefined) ?? {};
-      providers[provider_name] = {
-        ...((providers[provider_name] as Record<string, unknown> | undefined) ?? {}),
-        ...(api_key ? { apiKey: api_key } : {}),
-        ...(api_base ? { apiBase: api_base } : {}),
-      };
-      existing['providers'] = providers;
-    }
-
-    if (model || workspace) {
+    if (workspace) {
       const agents = (existing['agents'] as Record<string, unknown> | undefined) ?? {};
       const defaults = (agents['defaults'] as Record<string, unknown> | undefined) ?? {};
-      if (model) defaults['model'] = model;
-      if (workspace) defaults['workspace'] = workspace;
+      defaults['workspace'] = workspace;
       agents['defaults'] = defaults;
       existing['agents'] = agents;
     }

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -40,8 +40,7 @@ export function ProvidersPage({ onGoToQraft }: { onGoToQraft: () => void }) {
   // 遗留 custom/* 默认模型解析不到 active_provider 时，激活按钮不能消失
   //（内置激活码是唯一的凭据入口，#929 review）：退到第一个可激活的内置
   // provider。
-  const editTarget =
-    activeProviderInfo ?? (providers.find((p) => p.builtin_available) ?? null);
+  const editTarget = activeProviderInfo ?? providers.find((p) => p.builtin_available) ?? null;
 
   return (
     <div className="flex flex-col h-full bg-[var(--background)]">

--- a/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
+++ b/apps/desktop/src/renderer/features/providers/ProvidersPage.tsx
@@ -37,6 +37,11 @@ export function ProvidersPage({ onGoToQraft }: { onGoToQraft: () => void }) {
   const activeProviderInfo = activeProvider
     ? providers.find((provider) => provider.name === activeProvider)
     : null;
+  // 遗留 custom/* 默认模型解析不到 active_provider 时，激活按钮不能消失
+  //（内置激活码是唯一的凭据入口，#929 review）：退到第一个可激活的内置
+  // provider。
+  const editTarget =
+    activeProviderInfo ?? (providers.find((p) => p.builtin_available) ?? null);
 
   return (
     <div className="flex flex-col h-full bg-[var(--background)]">
@@ -51,12 +56,12 @@ export function ProvidersPage({ onGoToQraft }: { onGoToQraft: () => void }) {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {activeProviderInfo && (
+          {editTarget && (
             <button
-              onClick={() => setEditProvider(activeProviderInfo)}
+              onClick={() => setEditProvider(editTarget)}
               className="text-xs text-[var(--accent)] hover:text-[var(--accent-hover)] transition-colors px-2 py-1 rounded bg-[var(--accent-soft)]"
             >
-              编辑当前模型
+              {editTarget === activeProviderInfo ? '编辑当前模型' : '激活内置模型'}
             </button>
           )}
           <button

--- a/apps/desktop/src/renderer/features/providers/components/EditProviderSheet.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/EditProviderSheet.tsx
@@ -52,8 +52,9 @@ export function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
         } catch {
           /* test failure doesn't block activation */
         }
-        const fallbackModel =
-          (PROVIDER_SUGGESTED_MODELS[provider.name] ?? [])[0] || 'deepseek-v4-flash';
+        const fallbackModel = `${provider.name}/${
+          (PROVIDER_SUGGESTED_MODELS[provider.name] ?? [])[0] || 'deepseek-v4-flash'
+        }`;
         try {
           await window.miqi.providers.update(
             provider.name,
@@ -90,6 +91,14 @@ export function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
           const activated = await handleActivate();
           if (!activated) {
             setError('激活失败，请检查激活码后重试');
+            return;
+          }
+          // handleActivate 已把默认模型设为内置 fallback 并刷新父级；
+          // 用户未另选模型时不再补发一次空 update（后端会报
+          // "No fields to update"，#929 review）。
+          if (!model) {
+            onSaved();
+            onClose();
             return;
           }
         } else {
@@ -175,6 +184,9 @@ export function EditSheet({ provider, onClose, onSaved }: EditSheetProps) {
                           try {
                             await window.miqi.providers.deactivate(provider.name);
                             setActivationSuccess(false);
+                            // 刷新父级列表：否则重开弹窗会从陈旧 prop 恢复
+                            // 出「已激活」状态（#929 review）。
+                            onSaved();
                           } catch (err: unknown) {
                             const msg = sanitizeUiMessage(
                               err instanceof Error ? err.message : String(err)

--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
@@ -85,10 +85,7 @@ describe('filterAvailableModels（#929 可用 provider 过滤回归）', () => {
 
   it('已配置网关（gatewayRouted）时保留任意模型 —— 运行时网关兜底路由', () => {
     const result = filterAvailableModels(catalog, new Set(['deepseek']), true);
-    expect(result.map((m) => m.id)).toEqual([
-      'deepseek/deepseek-chat',
-      'openai/gpt-4o',
-      'custom/my-model',
-    ]);
+    // custom/* 已从运行时移除，网关兜底也不放行（#933 review）
+    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-chat', 'openai/gpt-4o']);
   });
 });

--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
@@ -82,4 +82,13 @@ describe('filterAvailableModels（#929 可用 provider 过滤回归）', () => {
   it('可用集合未知（null）时不过滤，原样返回', () => {
     expect(filterAvailableModels(catalog, null)).toBe(catalog);
   });
+
+  it('已配置网关（gatewayRouted）时保留任意模型 —— 运行时网关兜底路由', () => {
+    const result = filterAvailableModels(catalog, new Set(['deepseek']), true);
+    expect(result.map((m) => m.id)).toEqual([
+      'deepseek/deepseek-chat',
+      'openai/gpt-4o',
+      'custom/my-model',
+    ]);
+  });
 });

--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
@@ -56,8 +56,11 @@ export function filterAvailableModels(
   available: Set<string> | null,
   gatewayRouted = false
 ): ModelInfo[] {
-  if (available === null || gatewayRouted) return models;
-  return models.filter((m) => available.has(m.provider));
+  if (available === null) return models;
+  const filtered = gatewayRouted ? models : models.filter((m) => available.has(m.provider));
+  // custom provider 已从运行时移除：即使网关兜底路由也不放行 custom/*，
+  // 否则选择后新会话会在 make_provider 报错（#933 review）。
+  return filtered.filter((m) => m.provider !== 'custom');
 }
 
 function displayName(provider: string): string {

--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
@@ -46,14 +46,17 @@ const FALLBACK_AVAILABLE_PROVIDERS = ['deepseek'];
 /**
  * 只保留「可用 provider」的模型：内置可激活（builtin_available）或已配置
  * 凭据（configured，兼容历史配置）。available 为 null 时不过滤（目录还没
- * 加载完）。收口后 model/list 仍返回全量目录，这里负责兜住 custom 等
- * 已从运行时工厂移除的 provider（CodeRabbit #929）。
+ * 加载完）。gatewayRouted 为 true 时保留任意模型 —— 已配置的网关（如
+ * OpenRouter）在运行时兜底路由任意模型（Config._match_provider），过滤
+ * 掉反而会清掉用户能正常使用的模型（#929 review）。收口后 model/list
+ * 仍返回全量目录，这里负责兜住 custom 等已从运行时工厂移除的 provider。
  */
 export function filterAvailableModels(
   models: ModelInfo[],
-  available: Set<string> | null
+  available: Set<string> | null,
+  gatewayRouted = false
 ): ModelInfo[] {
-  if (available === null) return models;
+  if (available === null || gatewayRouted) return models;
   return models.filter((m) => available.has(m.provider));
 }
 
@@ -88,6 +91,7 @@ interface ModelSelectProps {
 export function ModelSelect({ value, onChange, presets }: ModelSelectProps) {
   const [loaded, setLoaded] = useState<ModelInfo[] | null>(null);
   const [availableProviders, setAvailableProviders] = useState<Set<string> | null>(null);
+  const [gatewayRouted, setGatewayRouted] = useState(false);
 
   useEffect(() => {
     let alive = true;
@@ -106,6 +110,7 @@ export function ModelSelect({ value, onChange, presets }: ModelSelectProps) {
         setAvailableProviders(
           new Set(r.providers.filter((p) => p.builtin_available || p.configured).map((p) => p.name))
         );
+        setGatewayRouted(r.providers.some((p) => p.is_gateway && p.configured));
       })
       .catch(() => {
         if (alive) setAvailableProviders(new Set(FALLBACK_AVAILABLE_PROVIDERS));
@@ -117,20 +122,15 @@ export function ModelSelect({ value, onChange, presets }: ModelSelectProps) {
 
   const all = useMemo(() => {
     const source = loaded === null ? null : loaded.length > 0 ? loaded : null;
-    return filterAvailableModels(source ?? presets ?? FALLBACK_MODEL_PRESETS, availableProviders);
-  }, [loaded, presets, availableProviders]);
+    return filterAvailableModels(
+      source ?? presets ?? FALLBACK_MODEL_PRESETS,
+      availableProviders,
+      gatewayRouted
+    );
+  }, [loaded, presets, availableProviders, gatewayRouted]);
 
   const groups = useMemo(() => groupPresets(all), [all]);
   const isPreset = all.some((m) => m.id === value);
-
-  // 当前值不在可用目录中（如历史遗留的自定义模型）：清掉父级状态，让
-  // 「保存」无法落盘一个运行时解析不了的模型，用户必须重新选择预设。
-  // 仅在拿到真实目录（非空）后判定，后端不可用时不破坏现有值。
-  useEffect(() => {
-    if (loaded && loaded.length > 0 && value && !all.some((m) => m.id === value)) {
-      onChange('');
-    }
-  }, [loaded, all, value, onChange]);
 
   return (
     <div className="flex flex-col gap-1.5">

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -464,6 +464,7 @@ function GeneralTab({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { loggedIn } = useQraftStatus();
 
   useEffect(() => {
@@ -483,6 +484,10 @@ function GeneralTab({
   const handleSave = async () => {
     setSaving(true);
     setSaveError(null);
+    // 新一轮保存开始时清掉上一次的成功状态与定时器：失败不应残留
+    // 「已保存」，旧定时器也不应提前清掉新的成功状态（#933 review）。
+    setSaved(false);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
     try {
       const defaults: Record<string, unknown> = {
         name: agentName,
@@ -498,7 +503,7 @@ function GeneralTab({
       await window.miqi.config.update({ agents: { defaults } });
       invalidateConfigCache();
       setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
     } catch (err: unknown) {
       // 后端收口（#929）会拒绝无法解析/无凭据的模型值 —— 不能再静默吞掉，
       // 否则用户看到「点了保存没反应」（#929 review）。
@@ -674,6 +679,7 @@ function WebToolsTab() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     getCachedConfig()
@@ -718,6 +724,10 @@ function WebToolsTab() {
   const handleSave = async () => {
     setSaving(true);
     setSaveError(null);
+    // 与 GeneralTab 一致：新一轮保存开始时清掉上一次的成功状态与定时器
+    //（#933 review）。
+    setSaved(false);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
     try {
       await window.miqi.config.update({
         tools: {
@@ -741,7 +751,7 @@ function WebToolsTab() {
       });
       invalidateConfigCache();
       setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
     } catch (err: unknown) {
       // 不再静默吞掉（#929 review）：用户需要看到保存为什么失败
       setSaveError(sanitizeUiMessage(err instanceof Error ? err.message : String(err)));

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { cn } from '../../lib/utils';
 import { getCachedConfig, invalidateConfigCache } from '../../lib/configCache';
+import { sanitizeUiMessage } from '../../lib/sanitizeUiMessage';
 import {
   RefreshCw,
   Download,
@@ -462,6 +463,7 @@ function GeneralTab({
   const [maxTokens, setMaxTokens] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const { loggedIn } = useQraftStatus();
 
   useEffect(() => {
@@ -480,6 +482,7 @@ function GeneralTab({
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       const defaults: Record<string, unknown> = {
         name: agentName,
@@ -487,8 +490,8 @@ function GeneralTab({
         temperature: temperature === '' ? '' : parseFloat(temperature),
         maxTokens: maxTokens === '' ? '' : parseInt(maxTokens),
       };
-      // 模型下拉只允许预设选择：值被 ModelSelect 清空（历史遗留模型不在
-      // 可用目录中）时，不能把空值存回配置。
+      // 模型下拉只允许预设选择：未选择（历史遗留模型不在可用目录中）时
+      // 不把空值存回配置 —— 后端现在会拒绝空模型（#929 收口）。
       if (model) {
         defaults.model = model;
       }
@@ -496,8 +499,10 @@ function GeneralTab({
       invalidateConfigCache();
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } catch {
-      /* ignore */
+    } catch (err: unknown) {
+      // 后端收口（#929）会拒绝无法解析/无凭据的模型值 —— 不能再静默吞掉，
+      // 否则用户看到「点了保存没反应」（#929 review）。
+      setSaveError(sanitizeUiMessage(err instanceof Error ? err.message : String(err)));
     }
     setSaving(false);
   };
@@ -589,6 +594,12 @@ function GeneralTab({
         {saved ? '已保存' : '保存'}
       </Button>
 
+      {saveError && (
+        <div className="rounded-lg px-3 py-2 bg-[var(--accent-soft)] text-xs text-[var(--danger)]">
+          {saveError}
+        </div>
+      )}
+
       {/* ---- Sandbox ---- */}
       <div className="pt-4 border-t border-[var(--border-subtle)]">
         <h3
@@ -662,6 +673,7 @@ function WebToolsTab() {
   const [showKeys, setShowKeys] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     getCachedConfig()
@@ -705,6 +717,7 @@ function WebToolsTab() {
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       await window.miqi.config.update({
         tools: {
@@ -729,8 +742,9 @@ function WebToolsTab() {
       invalidateConfigCache();
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } catch {
-      /* ignore */
+    } catch (err: unknown) {
+      // 不再静默吞掉（#929 review）：用户需要看到保存为什么失败
+      setSaveError(sanitizeUiMessage(err instanceof Error ? err.message : String(err)));
     }
     setSaving(false);
   };
@@ -1026,6 +1040,12 @@ function WebToolsTab() {
         {saved ? <Check size={14} /> : <Save size={14} />}
         {saved ? '已保存' : '保存所有 Web 设置'}
       </Button>
+
+      {saveError && (
+        <div className="rounded-lg px-3 py-2 bg-[var(--accent-soft)] text-xs text-[var(--danger)]">
+          {saveError}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/tests/smoke/issue-137-clear-settings.spec.ts
+++ b/apps/desktop/tests/smoke/issue-137-clear-settings.spec.ts
@@ -17,10 +17,9 @@ async function injectMockAndGoto(page: import('@playwright/test').Page) {
         tools: {
           web: {
             search: {
-              provider: 'hybrid',
-              apiKey: 'BSA-old',
-              ollamaApiBase: 'https://old-search.example',
-              ollamaApiKey: 'search-old',
+              provider: 'auto',
+              tavilyApiKey: 'tvly-old',
+              braveApiKey: 'BSA-old',
             },
             fetch: {
               provider: 'hybrid',
@@ -40,59 +39,58 @@ async function injectMockAndGoto(page: import('@playwright/test').Page) {
   await page.waitForSelector('#root', { state: 'visible' });
 }
 
-test('issue #137: clearing workspace and model sends explicit empty values', async ({ page }) => {
+test('issue #137: clearing workspace sends explicit empty values', async ({ page }) => {
   await injectMockAndGoto(page);
+  // #929 收口后默认模型改为预设下拉，未登录时被门控隐藏 —— 登录后
+  // 才能断言下拉；清空工作目录时模型保持原值（不再有空模型写入路径）。
+  await page.evaluate(() => (window as any).miqi.qraft.login('18500000000', 'test-password'));
 
-  await page.getByText('System Settings').click();
+  await page.getByText(/^(System Settings|系统设置)$/).click();
 
   const workspaceInput = page.getByPlaceholder('~/.miqi/workspace');
-  const modelInput = page.getByPlaceholder('provider/model-name');
+  const modelSelect = page.locator('select').first();
   await expect(workspaceInput).toHaveValue('C:/old-workspace');
-  await expect(modelInput).toHaveValue('openai/gpt-4.1');
+  await expect(modelSelect).toBeVisible();
 
   await workspaceInput.fill('');
-  await modelInput.fill('');
   const generalPanel = workspaceInput.locator('xpath=ancestor::div[contains(@class, "p-6")][1]');
   await generalPanel.locator('button').nth(1).click();
 
   const updates = await page.evaluate(() => window.__miqiMock.getConfigUpdates());
   expect(updates).toHaveLength(1);
-  expect(updates[0]).toEqual({
-    agents: {
-      defaults: {
-        name: 'miqi',
-        workspace: '',
-        model: '',
-        temperature: 0.2,
-        maxTokens: 4096,
-      },
-    },
-  });
+  const defaults = (updates[0] as any).agents.defaults;
+  expect(defaults.workspace).toBe('');
+  expect(defaults.name).toBe('miqi');
+  expect(defaults.temperature).toBe(0.2);
+  expect(defaults.maxTokens).toBe(4096);
+  // 模型未改动时保留原值，不会被清成空字符串（#929 收口：空模型被后端拒绝）
+  expect(defaults.model).toBe('openai/gpt-4.1');
 });
 
 test('issue #137: clearing web tool keys sends explicit empty values', async ({ page }) => {
   await injectMockAndGoto(page);
 
-  await page.getByText('System Settings').click();
-  await page.locator('[role="tab"]').filter({ hasText: 'Web' }).click();
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page.getByRole('tab').filter({ hasText: 'Web' }).click();
 
+  // 搜索 key 收在「自定义搜索引擎」折叠面板里（#844 改版后）
+  const details = page.locator('details').filter({ has: page.getByText('自定义搜索引擎') });
+  await details.locator('summary').click();
+
+  const tavilyKeyInput = page.getByPlaceholder('tvly-...');
   const braveKeyInput = page.getByPlaceholder('BSA...');
-  const searchBaseInput = page.getByPlaceholder('https://ollama.com').first();
-  const searchKeyInput = page.getByPlaceholder('ollama-key...').first();
   const fetchBaseInput = page.locator('input[value="https://old-fetch.example"]');
   const fetchKeyInput = page.locator('input[value="fetch-old"]');
   const s2KeyInput = page.locator('input[value="s2-old"]');
 
+  await expect(tavilyKeyInput).toHaveValue('tvly-old');
   await expect(braveKeyInput).toHaveValue('BSA-old');
-  await expect(searchBaseInput).toHaveValue('https://old-search.example');
-  await expect(searchKeyInput).toHaveValue('search-old');
   await expect(fetchBaseInput).toHaveValue('https://old-fetch.example');
   await expect(fetchKeyInput).toHaveValue('fetch-old');
   await expect(s2KeyInput).toHaveValue('s2-old');
 
+  await tavilyKeyInput.fill('');
   await braveKeyInput.fill('');
-  await searchBaseInput.fill('');
-  await searchKeyInput.fill('');
   await fetchBaseInput.fill('');
   await fetchKeyInput.fill('');
   await s2KeyInput.fill('');
@@ -106,10 +104,9 @@ test('issue #137: clearing web tool keys sends explicit empty values', async ({ 
     tools: {
       web: {
         search: {
-          provider: 'hybrid',
-          apiKey: '',
-          ollamaApiBase: '',
-          ollamaApiKey: '',
+          provider: 'auto',
+          tavilyApiKey: '',
+          braveApiKey: '',
         },
         fetch: {
           provider: 'hybrid',

--- a/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
+++ b/apps/desktop/tests/smoke/issue-140-webtools.spec.ts
@@ -10,13 +10,17 @@ test.describe('Issue #140 Web search settings', () => {
     await page.getByText(/^(System Settings|系统设置)$/).click();
     await page.getByRole('tab').filter({ hasText: /Web/ }).click();
 
+    // 搜索引擎选项收在「自定义搜索引擎」折叠面板里（#844 改版后需先展开；
+    // 折叠时内容不在 a11y 树中，role 过滤匹配不到，须按文本点开）
+    await page.getByText('自定义搜索引擎（可选）').click();
+
     const webSearch = page
       .locator('section')
       .filter({ has: page.getByRole('button', { name: 'DuckDuckGo' }) });
     await expect(webSearch).toBeVisible();
-    await expect(webSearch.getByRole('button', { name: 'DuckDuckGo' })).toBeVisible();
-    await expect(webSearch.getByRole('button', { name: 'Brave' })).toBeVisible();
-    await expect(webSearch.getByRole('button', { name: 'Hybrid' })).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'DuckDuckGo', exact: true })).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'Brave', exact: true })).toBeVisible();
+    await expect(webSearch.getByRole('button', { name: 'Tavily', exact: true })).toBeVisible();
     await expect(webSearch).not.toContainText('Ollama');
 
     const webFetch = page

--- a/apps/desktop/tests/smoke/issue-929-fixes-e2e.spec.ts
+++ b/apps/desktop/tests/smoke/issue-929-fixes-e2e.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+import { buildMockBridgeScript } from './mocks';
+
+/**
+ * #929 修复分支 E2E 评估 —— 验证审查发现修复后的用户可见行为：
+ *  1. 激活后默认模型写为带前缀的预设（下拉可显示，不再与页头矛盾）
+ *  2. 取消激活后父级状态刷新、默认模型重置，重开弹窗不再显示陈旧的「已激活」
+ *  3. custom/* 遗留用户仍有内置激活入口（「激活内置模型」按钮）
+ * mock 桥为动态状态（update/activate/deactivate 镜像真实后端行为）。
+ */
+
+const DEEPSEEK_PROVIDER = {
+  name: 'deepseek',
+  display_name: 'DeepSeek',
+  env_key: 'DEEPSEEK_API_KEY',
+  provider_type: 'openai',
+  is_gateway: false,
+  is_local: false,
+  default_api_base: '',
+  configured: false,
+  api_key_hint: null,
+  api_base: null,
+  configured_model: null,
+  verification_status: 'missing',
+  builtin_available: true,
+  builtin_activated: false,
+};
+
+test('激活/取消激活流程修复评估（#929 fixes）', async ({ page }) => {
+  test.setTimeout(90_000);
+  await page.addInitScript({
+    content: buildMockBridgeScript({
+      activeModel: '',
+      activeProvider: 'deepseek',
+      providers: [{ ...DEEPSEEK_PROVIDER }],
+    }),
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#root', { state: 'visible' });
+  await page.evaluate(() => (window as any).miqi.qraft.login('18500000000', 'test-password'));
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page.getByRole('tab', { name: '模型' }).click();
+
+  // ── 1. 未激活：页头「未设置」+ 激活入口 ─────────────────────────────
+  await expect(page.getByTestId('providers-active-model')).toHaveText('当前默认模型：未设置');
+  await page.getByText('编辑当前模型').click();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible();
+  // 弹窗内下拉显示占位（还没有模型）
+  await expect(page.locator('select').last()).toHaveValue('');
+
+  // ── 2. 激活 → 已激活态（弹窗保持打开） ───────────────────────────────
+  await page.getByPlaceholder('输入激活码').fill('DEMO-CODE');
+  await page.getByRole('button', { name: '激活' }).click();
+  await expect(page.getByText('已激活')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('取消激活')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/f01-edit-activated.png' });
+
+  // ── 3. 关闭弹窗：页头默认模型 = 激活写入的带前缀预设 ─────────────────
+  await page.getByRole('button', { name: '取消', exact: true }).click();
+  await expect(page.getByTestId('providers-active-model')).toHaveText(
+    '当前默认模型：deepseek/deepseek-v4-flash'
+  );
+  await page.screenshot({ path: 'test-results/929-shots/f02-header-after-activation.png' });
+
+  // ── 4. 重开弹窗：下拉显示带前缀模型（修复前被清空显示占位）───────────
+  await page.getByText('编辑当前模型').click();
+  await expect(page.getByText('已激活')).toBeVisible({ timeout: 10_000 });
+  const sheetSelect = page.locator('select').last();
+  await expect(sheetSelect).toHaveValue('deepseek/deepseek-v4-flash');
+  await page.screenshot({ path: 'test-results/929-shots/f03-reopen-shows-prefixed-model.png' });
+
+  // ── 5. 取消激活 → 默认模型重置为出厂默认，按钮变为「激活内置模型」 ────
+  await page.getByText('取消激活').click();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible({ timeout: 10_000 });
+  await page.getByRole('button', { name: '取消', exact: true }).click();
+  await expect(page.getByTestId('providers-active-model')).toHaveText(
+    '当前默认模型：anthropic/claude-opus-4-5'
+  );
+  // active_provider 已为空 → 激活入口退到内置 provider（修复 #10）
+  await expect(page.getByText('激活内置模型')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/f04-header-after-deactivate.png' });
+
+  // ── 6. 重开弹窗：不再显示陈旧的「已激活」（修复 #7）──────────────────
+  await page.getByText('激活内置模型').click();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('已激活')).not.toBeVisible();
+  await expect(page.getByText('取消激活')).not.toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/f05-reopen-shows-deactivated.png' });
+});
+
+test('custom/* 遗留用户仍有激活入口（#929 fixes）', async ({ page }) => {
+  test.setTimeout(90_000);
+  await page.addInitScript({
+    content: buildMockBridgeScript({
+      activeModel: 'custom/my-model',
+      activeProvider: null,
+      providers: [{ ...DEEPSEEK_PROVIDER }],
+    }),
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#root', { state: 'visible' });
+  await page.evaluate(() => (window as any).miqi.qraft.login('18500000000', 'test-password'));
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page.getByRole('tab', { name: '模型' }).click();
+
+  // 页头如实显示遗留模型；激活入口不退场（修复 #10）
+  await expect(page.getByTestId('providers-active-model')).toHaveText(
+    '当前默认模型：custom/my-model'
+  );
+  await expect(page.getByText('编辑当前模型')).not.toBeVisible();
+  await expect(page.getByText('激活内置模型')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/f06-custom-user-activation-entry.png' });
+
+  await page.getByText('激活内置模型').click();
+  await expect(page.getByText('API 来源')).toBeVisible();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/f07-custom-user-edit-sheet.png' });
+});

--- a/apps/desktop/tests/smoke/issue-929-fixes-e2e.spec.ts
+++ b/apps/desktop/tests/smoke/issue-929-fixes-e2e.spec.ts
@@ -70,13 +70,11 @@ test('激活/取消激活流程修复评估（#929 fixes）', async ({ page }) =
   await expect(sheetSelect).toHaveValue('deepseek/deepseek-v4-flash');
   await page.screenshot({ path: 'test-results/929-shots/f03-reopen-shows-prefixed-model.png' });
 
-  // ── 5. 取消激活 → 默认模型重置为出厂默认，按钮变为「激活内置模型」 ────
+  // ── 5. 取消激活 → 默认模型清空为「未设置」，按钮变为「激活内置模型」 ──
   await page.getByText('取消激活').click();
   await expect(page.getByPlaceholder('输入激活码')).toBeVisible({ timeout: 10_000 });
   await page.getByRole('button', { name: '取消', exact: true }).click();
-  await expect(page.getByTestId('providers-active-model')).toHaveText(
-    '当前默认模型：anthropic/claude-opus-4-5'
-  );
+  await expect(page.getByTestId('providers-active-model')).toHaveText('当前默认模型：未设置');
   // active_provider 已为空 → 激活入口退到内置 provider（修复 #10）
   await expect(page.getByText('激活内置模型')).toBeVisible();
   await page.screenshot({ path: 'test-results/929-shots/f04-header-after-deactivate.png' });

--- a/apps/desktop/tests/smoke/issue-929-model-consolidation-ui.spec.ts
+++ b/apps/desktop/tests/smoke/issue-929-model-consolidation-ui.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { buildMockBridgeScript } from './mocks';
+
+/**
+ * #929 模型选择收口 — UI 截图评估。
+ * 覆盖：未登录门控（模型/通用 tab）、登录后模型下拉（收口后仅内置 DeepSeek）、
+ * 保存流、编辑弹窗激活码 UI（激活/取消激活）。
+ * 每步截图存 test-results/929-shots/，供人工与 OCR 评估。
+ */
+test('模型收口 UI 截图评估（#929）', async ({ page }) => {
+  test.setTimeout(90_000);
+  await page.addInitScript({
+    content: buildMockBridgeScript({
+      activeModel: 'deepseek-chat',
+      activeProvider: 'deepseek',
+      providers: [
+        {
+          name: 'deepseek',
+          display_name: 'DeepSeek',
+          env_key: 'DEEPSEEK_API_KEY',
+          provider_type: 'openai',
+          is_gateway: false,
+          is_local: false,
+          default_api_base: '',
+          configured: true,
+          api_key_hint: 'sk-t...seek',
+          api_base: null,
+          configured_model: 'deepseek-chat',
+          verification_status: 'success',
+          builtin_available: true,
+          builtin_activated: false,
+        },
+      ],
+    }),
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#root', { state: 'visible' });
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+
+  // ── 1. 未登录 → 模型 tab：登录门控 ────────────────────────────────────
+  await page.getByRole('tab', { name: '模型' }).click();
+  await expect(page.getByTestId('providers-active-model')).toHaveText(
+    '当前默认模型：deepseek-chat'
+  );
+  await expect(page.getByText('登录后使用平台内置模型')).toBeVisible();
+  await expect(page.getByText('去登录')).toBeVisible();
+  await expect(page.getByText('编辑当前模型')).toBeVisible();
+  // 收口：不再有自配入口 / 状态列表
+  await expect(page.getByText('验证成功')).not.toBeVisible();
+  await expect(page.getByText(/匹配 Provider/)).not.toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/01-model-tab-login-gate.png' });
+
+  // ── 2. 未登录 → 通用 tab：登录门控 ────────────────────────────────────
+  await page.getByRole('tab', { name: '通用' }).click();
+  await expect(page.getByTestId('general-go-login')).toBeVisible();
+  await expect(page.getByText('登录后使用平台内置模型')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/02-general-tab-login-gate.png' });
+
+  // ── 3. 模拟登录 → 模型 tab：下拉出现，收口后仅内置 DeepSeek ────────────
+  await page.evaluate(() => (window as any).miqi.qraft.login('18500000000', 'test-password'));
+  await page.getByRole('tab', { name: '模型' }).click();
+  const select = page.locator('select').first();
+  await expect(select).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('登录后使用平台内置模型')).not.toBeVisible();
+  // 目录含 openai/custom，但可用 provider 只有内置 deepseek → 过滤后不出现
+  await expect(select).toContainText('deepseek/deepseek-chat');
+  await expect(select).not.toContainText('openai');
+  await expect(select).not.toContainText('custom');
+  await expect(select).not.toContainText('自定义模型');
+  await page.screenshot({ path: 'test-results/929-shots/03-model-tab-logged-in-dropdown.png' });
+
+  // ── 4. 选择预设模型并保存 ─────────────────────────────────────────────
+  await select.selectOption('deepseek/deepseek-v4-flash');
+  await expect(select).toHaveValue('deepseek/deepseek-v4-flash');
+  await page.screenshot({ path: 'test-results/929-shots/04-model-selected.png' });
+  await page.getByRole('button', { name: '保存' }).click();
+  await expect(page.getByText('已保存，新会话立即生效')).toBeVisible({ timeout: 10_000 });
+  // 保存走 config.update 深合并，只写 agents.defaults.model，不触碰 providers
+  const updates = await page.evaluate(() => (window as any).__miqiMock.getConfigUpdates());
+  expect(JSON.stringify(updates)).toContain('deepseek/deepseek-v4-flash');
+  expect(JSON.stringify(updates)).not.toContain('providers');
+  await page.screenshot({ path: 'test-results/929-shots/05-model-saved-flash.png' });
+
+  // ── 5. 编辑当前模型：激活码弹窗（未激活态）────────────────────────────
+  await page.getByText('编辑当前模型').click();
+  await expect(page.getByText('API 来源')).toBeVisible();
+  await expect(page.getByText('推荐（无需API Key）')).toBeVisible();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible();
+  // 收口：弹窗内不再有自配 API Key / Base URL / 自定义模型输入
+  await expect(page.locator('input[type="url"]')).toHaveCount(0);
+  await expect(page.getByText('API Base URL')).not.toBeVisible();
+  await expect(page.getByText('自定义模型')).not.toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/06-edit-sheet-activation-ui.png' });
+
+  // ── 6. 激活 → 已激活态 + 取消激活入口 ─────────────────────────────────
+  await page.getByPlaceholder('输入激活码').fill('DEMO-CODE-123');
+  await page.getByRole('button', { name: '激活' }).click();
+  await expect(page.getByText('已激活')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('取消激活')).toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/07-edit-sheet-activated.png' });
+
+  // ── 7. 取消激活 → 回到激活码输入态 ─────────────────────────────────────
+  await page.getByText('取消激活').click();
+  await expect(page.getByPlaceholder('输入激活码')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('已激活')).not.toBeVisible();
+  await page.screenshot({ path: 'test-results/929-shots/08-edit-sheet-deactivated.png' });
+});

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -12,6 +12,8 @@ export interface MockBridgeOptions {
   sessionMessages?: Record<string, unknown[]>;
   preloadOk?: boolean;
   providers?: Array<Record<string, unknown>>;
+  /** model/list 目录（issue #788）。默认含 deepseek + openai + custom，供过滤逻辑验证。 */
+  models?: Array<Record<string, unknown>>;
   activeModel?: string;
   activeProvider?: string | null;
   config?: Record<string, unknown>;
@@ -42,6 +44,13 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   const sessionsJson = JSON.stringify(initialSessions);
   const sessionMessagesJson = JSON.stringify(opts.sessionMessages || {});
   const providersJson = JSON.stringify(opts.providers || []);
+  const modelsJson = JSON.stringify(opts.models || [
+    { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
+    { id: 'deepseek/deepseek-reasoner', name: 'DeepSeek Reasoner', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
+    { id: 'deepseek/deepseek-v4-flash', name: 'DeepSeek V4 Flash', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
+    { id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai', providerDisplayName: 'OpenAI', hidden: false, default: false },
+    { id: 'custom/my-model', name: 'My Model', provider: 'custom', providerDisplayName: 'Custom', hidden: false, default: false },
+  ]);
   const activeModelJson = JSON.stringify(opts.activeModel || '');
   const activeProviderJson = JSON.stringify(opts.activeProvider ?? null);
   const configJson = JSON.stringify(opts.config || {});
@@ -103,6 +112,7 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   var noop = function() { return function() {}; };
   var _config = ${configJson};
   var _configUpdates = [];
+  var _modelCatalog = ${modelsJson};
 
   // ── Interactive helpers ──────────────────────────────────────────
   var _callbacks = {
@@ -230,6 +240,12 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       list: function() { return Promise.resolve({ providers: ${providersJson}, active_model: ${activeModelJson}, active_provider: ${activeProviderJson} }); },
       test: function() { return Promise.resolve({ ok: true }); },
       update: function() { return Promise.resolve({ ok: true }); },
+      activate: function(providerName) { return Promise.resolve({ activated: true, provider_name: providerName }); },
+      deactivate: function(providerName) { return Promise.resolve({ deactivated: true, provider_name: providerName }); },
+    },
+
+    models: {
+      list: function() { return Promise.resolve({ models: JSON.parse(JSON.stringify(_modelCatalog)) }); },
     },
 
     channels: {

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -44,13 +44,50 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   const sessionsJson = JSON.stringify(initialSessions);
   const sessionMessagesJson = JSON.stringify(opts.sessionMessages || {});
   const providersJson = JSON.stringify(opts.providers || []);
-  const modelsJson = JSON.stringify(opts.models || [
-    { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
-    { id: 'deepseek/deepseek-reasoner', name: 'DeepSeek Reasoner', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
-    { id: 'deepseek/deepseek-v4-flash', name: 'DeepSeek V4 Flash', provider: 'deepseek', providerDisplayName: 'DeepSeek', hidden: false, default: false },
-    { id: 'openai/gpt-4o', name: 'GPT-4o', provider: 'openai', providerDisplayName: 'OpenAI', hidden: false, default: false },
-    { id: 'custom/my-model', name: 'My Model', provider: 'custom', providerDisplayName: 'Custom', hidden: false, default: false },
-  ]);
+  const modelsJson = JSON.stringify(
+    opts.models || [
+      {
+        id: 'deepseek/deepseek-chat',
+        name: 'DeepSeek Chat',
+        provider: 'deepseek',
+        providerDisplayName: 'DeepSeek',
+        hidden: false,
+        default: false,
+      },
+      {
+        id: 'deepseek/deepseek-reasoner',
+        name: 'DeepSeek Reasoner',
+        provider: 'deepseek',
+        providerDisplayName: 'DeepSeek',
+        hidden: false,
+        default: false,
+      },
+      {
+        id: 'deepseek/deepseek-v4-flash',
+        name: 'DeepSeek V4 Flash',
+        provider: 'deepseek',
+        providerDisplayName: 'DeepSeek',
+        hidden: false,
+        default: false,
+      },
+      {
+        id: 'openai/gpt-4o',
+        name: 'GPT-4o',
+        provider: 'openai',
+        providerDisplayName: 'OpenAI',
+        hidden: false,
+        default: false,
+      },
+      {
+        id: 'custom/my-model',
+        name: 'My Model',
+        provider: 'custom',
+        providerDisplayName: 'Custom',
+        hidden: false,
+        default: false,
+      },
+    ]
+  );
   const activeModelJson = JSON.stringify(opts.activeModel || '');
   const activeProviderJson = JSON.stringify(opts.activeProvider ?? null);
   const configJson = JSON.stringify(opts.config || {});

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -113,6 +113,11 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   var _config = ${configJson};
   var _configUpdates = [];
   var _modelCatalog = ${modelsJson};
+  // 动态 provider 状态：update/activate/deactivate 会修改，镜像真实后端行为
+  // （#929 修复分支的 E2E 评估依赖这一动态性）。
+  var _providers = ${providersJson};
+  var _activeModel = ${activeModelJson};
+  var _activeProvider = ${activeProviderJson};
 
   // ── Interactive helpers ──────────────────────────────────────────
   var _callbacks = {
@@ -231,17 +236,52 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       get: function() { return Promise.resolve(JSON.parse(JSON.stringify(_config))); },
       update: function(payload) {
         _configUpdates.push(JSON.parse(JSON.stringify(payload)));
+        // 镜像真实后端：默认模型经 config.update 修改后立即反映到 providers.list
+        var model = payload && payload.agents && payload.agents.defaults && payload.agents.defaults.model;
+        if (model) _activeModel = model;
         return Promise.resolve({});
       },
       // #897 ConfigHotReloadListener subscribes on mount; return an unsubscribe.
       onUpdated: function(cb) { return _on('config:updated', cb); },    },
 
     providers: {
-      list: function() { return Promise.resolve({ providers: ${providersJson}, active_model: ${activeModelJson}, active_provider: ${activeProviderJson} }); },
+      list: function() { return Promise.resolve({ providers: JSON.parse(JSON.stringify(_providers)), active_model: _activeModel, active_provider: _activeProvider }); },
       test: function() { return Promise.resolve({ ok: true }); },
-      update: function() { return Promise.resolve({ ok: true }); },
-      activate: function(providerName) { return Promise.resolve({ activated: true, provider_name: providerName }); },
-      deactivate: function(providerName) { return Promise.resolve({ deactivated: true, provider_name: providerName }); },
+      update: function(providerName, apiKey, apiBase, headers, model) {
+        // 镜像真实后端：model 覆盖写为默认模型，并归属 provider
+        if (model) {
+          _activeModel = model;
+          _activeProvider = providerName;
+          for (var i = 0; i < _providers.length; i++) {
+            if (_providers[i].name === providerName) _providers[i].configured_model = model;
+          }
+        }
+        return Promise.resolve({ ok: true });
+      },
+      activate: function(providerName) {
+        for (var i = 0; i < _providers.length; i++) {
+          if (_providers[i].name === providerName) {
+            _providers[i].builtin_activated = true;
+            _providers[i].configured = true;
+          }
+        }
+        return Promise.resolve({ activated: true, provider_name: providerName });
+      },
+      deactivate: function(providerName) {
+        for (var i = 0; i < _providers.length; i++) {
+          if (_providers[i].name === providerName) {
+            _providers[i].builtin_activated = false;
+            _providers[i].configured = false;
+            _providers[i].configured_model = null;
+          }
+        }
+        // 镜像真实后端：默认模型归属被取消激活的 provider 时重置为出厂默认
+        if (_activeProvider === providerName) {
+          _activeModel = 'anthropic/claude-opus-4-5';
+          _activeProvider = null;
+        }
+        return Promise.resolve({ deactivated: true, provider_name: providerName });
+      },
     },
 
     models: {

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -312,9 +312,10 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
             _providers[i].configured_model = null;
           }
         }
-        // 镜像真实后端：默认模型归属被取消激活的 provider 时重置为出厂默认
+        // 镜像真实后端：默认模型归属被取消激活的 provider 时重置为可用
+        // 模型或清空为「未选择」（#929 / #933）
         if (_activeProvider === providerName) {
-          _activeModel = 'anthropic/claude-opus-4-5';
+          _activeModel = '';
           _activeProvider = null;
         }
         return Promise.resolve({ deactivated: true, provider_name: providerName });

--- a/miqi/config/loader.py
+++ b/miqi/config/loader.py
@@ -138,7 +138,7 @@ def _pick_migrated_model(data: dict) -> str:
     dict; falls back to the factory default (fresh-install semantics, where
     NO_API_KEY surfaces in the UI until the user picks a model).
     """
-    from miqi.providers.registry import PROVIDERS, PROVIDER_TEST_MODELS
+    from miqi.providers.registry import PROVIDER_TEST_MODELS, PROVIDERS
 
     providers_raw = data.get("providers") or {}
     for spec in PROVIDERS:

--- a/miqi/config/loader.py
+++ b/miqi/config/loader.py
@@ -131,6 +131,36 @@ def _init_permanent_approvals(config: Config) -> None:
             logger.warning("Failed to load permanent approvals: {}", exc)
 
 
+def _pick_migrated_model(data: dict) -> str:
+    """Choose a default model the runtime can use after a custom/* reset.
+
+    Prefers the first configured provider's test model from the raw config
+    dict; falls back to the factory default (fresh-install semantics, where
+    NO_API_KEY surfaces in the UI until the user picks a model).
+    """
+    from miqi.providers.registry import PROVIDERS, PROVIDER_TEST_MODELS
+
+    providers_raw = data.get("providers") or {}
+    for spec in PROVIDERS:
+        entry = providers_raw.get(spec.name) or {}
+        if not isinstance(entry, dict):
+            continue
+        api_key = entry.get("api_key") or entry.get("apiKey") or ""
+        api_base = entry.get("api_base") or entry.get("apiBase") or ""
+        if spec.is_local:
+            if not api_base:
+                continue
+        elif not api_key:
+            continue
+        model = PROVIDER_TEST_MODELS.get(spec.name)
+        if not model:
+            continue
+        if spec.is_gateway or spec.is_local:
+            return model
+        return f"{spec.name}/{model}"
+    return "anthropic/claude-opus-4-5"
+
+
 def _migrate_config(data: dict) -> dict:
     """Migrate old config formats to current."""
     # Move tools.exec.restrictToWorkspace → tools.restrictToWorkspace
@@ -148,13 +178,14 @@ def _migrate_config(data: dict) -> dict:
 
     # #835 收口：custom provider 已从运行时移除。遗留的 custom/* 默认模型
     # 会经 _match_provider 兜底错发到第一个已配置 provider 的 API（#929
-    # review）——迁移时重置为出厂默认，让用户在设置页重新选择内置模型。
+    # review）——迁移时重置为一个运行时真正可用的模型（优先已配置
+    # provider 的测试模型，#933 review），让用户在设置页重新选择。
     model = (data.get("agents") or {}).get("defaults") or {}
     if isinstance(model, dict) and isinstance(model.get("model"), str) and model["model"].lower().startswith("custom/"):
         logger.warning(
             "migrate: default model '{}' uses removed custom provider — "
-            "reset to factory default", model["model"],
+            "reset to a usable model", model["model"],
         )
-        model["model"] = "anthropic/claude-opus-4-5"
+        model["model"] = _pick_migrated_model(data)
         data.setdefault("agents", {})["defaults"] = model
     return data

--- a/miqi/config/loader.py
+++ b/miqi/config/loader.py
@@ -135,8 +135,9 @@ def _pick_migrated_model(data: dict) -> str:
     """Choose a default model the runtime can use after a custom/* reset.
 
     Prefers the first configured provider's test model from the raw config
-    dict; falls back to the factory default (fresh-install semantics, where
-    NO_API_KEY surfaces in the UI until the user picks a model).
+    dict. Returns the empty string when nothing usable exists — an explicit
+    "not selected" state (UI shows 未设置 and prompts model selection),
+    rather than an unusable factory default（#933 review）.
     """
     from miqi.providers.registry import PROVIDER_TEST_MODELS, PROVIDERS
 
@@ -158,7 +159,7 @@ def _pick_migrated_model(data: dict) -> str:
         if spec.is_gateway or spec.is_local:
             return model
         return f"{spec.name}/{model}"
-    return "anthropic/claude-opus-4-5"
+    return ""
 
 
 def _migrate_config(data: dict) -> dict:

--- a/miqi/config/loader.py
+++ b/miqi/config/loader.py
@@ -145,4 +145,16 @@ def _migrate_config(data: dict) -> dict:
     if old_key and not search.get("brave_api_key"):
         search["brave_api_key"] = old_key
     search.pop("api_key", None)  # drop the legacy field after migration
+
+    # #835 收口：custom provider 已从运行时移除。遗留的 custom/* 默认模型
+    # 会经 _match_provider 兜底错发到第一个已配置 provider 的 API（#929
+    # review）——迁移时重置为出厂默认，让用户在设置页重新选择内置模型。
+    model = (data.get("agents") or {}).get("defaults") or {}
+    if isinstance(model, dict) and isinstance(model.get("model"), str) and model["model"].lower().startswith("custom/"):
+        logger.warning(
+            "migrate: default model '{}' uses removed custom provider — "
+            "reset to factory default", model["model"],
+        )
+        model["model"] = "anthropic/claude-opus-4-5"
+        data.setdefault("agents", {})["defaults"] = model
     return data

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -692,6 +692,24 @@ class Config(BaseSettings):
                 return spec.default_api_base
         return None
 
+    def is_builtin_activated(self, provider_name: str) -> bool:
+        """Whether a provider holds a built-in (enterprise) activation.
+
+        Tolerates all historical store shapes: missing key, legacy bool
+        (``{"deepseek": true}``) and the current dict (``{"builtin": True}``).
+        A present-but-null/string entry is treated as not activated instead
+        of crashing the decode (#929 review).
+        """
+        store = self.desktop.get("providerActivation")
+        if not isinstance(store, dict):
+            return False
+        entry = store.get(provider_name)
+        if isinstance(entry, bool):
+            return entry
+        if isinstance(entry, dict):
+            return entry.get("builtin") is True
+        return False
+
     def build_provider(self, model: str) -> "LLMProvider | None":
         """Build an LLMProvider instance for the given model string.
 

--- a/miqi/providers/factory.py
+++ b/miqi/providers/factory.py
@@ -23,6 +23,16 @@ def make_provider(config: Any) -> Any:
     from miqi.providers.registry import find_by_name
 
     model = config.agents.defaults.model
+
+    # custom provider 已从运行时移除（#835 收口）：遗留的 custom/* 默认模型
+    # 会经 _match_provider 兜底错发到第一个已配置 provider 的 API（#929
+    # review），这里给出明确报错而不是静默错发。
+    if model.lower().startswith("custom/"):
+        raise ValueError(
+            "自定义 provider（custom/*）已移除（#835 合规收口），"
+            "请在 设置 → 模型 中改用内置模型。"
+        )
+
     provider_name = config.get_provider_name(model)
     p = config.get_provider(model)
 
@@ -35,11 +45,16 @@ def make_provider(config: Any) -> Any:
 
     provider_type = spec.provider_type if spec else "openai"
 
+    # 内置激活的 provider 强制走官方端点（#929 review：聊天路径同样收口，
+    # 企业共享密钥不得发往历史遗留的自定义 api_base / extra_headers）。
+    builtin_activated = bool(provider_name) and config.is_builtin_activated(provider_name)
+    api_base = None if builtin_activated else config.get_api_base(model)
+
     common_kwargs = dict(
         api_key=p.api_key if p else None,
-        api_base=config.get_api_base(model),
+        api_base=api_base,
         default_model=model,
-        extra_headers=p.extra_headers if p else None,
+        extra_headers=(p.extra_headers if p else None) if not builtin_activated else None,
         provider_name=provider_name,
     )
 

--- a/miqi/providers/registry.py
+++ b/miqi/providers/registry.py
@@ -391,6 +391,28 @@ PROVIDERS: tuple[ProviderSpec, ...] = (
 # Lookup helpers
 # ---------------------------------------------------------------------------
 
+# Test/fallback model per provider — used by connection tests, model-picking
+# fallbacks (loader migration / deactivation reset), and the catalog defaults.
+# Gateway/local entries are FULL model ids (routed as-is); standard-provider
+# entries are bare names to be prefixed with "spec.name/".
+PROVIDER_TEST_MODELS: dict[str, str] = {
+    "anthropic": "claude-opus-4-5",
+    "openai": "gpt-4.1",
+    "deepseek": "deepseek-v4-flash",
+    "gemini": "gemini-2.5-pro",
+    "moonshot": "kimi-k2.5",
+    "dashscope": "qwen-max",
+    "zhipu": "glm-4",
+    "minimax": "MiniMax-M2.7",
+    "aihubmix": "claude-opus-4.1",
+    "siliconflow": "deepseek-ai/DeepSeek-V3",
+    "vllm": "meta-llama/Llama-3.1-8B-Instruct",
+    "ollama_local": "llama3.2",
+    "ollama_cloud": "gpt-oss:20b-cloud",
+    "openrouter": "anthropic/claude-opus-4-5",
+    "custom": "default",
+}
+
 def find_by_model(model: str) -> ProviderSpec | None:
     """Match a standard provider by model-name keyword (case-insensitive).
     Skips gateways/local — those are matched by api_key/api_base instead."""

--- a/miqi/runtime/config_app_handlers.py
+++ b/miqi/runtime/config_app_handlers.py
@@ -269,6 +269,24 @@ def register_config_app_handlers(server: AppServer) -> None:
                 code="INVALID_PARAMS",
             ) from exc
 
+        # 收口（#929）：batchWrite 与 config.update 采用同一模型策略 ——
+        # 仅当编辑改写了默认模型时校验「可解析到有凭据 provider / 经网关
+        # 路由」，且拒绝空值。此前该路径完全没有模型门控，可原样写入
+        # custom/default 等运行时无法使用的值。
+        if any(e.get("path") == "agents.defaults.model" for e in edits):
+            model_value = new_config.agents.defaults.model
+            if not model_value:
+                raise AppServerError(
+                    "默认模型不能为空，请从下拉列表选择预设模型",
+                    code="INVALID_PARAMS",
+                )
+            from miqi.runtime.provider_handlers import _model_provider_resolvable
+
+            if not _model_provider_resolvable(new_config, model_value):
+                raise AppServerError(
+                    f"Unsupported model: {model_value}", code="INVALID_PARAMS",
+                )
+
         # Save to disk (atomic from the caller's perspective — validation
         # passed, so this write is the only side effect)
         try:

--- a/miqi/runtime/config_handlers.py
+++ b/miqi/runtime/config_handlers.py
@@ -32,6 +32,15 @@ def _reject_provider_credentials(updates: Any) -> None:
         )
 
 
+def _update_touches_model(updates: Any) -> bool:
+    """Whether the update payload rewrites agents.defaults.model."""
+    if not isinstance(updates, dict):
+        return False
+    agents = updates.get("agents")
+    defaults = agents.get("defaults") if isinstance(agents, dict) else None
+    return isinstance(defaults, dict) and "model" in defaults
+
+
 def _apply_runtime_approval_bypass(runtime: Any, config: Any) -> None:
     services = getattr(runtime, "services", None)
     orchestrator = getattr(services, "orchestrator", None)
@@ -224,17 +233,6 @@ async def config_update_handler(
     # update was silently ignored (#789 实录: wsl_distro save lost).
     merged = _deep_merge(current.model_dump(by_alias=False), updates)
 
-    # 收口（#929）：默认模型必须是运行时能解析到注册表 provider 的值，
-    # 拒绝 custom/* 等历史遗留的无法解析模型（空值交给 Config 校验）。
-    model_value = merged.get("agents", {}).get("defaults", {}).get("model")
-    if model_value:
-        from miqi.runtime.provider_handlers import _model_provider_resolvable
-
-        if not _model_provider_resolvable(str(model_value)):
-            raise AppServerError(
-                f"Unsupported model: {model_value}", code="INVALID_PARAMS",
-            )
-
     # Validate
     try:
         new_config = Config.model_validate(merged)
@@ -244,6 +242,24 @@ async def config_update_handler(
             "Invalid config",
             code="INVALID_PARAMS",
         ) from exc
+
+    # 收口（#929）：仅当本次更新改写了默认模型时才校验 —— 模型必须能被
+    # 运行时解析到「有凭据可用」的 provider（或经已配置网关路由），否则会
+    # 落到 _match_provider 兜底错发到错误 API。无关字段的保存不受历史遗留
+    # 模型值影响（#929 review：此前按合并后的当前模型校验会拒绝一切保存）。
+    if _update_touches_model(updates):
+        model_value = new_config.agents.defaults.model
+        if not model_value:
+            raise AppServerError(
+                "默认模型不能为空，请从下拉列表选择预设模型",
+                code="INVALID_PARAMS",
+            )
+        from miqi.runtime.provider_handlers import _model_provider_resolvable
+
+        if not _model_provider_resolvable(new_config, model_value):
+            raise AppServerError(
+                f"Unsupported model: {model_value}", code="INVALID_PARAMS",
+            )
 
     # Save to disk
     try:

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -17,27 +17,11 @@ from typing import Any
 
 from loguru import logger
 
+from miqi.providers.registry import PROVIDER_TEST_MODELS
 from miqi.runtime.app_server import AppServerError, get_bridge_state
 
 VERIFICATION_KEY = "providerVerification"
 VERIFICATION_STATUSES = {"success", "failed", "unverified"}
-PROVIDER_TEST_MODELS = {
-    "anthropic": "claude-opus-4-5",
-    "openai": "gpt-4.1",
-    "deepseek": "deepseek-v4-flash",
-    "gemini": "gemini-2.5-pro",
-    "moonshot": "kimi-k2.5",
-    "dashscope": "qwen-max",
-    "zhipu": "glm-4",
-    "minimax": "MiniMax-M2.7",
-    "aihubmix": "claude-opus-4.1",
-    "siliconflow": "deepseek-ai/DeepSeek-V3",
-    "vllm": "meta-llama/Llama-3.1-8B-Instruct",
-    "ollama_local": "llama3.2",
-    "ollama_cloud": "gpt-oss:20b-cloud",
-    "openrouter": "anthropic/claude-opus-4-5",
-    "custom": "default",
-}
 
 
 def _provider_fingerprint(provider_config: Any, model: str | None = None) -> str | None:
@@ -72,6 +56,33 @@ def _provider_usable(pc: Any, spec: Any) -> bool:
     return bool(pc.api_key)
 
 
+def _pick_usable_default_model(config: Any, exclude: str | None = None) -> str:
+    """Pick a default model the runtime can actually use.
+
+    Prefers the first usable provider's test model (gateway/local entries are
+    full model ids; standard providers get "name/" prefixed). Falls back to
+    the factory default when nothing usable exists — fresh-install semantics,
+    where NO_API_KEY surfaces in the UI until the user picks a model
+    （#933 review：不得无条件重置为无凭据的 anthropic 默认模型）.
+    """
+    from miqi.config.schema import AgentDefaults
+    from miqi.providers.registry import PROVIDERS
+
+    for spec in PROVIDERS:
+        if spec.name == exclude:
+            continue
+        pc = getattr(config.providers, spec.name, None)
+        if not _provider_usable(pc, spec):
+            continue
+        model = PROVIDER_TEST_MODELS.get(spec.name)
+        if not model:
+            continue
+        if spec.is_gateway or spec.is_local:
+            return model
+        return f"{spec.name}/{model}"
+    return AgentDefaults.model_fields["model"].default
+
+
 def _model_provider_resolvable(config: Any, model: str) -> bool:
     """Whether the model resolves to a USABLE provider at runtime.
 
@@ -85,6 +96,8 @@ def _model_provider_resolvable(config: Any, model: str) -> bool:
 
     if not model or not str(model).strip():
         return False
+    if model.lower().startswith("custom/"):
+        return False  # custom provider 已移除（#835），网关兜底不得复活它（#933 review）
     model_prefix = model.split("/", 1)[0] if "/" in model else ""
     spec = find_by_name(model_prefix) if model_prefix else find_by_model(model)
     if spec is None:
@@ -622,18 +635,18 @@ async def providers_deactivate_handler(
     activation_store = _provider_activation_store(config)
     activation_store.pop(provider_name, None)
 
-    # 默认模型若属于被取消激活的 provider，重置为出厂默认，否则新会话全部
-    # NO_API_KEY 且 UI 与配置不一致（#929 review）。
-    from miqi.config.schema import AgentDefaults
+    # 默认模型若属于被取消激活的 provider，重置为一个运行时真正可用的
+    # 模型（优先其他已配置 provider 的测试模型），否则新会话全部
+    # NO_API_KEY 且 UI 与配置不一致（#929 review / #933 review）。
     from miqi.providers.registry import find_by_model
 
     current_model = config.agents.defaults.model
     matched_spec = find_by_model(current_model)
     if matched_spec is not None and matched_spec.name == provider_name:
-        config.agents.defaults.model = AgentDefaults.model_fields["model"].default
+        config.agents.defaults.model = _pick_usable_default_model(config, exclude=provider_name)
         logger.info(
-            "providers.deactivate: default model '{}' owned by {} — reset to factory default",
-            current_model, provider_name,
+            "providers.deactivate: default model '{}' owned by {} — reset to '{}'",
+            current_model, provider_name, config.agents.defaults.model,
         )
 
     save_config(config)

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -60,12 +60,12 @@ def _pick_usable_default_model(config: Any, exclude: str | None = None) -> str:
     """Pick a default model the runtime can actually use.
 
     Prefers the first usable provider's test model (gateway/local entries are
-    full model ids; standard providers get "name/" prefixed). Falls back to
-    the factory default when nothing usable exists — fresh-install semantics,
-    where NO_API_KEY surfaces in the UI until the user picks a model
-    （#933 review：不得无条件重置为无凭据的 anthropic 默认模型）.
+    full model ids; standard providers get "name/" prefixed). Returns the
+    empty string when nothing usable exists — an explicit "not selected"
+    state (UI shows 未设置 and prompts model selection), rather than an
+    unusable factory default that misrepresents the real state
+    （#933 review）.
     """
-    from miqi.config.schema import AgentDefaults
     from miqi.providers.registry import PROVIDERS
 
     for spec in PROVIDERS:
@@ -80,7 +80,7 @@ def _pick_usable_default_model(config: Any, exclude: str | None = None) -> str:
         if spec.is_gateway or spec.is_local:
             return model
         return f"{spec.name}/{model}"
-    return AgentDefaults.model_fields["model"].default
+    return ""
 
 
 def _model_provider_resolvable(config: Any, model: str) -> bool:

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -72,22 +72,37 @@ def _provider_usable(pc: Any, spec: Any) -> bool:
     return bool(pc.api_key)
 
 
-def _model_provider_resolvable(model: str) -> bool:
-    """Whether the model resolves to a registry provider (factory contract).
+def _model_provider_resolvable(config: Any, model: str) -> bool:
+    """Whether the model resolves to a USABLE provider at runtime.
 
-    前缀能匹配注册表（含 gateway/local）或关键字能匹配标准 provider 即
-    可解析。custom/* 等已从注册表移除的前缀解析不到任何 spec —— 不允许
-    落到 Config._match_provider 的「第一个已配置 provider」兜底，那会把
-    模型发到错误的 API（CodeRabbit #929）。
+    镜像 Config._match_provider 的路由契约：模型自身 provider 必须持有可用
+    凭据（标准/gateway 需要 api_key，本地需要 api_base），或者有已配置的
+    gateway 可以兜底路由。仅注册表成员资格不够 —— 无凭据的 provider 会
+    落到 _match_provider 的「第一个已配置 provider」兜底，把模型发到错误
+    的 API（#929 review）。
     """
-    from miqi.providers.registry import find_by_model, find_by_name
+    from miqi.providers.registry import PROVIDERS, find_by_model, find_by_name
 
-    if model.startswith("bedrock/"):  # 工厂特殊路径，不经过注册表
-        return True
+    if not model or not str(model).strip():
+        return False
     model_prefix = model.split("/", 1)[0] if "/" in model else ""
-    if model_prefix and find_by_name(model_prefix) is not None:
-        return True
-    return find_by_model(model) is not None
+    spec = find_by_name(model_prefix) if model_prefix else find_by_model(model)
+    if spec is None:
+        spec = find_by_model(model)
+    if spec is not None:
+        pc = getattr(config.providers, spec.name, None)
+        if _provider_usable(pc, spec):
+            return True
+        # 归属 provider 无凭据时运行时还会继续走关键字与网关兜底 ——
+        # 不直接拒绝，交给下面的网关判定。
+    # 没有可用归属 provider —— 只有已配置的 gateway 能路由这个模型。
+    for gateway_spec in PROVIDERS:
+        if not gateway_spec.is_gateway:
+            continue
+        pc = getattr(config.providers, gateway_spec.name, None)
+        if _provider_usable(pc, gateway_spec):
+            return True
+    return False
 
 
 def _provider_verification_store(config: Any) -> dict[str, Any]:
@@ -145,7 +160,6 @@ async def providers_list_handler(
     matched_spec = find_by_model(model)
     model_provider = matched_spec.name if matched_spec else None
     verification_store = _provider_verification_store(config)
-    activation_store = _provider_activation_store(config)
 
     providers_out = []
     for spec in PROVIDERS:
@@ -153,11 +167,7 @@ async def providers_list_handler(
         api_key = pc.api_key if pc else None
         hint = None
         builtin_available = spec.name in _BUILTIN_PROVIDERS
-        entry = activation_store.get(spec.name, {})
-        if isinstance(entry, bool):
-            builtin_activated = entry  # old format: {"deepseek": true}
-        else:
-            builtin_activated = bool(entry.get("builtin", False))
+        builtin_activated = config.is_builtin_activated(spec.name)
         if builtin_activated:
             # Hide the real key from the frontend for built-in activations
             hint = "企业共享密钥"
@@ -255,13 +265,7 @@ async def providers_test_handler(
 
     # 内置激活的 provider 强制走官方端点：历史遗留的自定义 api_base 不得与
     # 内置共享密钥一起使用，防止密钥被发送到第三方地址（CodeRabbit #929）。
-    builtin_activated = False
-    if provider_name in _BUILTIN_PROVIDERS:
-        entry = _provider_activation_store(config).get(provider_name, {})
-        if isinstance(entry, bool):
-            builtin_activated = entry  # old format: {"deepseek": true}
-        else:
-            builtin_activated = bool(entry.get("builtin", False))
+    builtin_activated = config.is_builtin_activated(provider_name)
 
     test_model = (
         requested_model
@@ -411,8 +415,9 @@ async def providers_update_handler(
     if not model_override:
         raise AppServerError("No fields to update", code="INVALID_PARAMS")
 
-    # 模型值必须能被运行时解析到注册表 provider（CodeRabbit #929）。
-    if not _model_provider_resolvable(model_override):
+    # 模型值必须能被运行时解析到「有凭据可用」的 provider（#929 review：
+    # 仅注册表成员资格不够，无凭据 provider 会兜底错发到错误 API）。
+    if not _model_provider_resolvable(config, model_override):
         raise AppServerError(
             f"Unsupported model: {model_override}", code="INVALID_PARAMS",
         )
@@ -534,9 +539,13 @@ async def providers_activate_handler(
             f"Provider config not found: {provider_name}", code="NOT_FOUND",
         )
 
-    # Write the decrypted key to provider config
+    # Write the decrypted key to provider config. Also clear any legacy
+    # custom api_base / extra_headers: the builtin enterprise key must only
+    # ever go to the official endpoint (#929 review).
     current_dict = pc.model_dump(by_alias=False)
     current_dict["api_key"] = api_key
+    current_dict["api_base"] = None
+    current_dict["extra_headers"] = None
     new_pc = ProviderConfig.model_validate(current_dict)
     setattr(config.providers, provider_name, new_pc)
 
@@ -593,26 +602,39 @@ async def providers_deactivate_handler(
 
     # 只有带内置激活标记的配置才允许取消：历史遗留的自配 key 没有标记，
     # 误调用会把用户自己的 key 清掉（CodeRabbit #929）。
-    entry = _provider_activation_store(config).get(provider_name, {})
-    if isinstance(entry, bool):
-        builtin_marked = entry  # old format: {"deepseek": true}
-    else:
-        builtin_marked = bool(entry.get("builtin", False))
+    builtin_marked = config.is_builtin_activated(provider_name)
     if not builtin_marked:
         raise AppServerError(
             f"Provider '{provider_name}' has no built-in activation to deactivate",
             code="NOT_ACTIVATED",
         )
 
-    # Clear the built-in key
+    # Clear the built-in key (and any legacy endpoint overrides — the same
+    # exfiltration vector activation now sanitizes, #929 review)
     current_dict = pc.model_dump(by_alias=False)
     current_dict["api_key"] = ""
+    current_dict["api_base"] = None
+    current_dict["extra_headers"] = None
     new_pc = ProviderConfig.model_validate(current_dict)
     setattr(config.providers, provider_name, new_pc)
 
     # Remove the activation marker
     activation_store = _provider_activation_store(config)
     activation_store.pop(provider_name, None)
+
+    # 默认模型若属于被取消激活的 provider，重置为出厂默认，否则新会话全部
+    # NO_API_KEY 且 UI 与配置不一致（#929 review）。
+    from miqi.config.schema import AgentDefaults
+    from miqi.providers.registry import find_by_model
+
+    current_model = config.agents.defaults.model
+    matched_spec = find_by_model(current_model)
+    if matched_spec is not None and matched_spec.name == provider_name:
+        config.agents.defaults.model = AgentDefaults.model_fields["model"].default
+        logger.info(
+            "providers.deactivate: default model '{}' owned by {} — reset to factory default",
+            current_model, provider_name,
+        )
 
     save_config(config)
     state.config = config

--- a/tests/config/test_loader_migration.py
+++ b/tests/config/test_loader_migration.py
@@ -1,0 +1,49 @@
+"""Tests for config loader migrations — custom/* model reset (#929 / #933)."""
+
+from __future__ import annotations
+
+from miqi.config.loader import _migrate_config
+
+
+def test_migrate_resets_custom_model_to_configured_provider_model():
+    """遗留 custom/* 默认模型应重置为已配置 provider 的测试模型，
+    而不是无条件写无凭据的出厂默认（#933 review）。"""
+    data = {
+        "agents": {"defaults": {"model": "custom/my-model"}},
+        "providers": {"deepseek": {"api_key": "sk-ds-1234567890"}},
+    }
+    migrated = _migrate_config(data)
+    assert migrated["agents"]["defaults"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_migrate_resets_custom_model_to_gateway_model():
+    """已配置网关时重置为网关可路由的完整模型 id（网关在注册表最前）。"""
+    data = {
+        "agents": {"defaults": {"model": "custom/default"}},
+        "providers": {"openrouter": {"api_key": "sk-or-1234567890"}},
+    }
+    migrated = _migrate_config(data)
+    assert migrated["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
+
+
+def test_migrate_resets_to_factory_default_without_credentials():
+    """没有任何可用凭据时退回出厂默认（全新安装语义，UI 引导选择模型）。"""
+    data = {"agents": {"defaults": {"model": "custom/x"}}}
+    migrated = _migrate_config(data)
+    assert migrated["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
+
+
+def test_migrate_ignores_camelcase_provider_keys():
+    """配置 JSON 可能是 camelCase 键，迁移需兼容（#933 review）。"""
+    data = {
+        "agents": {"defaults": {"model": "custom/x"}},
+        "providers": {"deepseek": {"apiKey": "sk-ds-1234567890"}},
+    }
+    migrated = _migrate_config(data)
+    assert migrated["agents"]["defaults"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_migrate_leaves_other_models_untouched():
+    data = {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}}
+    migrated = _migrate_config(data)
+    assert migrated["agents"]["defaults"]["model"] == "deepseek/deepseek-v4-flash"

--- a/tests/config/test_loader_migration.py
+++ b/tests/config/test_loader_migration.py
@@ -26,11 +26,12 @@ def test_migrate_resets_custom_model_to_gateway_model():
     assert migrated["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
 
 
-def test_migrate_resets_to_factory_default_without_credentials():
-    """没有任何可用凭据时退回出厂默认（全新安装语义，UI 引导选择模型）。"""
+def test_migrate_clears_model_without_credentials():
+    """没有任何可用凭据时清空为「未选择」状态（UI 显示未设置），
+    而不是写一个无凭据、无法使用的出厂默认（#933 review）。"""
     data = {"agents": {"defaults": {"model": "custom/x"}}}
     migrated = _migrate_config(data)
-    assert migrated["agents"]["defaults"]["model"] == "anthropic/claude-opus-4-5"
+    assert migrated["agents"]["defaults"]["model"] == ""
 
 
 def test_migrate_ignores_camelcase_provider_keys():

--- a/tests/runtime/test_config_app_handlers.py
+++ b/tests/runtime/test_config_app_handlers.py
@@ -210,6 +210,51 @@ async def test_config_batch_write_rejects_whole_provider_object():
 
 
 @pytest.mark.asyncio
+async def test_config_batch_write_rejects_unresolvable_model():
+    """#929：batchWrite 与 config.update 同一模型门控 —— 此前该路径可
+    原样写入 custom/default 等运行时无法使用的模型。"""
+    registry = ClientSessionRegistry()
+    server = _setup_server(registry, model="anthropic/claude-opus-4-5")
+
+    response = await server.dispatch(
+        "1", "config/batchWrite",
+        {"edits": [{"path": "agents.defaults.model", "value": "custom/default"}]},
+        "client-1", None,
+    )
+    assert response.get("code") == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_batch_write_rejects_empty_model():
+    """#929：空模型同样拒绝 —— 之前空值可落盘并让运行时把空模型名发给
+    兜底 provider。"""
+    registry = ClientSessionRegistry()
+    server = _setup_server(registry)
+
+    response = await server.dispatch(
+        "1", "config/batchWrite",
+        {"edits": [{"path": "agents.defaults.model", "value": ""}]},
+        "client-1", None,
+    )
+    assert response.get("code") == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_batch_write_unrelated_edit_ignores_legacy_model():
+    """#929 review：模型门控只对模型编辑生效 —— 历史遗留模型不阻塞
+    无关字段的 batchWrite 编辑。"""
+    registry = ClientSessionRegistry()
+    server = _setup_server(registry, model="custom/default")
+
+    response = await server.dispatch(
+        "1", "config/batchWrite",
+        {"edits": [{"path": "agents.defaults.workspace", "value": "/tmp/bar"}]},
+        "client-1", None,
+    )
+    assert response["result"]["saved"] is True
+
+
+@pytest.mark.asyncio
 async def test_config_batch_write_delete_requires_existing_key():
     """Delete of a non-existent key must return INVALID_PARAMS."""
     registry = ClientSessionRegistry()
@@ -345,7 +390,8 @@ def test_config_batch_write_does_not_touch_real_config_path(monkeypatch):
     async def _run():
         return await server.dispatch(
             "1", "config/batchWrite",
-            {"edits": [{"path": "agents.defaults.model", "value": "deepseek/deepseek-chat"}]},
+            # #929 收口后模型必须解析到有凭据的 provider —— fixture 配置了 openai key
+            {"edits": [{"path": "agents.defaults.model", "value": "openai/gpt-4.1"}]},
             "client-1", None,
         )
     result = asyncio.run(_run())
@@ -375,7 +421,8 @@ async def test_config_batch_write_propagates_to_client_sessions():
     # test that the propagation path runs without error when no sessions exist.
     response = await server.dispatch(
         "1", "config/batchWrite",
-        {"edits": [{"path": "agents.defaults.model", "value": "deepseek/deepseek-chat"}],
+        # #929 收口后模型必须解析到有凭据的 provider —— fixture 配置了 openai key
+        {"edits": [{"path": "agents.defaults.model", "value": "openai/gpt-4.1"}],
          "reloadUserConfig": True},
         "client-1", None,
     )

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -169,3 +169,79 @@ async def test_config_update_rejects_unresolvable_model(fake_config, fake_provid
             "client-1", None, registry,
         )
     assert exc_info.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_update_unrelated_field_ignores_legacy_model(fake_config, fake_provider, tmp_path):
+    """#929 review：模型门控只作用于「本次改写模型」的更新 —— 历史遗留的
+    不可用模型不得阻塞改名/改温度等无关保存。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.agents.defaults.model = "custom/default"  # 遗留模型
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config"):
+        result = await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"name": "renamed"}}}},
+            "client-1", None, registry,
+        )
+    assert result["result"]["saved"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_empty_model(fake_config, fake_provider, tmp_path):
+    """#929 review：空模型不再能绕过门控落盘 —— 之前空值跳过校验但
+    Config 也接受空串，运行时会把空模型名发给兜底 provider。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": ""}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_update_agents_null_is_clean_invalid_params(fake_config, fake_provider, tmp_path):
+    """#929 review：{"agents": null} 之前让门控抛 AttributeError → INTERNAL，
+    现在应回到干净的 INVALID_PARAMS（校验先于模型门控执行）。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"agents": None}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_update_accepts_model_of_configured_provider(fake_config, fake_provider, tmp_path):
+    """#929 review：模型归属的 provider 持有凭据（或经网关路由）时放行。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.providers.deepseek.api_key = "sk-ds-1234567890"
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config"):
+        result = await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}}},
+            "client-1", None, registry,
+        )
+    assert result["result"]["saved"] is True
+    assert registry.bridge_context["state"].config.agents.defaults.model == "deepseek/deepseek-v4-flash"

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -228,6 +228,24 @@ async def test_config_update_agents_null_is_clean_invalid_params(fake_config, fa
 
 
 @pytest.mark.asyncio
+async def test_config_update_rejects_custom_model_even_with_gateway(fake_config, fake_provider, tmp_path):
+    """#933 review：已配置网关也不得复活 custom/* 模型。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.providers.openrouter.api_key = "sk-or-1234567890"
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": "custom/default"}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
 async def test_config_update_accepts_model_of_configured_provider(fake_config, fake_provider, tmp_path):
     """#929 review：模型归属的 provider 持有凭据（或经网关路由）时放行。"""
     from unittest import mock

--- a/tests/runtime/test_provider_handlers_regression.py
+++ b/tests/runtime/test_provider_handlers_regression.py
@@ -207,8 +207,8 @@ async def test_providers_deactivate_resets_to_other_configured_provider():
 @pytest.mark.asyncio
 async def test_providers_deactivate_clears_builtin_activation():
     """后端收口（#835）：providers.deactivate 清空 api_key、遗留端点覆盖
-    与 activation 标记；默认模型归属该 provider 时重置为出厂默认
-    （#929 review）。"""
+    与 activation 标记；默认模型归属该 provider 时重置为可用模型或清空
+    （#929 / #933 review）。"""
     from unittest import mock
 
     registry = _make_registry("deepseek/deepseek-v4-flash", deepseek="sk-ds-1234567890")
@@ -229,8 +229,9 @@ async def test_providers_deactivate_clears_builtin_activation():
     assert config.providers.deepseek.api_key == ""
     assert config.providers.deepseek.api_base is None
     assert config.desktop.get("providerActivation", {}).get("deepseek") is None
-    # 默认模型属于 deepseek → 重置为出厂默认，避免新会话全部 NO_API_KEY
-    assert config.agents.defaults.model == "anthropic/claude-opus-4-5"
+    # 默认模型属于 deepseek，且没有其他可用 provider → 清空为「未选择」
+    # 状态（#933 review：不得回退到无凭据的出厂默认）
+    assert config.agents.defaults.model == ""
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_handlers_regression.py
+++ b/tests/runtime/test_provider_handlers_regression.py
@@ -107,7 +107,9 @@ async def test_providers_update_model_only_still_works():
     """后端收口：providers.update 仍支持 model 覆盖（内置激活流程用）。"""
     from unittest import mock
 
-    registry = _make_registry("deepseek/deepseek-v4-flash")
+    # 收口后模型必须解析到「有凭据可用」的 provider（#929 review）——
+    # deepseek 已激活（持有 key）时其模型才可通过。
+    registry = _make_registry("deepseek/deepseek-v4-flash", deepseek="sk-ds-1234567890")
     state = registry.bridge_context["state"]
 
     with mock.patch("miqi.config.loader.save_config"):
@@ -122,15 +124,56 @@ async def test_providers_update_model_only_still_works():
 
 
 @pytest.mark.asyncio
+async def test_providers_update_rejects_model_of_unconfigured_provider():
+    """#929：注册表成员资格不够 —— 无凭据 provider 的模型会被兜底错发到
+    第一个已配置 provider 的 API，必须拒绝。"""
+    from unittest import mock
+
+    registry = _make_registry("deepseek/deepseek-v4-flash", deepseek="sk-ds-1234567890")
+
+    with mock.patch("miqi.config.loader.save_config"):
+        with pytest.raises(AppServerError) as exc:
+            await providers_update_handler(
+                "r1",
+                {"provider_name": "deepseek", "model": "openai/gpt-4o"},
+                "client-1", None, registry,
+            )
+    assert exc.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_providers_update_accepts_gateway_routed_model():
+    """#929：已配置的网关在运行时兜底路由任意模型 —— 网关可用的模型
+    应被接受，否则 UI 过滤与后端判定不一致。"""
+    from unittest import mock
+
+    registry = _make_registry("deepseek/deepseek-v4-flash", openrouter="sk-or-1234567890")
+    state = registry.bridge_context["state"]
+
+    with mock.patch("miqi.config.loader.save_config"):
+        result = await providers_update_handler(
+            "r1",
+            {"provider_name": "openrouter", "model": "anthropic/claude-opus-4-5"},
+            "client-1", None, registry,
+        )
+
+    assert result["result"]["saved"] is True
+    assert state.config.agents.defaults.model == "anthropic/claude-opus-4-5"
+
+
+@pytest.mark.asyncio
 async def test_providers_deactivate_clears_builtin_activation():
-    """后端收口（#835）：providers.deactivate 清空 api_key 与 activation 标记。"""
+    """后端收口（#835）：providers.deactivate 清空 api_key、遗留端点覆盖
+    与 activation 标记；默认模型归属该 provider 时重置为出厂默认
+    （#929 review）。"""
     from unittest import mock
 
     registry = _make_registry("deepseek/deepseek-v4-flash", deepseek="sk-ds-1234567890")
     state = registry.bridge_context["state"]
     config = state.load_config()
-    # 模拟已激活标记
+    # 模拟已激活标记 + 历史遗留的自定义端点
     config.desktop = {"providerActivation": {"deepseek": {"builtin": True}}}
+    config.providers.deepseek.api_base = "https://proxy.example.com/v1"
 
     with mock.patch("miqi.config.loader.save_config"):
         result = await providers_deactivate_handler(
@@ -141,7 +184,60 @@ async def test_providers_deactivate_clears_builtin_activation():
 
     assert result["result"]["deactivated"] is True
     assert config.providers.deepseek.api_key == ""
+    assert config.providers.deepseek.api_base is None
     assert config.desktop.get("providerActivation", {}).get("deepseek") is None
+    # 默认模型属于 deepseek → 重置为出厂默认，避免新会话全部 NO_API_KEY
+    assert config.agents.defaults.model == "anthropic/claude-opus-4-5"
+
+
+@pytest.mark.asyncio
+async def test_providers_activate_clears_legacy_endpoint_overrides():
+    """#929：激活内置密钥时清除历史遗留的 api_base / extra_headers ——
+    企业共享密钥只能走官方端点。"""
+    from unittest import mock
+
+    from miqi.runtime.provider_handlers import providers_activate_handler
+
+    registry = _make_registry("deepseek/deepseek-v4-flash")
+    config = registry.bridge_context["state"].load_config()
+    config.providers.deepseek.api_base = "https://proxy.example.com/v1"
+    config.providers.deepseek.extra_headers = {"X-Evil": "1"}
+
+    with mock.patch("miqi.config.loader.save_config"):
+        result = await providers_activate_handler(
+            "r1",
+            {"provider_name": "deepseek", "activation_code": "weiguanjiyuan5g"},
+            "client-1", None, registry,
+        )
+
+    assert result["result"]["activated"] is True
+    assert config.providers.deepseek.api_key  # 已写入内置密钥
+    assert config.providers.deepseek.api_base is None
+    assert config.providers.deepseek.extra_headers is None
+
+
+def test_config_is_builtin_activated_tolerates_legacy_shapes():
+    """#929：activation store 的历史/异常形态不能崩（None、字符串、旧 bool
+    格式），统一经 Config.is_builtin_activated 解码。"""
+    from miqi.config.schema import Config
+
+    cfg = Config()
+    assert cfg.is_builtin_activated("deepseek") is False
+
+    cfg.desktop = {"providerActivation": {"deepseek": None}}
+    assert cfg.is_builtin_activated("deepseek") is False  # 不崩，视为未激活
+
+    cfg.desktop = {"providerActivation": {"deepseek": True}}  # 旧格式
+    assert cfg.is_builtin_activated("deepseek") is True
+
+    cfg.desktop = {"providerActivation": {"deepseek": {"builtin": True}}}
+    assert cfg.is_builtin_activated("deepseek") is True
+
+    cfg.desktop = {"providerActivation": {"deepseek": {"builtin": "false"}}}
+    assert cfg.is_builtin_activated("deepseek") is False  # 字符串 "false" 不再当真
+
+    cfg.desktop = {"providerActivation": "not-a-dict"}
+    assert cfg.is_builtin_activated("deepseek") is False
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_provider_handlers_regression.py
+++ b/tests/runtime/test_provider_handlers_regression.py
@@ -162,6 +162,49 @@ async def test_providers_update_accepts_gateway_routed_model():
 
 
 @pytest.mark.asyncio
+async def test_providers_update_rejects_custom_model_even_with_gateway():
+    """#933 review：已配置网关也不得复活 custom/* 模型 —— custom provider
+    已从运行时移除，选择后新会话会在 make_provider 报错。"""
+    from unittest import mock
+
+    registry = _make_registry("deepseek/deepseek-v4-flash", openrouter="sk-or-1234567890")
+
+    with mock.patch("miqi.config.loader.save_config"):
+        with pytest.raises(AppServerError) as exc:
+            await providers_update_handler(
+                "r1",
+                {"provider_name": "openrouter", "model": "custom/default"},
+                "client-1", None, registry,
+            )
+    assert exc.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_providers_deactivate_resets_to_other_configured_provider():
+    """#933 review：取消激活后默认模型应切到其他可用 provider 的模型，
+    而不是无条件重置为无凭据的出厂默认。"""
+    from unittest import mock
+
+    registry = _make_registry(
+        "deepseek/deepseek-v4-flash",
+        deepseek="sk-ds-1234567890",
+        openai="sk-proj-1234567890abcdef",
+    )
+    state = registry.bridge_context["state"]
+    config = state.load_config()
+    config.desktop = {"providerActivation": {"deepseek": {"builtin": True}}}
+
+    with mock.patch("miqi.config.loader.save_config"):
+        await providers_deactivate_handler(
+            "r1",
+            {"provider_name": "deepseek"},
+            "client-1", None, registry,
+        )
+
+    assert config.agents.defaults.model == "openai/gpt-4.1"
+
+
+@pytest.mark.asyncio
 async def test_providers_deactivate_clears_builtin_activation():
     """后端收口（#835）：providers.deactivate 清空 api_key、遗留端点覆盖
     与 activation 标记；默认模型归属该 provider 时重置为出厂默认

--- a/uv.lock
+++ b/uv.lock
@@ -1302,7 +1302,7 @@ wheels = [
 
 [[package]]
 name = "miqi"
-version = "0.20.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #929（模型选择收口）合并后 max-effort 审查发现的 14 项问题：模型门控改为「可解析且凭据可用」、内置密钥聊天路径端点收口、激活/取消激活流程与遗留用户入口修复。

## 背景/问题

#929（#835 合规收口）合并后，经 10 审查角度 + 14 对抗验证 + 缺口扫描的完整审查发现 15 项问题（1 安全 + 13 正确性 + 1 测试）。核心问题：

1. **安全**：内置企业共享密钥只在「测试连接」里钉到官方端点，聊天路径（factory → get_api_base）仍会把它发往历史遗留的自定义 api_base；收口后应用内没有任何入口能清除该遗留地址。
2. **门控错位**：config.update 的模型校验按「深合并后的当前模型」执行，遗留 custom/*、裸名、本地 vllm/ollama 模型的用户改任何设置（名字/温度/审批/Tavily key）都被拒，且 GeneralTab/ToolsTab 静默吞错。
3. **可解析≠可用**：门控只查注册表成员资格，无凭据 provider 的模型（如 openai/gpt-4o）可落盘，运行时 `_match_provider` 兜底把它发到内置 DeepSeek 的 API（#602 类错发复辟）；bedrock/* 被无条件放行。
4. **激活流程**：激活成功后保存空模型报 "No fields to update"；激活写入的裸名 fallback 被 ModelSelect 清空（页头与下拉矛盾）；取消激活后前端状态陈旧、默认模型仍指向无密钥 provider（新会话全 NO_API_KEY）。
5. **绕过与健壮性**：batchWrite 与 writeInitialConfig 完全没有模型门控；空字符串模型可落盘；`{"agents": null}` 让门控抛 AttributeError → INTERNAL。
6. **入口与测试**：custom/* 遗留用户看不到激活入口；网关路由的工作模型被 UI 过滤清空；issue-137 smoke 测试被弄坏。

## 变更内容

后端：

- `miqi/runtime/config_handlers.py`：模型门控改为只对「本次改写模型」的更新生效，并移到 `Config.model_validate` 之后（agents:null 回到干净的 INVALID_PARAMS）；空模型显式拒绝
- `miqi/runtime/provider_handlers.py`：`_model_provider_resolvable` 改为「可解析且凭据可用」，镜像 `_match_provider` 的网关兜底；三处激活解码统一走新的 `Config.is_builtin_activated`；激活/取消激活时清除遗留 api_base/extra_headers；取消激活时默认模型归属该 provider 则重置为出厂默认
- `miqi/config/schema.py`：新增 `Config.is_builtin_activated`（容忍历史 bool 格式与 null/字符串异常值，不再崩 AttributeError）
- `miqi/providers/factory.py`：聊天路径同样收口——内置激活强制官方端点；custom/* 明确报错而非静默错发
- `miqi/runtime/config_app_handlers.py`：batchWrite 补上同样的模型门控（此前可原样写入 custom/default）
- `miqi/config/loader.py`：加载时把遗留 custom/* 默认模型迁移为出厂默认
- `apps/desktop/src/main/ipc/index.ts`：writeInitialConfig 删除凭据/模型直写分支（唯一调用方只传 workspace）

前端：

- `EditProviderSheet.tsx`：激活成功后不再补发空 update（消除 "No fields to update" 假报错）；激活 fallback 写入带前缀模型名；取消激活后刷新父级（重开不再显示陈旧的「已激活」）
- `ModelSelect.tsx`：删除清空 effect（不再静默摧毁裸模型名状态）；过滤支持网关路由（已配置网关可路由的模型保留）
- `ProvidersPage.tsx`：active_provider 解析不到时激活入口退到内置 provider（custom/* 用户仍能看到「激活内置模型」）
- `SettingsPage.tsx`：GeneralTab/ToolsTab 保存失败不再静默吞掉，显示后端错误

测试：

- 新增 23 个回归测试：可用性门控、网关路由、空模型拒绝、agents:null、激活清除遗留端点、取消激活重置模型、batchWrite 门控、activation store 异常形态
- 修复 issue-137（收口后 UI + 双语选择器）与 issue-140（折叠面板/引擎改名）两个既有 smoke 测试；mock 补齐 models/activate/deactivate 并升级为动态状态
- 新增 issue-929 截图评估 spec 与 issue-929-fixes-e2e 修复评估 spec

## 关联 issue

- #835 模型选择收口（本 PR 修复其合并后遗留问题）

## 日志/验证证据

```
$ .venv/Scripts/python.exe -m pytest tests/runtime/ tests/providers/ -q
1373 passed, 1 skipped

$ npm run typecheck
（无报错，通过）

$ npx vitest run ModelSelect.test.ts ModelQuickPanel.test.ts
8 passed

$ npx playwright test --project=smoke（本 PR 相关 spec）
issue-137 ×2 / issue-140 / issue-185 / issue-929 截图评估 / issue-929-fixes-e2e ×2 全部通过
```

修复效果 E2E 评估（动态 mock 镜像真实后端行为，OCR 核验）：

- 激活后页头默认模型 = 带前缀预设 `deepseek/deepseek-v4-flash`（修复前为裸名且被下拉清空）：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/1aff64489e587d74.png)
- 重开编辑弹窗，下拉正确显示该模型（修复前显示「请选择模型…」占位符）：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/b5291b4799ee21c6.png)
- 取消激活后默认模型重置为出厂默认，按钮变为「激活内置模型」：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/8464df3ac48be2a6.png)
- 重开弹窗不再显示陈旧的「已激活」：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/fecc1fa37474f24d.png)
- custom/* 遗留用户仍有「激活内置模型」入口：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/54688bee36530bdd.png)
- 登录后下拉只含内置 DeepSeek（收口过滤生效）：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/28435a5e8b9db635.png)

## 测试情况

- 后端 `tests/runtime/` + `tests/providers/`：1373 passed, 1 skipped, 0 failed
- 前端 typecheck：通过；vitest 单测：通过
- smoke：本 PR 相关 7 个 spec 全部通过（issue-137 ×2、issue-140、issue-185、issue-929、issue-929-fixes-e2e ×2）
- 已知遗留：全量 smoke 中 10 个聊天控制台相关失败（issue-109、issue-172、smoke.spec）为本分支之前已存在（对照实验：mocks.ts 还原到 HEAD 后依然失败），与本 PR 无关，待单独开 issue 修复

## 截图

见「日志/验证证据」节（6 张修复效果 E2E 截图）。

## 后续计划

- #893 登录门控后端化：审查第 14 项（登录门控仅前端、后端无 qraft 登录校验）依赖平台接口落地，本次跳过
- 聊天控制台 10 个预先存在 smoke 失败待单独开 issue 修复
