### PR TITLE
feat(desktop): 模型列表移除 deepseek-chat/reasoner，仅保留 v4-flash

### DIFF
--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.test.ts
@@ -4,13 +4,14 @@ import { createElement } from 'react';
 import { ModelSelect, filterAvailableModels, FALLBACK_MODEL_PRESETS } from './ModelSelect';
 
 describe('ModelSelect（issue #788 常用模型预设）', () => {
-  it('后端不可用时回退预设列表，且只包含内置 DeepSeek（SSR：useEffect 不执行）', () => {
+  it('后端不可用时回退预设列表，且只包含内置 DeepSeek v4-flash（SSR：useEffect 不执行）', () => {
     const html = renderToStaticMarkup(
-      createElement(ModelSelect, { value: 'deepseek/deepseek-chat', onChange: () => {} })
+      createElement(ModelSelect, { value: 'deepseek/deepseek-v4-flash', onChange: () => {} })
     );
-    expect(html).toContain('deepseek/deepseek-chat');
-    expect(html).toContain('deepseek/deepseek-reasoner');
     expect(html).toContain('deepseek/deepseek-v4-flash');
+    // 收口：chat/reasoner 已下线，兜底列表不再出现
+    expect(html).not.toContain('deepseek/deepseek-chat');
+    expect(html).not.toContain('deepseek/deepseek-reasoner');
     // 收口后兜底列表不再出现无凭据入口的其他 provider
     expect(html).not.toContain('openai/gpt-4o');
     expect(html).not.toContain('anthropic/claude-opus-4-5');
@@ -71,12 +72,12 @@ describe('filterAvailableModels（#929 可用 provider 过滤回归）', () => {
 
   it('只保留可用 provider 的模型（内置可激活或已配置凭据）', () => {
     const result = filterAvailableModels(catalog, new Set(['deepseek']));
-    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-chat']);
+    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-v4-flash']);
   });
 
   it('可用集合含历史已配置的 openai 时保留其模型', () => {
     const result = filterAvailableModels(catalog, new Set(['deepseek', 'openai']));
-    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-chat', 'openai/gpt-4o']);
+    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-v4-flash', 'openai/gpt-4o']);
   });
 
   it('可用集合未知（null）时不过滤，原样返回', () => {
@@ -86,6 +87,6 @@ describe('filterAvailableModels（#929 可用 provider 过滤回归）', () => {
   it('已配置网关（gatewayRouted）时保留任意模型 —— 运行时网关兜底路由', () => {
     const result = filterAvailableModels(catalog, new Set(['deepseek']), true);
     // custom/* 已从运行时移除，网关兜底也不放行（#933 review）
-    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-chat', 'openai/gpt-4o']);
+    expect(result.map((m) => m.id)).toEqual(['deepseek/deepseek-v4-flash', 'openai/gpt-4o']);
   });
 });

--- a/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx
@@ -15,22 +15,6 @@ import { PROVIDER_DISPLAY_NAMES } from '../../../lib/providers';
 // 出现在下拉里只会诱导保存一个运行时无法使用的模型。
 export const FALLBACK_MODEL_PRESETS: ModelInfo[] = [
   {
-    id: 'deepseek/deepseek-chat',
-    name: 'DeepSeek Chat',
-    provider: 'deepseek',
-    providerDisplayName: 'DeepSeek',
-    hidden: false,
-    default: false,
-  },
-  {
-    id: 'deepseek/deepseek-reasoner',
-    name: 'DeepSeek Reasoner',
-    provider: 'deepseek',
-    providerDisplayName: 'DeepSeek',
-    hidden: false,
-    default: false,
-  },
-  {
     id: 'deepseek/deepseek-v4-flash',
     name: 'DeepSeek V4 Flash',
     provider: 'deepseek',

--- a/apps/desktop/src/renderer/lib/providers.ts
+++ b/apps/desktop/src/renderer/lib/providers.ts
@@ -27,7 +27,7 @@ export const PROVIDER_SUGGESTED_MODELS: Record<string, string[]> = {
   volcengine: ['doubao-pro-32k', 'doubao-lite-32k', 'doubao-1-5-pro-32k'],
   anthropic: ['claude-opus-4-5', 'claude-sonnet-4-5', 'claude-haiku-4-5'],
   openai: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
-  deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'],
+  deepseek: ['deepseek-v4-flash', 'deepseek-v4-pro'],
   gemini: ['gemini-2.5-pro', 'gemini-2.0-flash', 'gemini-2.5-flash'],
   groq: ['llama-3.3-70b-versatile', 'llama-3.1-8b-instant', 'moonshard-whisper-large-v3'],
   zhipu: ['glm-4-plus', 'glm-z1-flash', 'glm-4-long'],

--- a/apps/desktop/tests/smoke/issue-929-model-consolidation-ui.spec.ts
+++ b/apps/desktop/tests/smoke/issue-929-model-consolidation-ui.spec.ts
@@ -63,8 +63,11 @@ test('模型收口 UI 截图评估（#929）', async ({ page }) => {
   const select = page.locator('select').first();
   await expect(select).toBeVisible({ timeout: 10_000 });
   await expect(page.getByText('登录后使用平台内置模型')).not.toBeVisible();
-  // 目录含 openai/custom，但可用 provider 只有内置 deepseek → 过滤后不出现
-  await expect(select).toContainText('deepseek/deepseek-chat');
+  // 目录含 openai/custom，但可用 provider 只有内置 deepseek → 过滤后不出现；
+  // chat/reasoner 已下线，下拉只保留 deepseek/deepseek-v4-flash
+  await expect(select).toContainText('deepseek/deepseek-v4-flash');
+  await expect(select).not.toContainText('deepseek/deepseek-chat');
+  await expect(select).not.toContainText('deepseek/deepseek-reasoner');
   await expect(select).not.toContainText('openai');
   await expect(select).not.toContainText('custom');
   await expect(select).not.toContainText('自定义模型');

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -47,22 +47,6 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   const modelsJson = JSON.stringify(
     opts.models || [
       {
-        id: 'deepseek/deepseek-chat',
-        name: 'DeepSeek Chat',
-        provider: 'deepseek',
-        providerDisplayName: 'DeepSeek',
-        hidden: false,
-        default: false,
-      },
-      {
-        id: 'deepseek/deepseek-reasoner',
-        name: 'DeepSeek Reasoner',
-        provider: 'deepseek',
-        providerDisplayName: 'DeepSeek',
-        hidden: false,
-        default: false,
-      },
-      {
         id: 'deepseek/deepseek-v4-flash',
         name: 'DeepSeek V4 Flash',
         provider: 'deepseek',

--- a/miqi/runtime/model_catalog.py
+++ b/miqi/runtime/model_catalog.py
@@ -192,22 +192,6 @@ _BUILTIN_MODELS: dict[str, dict[str, Any]] = {
         "default_service_tier": "standard",
     },
     # ── DeepSeek ───────────────────────────────────────────────────────
-    "deepseek/deepseek-reasoner": {
-        "name": "DeepSeek Reasoner",
-        "provider": "deepseek",
-        "hidden": False,
-        "supported_reasoning_efforts": ["medium", "high"],
-        "service_tiers": ["standard"],
-        "default_service_tier": "standard",
-    },
-    "deepseek/deepseek-chat": {
-        "name": "DeepSeek Chat",
-        "provider": "deepseek",
-        "hidden": False,
-        "supported_reasoning_efforts": ["low", "medium"],
-        "service_tiers": ["standard"],
-        "default_service_tier": "standard",
-    },
     "deepseek/deepseek-v4-flash": {
         "name": "DeepSeek V4 Flash",
         "provider": "deepseek",

--- a/tests/runtime/test_model_catalog.py
+++ b/tests/runtime/test_model_catalog.py
@@ -91,8 +91,6 @@ def test_model_catalog_covers_common_preset_models():
     catalog = ModelCatalog(current_config_model="")
     ids = {m.id for m in catalog.list_models()}
     for expected in [
-        "deepseek/deepseek-chat",
-        "deepseek/deepseek-reasoner",
         "deepseek/deepseek-v4-flash",
         "openai/gpt-4o",
         "openai/gpt-4o-mini",


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

模型列表移除 `deepseek/deepseek-chat` 与 `deepseek/deepseek-reasoner`，仅保留 `deepseek/deepseek-v4-flash`，并把它设为出厂默认模型。

## 背景/问题

#835 合规收口后模型统一走内置 DeepSeek；chat/reasoner 为旧代模型已下线，继续出现在下拉中会诱导用户选择平台不再提供的模型。既然列表只剩一个模型，直接默认它，减少一步选择。

## 变更内容

- `miqi/runtime/model_catalog.py`：model/list 目录移除两个条目（运行时在线的下拉数据源）
- `miqi/config/schema.py`：出厂默认模型 `anthropic/claude-opus-4-5` → `deepseek/deepseek-v4-flash`
- `miqi/config/loader.py`：custom/* 迁移无可用凭据时回退到该产品默认
- `miqi/runtime/provider_handlers.py`：取消激活无其他可用 provider 时回退到该产品默认
- `apps/desktop/src/renderer/features/providers/components/ModelSelect.tsx`：兜底预设只保留 v4-flash
- `apps/desktop/src/renderer/lib/providers.ts`：`PROVIDER_SUGGESTED_MODELS.deepseek` 同步收敛
- mock 目录与相关断言同步更新

## 关联 issue

- #835 模型选择收口（后续收敛）

## 日志/验证证据

```
$ .venv/Scripts/python.exe -m pytest tests/runtime/ tests/providers/ tests/config/ -q
1404 passed, 1 skipped

$ .venv/Scripts/python.exe -m ruff check .
All checks passed!

$ npx vitest run ModelSelect.test.ts
7 passed

$ npx playwright test issue-929-model-consolidation-ui issue-929-fixes-e2e issue-185 --project=smoke
4 passed（DOM 断言确认下拉仅剩 deepseek/deepseek-v4-flash；取消激活后默认模型回退到 v4-flash）
```

- 登录后模型 tab（下拉选项由 DOM 断言背书，chat/reasoner 已不在目录中）：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/28435a5e8b9db635.png)
- 选中后下拉显示 deepseek/deepseek-v4-flash：
  ![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/ec8563a00d5c34ee.png)

## 测试情况

- 后端 `tests/runtime/` + `tests/providers/` + `tests/config/`：1404 passed, 1 skipped
- vitest ModelSelect/ModelQuickPanel：通过；typecheck 通过；ruff/prettier 通过
- smoke：issue-929 截图评估、issue-929-fixes-e2e ×2、issue-185 全部通过

## 截图

见「日志/验证证据」节（2 张）。

## 后续计划

无