### PR TITLE
feat(desktop): 登录后获取 encryptedApiKey，模型调用走 AI 网关 (#922)

### DIFF
--- a/apps/desktop/src/main/qraft/client.test.ts
+++ b/apps/desktop/src/main/qraft/client.test.ts
@@ -560,6 +560,74 @@ describe('QraftClient.getUserInfo', () => {
       code: 'SESSION_EXPIRED',
     });
   });
+
+  it('解析顶层平铺的网关字段（encryptedApiKey/aiGatewayStatus/configVersion）', async () => {
+    const body = JSON.stringify({
+      sub: '19',
+      username: 'U-HKY4-GB4E',
+      nickname: 'MiQi测试',
+      encryptedApiKey: 'sk-test-top-level',
+      aiGatewayStatus: 'active',
+      configVersion: 1,
+      consumerId: 'C-123',
+    });
+    const fetch = createFetchMock([
+      { url: /\/oauth2\/userinfo$/, response: mockResponse(200, body, jsonHeaders()) },
+    ]);
+    const client = new QraftClient(fetch, noopLog);
+    const info = await client.getUserInfo(CONFIG, 'ACCESS-TOKEN');
+    expect(info).toEqual({
+      sub: '19',
+      username: 'U-HKY4-GB4E',
+      nickname: 'MiQi测试',
+      aiGateway: {
+        encryptedApiKey: 'sk-test-top-level',
+        status: 'active',
+        configVersion: 1,
+        consumerId: 'C-123',
+      },
+    });
+  });
+
+  it('解析嵌套在 data 内的网关字段；configVersion 数字字符串归一为 number', async () => {
+    const body = JSON.stringify({
+      sub: '19',
+      username: 'U-HKY4-GB4E',
+      nickname: 'MiQi测试',
+      data: {
+        encryptedApiKey: 'sk-test-nested',
+        aiGatewayStatus: 'active',
+        configVersion: '3',
+      },
+    });
+    const fetch = createFetchMock([
+      { url: /\/oauth2\/userinfo$/, response: mockResponse(200, body, jsonHeaders()) },
+    ]);
+    const client = new QraftClient(fetch, noopLog);
+    const info = await client.getUserInfo(CONFIG, 'ACCESS-TOKEN');
+    expect(info.aiGateway).toEqual({
+      encryptedApiKey: 'sk-test-nested',
+      status: 'active',
+      configVersion: 3,
+    });
+  });
+
+  it('encryptedApiKey 缺失（即使有 aiGatewayStatus）时整体省略 aiGateway', async () => {
+    const body = JSON.stringify({
+      sub: '19',
+      username: 'U-HKY4-GB4E',
+      nickname: 'MiQi测试',
+      aiGatewayStatus: 'disabled',
+      configVersion: 0,
+    });
+    const fetch = createFetchMock([
+      { url: /\/oauth2\/userinfo$/, response: mockResponse(200, body, jsonHeaders()) },
+    ]);
+    const client = new QraftClient(fetch, noopLog);
+    const info = await client.getUserInfo(CONFIG, 'ACCESS-TOKEN');
+    expect(info).toEqual({ sub: '19', username: 'U-HKY4-GB4E', nickname: 'MiQi测试' });
+    expect('aiGateway' in info).toBe(false);
+  });
 });
 
 describe('QraftClient 错误分类与重试', () => {

--- a/apps/desktop/src/main/qraft/client.ts
+++ b/apps/desktop/src/main/qraft/client.ts
@@ -22,7 +22,13 @@ import {
   findEraBundleUrls,
   maskSecret,
 } from './rsa';
-import type { QraftAccount, QraftErrorCode, QraftPointsBalance, QraftTokens } from './types';
+import type {
+  QraftAccount,
+  QraftAiGateway,
+  QraftErrorCode,
+  QraftPointsBalance,
+  QraftTokens,
+} from './types';
 
 // ── 可注入依赖（生产用 electron.net.fetch，测试用 mock） ──────────────
 
@@ -433,11 +439,15 @@ export class QraftClient {
 
   // ── 业务接口 ─────────────────────────────────────────────────────────
 
-  /** GET /oauth2/userinfo：实测响应无 picture 字段。 */
+  /** GET /oauth2/userinfo：实测响应无 picture 字段。
+   *  网关字段（encryptedApiKey/aiGatewayStatus/configVersion/consumerId 等）可能
+   *  平铺在顶层或嵌套在 data 内（实测两层都出现过），两层都取。
+   *  encryptedApiKey 为空（未开通/未下发）时省略 aiGateway —— 调用方据此区分
+   *  "平台未开通网关" 与 "已开通"，同时不把空串当密钥处理。 */
   async getUserInfo(
     config: ResolvedQraftConfig,
     accessToken: string
-  ): Promise<Omit<QraftAccount, 'phone'>> {
+  ): Promise<Omit<QraftAccount, 'phone'> & { aiGateway?: QraftAiGateway }> {
     const { res, bodyText } = await this.request(`${config.baseUrl}/oauth2/userinfo`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -453,11 +463,27 @@ export class QraftClient {
     if (typeof data.sub !== 'string' && typeof data.username !== 'string') {
       throw new QraftError('USERINFO_FAILED', 'userinfo 响应缺少 sub/username 字段');
     }
+    const nested = (data.data ?? {}) as Record<string, unknown>;
+    const field = (name: string): unknown =>
+      name in data ? data[name] : (nested[name] ?? undefined);
+    const encryptedApiKey = String(field('encryptedApiKey') ?? '');
+    const status = String(field('aiGatewayStatus') ?? '');
+    const aiGateway: QraftAiGateway | undefined = encryptedApiKey
+      ? {
+          encryptedApiKey,
+          status,
+          configVersion: coerceConfigVersion(field('configVersion')),
+          consumerId: field('consumerId') != null ? String(field('consumerId')) : undefined,
+          consumerGroupId:
+            field('consumerGroupId') != null ? String(field('consumerGroupId')) : undefined,
+        }
+      : undefined;
     this.log('INFO', 'qraft: userinfo 获取成功');
     return {
       sub: String(data.sub ?? ''),
       username: String(data.username ?? ''),
       nickname: String(data.nickname ?? ''),
+      ...(aiGateway ? { aiGateway } : {}),
     };
   }
 
@@ -612,6 +638,16 @@ function isInvalidRefreshToken(detail: string): boolean {
   return /RefreshTokenException|无效\s*refresh_token|refresh_token\s*(无效|已失效|已过期|过期)|invalid\s+refresh/i.test(
     detail
   );
+}
+
+/** configVersion 防御性归一为 number：平台可能下发数字或数字字符串。 */
+function coerceConfigVersion(raw: unknown): number | undefined {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
 }
 
 /** 解析 PointBalanceVO（balance/deduct 响应的 data 字段）。 */

--- a/apps/desktop/src/main/qraft/service.test.ts
+++ b/apps/desktop/src/main/qraft/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -580,6 +581,70 @@ describe('QraftService 登出竞态与 token 文件防护', () => {
     expect(result.ok).toBe(true);
     // 凭据绝不能写到 symlink 指向的目标目录
     expect(existsSync(join(targetDir, 'token.json'))).toBe(false);
+  });
+
+  it('预置 token 文件经硬链接共享时：原子替换不覆写共享 inode', async () => {
+    // 攻击者在 .qraft 预置一个 token 文件并持有硬链接别名。若实现原地
+    // writeFileSync，凭据会写进共享 inode，攻击者经别名即可读到；原子
+    // 替换（临时文件 + rename）后别名仍应是旧内容。
+    const qraftDir = join(dir, 'qraft-hardlink');
+    mkdirSync(qraftDir, { recursive: true });
+    const tokenPath = join(qraftDir, 'token.json');
+    const attackerAlias = join(dir, 'attacker-alias.json');
+    writeFileSync(tokenPath, '{"planted":"old"}', 'utf8');
+    linkSync(tokenPath, attackerAlias);
+
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    const service = new QraftService({
+      client: stub as unknown as QraftClient,
+      store,
+      log: noopLog,
+      makeRedirectUri: () => 'http://localhost:38000/callback',
+      tokenFilePath: () => tokenPath,
+    });
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    // 主路径已被替换为新凭据
+    expect(JSON.parse(readFileSync(tokenPath, 'utf8')).accessToken).toBe('ACCESS-TOKEN');
+    // 攻击者别名仍是旧内容 —— 凭据未落入共享 inode
+    expect(JSON.parse(readFileSync(attackerAlias, 'utf8'))).toEqual({ planted: 'old' });
+  });
+
+  it.skipIf(process.platform === 'win32')('预置文件为其他用户所有时拒绝写入', async () => {
+    const qraftDir = join(dir, 'qraft-owned');
+    mkdirSync(qraftDir, { recursive: true });
+    const tokenPath = join(qraftDir, 'token.json');
+    writeFileSync(tokenPath, '{"planted":"attacker"}', 'utf8');
+    // 模拟非本用户 uid（测试进程无法 chown）：owner 检查据此拒绝写入。
+    // process.getuid 仅 POSIX 存在，类型上需断言（tsconfig.node 不含该声明）。
+    const realUid = process.getuid?.() ?? 0;
+    const getuidSpy = vi
+      .spyOn(process as unknown as { getuid: () => number }, 'getuid')
+      .mockReturnValue(realUid + 1);
+    try {
+      const stub = makeClientStub();
+      stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+      stub.authorizeFlow.mockResolvedValue(makeTokens());
+      stub.getUserInfo.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+      const service = new QraftService({
+        client: stub as unknown as QraftClient,
+        store,
+        log: noopLog,
+        makeRedirectUri: () => 'http://localhost:38000/callback',
+        tokenFilePath: () => tokenPath,
+      });
+
+      const result = await service.login('18500000000', 'p');
+      expect(result.ok).toBe(true); // 登录不受 token 文件失败影响
+      // 凭据绝不能写入其他用户拥有的文件
+      expect(JSON.parse(readFileSync(tokenPath, 'utf8'))).toEqual({ planted: 'attacker' });
+    } finally {
+      getuidSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/desktop/src/main/qraft/service.test.ts
+++ b/apps/desktop/src/main/qraft/service.test.ts
@@ -582,3 +582,83 @@ describe('QraftService 登出竞态与 token 文件防护', () => {
     expect(existsSync(join(targetDir, 'token.json'))).toBe(false);
   });
 });
+
+describe('QraftService AI 网关字段（#922）', () => {
+  const GATEWAY = {
+    encryptedApiKey: 'sk-test-gateway-secret',
+    status: 'active',
+    configVersion: 2,
+    consumerId: 'C-1',
+  };
+  const userinfoWithGateway = () => ({
+    sub: '19',
+    username: 'U-GATEWAY',
+    nickname: '网关用户',
+    aiGateway: { ...GATEWAY },
+  });
+
+  it('登录后：store 保存 encryptedApiKey；status() 只透出非敏感字段', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue(userinfoWithGateway());
+    const service = makeService(stub);
+
+    const result = await service.login('18500000000', 'p');
+    expect(result.ok).toBe(true);
+    // 加密 store 内保存完整 aiGateway（含密钥）
+    expect(store.current?.aiGateway).toEqual(GATEWAY);
+    // 透给渲染进程的状态只含 status/configVersion，不含 encryptedApiKey
+    expect(service.status().aiGateway).toEqual({ status: 'active', configVersion: 2 });
+    expect(JSON.stringify(service.status())).not.toContain('sk-test-gateway-secret');
+  });
+
+  it('token 文件写入 aiGateway 块（Python 握手）；登出删除', async () => {
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue(userinfoWithGateway());
+    const service = makeService(stub);
+    const tokenPath = () => join(dir, 'qraft-token.json');
+
+    await service.login('18500000000', 'p');
+    const content = JSON.parse(readFileSync(tokenPath(), 'utf8'));
+    expect(content.aiGateway).toEqual(GATEWAY);
+    expect(content.accessToken).toBe('ACCESS-TOKEN');
+
+    service.logout();
+    expect(existsSync(tokenPath())).toBe(false);
+    expect(store.current).toBeNull();
+  });
+
+  it('自动刷新重写 token 文件时保留 aiGateway（刷新不重拉 userinfo）', async () => {
+    vi.useFakeTimers();
+    const stub = makeClientStub();
+    stub.platformLogin.mockResolvedValue({ sub: '19', username: 'u', nickname: 'n' });
+    stub.authorizeFlow.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue(userinfoWithGateway());
+    stub.refreshTokens.mockImplementation(async () =>
+      makeTokens({ accessToken: 'ACCESS-NEW', expiresAt: Date.now() + 7_199_000 })
+    );
+    const service = makeService(stub);
+    await service.login('18500000000', 'p');
+
+    await vi.advanceTimersByTimeAsync(7_199_000 - 15 * 60_000 + 100);
+    const content = JSON.parse(readFileSync(join(dir, 'qraft-token.json'), 'utf8'));
+    expect(content.accessToken).toBe('ACCESS-NEW');
+    expect(content.aiGateway).toEqual(GATEWAY);
+    expect(store.current?.aiGateway).toEqual(GATEWAY);
+  });
+
+  it('浏览器登录路径同样携带 aiGateway', async () => {
+    const stub = makeClientStub();
+    stub.exchangeCode.mockResolvedValue(makeTokens());
+    stub.getUserInfo.mockResolvedValue(userinfoWithGateway());
+    const service = makeService(stub);
+
+    const result = await service.loginWithCode('browser-code');
+    expect(result.ok).toBe(true);
+    expect(store.current?.aiGateway?.encryptedApiKey).toBe('sk-test-gateway-secret');
+    expect(service.status().aiGateway?.status).toBe('active');
+  });
+});

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -8,8 +8,20 @@
  * 由设置页引导用户重新登录。
  */
 
-import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from 'fs';
-import { dirname } from 'path';
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { randomUUID } from 'crypto';
+import { dirname, join } from 'path';
 import { CookieJar } from './cookie-jar';
 import { QraftClient, QraftError, type QraftLogger, type ResolvedQraftConfig } from './client';
 import { maskSecret } from './rsa';
@@ -314,12 +326,16 @@ export class QraftService {
 
   /** 登录/刷新成功后写入 token 文件：accessToken + expiresAt + baseUrl（0600）。
    *  baseUrl 供 KUN 计费闸门定位平台接口；Skill 侧 auth.py 只读前两个字段。
-   *  防符号链接重定向：.qraft 目录必须是真实目录、token 文件必须是真实
-   *  常规文件，否则跳过写入并告警（workspace 对 agent 可写，恶意/意外
-   *  替换成 symlink 时不能把凭据写到重定向目标）。 */
+   *  防符号链接/硬链接重定向：.qraft 目录必须是真实目录、token 文件必须是
+   *  真实常规文件且为本进程用户所有，否则跳过写入并告警（workspace 对
+   *  agent 可写，恶意/意外替换成 symlink 或预置文件时不能把凭据写进去）。
+   *  写入采用同目录临时文件 + rename 原子替换：rename 替换目录条目本身
+   *  （不跟随目标 symlink），且凭据只落在新建 inode 上 —— 原地 writeFileSync
+   *  会跟随 symlink、并把攻击者经硬链接预置的文件就地覆写。 */
   private syncTokenFile(state: QraftStoredState): void {
     const filePath = this.options.tokenFilePath?.();
     if (!filePath) return;
+    let tmpPath: string | null = null;
     try {
       const dir = dirname(filePath);
       mkdirSync(dir, { recursive: true });
@@ -333,37 +349,62 @@ export class QraftService {
         if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
           throw new Error('token 文件路径被非常规文件/symlink 占用，跳过写入');
         }
+        // 拒绝替换其他用户拥有的文件（POSIX 语义；Windows 无 uid 概念，
+        // rename 替换 + 0600 已足够）。攻击者预置的文件绝不原地覆写。
+        if (process.platform !== 'win32' && typeof process.getuid === 'function') {
+          if (statSync(filePath).uid !== process.getuid()) {
+            throw new Error('token 文件被其他用户所有，跳过写入');
+          }
+        }
       }
-      writeFileSync(
-        filePath,
-        JSON.stringify({
-          accessToken: state.tokens.accessToken,
-          expiresAt: state.tokens.expiresAt,
-          // 平台 API 基础地址：KUN 计费闸门（billing.py）据此定位
-          // /oauth2/points/deduct；Skill 侧 auth.py 只读前两个字段，无影响。
-          baseUrl: state.baseUrl,
-          // AI 网关信息（Python make_provider 读取；登出即随文件删除）。
-          // billing/auth.py 只读已知字段，追加字段向后兼容。
-          ...(state.aiGateway
-            ? {
-                aiGateway: {
-                  encryptedApiKey: state.aiGateway.encryptedApiKey,
-                  status: state.aiGateway.status,
-                  configVersion: state.aiGateway.configVersion,
-                  consumerId: state.aiGateway.consumerId,
-                  consumerGroupId: state.aiGateway.consumerGroupId,
-                },
-              }
-            : {}),
-        }),
-        { encoding: 'utf8', mode: 0o600 }
-      );
+      // 原子替换：临时文件 O_EXCL 创建（0600）→ rename。任何异常路径下
+      // 临时文件都会被 finally 清理，不残留凭据。
+      tmpPath = join(dir, `.qraft-token-${process.pid}-${randomUUID()}.tmp`);
+      const fd = openSync(tmpPath, 'wx', 0o600);
+      try {
+        writeFileSync(
+          fd,
+          JSON.stringify({
+            accessToken: state.tokens.accessToken,
+            expiresAt: state.tokens.expiresAt,
+            // 平台 API 基础地址：KUN 计费闸门（billing.py）据此定位
+            // /oauth2/points/deduct；Skill 侧 auth.py 只读前两个字段，无影响。
+            baseUrl: state.baseUrl,
+            // AI 网关信息（Python make_provider 读取；登出即随文件删除）。
+            // billing/auth.py 只读已知字段，追加字段向后兼容。
+            ...(state.aiGateway
+              ? {
+                  aiGateway: {
+                    encryptedApiKey: state.aiGateway.encryptedApiKey,
+                    status: state.aiGateway.status,
+                    configVersion: state.aiGateway.configVersion,
+                    consumerId: state.aiGateway.consumerId,
+                    consumerGroupId: state.aiGateway.consumerGroupId,
+                  },
+                }
+              : {}),
+          }),
+          { encoding: 'utf8' }
+        );
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(tmpPath, filePath);
+      tmpPath = null;
       chmodSync(filePath, 0o600);
     } catch (err) {
       this.options.log(
         'WARN',
         `qraft: 同步 token 文件失败（${err instanceof Error ? err.message : err}）`
       );
+    } finally {
+      if (tmpPath) {
+        try {
+          rmSync(tmpPath, { force: true });
+        } catch {
+          // 清理失败无碍：临时文件不包含可用凭据引用，且 0600。
+        }
+      }
     }
   }
 

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -19,6 +19,7 @@ import {
   prodEnvClientSecret,
   testEnvClientSecret,
   type QraftAccount,
+  type QraftAiGateway,
   type QraftEnv,
   type QraftErrorCode,
   type QraftLoginOptions,
@@ -174,9 +175,18 @@ export class QraftService {
       // 登录后展示账号信息以 userinfo 为准（实测响应无 picture 字段）；
       // userinfo 失败不阻断登录 —— 回退用平台登录响应里的 nickname/username。
       let account: QraftAccount = { phone, ...loginAccount };
+      let aiGateway: QraftAiGateway | undefined;
       try {
         const info = await this.options.client.getUserInfo(config, tokens.accessToken);
-        account = { phone, ...info, sub: info.sub || loginAccount.sub };
+        // 显式取身份字段：info 额外携带 aiGateway（含密钥），绝不并入 account，
+        // 否则会经 status().account 泄漏给渲染进程。
+        account = {
+          phone,
+          sub: info.sub || loginAccount.sub,
+          username: info.username,
+          nickname: info.nickname,
+        };
+        aiGateway = info.aiGateway;
       } catch (err) {
         this.options.log(
           'WARN',
@@ -184,7 +194,7 @@ export class QraftService {
         );
       }
 
-      this.persistLogin(env, config, account, tokens);
+      this.persistLogin(env, config, account, tokens, aiGateway);
       this.options.log('INFO', `qraft: 登录完成（${account.nickname || account.username}）`);
       // 登录后尽力拉取一次积分余额，让设置页直接展示（失败不阻断登录）。
       void this.fetchPointsBalance().catch(() => {});
@@ -217,9 +227,16 @@ export class QraftService {
       // 浏览器路径没有平台登录响应，账号信息以 userinfo 为准
       //（实测响应无 picture 字段、也不含手机号）。
       let account: QraftAccount = { phone: '', sub: '', username: '', nickname: '' };
+      let aiGateway: QraftAiGateway | undefined;
       try {
         const info = await this.options.client.getUserInfo(config, tokens.accessToken);
-        account = { phone: '', ...info };
+        account = {
+          phone: '',
+          sub: info.sub,
+          username: info.username,
+          nickname: info.nickname,
+        };
+        aiGateway = info.aiGateway;
       } catch (err) {
         this.options.log(
           'WARN',
@@ -227,7 +244,7 @@ export class QraftService {
         );
       }
 
-      this.persistLogin(env, config, account, tokens);
+      this.persistLogin(env, config, account, tokens, aiGateway);
       this.options.log(
         'INFO',
         `qraft: 浏览器登录完成（${account.nickname || account.username || account.sub}）`
@@ -261,7 +278,8 @@ export class QraftService {
     env: QraftEnv,
     config: ResolvedQraftConfig,
     account: QraftAccount,
-    tokens: QraftTokens
+    tokens: QraftTokens,
+    aiGateway?: QraftAiGateway
   ): void {
     const state: QraftStoredState = {
       version: 1,
@@ -273,6 +291,7 @@ export class QraftService {
       cookie: this.jar.header(),
       account,
       tokens,
+      ...(aiGateway ? { aiGateway } : {}),
     };
     this.options.store.save(state);
     this.refreshError = null;
@@ -323,6 +342,19 @@ export class QraftService {
           // 平台 API 基础地址：KUN 计费闸门（billing.py）据此定位
           // /oauth2/points/deduct；Skill 侧 auth.py 只读前两个字段，无影响。
           baseUrl: state.baseUrl,
+          // AI 网关信息（Python make_provider 读取；登出即随文件删除）。
+          // billing/auth.py 只读已知字段，追加字段向后兼容。
+          ...(state.aiGateway
+            ? {
+                aiGateway: {
+                  encryptedApiKey: state.aiGateway.encryptedApiKey,
+                  status: state.aiGateway.status,
+                  configVersion: state.aiGateway.configVersion,
+                  consumerId: state.aiGateway.consumerId,
+                  consumerGroupId: state.aiGateway.consumerGroupId,
+                },
+              }
+            : {}),
         }),
         { encoding: 'utf8', mode: 0o600 }
       );
@@ -366,6 +398,10 @@ export class QraftService {
         // 已过期且最近一次自动刷新失败 → 引导重新登录
         (this.refreshError !== null && now > state.tokens.expiresAt),
       points: this.pointsBalance ?? undefined,
+      // 只透出非敏感网关信息（status/configVersion）；encryptedApiKey 不外发渲染进程。
+      aiGateway: state.aiGateway
+        ? { status: state.aiGateway.status, configVersion: state.aiGateway.configVersion }
+        : undefined,
     };
   }
 

--- a/apps/desktop/src/main/qraft/types.ts
+++ b/apps/desktop/src/main/qraft/types.ts
@@ -91,4 +91,22 @@ export interface QraftStoredState {
   cookie: string;
   account: QraftAccount;
   tokens: QraftTokens;
+  /**
+   * 平台 AI 网关信息（userinfo 下发）。encryptedApiKey 属密钥：只存在于
+   * safeStorage 加密的 store 与 0600 的 token 文件中，绝不进渲染进程/日志。
+   * token 刷新不重拉 userinfo，故随本存储带入并在重写 token 文件时保留。
+   */
+  aiGateway?: QraftAiGateway;
+}
+
+/** 平台 AI 网关开通信息（腾讯云消费者密钥 + 状态 + 配置版本）。 */
+export interface QraftAiGateway {
+  /** 网关消费者密钥（X-Api-Key）。 */
+  encryptedApiKey: string;
+  /** 网关开通状态：active / provisioning / failed / disabled 等。 */
+  status: string;
+  /** 平台配置版本号（可热刷本地模型/网关清单，留后续）。 */
+  configVersion?: number;
+  consumerId?: string;
+  consumerGroupId?: string;
 }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -446,6 +446,16 @@ function createProviderConfigMessage(content?: string): Message {
   };
 }
 
+/** #922：登录但 AI 网关未 active 时的发送阻断提示（不含可点 action，指向平台页文案）。 */
+function createGatewayBlockedMessage(): Message {
+  return {
+    role: 'error',
+    content:
+      'AI 网关未就绪（平台开通中或不可用），暂时无法发起会话。请到 设置 → MiQroForge 平台 查看网关状态或重新登录后重试。',
+    timestamp: Date.now(),
+  };
+}
+
 /* ─── Tracked file from tool hints ───────────────────────────────── */
 interface TrackedFile {
   path: string;
@@ -3839,6 +3849,37 @@ export function ChatConsole({
             const last = prev[prev.length - 1];
             if (last?.timestamp === userMsg.timestamp) {
               return [...prev.slice(0, -1), createProviderConfigMessage()];
+            }
+            return prev;
+          });
+          setInput(text);
+          setAttachments(atts);
+        }
+        return;
+      }
+
+      // ── #922 AI 网关门禁 ──
+      // 登录后网关状态明确非 active（provisioning/failed/disabled）时拒绝发起
+      // 会话：把乐观气泡换成网关提示并恢复输入框。未登录 / 平台未下发网关状态
+      // 时放行（与模型面板语义一致）。旧 preload/smoke mock 无 qraft 命名空间则跳过。
+      const gatewayStatus =
+        typeof window.miqi.qraft?.status === 'function'
+          ? await window.miqi.qraft.status().catch(() => null)
+          : null;
+      if (
+        gatewayStatus?.loggedIn === true &&
+        gatewayStatus.aiGateway &&
+        gatewayStatus.aiGateway.status !== 'active'
+      ) {
+        pendingSendIdsRef.current.delete(sendSessionKey);
+        streamingBySession.delete(sendSessionKey);
+        setSendingFor(sendSessionKey, null);
+        if (currentSessionRef.current === sendSessionKey) {
+          setStreaming(false);
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.timestamp === userMsg.timestamp) {
+              return [...prev.slice(0, -1), createGatewayBlockedMessage()];
             }
             return prev;
           });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3789,6 +3789,9 @@ export function ChatConsole({
     retry?: boolean;
   } | null>(null);
   const handleSendRef = useRef<() => void>(() => {});
+  /** 程序化发送（论文下载 fallback 等）经此 ref 显式传文本，handleSend
+   *  一次性消费。不依赖 setInput 后的渲染 flush（旧闭包读 input 是旧值）。 */
+  const programmaticTextRef = useRef<string | null>(null);
   /** #740: pending resume-turn id — set by 继续执行, consumed by handleSend
    *  so the resume request flows through the full send pipeline (listeners,
    *  streaming render) instead of a bare chat.send call. */
@@ -3851,7 +3854,11 @@ export function ChatConsole({
     const _resumeId = resumeTurnIdRef.current;
     resumeTurnIdRef.current = null;
     const payload = retryPayloadRef.current;
-    const text = (payload?.text ?? input).trim();
+    // 程序化发送（论文下载 fallback 等）经 ref 显式传文本：不依赖
+    // setInput 后的渲染 flush（旧闭包读到的 input state 是旧值）。
+    const programmaticText = programmaticTextRef.current;
+    programmaticTextRef.current = null;
+    const text = (payload?.text ?? programmaticText ?? input).trim();
     const atts = payload?.attachments ?? attachments;
     if (!text && atts.length === 0 && !_resumeId) {
       retryPayloadRef.current = null;
@@ -5218,17 +5225,18 @@ export function ChatConsole({
     setInput(instruction);
     setTimeout(() => {
       const text = instruction.trim();
-      if (!text) return;
-      // Direct send: bypasses the input-state read in handleSend since
-      // we just set it. We inline the send logic here for simplicity.
-      window.miqi.chat
-        .send(text, sessionKey)
-        .then(() => {
-          setDownloadingPaperId(null);
-        })
-        .catch(() => {
-          setDownloadingPaperId(null);
-        });
+      if (!text) {
+        programmaticTextRef.current = null;
+        setDownloadingPaperId(null);
+        return;
+      }
+      // 经 handleSend 主流程发送（而非直连 chat.send）：网关门禁、乐观气泡
+      // 与流式渲染路径一致（#922）。文本经 programmaticTextRef 显式传入。
+      programmaticTextRef.current = instruction;
+      handleSendRef.current();
+      // 发出即清理下载指示：无论网关拦截（handleSend 恢复草稿）还是发送
+      // 失败，指示都不悬挂；流式回复由 handleSend 的监听链负责渲染。
+      setDownloadingPaperId(null);
     }, 0);
   };
 

--- a/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.test.ts
+++ b/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.test.ts
@@ -1,26 +1,103 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
 import { ModelQuickPanel } from './ModelQuickPanel';
+import { useQraftStatus } from '../../../hooks/useQraftStatus';
 
-describe('ModelQuickPanel（#835 合规收口后）', () => {
+vi.mock('../../../hooks/useQraftStatus', () => ({
+  useQraftStatus: vi.fn(),
+}));
+
+const mockedStatus = vi.mocked(useQraftStatus);
+
+// SSR 不跑 useEffect，故各测试显式控制 useQraftStatus 返回值以覆盖三态门禁（#922）。
+function loggedOut() {
+  return {
+    status: { loggedIn: false },
+    loggedIn: false,
+    aiGatewayStatus: undefined,
+    gatewayActive: false,
+    aiGatewayKnown: false,
+  };
+}
+
+function loggedInGatewayActive() {
+  return {
+    status: { loggedIn: true, aiGateway: { status: 'active', configVersion: 1 } },
+    loggedIn: true,
+    aiGatewayStatus: 'active',
+    gatewayActive: true,
+    aiGatewayKnown: true,
+  };
+}
+
+function loggedInGatewayNotReady(status: string) {
+  return {
+    status: { loggedIn: true, aiGateway: { status } },
+    loggedIn: true,
+    aiGatewayStatus: status,
+    gatewayActive: false,
+    aiGatewayKnown: true,
+  };
+}
+
+/** 登录但平台未下发 aiGateway：视为可用，避免误锁（#922 门禁边界）。 */
+function loggedInGatewayUnknown() {
+  return {
+    status: { loggedIn: true },
+    loggedIn: true,
+    aiGatewayStatus: undefined,
+    gatewayActive: false,
+    aiGatewayKnown: false,
+  };
+}
+
+const render = () =>
+  renderToStaticMarkup(
+    createElement(ModelQuickPanel, {
+      activeModel: 'deepseek/deepseek-v4-flash',
+      onSaved: () => {},
+      onGoToQraft: () => {},
+    })
+  );
+
+describe('ModelQuickPanel（#835/#922 门控）', () => {
+  beforeEach(() => {
+    mockedStatus.mockReturnValue(loggedOut());
+  });
+
   it('未登录时显示登录门控，隐藏自定义配置入口', () => {
-    // renderToStaticMarkup 不跑 useEffect，useQraftStatus 初始 status 为 null →
-    // loggedIn=false，应渲染登录引导而非模型下拉。
-    const html = renderToStaticMarkup(
-      createElement(ModelQuickPanel, {
-        activeModel: 'deepseek/deepseek-v4-flash',
-        onSaved: () => {},
-        onGoToQraft: () => {},
-      })
-    );
+    const html = render();
     expect(html).toContain('模型设置');
     expect(html).toContain('默认模型');
     expect(html).toContain('登录后使用平台内置模型');
     expect(html).toContain('去登录');
-    // 收口后不再出现自配 API Key / Base URL 入口
+    expect(html).not.toContain('保存');
     expect(html).not.toContain('API Key');
     expect(html).not.toContain('API Base URL');
-    expect(html).not.toContain('快速配置引导');
+  });
+
+  it('登录且网关 active：显示模型下拉与保存', () => {
+    mockedStatus.mockReturnValue(loggedInGatewayActive());
+    const html = render();
+    expect(html).not.toContain('登录后使用平台内置模型');
+    expect(html).not.toContain('AI 网关未就绪');
+    expect(html).toContain('保存');
+  });
+
+  it('登录但网关非 active（provisioning）：禁用并给出平台账号引导', () => {
+    mockedStatus.mockReturnValue(loggedInGatewayNotReady('provisioning'));
+    const html = render();
+    expect(html).toContain('AI 网关未就绪');
+    expect(html).toContain('查看平台账号');
+    expect(html).not.toContain('登录后使用平台内置模型');
+    expect(html).not.toContain('保存');
+  });
+
+  it('登录但网关状态未下发：按可用放行，不误锁', () => {
+    mockedStatus.mockReturnValue(loggedInGatewayUnknown());
+    const html = render();
+    expect(html).toContain('保存');
+    expect(html).not.toContain('AI 网关未就绪');
   });
 });

--- a/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.tsx
@@ -22,7 +22,11 @@ export function ModelQuickPanel({ activeModel, onSaved, onGoToQraft }: ModelQuic
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { loggedIn } = useQraftStatus();
+  const { loggedIn, gatewayActive, aiGatewayKnown } = useQraftStatus();
+  // 可改模型 = 未登录时引导登录（现状）；登录时需网关 active；平台未下发网关
+  // 状态（aiGatewayKnown=false）视为可用，避免误锁存量账号。
+  const canUseModel = loggedIn && (gatewayActive || !aiGatewayKnown);
+  const gatewayBlocked = loggedIn && aiGatewayKnown && !gatewayActive;
 
   useEffect(() => {
     if (activeModel) setModelValue(activeModel);
@@ -70,8 +74,22 @@ export function ModelQuickPanel({ activeModel, onSaved, onGoToQraft }: ModelQuic
           <label className="text-xs font-medium text-[var(--text-muted)] uppercase tracking-wide">
             默认模型
           </label>
-          {loggedIn ? (
+          {canUseModel ? (
             <ModelSelect value={modelValue} onChange={setModelValue} />
+          ) : gatewayBlocked ? (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2.5">
+              <span className="text-sm text-[var(--text-muted)]">
+                AI 网关未就绪（平台开通中或不可用），暂不可选模型
+              </span>
+              <button
+                onClick={onGoToQraft}
+                data-testid="model-quickpanel-go-gateway"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white transition-colors shrink-0"
+              >
+                <LogIn size={13} />
+                查看平台账号
+              </button>
+            </div>
           ) : (
             <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2.5">
               <span className="text-sm text-[var(--text-muted)]">登录后使用平台内置模型</span>
@@ -87,7 +105,7 @@ export function ModelQuickPanel({ activeModel, onSaved, onGoToQraft }: ModelQuic
           )}
         </div>
 
-        {loggedIn && (
+        {canUseModel && (
           <div className="flex items-center gap-2">
             <button
               onClick={handleSave}

--- a/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/SettingsPage.tsx
@@ -462,7 +462,10 @@ function GeneralTab({
   const [maxTokens, setMaxTokens] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
-  const { loggedIn } = useQraftStatus();
+  const { loggedIn, gatewayActive, aiGatewayKnown } = useQraftStatus();
+  // #922 网关门控：未登录引导登录；登录且网关 active（或未下发）可改模型。
+  const canUseModel = loggedIn && (gatewayActive || !aiGatewayKnown);
+  const gatewayBlocked = loggedIn && aiGatewayKnown && !gatewayActive;
 
   useEffect(() => {
     getCachedConfig()
@@ -539,8 +542,23 @@ function GeneralTab({
 
       <div className="flex flex-col gap-1.5">
         <label className="text-size-sm font-medium text-[var(--text-muted)]">默认模型</label>
-        {loggedIn ? (
+        {canUseModel ? (
           <ModelSelect value={model} onChange={setModel} />
+        ) : gatewayBlocked ? (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2.5">
+            <span className="text-sm text-[var(--text-muted)]">
+              AI 网关未就绪（平台开通中或不可用），暂不可选模型
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onGoToQraft}
+              data-testid="general-go-gateway"
+            >
+              <LogIn size={14} />
+              查看平台账号
+            </Button>
+          </div>
         ) : (
           <div className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2.5">
             <span className="text-sm text-[var(--text-muted)]">登录后使用平台内置模型</span>

--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -70,6 +70,25 @@ function errorText(result: QraftLoginResult | null, fallback: string): string {
   return ERROR_GUIDANCE[result.code ?? 'INTERNAL'] ?? fallback;
 }
 
+/** AI 网关状态展示文案（#922）。 */
+function gatewayStatusText(status: string): { label: string; hint: string } {
+  switch (status) {
+    case 'active':
+      return {
+        label: '可用',
+        hint: 'AI 网关已开通：模型调用将走平台网关，计入平台消费组配额与计费。',
+      };
+    case 'provisioning':
+      return { label: '开通中', hint: 'AI 网关正在开通，暂时无法发起会话。请稍后刷新查看。' };
+    case 'failed':
+      return { label: '开通失败', hint: 'AI 网关开通失败，请联系平台处理后再试。' };
+    case 'disabled':
+      return { label: '已停用', hint: 'AI 网关已停用，请联系平台启用后再试。' };
+    default:
+      return { label: status || '未知', hint: 'AI 网关状态未知，请联系平台确认。' };
+  }
+}
+
 const ModeBtn = ({
   value,
   current,
@@ -544,6 +563,37 @@ export function QraftPage() {
               <BadgeInfo size={11} />
               实测 access_token 有效期约 2 小时，MiQroForge 会在到期前 15 分钟自动刷新。
             </p>
+
+            {/* AI 网关状态：#922 —— active 才允许模型调用走网关 */}
+            {status?.aiGateway &&
+              (() => {
+                const gw = gatewayStatusText(status.aiGateway.status);
+                return (
+                  <div
+                    className="mt-4 border-t border-[var(--border-subtle)] pt-3"
+                    data-testid="qraft-ai-gateway"
+                  >
+                    <div className="flex items-center gap-2 text-size-sm text-[var(--text-muted)]">
+                      <ShieldCheck size={14} className="shrink-0 text-[var(--accent)]" />
+                      <span className="text-[var(--text-muted)]">AI 网关</span>
+                      <span
+                        className="font-mono text-[var(--text)]"
+                        data-testid="qraft-ai-gateway-status"
+                      >
+                        {gw.label}
+                      </span>
+                      {status.aiGateway.configVersion != null && (
+                        <span className="ml-auto text-size-2xs text-[var(--text-faint)]">
+                          配置版本 v{status.aiGateway.configVersion}
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1.5 text-size-2xs leading-relaxed text-[var(--text-faint)]">
+                      {gw.hint}
+                    </p>
+                  </div>
+                );
+              })()}
 
             {/* 积分余额：执行任务（首次使用工具/技能）每次扣 30 分，普通对话不扣分 */}
             <div

--- a/apps/desktop/src/renderer/hooks/useQraftStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useQraftStatus.ts
@@ -2,10 +2,17 @@ import { useEffect, useState } from 'react';
 import type { QraftStatus } from '../../shared/ipc';
 
 /**
- * 共享 Qraft 登录态（#835 登录门控）。
+ * 共享 Qraft 登录态（#835 登录门控；#922 网关门控）。
  *
  * 复用 QraftPage 的 status + onStatusChanged 模式，供设置页 / Providers 页
- * 判断「是否已登录」，在未登录时禁用模型选择并引导登录。
+ * 判断「是否已登录」以及「AI 网关是否 active」，在未登录或登录但网关未就绪
+ * 时禁用模型选择并引导。
+ *
+ * 返回值语义（#922）：
+ *  - loggedIn：已登录（无论网关状态）。
+ *  - aiGatewayStatus：登录态下平台下发的网关状态；未登录/未下发为 undefined。
+ *  - gatewayActive：已登录且 aiGatewayStatus === 'active' → 允许模型走网关。
+ *  - aiGatewayKnown：登录且平台明确返回了 aiGateway（用于区分"未下发"与"非 active"）。
  */
 export function useQraftStatus() {
   const [status, setStatus] = useState<QraftStatus | null>(null);
@@ -38,5 +45,9 @@ export function useQraftStatus() {
     };
   }, []);
 
-  return { status, loggedIn: status?.loggedIn === true };
+  const loggedIn = status?.loggedIn === true;
+  const aiGatewayStatus = loggedIn ? status?.aiGateway?.status : undefined;
+  const gatewayActive = aiGatewayStatus === 'active';
+  const aiGatewayKnown = loggedIn && aiGatewayStatus !== undefined;
+  return { status, loggedIn, aiGatewayStatus, gatewayActive, aiGatewayKnown };
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1429,6 +1429,16 @@ export interface QraftPointsBalance {
   totalSpent: number;
 }
 
+/** 平台 AI 网关开通状态（userinfo 下发；"active" 才允许模型调用走网关）。 */
+export type QraftAiGatewayStatus = string;
+
+/** 登录态中下发的网关开通信息（仅非敏感字段进渲染进程；encryptedApiKey 永不外发）。 */
+export interface QraftAiGatewayInfo {
+  status: QraftAiGatewayStatus;
+  /** 平台配置版本号（本切片仅展示/透出，热刷新留后续）。 */
+  configVersion?: number;
+}
+
 export interface QraftStatus {
   loggedIn: boolean;
   account?: QraftAccount;
@@ -1442,4 +1452,6 @@ export interface QraftStatus {
   requiresRelogin?: boolean;
   /** 最近一次拉取的积分余额（设置页拉取后缓存，随状态事件推送）。 */
   points?: QraftPointsBalance;
+  /** 平台 AI 网关开通状态（登录且 active 时模型调用走网关）。 */
+  aiGateway?: QraftAiGatewayInfo;
 }

--- a/apps/desktop/tests/e2e/ai-gateway.spec.ts
+++ b/apps/desktop/tests/e2e/ai-gateway.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * AI 网关（issue #922）— Electron E2E。
+ *
+ * 覆盖真实主进程链路（qraft IPC → QraftService → QraftStore → token 文件）：
+ *   1. 预置登录态携带 aiGateway（active）→ QraftPage 展示网关状态与配置版本；
+ *      token 文件（Python 握手通道）写入 aiGateway 块（含 encryptedApiKey）；
+ *      status() IPC 不泄漏密钥、account 不携带网关密钥。
+ *   2. 预置登录态 aiGatewayStatus=provisioning → QraftPage 展示"开通中"，
+ *      模型 tab 禁用模型下拉并引导查看平台账号。
+ *
+ * 不依赖 MiQroForge 网络：登录态由测试预置（plain 信封），与 qraft-login 同策略。
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import {
+  launchElectronApp,
+  closeElectronApp,
+  type ElectronFixture,
+} from './helpers/electron-setup';
+
+const STORE_ENV = 'MIQI_QRAFT_STORE';
+const GATEWAY_KEY = 'sk-e2e-gateway-secret-key';
+
+interface SeededAiGateway {
+  status: string;
+  configVersion?: number;
+}
+
+/** 构造 plain 信封的预置登录态（QraftStore 无 safeStorage 降级读取），可携带 aiGateway。 */
+function buildSeededStoreContent(aiGateway: SeededAiGateway | null): string {
+  const state: Record<string, unknown> = {
+    version: 1,
+    env: 'test',
+    baseUrl: 'https://test.forge.miqroera.com/api',
+    clientId: 'miqi',
+    clientSecret: 'test-client-secret',
+    redirectUri: 'http://localhost:38000/callback',
+    cookie: 'Authorization=e2e-test-cookie',
+    account: {
+      phone: '18500000000',
+      sub: '19',
+      username: 'E2E-GATEWAY',
+      nickname: 'E2E网关测试',
+    },
+    tokens: {
+      accessToken: 'e2e-fake-access-token',
+      refreshToken: 'e2e-fake-refresh-token',
+      openid: 'e2e-fake-openid',
+      expiresAt: Date.now() + 7_199_000, // 实测 expires_in=7199
+    },
+  };
+  if (aiGateway) {
+    state.aiGateway = {
+      encryptedApiKey: GATEWAY_KEY,
+      status: aiGateway.status,
+      configVersion: aiGateway.configVersion ?? 1,
+      consumerId: 'C-E2E',
+    };
+  }
+  return JSON.stringify({
+    v: 1,
+    enc: 'plain',
+    payload: Buffer.from(JSON.stringify(state), 'utf8').toString('base64'),
+  });
+}
+
+async function gotoQraftTab(page: Page): Promise<void> {
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page
+    .getByRole('tab')
+    .filter({ hasText: /MiQroForge/ })
+    .click();
+}
+
+let storePath: string;
+
+test.describe('AI 网关 E2E (issue #922)', () => {
+  let fixture: ElectronFixture;
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    storePath = join(tmpdir(), `qraft-gateway-e2e-store-${process.pid}.json`);
+    process.env[STORE_ENV] = storePath;
+    writeFileSync(storePath, buildSeededStoreContent({ status: 'active' }), 'utf8');
+    fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+  });
+
+  test.afterAll(async () => {
+    delete process.env[STORE_ENV];
+    if (electronApp) await closeElectronApp(electronApp, fixture?.miqiHome);
+    if (existsSync(storePath)) rmSync(storePath, { force: true });
+  });
+
+  test('active：网关状态展示、token 文件握手、密钥不泄漏渲染进程', async () => {
+    await gotoQraftTab(page);
+
+    // QraftPage 网关状态行：可用 + 配置版本
+    await expect(page.getByTestId('qraft-ai-gateway')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('qraft-ai-gateway-status')).toHaveText('可用');
+    await expect(page.getByTestId('qraft-ai-gateway')).toContainText('配置版本 v1');
+
+    // token 文件握手：登录态恢复时同步写入 aiGateway 块（Python make_provider 读取）
+    const tokenFile = join(fixture.miqiHome, 'workspace', '.qraft', 'token.json');
+    await expect
+      .poll(() => (existsSync(tokenFile) ? readFileSync(tokenFile, 'utf8') : ''), {
+        timeout: 10_000,
+      })
+      .toContain('"aiGateway"');
+    const tokenContent = JSON.parse(readFileSync(tokenFile, 'utf8'));
+    expect(tokenContent.aiGateway).toMatchObject({
+      encryptedApiKey: GATEWAY_KEY,
+      status: 'active',
+      configVersion: 1,
+    });
+
+    // 渲染进程可见的状态：aiGateway 只含 status/configVersion；account 不含密钥。
+    //（回归 #922 实现中的 account 展开泄漏 —— encryptedApiKey 绝不能进 renderer）
+    const statusJson = await page.evaluate(async () => {
+      const s = await (window as any).miqi.qraft.status();
+      return JSON.stringify(s);
+    });
+    expect(statusJson).not.toContain(GATEWAY_KEY);
+    expect(statusJson).toContain('"aiGateway":{"status":"active","configVersion":1}');
+    expect(statusJson).not.toContain('"encryptedApiKey"');
+
+    await page.screenshot({
+      path: 'test-results/ai-gateway-e2e-active.png',
+      fullPage: true,
+    });
+  });
+
+  test('provisioning：平台页展示"开通中"，模型 tab 禁用并引导', async () => {
+    // 重新预置非 active 登录态并重启应用（store 只在 service 构造时读取）
+    await closeElectronApp(electronApp, fixture.miqiHome);
+    writeFileSync(storePath, buildSeededStoreContent({ status: 'provisioning' }), 'utf8');
+    const f2 = await launchElectronApp();
+    electronApp = f2.electronApp;
+    page = f2.page;
+    fixture = f2;
+
+    await gotoQraftTab(page);
+    await expect(page.getByTestId('qraft-ai-gateway')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('qraft-ai-gateway-status')).toHaveText('开通中');
+    await expect(page.getByTestId('qraft-ai-gateway')).toContainText('暂时无法发起会话');
+
+    // 模型 tab：ModelQuickPanel 网关门禁（未就绪 → 禁用下拉 + 平台账号引导）
+    await page.getByRole('tab', { name: '模型' }).click();
+    await expect(page.getByText('AI 网关未就绪')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('查看平台账号')).toBeVisible();
+    await expect(page.getByText('登录后使用平台内置模型')).not.toBeVisible();
+
+    await page.screenshot({
+      path: 'test-results/ai-gateway-e2e-provisioning.png',
+      fullPage: true,
+    });
+  });
+});

--- a/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
+++ b/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
@@ -180,4 +180,91 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
     const sends = await page.evaluate(() => (window as any).__chatSends);
     expect(sends).toBe(1);
   });
+
+  test('网关非 active（provisioning）：论文无直链的 AI 下载 fallback 同样被拦截（chat.send 零调用）', async ({
+    page,
+  }) => {
+    // 论文无 open_access_pdf_url / pdf_url / arxiv_id → 点击「下载 PDF」走
+    // aiDownload fallback。该路径此前直连 chat.send 绕过网关门禁（CodeRabbit
+    // #943），修复后必须经 handleSend 主流程同样被拦截。
+    const paperJson = JSON.stringify({
+      query: 'transformer',
+      source: 'semantic_scholar',
+      total: 1,
+      count: 1,
+      items: [
+        {
+          id: 'p-922',
+          title: 'Attention Is All You Need',
+          abstract: 'A novel neural network architecture based solely on attention mechanisms.',
+          authors: ['A. Vaswani', 'N. Shazeer'],
+          year: 2017,
+          is_open_access: true,
+        },
+      ],
+    });
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [CONFIGURED_DEEPSEEK],
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'provisioning' },
+        },
+        sessions: [
+          {
+            key: 'gw-paper-session',
+            title: '网关论文会话',
+            updated_at: Date.now(),
+            message_count: 2,
+          },
+        ],
+        sessionMessages: {
+          'gw-paper-session': [
+            { role: 'user', content: '找 transformer 论文', timestamp: '2026-09-04T01:00:00.000Z' },
+            {
+              role: 'tool',
+              name: 'paper_search',
+              content: paperJson,
+              timestamp: '2026-09-04T01:00:01.000Z',
+            },
+          ],
+        },
+      }),
+    });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+    await page.getByText('网关论文会话').click();
+    await expect(page.getByText('Attention Is All You Need')).toBeVisible({ timeout: 10_000 });
+
+    // 统计 chat.send 调用次数（网关拦截意味着后端根本不该收到发送请求）
+    await page.evaluate(() => {
+      (window as any).__chatSends = 0;
+      const orig = (window as any).miqi.chat.send.bind((window as any).miqi.chat);
+      (window as any).miqi.chat.send = (...args: unknown[]) => {
+        (window as any).__chatSends += 1;
+        return orig(...args);
+      };
+    });
+
+    await page.getByText('下载 PDF').click();
+
+    // 乐观气泡被替换为网关阻断提示，输入框恢复下载指令草稿
+    await expect(page.getByText(/AI 网关未就绪/)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/暂时无法发起会话/)).toBeVisible();
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await expect(textarea).toHaveValue(/请下载论文《Attention Is All You Need》/);
+
+    // 后端 chat.send 从未被调用
+    await page.waitForTimeout(500);
+    const sends = await page.evaluate(() => (window as any).__chatSends);
+    expect(sends).toBe(0);
+  });
 });

--- a/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
+++ b/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #922 — AI 网关门禁（smoke，mock bridge）。
+ *
+ * 覆盖渲染侧两个门禁面：
+ *   1. 模型 tab（ModelQuickPanel）：登录且 aiGatewayStatus 非 active →
+ *      禁用模型下拉并给出"查看平台账号"引导；active → 正常可选模型。
+ *   2. 聊天发送（ChatConsole）：登录且网关非 active → 发送被拦截，
+ *      乐观气泡替换为网关提示、输入框恢复、chat.send 未被调用。
+ */
+
+import { test, expect } from '@playwright/test';
+import { buildMockBridgeScript } from './mocks';
+
+const CONFIGURED_DEEPSEEK = {
+  name: 'deepseek',
+  display_name: 'DeepSeek',
+  env_key: 'DEEPSEEK_API_KEY',
+  provider_type: 'openai',
+  is_gateway: false,
+  is_local: false,
+  default_api_base: '',
+  configured: true,
+  api_key_hint: 'sk-t...seek',
+  api_base: null,
+  configured_model: 'deepseek-chat',
+  verification_status: 'success',
+  builtin_available: true,
+  builtin_activated: false,
+};
+
+async function gotoModelTab(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.waitForSelector('#root', { state: 'visible' });
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page.getByRole('tab', { name: '模型' }).click();
+}
+
+test.describe('Issue #922 — AI 网关状态门禁', () => {
+  test('登录且网关非 active（provisioning）：模型 tab 禁用并引导查看平台账号', async ({ page }) => {
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [CONFIGURED_DEEPSEEK],
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'provisioning' },
+        },
+      }),
+    });
+    await gotoModelTab(page);
+
+    // 模型下拉不可见，出现网关未就绪门禁与平台账号引导
+    await expect(page.getByText('AI 网关未就绪')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('查看平台账号')).toBeVisible();
+    await expect(page.getByText('登录后使用平台内置模型')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: '保存' })).not.toBeVisible();
+  });
+
+  test('登录且网关 active：模型 tab 可正常选择与保存', async ({ page }) => {
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [CONFIGURED_DEEPSEEK],
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'active', configVersion: 1 },
+        },
+      }),
+    });
+    await gotoModelTab(page);
+
+    await expect(page.getByText('AI 网关未就绪')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: '保存' })).toBeVisible({ timeout: 10_000 });
+    // ModelSelect 已渲染（select 元素存在，含内置 DeepSeek 兜底预设）
+    await expect(page.locator('select').first()).toBeVisible();
+  });
+
+  test('登录且网关非 active（failed）：聊天发送被拦截，chat.send 不被调用', async ({ page }) => {
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [CONFIGURED_DEEPSEEK],
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'failed' },
+        },
+      }),
+    });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+
+    // 统计 chat.send 调用次数（网关拦截意味着后端根本不该收到发送请求）
+    await page.evaluate(() => {
+      (window as any).__chatSends = 0;
+      const orig = (window as any).miqi.chat.send.bind((window as any).miqi.chat);
+      (window as any).miqi.chat.send = (...args: unknown[]) => {
+        (window as any).__chatSends += 1;
+        return orig(...args);
+      };
+    });
+
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await expect(textarea).toBeVisible({ timeout: 10_000 });
+    await textarea.fill('ping gateway');
+    await textarea.press('Enter');
+
+    // 乐观气泡被替换为网关阻断提示，输入框恢复草稿
+    await expect(page.getByText(/AI 网关未就绪/)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/暂时无法发起会话/)).toBeVisible();
+    await expect(textarea).toHaveValue('ping gateway');
+
+    // 后端 chat.send 从未被调用
+    await page.waitForTimeout(500);
+    const sends = await page.evaluate(() => (window as any).__chatSends);
+    expect(sends).toBe(0);
+  });
+
+  test('网关 active 时聊天发送走正常链路（chat.send 被调用）', async ({ page }) => {
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [CONFIGURED_DEEPSEEK],
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'active', configVersion: 1 },
+        },
+      }),
+    });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+
+    await page.evaluate(() => {
+      (window as any).__chatSends = 0;
+      const orig = (window as any).miqi.chat.send.bind((window as any).miqi.chat);
+      (window as any).miqi.chat.send = (...args: unknown[]) => {
+        (window as any).__chatSends += 1;
+        return orig(...args);
+      };
+    });
+
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await expect(textarea).toBeVisible({ timeout: 10_000 });
+    await textarea.fill('hello gateway');
+    await textarea.press('Enter');
+
+    // 用户气泡保留（未被替换为错误气泡；首条消息同时成为会话标题，用 testid 限定）
+    await expect(page.getByTestId('chat-message-user').getByText('hello gateway')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(/AI 网关未就绪/)).not.toBeVisible();
+    await page.waitForTimeout(500);
+    const sends = await page.evaluate(() => (window as any).__chatSends);
+    expect(sends).toBe(1);
+  });
+});

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -70,6 +70,8 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       baseUrl: 'https://test.forge.miqroera.com/api',
       expiresAt: Date.now() + 7_199_000,
       refreshScheduledAt: Date.now() + 6_299_000,
+      // #922：登录态默认网关已开通（active），模型面板/发送门禁放行。
+      aiGateway: { status: 'active', configVersion: 1 },
     }
   );
   const qraftPointsResultJson = JSON.stringify(
@@ -230,6 +232,11 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       list: function() { return Promise.resolve({ providers: ${providersJson}, active_model: ${activeModelJson}, active_provider: ${activeProviderJson} }); },
       test: function() { return Promise.resolve({ ok: true }); },
       update: function() { return Promise.resolve({ ok: true }); },
+    },
+
+    models: {
+      // 空目录 → ModelSelect 回退 FALLBACK_MODEL_PRESETS（内置 DeepSeek 下拉）。
+      list: function() { return Promise.resolve({ models: [] }); },
     },
 
     channels: {

--- a/miqi/providers/anthropic_provider.py
+++ b/miqi/providers/anthropic_provider.py
@@ -36,11 +36,14 @@ class AnthropicProvider(LLMProvider):
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
         request_timeout: float | None = None,
+        model_prefix: str | None = None,
     ):
         self._selected_spec = find_by_name(provider_name) if provider_name else None
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}
+        # 走非 anthropic 前缀(如 AI 网关承载 deepseek 模型)时,请求前剥掉该前缀。
+        self._model_prefix = model_prefix
 
         client_kwargs: dict[str, Any] = {
             "api_key": api_key or None,
@@ -57,10 +60,20 @@ class AnthropicProvider(LLMProvider):
     # ------------------------------------------------------------------
 
     def _resolve_model(self, model: str) -> str:
-        """Strip 'anthropic/' prefix if present; Anthropic SDK wants bare model names."""
+        """Strip provider prefix if present; Anthropic SDK wants bare model names.
+
+        anthropic 前缀剥 'anthropic/'；经 AI 网关承载其他 provider 的模型时
+        (如 deepseek-v4-flash 走 Anthropic 兼容网关)按构造时的 model_prefix 剥。
+        """
         for prefix in ("anthropic/", "anthropic-"):
             if model.startswith(prefix):
                 return model[len(prefix):]
+        mp = self._model_prefix
+        if mp:
+            for sep in ("/", "-"):
+                prefix = f"{mp}{sep}"
+                if model.startswith(prefix):
+                    return model[len(prefix):]
         return model
 
     # ------------------------------------------------------------------

--- a/miqi/providers/factory.py
+++ b/miqi/providers/factory.py
@@ -27,6 +27,35 @@ def make_provider(config: Any) -> Any:
     p = config.get_provider(model)
 
     spec = find_by_name(provider_name)
+
+    # AI 网关路由(issue #922):登录且 aiGateway 状态为 active、且模型为网关实测
+    # 模型时,把该模型调用经 AnthropicProvider(Anthropic Messages 兼容)指向平台
+    # 网关 —— 走用户 encryptedApiKey,计入平台消费组配额。前提不满足则落回直连。
+    # 必须位于下方 API-key 守卫之前:登录用户即使未激活内置密钥也能经网关调用。
+    workspace = getattr(config, "workspace_path", None)
+    if provider_name == "deepseek" and workspace:
+        from miqi.providers.gateway import (
+            GATEWAY_MODEL,
+            GATEWAY_ORIGIN,
+            GATEWAY_PREFIX,
+            gateway_token_file,
+            read_gateway_creds,
+        )
+
+        bare = model[len("deepseek/") :] if model.startswith("deepseek/") else model
+        if bare == GATEWAY_MODEL:
+            creds = read_gateway_creds(gateway_token_file(config))
+            if creds:
+                from miqi.providers.anthropic_provider import AnthropicProvider
+
+                return AnthropicProvider(
+                    api_key=creds["encryptedApiKey"],
+                    api_base=f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}",
+                    default_model=model,
+                    provider_name="deepseek",
+                    model_prefix="deepseek",
+                )
+
     if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_local):
         raise ValueError(
             "No API key configured. "

--- a/miqi/providers/factory.py
+++ b/miqi/providers/factory.py
@@ -29,8 +29,7 @@ def make_provider(config: Any) -> Any:
     # review），这里给出明确报错而不是静默错发。
     if model.lower().startswith("custom/"):
         raise ValueError(
-            "自定义 provider（custom/*）已移除（#835 合规收口），"
-            "请在 设置 → 模型 中改用内置模型。"
+            "自定义 provider（custom/*）已移除（#835 合规收口），请在 设置 → 模型 中改用内置模型。"
         )
 
     provider_name = config.get_provider_name(model)
@@ -46,8 +45,8 @@ def make_provider(config: Any) -> Any:
     if provider_name == "deepseek" and workspace:
         from miqi.providers.gateway import (
             GATEWAY_MODEL,
-            GATEWAY_ORIGIN,
             GATEWAY_PREFIX,
+            gateway_origin,
             gateway_token_file,
             read_gateway_creds,
         )
@@ -55,12 +54,14 @@ def make_provider(config: Any) -> Any:
         bare = model[len("deepseek/") :] if model.startswith("deepseek/") else model
         if bare == GATEWAY_MODEL:
             creds = read_gateway_creds(gateway_token_file(config))
-            if creds:
+            # 网关 origin 必须可用（显式配置强制 https，非法则回退直连）
+            origin = gateway_origin() if creds else None
+            if creds and origin:
                 from miqi.providers.anthropic_provider import AnthropicProvider
 
                 return AnthropicProvider(
                     api_key=creds["encryptedApiKey"],
-                    api_base=f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}",
+                    api_base=f"{origin}{GATEWAY_PREFIX}",
                     default_model=model,
                     provider_name="deepseek",
                     model_prefix="deepseek",
@@ -68,8 +69,7 @@ def make_provider(config: Any) -> Any:
 
     if not model.startswith("bedrock/") and not (p and p.api_key) and not (spec and spec.is_local):
         raise ValueError(
-            "No API key configured. "
-            "Set one in your config file under the providers section."
+            "No API key configured. Set one in your config file under the providers section."
         )
 
     provider_type = spec.provider_type if spec else "openai"
@@ -89,11 +89,14 @@ def make_provider(config: Any) -> Any:
 
     if provider_type == "anthropic":
         from miqi.providers.anthropic_provider import AnthropicProvider
+
         return AnthropicProvider(**common_kwargs)
 
     if provider_type == "gemini":
         from miqi.providers.gemini_provider import GeminiProvider
+
         return GeminiProvider(**common_kwargs)
 
     from miqi.providers.openai_provider import OpenAIProvider
+
     return OpenAIProvider(**common_kwargs)

--- a/miqi/providers/gateway.py
+++ b/miqi/providers/gateway.py
@@ -1,0 +1,58 @@
+"""Platform AI gateway — creds + endpoint constants for issue #922.
+
+Qraft OAuth 登录后,Electron 主进程把 /oauth2/userinfo 下发的 AI 网关信息
+(encryptedApiKey / aiGatewayStatus / configVersion)随 token 文件
+`<workspace>/.qraft/token.json` 的 `aiGateway` 块同步到 Python。本模块负责
+读取该块并判定是否应把 deepseek 模型调用路由到平台 AI 网关。
+
+网关契约定稿于 apps/desktop/src/main/qraft/live.ai-gateway.test.ts:
+  POST {GATEWAY_ORIGIN}{GATEWAY_PREFIX}/v1/messages
+  header X-Api-Key: <encryptedApiKey>
+  Anthropic Messages 兼容(复用 AnthropicProvider)。
+
+放 providers 下而非 kun_runtime:providers/factory 构造 provider 时读取,
+避免 providers → kun_runtime 反向依赖。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+# 网关地址走环境变量注入,默认沿用实测值(test env)。生产域名确认后经
+# QRAFT_GATEWAY_BASE 下发,勿在此处硬编码密钥。
+GATEWAY_ORIGIN = os.environ.get("QRAFT_GATEWAY_BASE", "http://118.25.115.164").rstrip("/")
+GATEWAY_PREFIX = os.environ.get("QRAFT_GATEWAY_PREFIX", "/miqroera-deepseek")
+# 唯一经过实测的网关模型(issue #922;平台模型清单随 #893 后续下发)。
+GATEWAY_MODEL = "deepseek-v4-flash"
+GATEWAY_ENDPOINT = f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}/v1/messages"
+
+
+def gateway_token_file(config: Any) -> Path:
+    """Python 侧 token 文件路径(与 services._build_billing 同源)。"""
+    return Path(config.workspace_path) / ".qraft" / "token.json"
+
+
+def read_gateway_creds(token_file: Path) -> dict[str, Any] | None:
+    """读取可用网关凭据:aiGateway 块存在、encryptedApiKey 非空、status=='active'。
+
+    任一前提不满足(未登录/文件缺失损坏/网关未 active/无密钥)返回 None → 保持
+    直连路径。损坏/缺失按"无凭据"静默处理,不抛给 provider 构造链。
+    """
+    try:
+        if not token_file.is_file():
+            return None
+        data = json.loads(token_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    gateway = data.get("aiGateway")
+    if not isinstance(gateway, dict):
+        return None
+    key = gateway.get("encryptedApiKey")
+    if not (isinstance(key, str) and key) or gateway.get("status") != "active":
+        return None
+    return dict(gateway)

--- a/miqi/providers/gateway.py
+++ b/miqi/providers/gateway.py
@@ -6,7 +6,7 @@ Qraft OAuth 登录后,Electron 主进程把 /oauth2/userinfo 下发的 AI 网关
 读取该块并判定是否应把 deepseek 模型调用路由到平台 AI 网关。
 
 网关契约定稿于 apps/desktop/src/main/qraft/live.ai-gateway.test.ts:
-  POST {GATEWAY_ORIGIN}{GATEWAY_PREFIX}/v1/messages
+  POST {origin}{GATEWAY_PREFIX}/v1/messages（origin 见 gateway_origin()）
   header X-Api-Key: <encryptedApiKey>
   Anthropic Messages 兼容(复用 AnthropicProvider)。
 
@@ -21,13 +21,37 @@ import os
 from pathlib import Path
 from typing import Any
 
-# 网关地址走环境变量注入,默认沿用实测值(test env)。生产域名确认后经
-# QRAFT_GATEWAY_BASE 下发,勿在此处硬编码密钥。
-GATEWAY_ORIGIN = os.environ.get("QRAFT_GATEWAY_BASE", "http://118.25.115.164").rstrip("/")
+from loguru import logger
+
+# 网关地址经环境变量注入。生产必须为 https 域名：encryptedApiKey 实为
+# 明文腾讯云密钥（#923 实测），明文通道禁止承载密钥与聊天内容。
+# 默认值仅为 test env 实测 IP（#923：平台尚未提供带证书的真实网关域名，
+# https 裸 IP 证书不可用；生产域名 forge.miqroera.com 公网 NXDOMAIN）。
+# 生产上线后平台经 QRAFT_GATEWAY_BASE 下发 https 域名，勿再回退 http。
+_DEFAULT_TEST_ORIGIN = "http://118.25.115.164"
 GATEWAY_PREFIX = os.environ.get("QRAFT_GATEWAY_PREFIX", "/miqroera-deepseek")
-# 唯一经过实测的网关模型(issue #922;平台模型清单随 #893 后续下发)。
+# 唯一经过实测的网关模型（issue #922；平台模型清单随 #893 后续下发）。
 GATEWAY_MODEL = "deepseek-v4-flash"
-GATEWAY_ENDPOINT = f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}/v1/messages"
+
+
+def gateway_origin() -> str | None:
+    """网关 origin（末尾斜杠已归一化）；配置非法返回 None，调用方回退直连。
+
+    显式配置的 QRAFT_GATEWAY_BASE 必须为 https:// 开头，否则拒绝接受
+    （CWE-319：明文通道不能承载密钥）。未配置时回退 test env 实测
+    http IP（见模块注释），使测试环境仍可实测网关。
+    """
+    raw = os.environ.get("QRAFT_GATEWAY_BASE")
+    if raw is None:
+        return _DEFAULT_TEST_ORIGIN
+    origin = raw.rstrip("/")
+    if not origin.startswith("https://"):
+        logger.warning(
+            "QRAFT_GATEWAY_BASE 必须为 https:// 地址（明文通道禁止承载密钥），已忽略并回退直连：{}",
+            raw,
+        )
+        return None
+    return origin
 
 
 def gateway_token_file(config: Any) -> Path:

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -1,0 +1,160 @@
+"""Platform AI gateway — creds 解析 + factory 路由(issue #922)。
+
+覆盖:token 文件缺失/无 aiGateway/非 active/空密钥 → 无凭据回直连;
+aiGateway active + encryptedApiKey → make_provider 把 deepseek-v4-flash 路由到
+AnthropicProvider(网关),其余 deepseek 模型与非 active 场景仍走 OpenAI 直连。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from miqi.providers.anthropic_provider import AnthropicProvider
+from miqi.providers.factory import make_provider
+from miqi.providers.gateway import (
+    GATEWAY_MODEL,
+    GATEWAY_ORIGIN,
+    GATEWAY_PREFIX,
+    read_gateway_creds,
+)
+from miqi.providers.openai_provider import OpenAIProvider
+
+SK = "sk-test-gateway-secret"
+
+
+def _write_token(tmp_path: Path, *, gateway: dict[str, Any] | None) -> Path:
+    token_file = tmp_path / ".qraft" / "token.json"
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "accessToken": "tok-123",
+        "expiresAt": 4102444800000,
+        "baseUrl": "https://test.forge.miqroera.com/api",
+    }
+    if gateway is not None:
+        payload["aiGateway"] = gateway
+    token_file.write_text(json.dumps(payload), encoding="utf-8")
+    return token_file
+
+
+def _active_gateway(**overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "encryptedApiKey": SK,
+        "status": "active",
+        "configVersion": 1,
+    }
+    data.update(overrides)
+    return data
+
+
+class _FakeConfig:
+    """make_provider 只 duck-type 用到的 Config 成员。"""
+
+    def __init__(self, workspace: Path, *, model: str, api_key: str = "builtin-key"):
+        self.workspace_path = workspace
+        self.agents = SimpleNamespace(defaults=SimpleNamespace(model=model))
+        self._api_key = api_key
+
+    def get_provider_name(self, model: str) -> str:
+        return model.split("/", 1)[0]
+
+    def get_provider(self, _model: str):
+        return SimpleNamespace(api_key=self._api_key, extra_headers=None)
+
+    def get_api_base(self, _model: str) -> str | None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# read_gateway_creds
+# ---------------------------------------------------------------------------
+
+
+class TestReadGatewayCreds:
+    def test_missing_token_file_returns_none(self, tmp_path: Path):
+        assert read_gateway_creds(tmp_path / ".qraft" / "token.json") is None
+
+    def test_broken_or_no_ai_gateway_returns_none(self, tmp_path: Path):
+        broken = _write_token(tmp_path, gateway=None)
+        assert read_gateway_creds(broken) is None
+        broken.write_text("{not json", encoding="utf-8")
+        assert read_gateway_creds(broken) is None
+
+    @pytest.mark.parametrize(
+        "status",
+        ["provisioning", "failed", "disabled", "unknown"],
+    )
+    def test_non_active_status_returns_none(self, tmp_path: Path, status: str):
+        token = _write_token(tmp_path, gateway=_active_gateway(status=status))
+        assert read_gateway_creds(token) is None
+
+    def test_empty_key_returns_none(self, tmp_path: Path):
+        token = _write_token(tmp_path, gateway=_active_gateway(encryptedApiKey=""))
+        assert read_gateway_creds(token) is None
+
+    def test_active_returns_creds(self, tmp_path: Path):
+        token = _write_token(tmp_path, gateway=_active_gateway(configVersion=3))
+        creds = read_gateway_creds(token)
+        assert creds == {"encryptedApiKey": SK, "status": "active", "configVersion": 3}
+
+
+# ---------------------------------------------------------------------------
+# make_provider 网关路由
+# ---------------------------------------------------------------------------
+
+
+def _token_for(tmp_path: Path, gateway: dict[str, Any] | None) -> Path:
+    return _write_token(tmp_path, gateway=gateway)
+
+
+class TestMakeProviderGatewayRoute:
+    def test_active_creds_routes_deepseek_v4_flash_to_anthropic(self, tmp_path: Path):
+        _token_for(tmp_path, _active_gateway())
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.api_key == SK
+        assert provider.api_base == f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}"
+        assert provider._resolve_model("deepseek/deepseek-v4-flash") == "deepseek-v4-flash"
+
+    def test_gateway_route_bypasses_missing_builtin_key(self, tmp_path: Path):
+        # 登录用户即使未激活内置密钥也走网关(守卫之前已路由)
+        _token_for(tmp_path, _active_gateway())
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash", api_key="")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.api_key == SK
+
+    def test_no_creds_keeps_openai_direct(self, tmp_path: Path):
+        _token_for(tmp_path, None)
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, OpenAIProvider)
+        assert provider.api_key == "builtin-key"
+
+    def test_non_active_keeps_openai_direct(self, tmp_path: Path):
+        _token_for(tmp_path, _active_gateway(status="provisioning"))
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, OpenAIProvider)
+
+    def test_gateway_only_for_verified_model(self, tmp_path: Path):
+        # 网关只实测支持 v4-flash;deepseek-chat 等仍走直连,不回退也不硬塞网关
+        _token_for(tmp_path, _active_gateway())
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-chat")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, OpenAIProvider)

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -17,14 +17,20 @@ import pytest
 from miqi.providers.anthropic_provider import AnthropicProvider
 from miqi.providers.factory import make_provider
 from miqi.providers.gateway import (
-    GATEWAY_MODEL,
-    GATEWAY_ORIGIN,
     GATEWAY_PREFIX,
+    gateway_origin,
     read_gateway_creds,
 )
 from miqi.providers.openai_provider import OpenAIProvider
 
 SK = "sk-test-gateway-secret"
+
+
+@pytest.fixture(autouse=True)
+def _clean_gateway_env(monkeypatch: pytest.MonkeyPatch):
+    """网关地址/前缀由环境变量注入,测试须与宿主环境隔离。"""
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    monkeypatch.delenv("QRAFT_GATEWAY_PREFIX", raising=False)
 
 
 def _write_token(tmp_path: Path, *, gateway: dict[str, Any] | None) -> Path:
@@ -68,6 +74,9 @@ class _FakeConfig:
     def get_api_base(self, _model: str) -> str | None:
         return None
 
+    def is_builtin_activated(self, _provider_name: str) -> bool:
+        return False
+
 
 # ---------------------------------------------------------------------------
 # read_gateway_creds
@@ -103,6 +112,26 @@ class TestReadGatewayCreds:
 
 
 # ---------------------------------------------------------------------------
+# gateway_origin（QRAFT_GATEWAY_BASE 校验）
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayOrigin:
+    def test_unset_returns_test_default(self):
+        # 未配置时回退 test env 实测 IP（平台尚无 https 网关域名，#923）
+        assert gateway_origin() == "http://118.25.115.164"
+
+    def test_https_accepted_with_trailing_slash_normalized(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("QRAFT_GATEWAY_BASE", "https://gateway.example.com/v1/")
+        assert gateway_origin() == "https://gateway.example.com/v1"
+
+    @pytest.mark.parametrize("raw", ["http://gateway.example.com", "ftp://g.example.com"])
+    def test_non_https_rejected(self, monkeypatch: pytest.MonkeyPatch, raw: str):
+        monkeypatch.setenv("QRAFT_GATEWAY_BASE", raw)
+        assert gateway_origin() is None
+
+
+# ---------------------------------------------------------------------------
 # make_provider 网关路由
 # ---------------------------------------------------------------------------
 
@@ -120,8 +149,34 @@ class TestMakeProviderGatewayRoute:
 
         assert isinstance(provider, AnthropicProvider)
         assert provider.api_key == SK
-        assert provider.api_base == f"{GATEWAY_ORIGIN}{GATEWAY_PREFIX}"
+        assert provider.api_base == f"{gateway_origin()}{GATEWAY_PREFIX}"
         assert provider._resolve_model("deepseek/deepseek-v4-flash") == "deepseek-v4-flash"
+
+    def test_https_gateway_base_accepted_with_trailing_slash_normalized(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("QRAFT_GATEWAY_BASE", "https://gateway.example.com/")
+        _token_for(tmp_path, _active_gateway())
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.api_base == f"https://gateway.example.com{GATEWAY_PREFIX}"
+
+    def test_non_https_gateway_base_rejected_back_to_direct(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # CWE-319：明文通道禁止承载密钥 —— 显式配置 http 地址时拒绝接受，
+        # 回退直连而不是把 encryptedApiKey 发到明文网关。
+        monkeypatch.setenv("QRAFT_GATEWAY_BASE", "http://gateway.example.com")
+        _token_for(tmp_path, _active_gateway())
+        config = _FakeConfig(tmp_path, model="deepseek/deepseek-v4-flash")
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, OpenAIProvider)
+        assert provider.api_key == "builtin-key"
 
     def test_gateway_route_bypasses_missing_builtin_key(self, tmp_path: Path):
         # 登录用户即使未激活内置密钥也走网关(守卫之前已路由)


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

登录后从 `/oauth2/userinfo` 获取 `encryptedApiKey / aiGatewayStatus / configVersion` 并安全落盘；网关 active 时 `deepseek-v4-flash` 调用经 Anthropic 兼容协议路由至平台 AI 网关，渲染侧三态门禁与状态展示。

## 背景/问题

Qraft OAuth 登录后 `/oauth2/userinfo` 已实测下发 `encryptedApiKey / aiGatewayStatus / configVersion`（#923/#924 已闭环，契约定稿于 #932 的 live.ai-gateway.test.ts）。此前桌面端丢弃这些字段，模型调用仍走本地 provider。本 PR 落地“密钥从平台获取、调用走网关”的执行路径，与 #835 内置模型方案协调（登录且网关 active 时该用户调用走网关；未登录维持内置共享密钥直连）。

## 关联 issue

- Closes #922（核心垂直切片；剩余项见下方“范围外”）

## 变更内容

**① 主进程捕获与安全保存（Electron）**
- `client.getUserInfo` 解析网关字段（顶层或嵌套 `data` 两层取法，与实测一致）；`encryptedApiKey` 为空时整体省略
- 登录/浏览器登录透传 → `QraftStoredState.aiGateway`（safeStorage 整包加密落盘）；token 刷新不重拉 userinfo，随存储带入并在重写 token 文件时保留；登出清除
- `status()` 只透出非敏感 `aiGateway:{status,configVersion}`；`encryptedApiKey` 永不进渲染进程
- 修复 account 展开导致的密钥泄漏隐患（`{...info}` 会把含密钥的 aiGateway 并进 `QraftAccount` 进而进 renderer）
- token 文件原子替换写入（临时文件 O_EXCL + rename，不跟随 symlink、硬链接共享 inode 不被覆写）+ POSIX 非本用户 owner 拒绝（CodeRabbit #943）

**② Python 握手与网关路由**
- `.qraft/token.json` 追加可选 `aiGateway` 块（0600，登出随文件删除；billing/auth.py 只读已知字段，向后兼容）
- 新增 `miqi/providers/gateway.py`：读取凭据（仅 `encryptedApiKey` 非空且 `status=='active'` 才命中）；`QRAFT_GATEWAY_BASE` 显式配置强制 https，非 https 回退直连并告警（CWE-319；默认 http 仅限 test env 实测值，#923 平台暂无带证书的网关域名）
- `make_provider` 在 API-key 守卫之前路由：deepseek + `deepseek-v4-flash` + 凭据 active → `AnthropicProvider`（Anthropic Messages 兼容）指向 `{gateway}/miqroera-deepseek`，`X-Api-Key=encryptedApiKey`；会话创建与热更新两条路径共用
- `AnthropicProvider` 新增 `model_prefix` 剥离（`deepseek/` → 裸模型名，对称现有 `anthropic/` 语义）

**③ 渲染侧门禁与展示**
- `useQraftStatus` 派生 `aiGatewayStatus / gatewayActive / aiGatewayKnown`
- 模型面板/设置页三态：未登录→引导登录；active→可选模型；非 active→禁用并引导查看平台账号（仅状态明确非 active 才拦，未下发不误锁）
- `QraftPage` 展示 AI 网关状态行（可用/开通中/开通失败/已停用 + 配置版本）
- `ChatConsole` 发送前拦截非 active 会话（乐观气泡替换为网关提示、恢复草稿、chat.send 零调用）；论文下载无直链 fallback 同样经 handleSend 主流程受门禁约束（CodeRabbit #943）

## 范围外（#922 后续 PR）

- configVersion 热刷新（本地模型清单/网关地址随版本更新）
- 网关 401 → 重新登录引导 UX
- 会话中途登录的旧 provider 切换（新会话/热更新后生效）
- 仅实测验证 `deepseek-v4-flash` 走网关，其余目录模型仍直连

## 日志/验证证据

```
vitest（desktop 全量）: 363 passed / 5 skipped
pytest（本机，排除 WSL 沙箱用例）: 3333 passed / 16 skipped
Playwright smoke（含 #922 与下载 fallback 拦截用例）: 67 passed / 1 skipped
Playwright electron e2e（ai-gateway + qraft 回归）: 见 CI electron-e2e
tsc node+web / prettier / ruff: 通过
```

## 测试情况

| 套件 | 结果 |
|---|---|
| vitest（desktop 全量） | 363 passed / 5 skipped |
| pytest（本机全量，排除 WSL 沙箱） | 3333 passed / 16 skipped（WSL 沙箱用例需本机免密 sudo，与本改动无关） |
| Playwright smoke（含新增 #922 spec） | 67 passed / 1 skipped |
| Playwright electron（新增 #922 + qraft 回归） | 6 passed / 1 skipped（CI） |
| tsc node+web / prettier / ruff | 通过 |

新增测试：
- `tests/providers/test_gateway.py`：creds 解析（缺失/损坏/非 active/空密钥）+ factory 路由正反路径 + `QRAFT_GATEWAY_BASE` https 校验
- `src/main/qraft/service.test.ts`：token 文件硬链接原子替换 + 非本用户 owner 拒绝
- `tests/smoke/issue-922-ai-gateway.spec.ts`：模型面板三态 + 发送拦截 + 论文下载 fallback 拦截（chat.send 零调用）
- `tests/e2e/ai-gateway.spec.ts`：真实主进程链路——token.json 握手含 aiGateway、status() 无密钥泄漏、provisioning 门禁

## 手工验证建议

登录后 QraftPage 应显示“AI 网关：可用（配置版本 v1）”；选 deepseek-v4-flash 发新会话后端走网关；登出后门禁恢复、token.json 删除。真实网关冒烟可用 `QRAFT_LIVE=1 npx vitest run src/main/qraft/live.ai-gateway.test.ts`。

## 截图

**网关 active：QraftPage 状态行 + 模型可选**

![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/88af7ba5366c0894.png)

**网关 provisioning：平台页“开通中” + 模型 tab 禁用引导**

![](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/855b80412029d1e7.png)
