### PR TITLE
fix(e2e): 夹具剥离 providerActivation 标记，避免内置激活端点钉死劫持 mock 测试

### DIFF
--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -471,6 +471,16 @@ export async function launchElectronApp(
   const config = existsSync(destConfigPath)
     ? JSON.parse(readFileSync(destConfigPath, 'utf-8'))
     : {};
+  // ── E2E: start from a clean provider state ──
+  // The user's real config carries desktop.providerActivation (builtin key
+  // markers). The runtime pins builtin-activated providers to their official
+  // endpoint (#933), which would silently redirect specs that patch apiBase
+  // to local mock servers (confirm-card, bridge-chinese-error, …) at the
+  // real API — mock never receives a request. Strip the markers; specs that
+  // need activation re-add it explicitly via patchConfig.
+  if (config.desktop && typeof config.desktop === 'object') {
+    delete (config.desktop as Record<string, unknown>).providerActivation;
+  }
   if (patchConfig) patchConfig(config);
   const bypassAll = opts?.bypassAll ?? true;
   if (bypassAll) {


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

E2E 夹具 `launchElectronApp` 复制用户真实配置时剥离 `desktop.providerActivation` 标记，e2e 从干净 provider 状态启动。

## 背景/问题

#933（内置激活 provider 在聊天路径强制官方端点）合入后，本地 e2e 出现环境相关性失败：夹具会把用户真实配置（含内置激活标记）复制进临时 MIQI_HOME，凡是把 provider apiBase 指向本地 mock 服务器的 spec（confirm-card、bridge-chinese-error 等），聊天请求被静默钉到真实 DeepSeek 端点，mock 收不到请求而超时失败。CI runner 上没有激活标记，故 CI 不暴露、本地必现。

实测：bridge-chinese-error 修复前失败（mock 无请求），修复后通过；confirm-card 修复后请求已到达 mock（工具调用推进到 ask_user_confirm_card，卡渲染问题属另一遗留，见后续计划）。

## 变更内容

- `apps/desktop/tests/e2e/helpers/electron-setup.ts`：复制用户配置后删除 `desktop.providerActivation`（需要激活态的 spec 可经 `patchConfig` 显式设置）

## 关联 issue

- #933 修复 PR（其端点钉死行为引发的 e2e 交互缺陷）

## 日志/验证证据

```
$ npx playwright test tests/e2e/bridge-chinese-error.spec.ts --project=electron
修复前：mock 服务器只打印 banner、无任何请求（失败）
修复后：1 passed（请求到达 mock，脏 key 自愈 + 中文报错链路验证通过）
```

## 测试情况

- bridge-chinese-error.spec：修复后本地通过
- confirm-card.spec：修复后请求已到达 mock，卡渲染不出来的问题为 develop 既有缺陷（与本修复无关，待单独排查）
- typecheck 通过

## 截图

无需截图

## 后续计划

- confirm-card 确认卡不渲染问题单独排查（本地 + CI 均可见）