### PR TITLE
feat(mcp): 内置默认 MCP 服务器——平台托管 slurm 网关零配置预置 + 登录态凭据注入

### DIFF
--- a/apps/desktop/src/main/qraft/client.ts
+++ b/apps/desktop/src/main/qraft/client.ts
@@ -447,7 +447,7 @@ export class QraftClient {
   async getUserInfo(
     config: ResolvedQraftConfig,
     accessToken: string
-  ): Promise<Omit<QraftAccount, 'phone'> & { aiGateway?: QraftAiGateway }> {
+  ): Promise<Omit<QraftAccount, 'phone'> & { aiGateway?: QraftAiGateway; mcpGatewayKey?: string }> {
     const { res, bodyText } = await this.request(`${config.baseUrl}/oauth2/userinfo`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -478,12 +478,17 @@ export class QraftClient {
             field('consumerGroupId') != null ? String(field('consumerGroupId')) : undefined,
         }
       : undefined;
+    // 平台托管 MCP 网关凭据（作 Authorization Bearer 使用）：平台下发后
+    // 由主进程写入 0600 token 文件，Python 连接默认网关时注入；缺失时
+    // 省略（未开通/未下发），调用方据此区分。
+    const mcpGatewayKey = String(field('mcpGatewayKey') ?? '');
     this.log('INFO', 'qraft: userinfo 获取成功');
     return {
       sub: String(data.sub ?? ''),
       username: String(data.username ?? ''),
       nickname: String(data.nickname ?? ''),
       ...(aiGateway ? { aiGateway } : {}),
+      ...(mcpGatewayKey ? { mcpGatewayKey } : {}),
     };
   }
 

--- a/apps/desktop/src/main/qraft/mcp-gateway-key.test.ts
+++ b/apps/desktop/src/main/qraft/mcp-gateway-key.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { decryptMcpGatewayKey } from './mcp-gateway-key';
+
+describe('mcp-gateway-key（内置共享网关凭据，登录时解密）', () => {
+  it('解密内置密文得到非空网关 token', () => {
+    const key = decryptMcpGatewayKey();
+    expect(key).toBeTruthy();
+    // 网关 Bearer key 形态（非空、无空白字符）
+    expect(key).toMatch(/^\S{20,}$/);
+  });
+
+  it('解密结果稳定（幂等）', () => {
+    expect(decryptMcpGatewayKey()).toBe(decryptMcpGatewayKey());
+  });
+});

--- a/apps/desktop/src/main/qraft/mcp-gateway-key.ts
+++ b/apps/desktop/src/main/qraft/mcp-gateway-key.ts
@@ -1,0 +1,44 @@
+/**
+ * 平台托管 MCP 网关共享凭据（全客户端同一个 token，2026-09-07 产品确认）。
+ *
+ * 凭据不以明文进入仓库：此处只存 AES-256-GCM 密文，登录时在主进程
+ * 解密并写入 0600 token 文件（workspace/.qraft/token.json 的
+ * mcpGatewayKey），Python 连接默认网关时注入 Authorization Bearer。
+ *
+ * 说明（已知边界）：解密钥由代码内 passphrase 派生——这是「防扫描/
+ * 防明文扩散」级别的保护，不是对抗拿到仓库的攻击者的真实机密性；
+ * 真实方案是平台侧 HTTPS + 按会话/用户下发凭据（届时优先使用
+ * userinfo 下发的 mcpGatewayKey 覆盖本内置值）。
+ */
+
+import { createDecipheriv, scryptSync } from 'crypto';
+
+/** AES-256-GCM 密文包（iv/tag/ct 均为 base64）。 */
+const ENCRYPTED_GATEWAY_KEY = {
+  iv: 'B5YixfC/CVpu/7E3',
+  tag: '9etlylKwzzm7irHZ3He2Kw==',
+  ct: '/OP91ondSnxfSoS6ZJqXHhI3b0ACMl0U2VDMPZmdpbOh5LPiz8tnBTOZag==',
+};
+
+const PASSPHRASE = 'miqroforge-desktop built-in slurm gateway key v1';
+const SALT = 'miqroforge-mcp-gateway-salt-v1';
+
+/** 解密内置网关凭据；失败（密文/派生参数被改动）返回 null。 */
+export function decryptMcpGatewayKey(): string | null {
+  try {
+    const key = scryptSync(PASSPHRASE, SALT, 32);
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      key,
+      Buffer.from(ENCRYPTED_GATEWAY_KEY.iv, 'base64')
+    );
+    decipher.setAuthTag(Buffer.from(ENCRYPTED_GATEWAY_KEY.tag, 'base64'));
+    const plain = Buffer.concat([
+      decipher.update(Buffer.from(ENCRYPTED_GATEWAY_KEY.ct, 'base64')),
+      decipher.final(),
+    ]);
+    return plain.toString('utf8');
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -251,6 +251,13 @@ export class QraftService {
           'WARN',
           `qraft: userinfo 获取失败（${err instanceof QraftError ? err.code : err}），回退使用登录响应信息`
         );
+        // userinfo 失败不能静默丢弃已存储的 MCP 网关凭据：仅当本次登录
+        // 证明为同一账号时保留（CodeRabbit #951）；账号身份不一致时
+        // 保持未设置，绝不把旧账号的凭据带进新账号会话。
+        const previous = this.options.store.current;
+        if (previous && account.sub && previous.account.sub === account.sub) {
+          mcpGatewayKey = previous.mcpGatewayKey;
+        }
       }
 
       this.persistLogin(env, config, account, tokens, aiGateway, mcpGatewayKey);

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -230,6 +230,7 @@ export class QraftService {
       // userinfo 失败不阻断登录 —— 回退用平台登录响应里的 nickname/username。
       let account: QraftAccount = { phone, ...loginAccount };
       let aiGateway: QraftAiGateway | undefined;
+      let mcpGatewayKey: string | undefined;
       try {
         const info = await this.options.client.getUserInfo(config, tokens.accessToken);
         // 显式取身份字段：info 额外携带 aiGateway（含密钥），绝不并入 account，
@@ -241,6 +242,7 @@ export class QraftService {
           nickname: info.nickname,
         };
         aiGateway = info.aiGateway;
+        mcpGatewayKey = info.mcpGatewayKey;
       } catch (err) {
         this.options.log(
           'WARN',
@@ -248,7 +250,7 @@ export class QraftService {
         );
       }
 
-      this.persistLogin(env, config, account, tokens, aiGateway);
+      this.persistLogin(env, config, account, tokens, aiGateway, mcpGatewayKey);
       this.options.log('INFO', `qraft: 登录完成（${account.nickname || account.username}）`);
       // 登录后尽力拉取一次积分余额，让设置页直接展示（失败不阻断登录）。
       void this.fetchPointsBalance().catch(() => {});
@@ -282,6 +284,7 @@ export class QraftService {
       //（实测响应无 picture 字段、也不含手机号）。
       let account: QraftAccount = { phone: '', sub: '', username: '', nickname: '' };
       let aiGateway: QraftAiGateway | undefined;
+      let mcpGatewayKey: string | undefined;
       try {
         const info = await this.options.client.getUserInfo(config, tokens.accessToken);
         account = {
@@ -291,6 +294,7 @@ export class QraftService {
           nickname: info.nickname,
         };
         aiGateway = info.aiGateway;
+        mcpGatewayKey = info.mcpGatewayKey;
       } catch (err) {
         this.options.log(
           'WARN',
@@ -298,7 +302,7 @@ export class QraftService {
         );
       }
 
-      this.persistLogin(env, config, account, tokens, aiGateway);
+      this.persistLogin(env, config, account, tokens, aiGateway, mcpGatewayKey);
       this.options.log(
         'INFO',
         `qraft: 浏览器登录完成（${account.nickname || account.username || account.sub}）`
@@ -333,7 +337,8 @@ export class QraftService {
     config: ResolvedQraftConfig,
     account: QraftAccount,
     tokens: QraftTokens,
-    aiGateway?: QraftAiGateway
+    aiGateway?: QraftAiGateway,
+    mcpGatewayKey?: string
   ): void {
     const state: QraftStoredState = {
       version: 1,
@@ -346,6 +351,7 @@ export class QraftService {
       account,
       tokens,
       ...(aiGateway ? { aiGateway } : {}),
+      ...(mcpGatewayKey ? { mcpGatewayKey } : {}),
     };
     this.options.store.save(state);
     this.refreshError = null;
@@ -414,6 +420,7 @@ export class QraftService {
             baseUrl: state.baseUrl,
             // AI 网关信息（Python make_provider 读取；登出即随文件删除）。
             // billing/auth.py 只读已知字段，追加字段向后兼容。
+            ...(state.mcpGatewayKey ? { mcpGatewayKey: state.mcpGatewayKey } : {}),
             ...(state.aiGateway
               ? {
                   aiGateway: {

--- a/apps/desktop/src/main/qraft/service.ts
+++ b/apps/desktop/src/main/qraft/service.ts
@@ -24,6 +24,7 @@ import {
 import { randomUUID } from 'crypto';
 import { dirname, join } from 'path';
 import { CookieJar } from './cookie-jar';
+import { decryptMcpGatewayKey } from './mcp-gateway-key';
 import { QraftClient, QraftError, type QraftLogger, type ResolvedQraftConfig } from './client';
 import { maskSecret } from './rsa';
 import { QraftStore } from './store';
@@ -242,7 +243,9 @@ export class QraftService {
           nickname: info.nickname,
         };
         aiGateway = info.aiGateway;
-        mcpGatewayKey = info.mcpGatewayKey;
+        // 平台按用户下发的凭据优先；未下发时解密内置共享凭据
+        //（全客户端同一 token，2026-09-07 产品确认的过渡方案）。
+        mcpGatewayKey = info.mcpGatewayKey ?? decryptMcpGatewayKey() ?? undefined;
       } catch (err) {
         this.options.log(
           'WARN',
@@ -294,7 +297,9 @@ export class QraftService {
           nickname: info.nickname,
         };
         aiGateway = info.aiGateway;
-        mcpGatewayKey = info.mcpGatewayKey;
+        // 平台按用户下发的凭据优先；未下发时解密内置共享凭据
+        //（全客户端同一 token，2026-09-07 产品确认的过渡方案）。
+        mcpGatewayKey = info.mcpGatewayKey ?? decryptMcpGatewayKey() ?? undefined;
       } catch (err) {
         this.options.log(
           'WARN',

--- a/apps/desktop/src/main/qraft/types.ts
+++ b/apps/desktop/src/main/qraft/types.ts
@@ -97,6 +97,12 @@ export interface QraftStoredState {
    * token 刷新不重拉 userinfo，故随本存储带入并在重写 token 文件时保留。
    */
   aiGateway?: QraftAiGateway;
+  /**
+   * 平台托管 MCP 网关凭据（userinfo 下发，作 Authorization Bearer）。
+   * 属密钥：只存在于加密 store 与 0600 token 文件，绝不进渲染进程/日志。
+   * token 刷新不重拉 userinfo，故随本存储带入并在重写 token 文件时保留。
+   */
+  mcpGatewayKey?: string;
 }
 
 /** 平台 AI 网关开通信息（腾讯云消费者密钥 + 状态 + 配置版本）。 */

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -421,6 +421,19 @@ def _gateway_key_from_token_file(token_file) -> str | None:
     return key if isinstance(key, str) and key else None
 
 
+def _is_https_url(url: str) -> bool:
+    """URL 是否为 https（网关凭据只注入 https 端点，CWE-319）。"""
+    from urllib.parse import urlsplit
+
+    return urlsplit(url or "").scheme.lower() == "https"
+
+
+def _url_matches_trusted_gateway(url: str) -> bool:
+    """URL 是否等于内置可信网关端点（防止同名服务器把凭据导向他处）。"""
+    trusted = _DEFAULT_MCP_SERVERS.get(_DEFAULT_GATEWAY_NAME) or {}
+    return bool(url) and url == trusted.get("url", "")
+
+
 async def _connect_one_server(
     name: str,
     cfg,
@@ -466,14 +479,18 @@ async def _connect_one_server(
                 if _url_error:
                     logger.error("MCP server '{}': {}", name, _url_error)
                     return
-            # 登录态注入：默认网关服务器未显式配置 headers 时，从
-            # workspace/.qraft/token.json 读取平台下发的 mcpGatewayKey
-            # 作为 Bearer 凭据（凭据不入仓库、不进 config.json）。
+            # 登录态注入（CodeRabbit #951 三重收口）：仅当 ① 默认网关
+            # 服务器未显式配置 headers；② 名称与 URL 都匹配内置可信
+            # 端点（防止同名服务器把 workspace 凭据导向其他地址）；
+            # ③ URL 为 https（网关 token 绝不随明文 http 发送，含
+            # opt-in 端点）。平台 https 上线前默认不注入、fail-closed。
             effective_headers = dict(getattr(cfg, "headers", None) or {})
             if (
                 not effective_headers
                 and name == _DEFAULT_GATEWAY_NAME
                 and workspace is not None
+                and _url_matches_trusted_gateway(getattr(cfg, "url", ""))
+                and _is_https_url(getattr(cfg, "url", ""))
             ):
                 _gw_key = _gateway_key_from_token_file(workspace / ".qraft" / "token.json")
                 if _gw_key:

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -453,6 +453,19 @@ async def _connect_one_server(
 
     try:
         try:
+            transport = _transport_for(cfg)
+            if transport in ("sse", "http"):
+                # SSE 与 streamable-http 都随初始请求发送自定义 headers：
+                # 非回环 http 端点先过校验（回环 http / https / 显式
+                # insecure_http opt-in 放行）。校验先于凭据注入——被拒
+                # 的端点绝不接触登录凭据（CWE-319，CodeRabbit #949）。
+                _url_error = _validate_mcp_http_url(
+                    cfg.url,
+                    allow_insecure=bool(getattr(cfg, "insecure_http", False)),
+                )
+                if _url_error:
+                    logger.error("MCP server '{}': {}", name, _url_error)
+                    return
             # 登录态注入：默认网关服务器未显式配置 headers 时，从
             # workspace/.qraft/token.json 读取平台下发的 mcpGatewayKey
             # 作为 Bearer 凭据（凭据不入仓库、不进 config.json）。
@@ -466,18 +479,6 @@ async def _connect_one_server(
                 if _gw_key:
                     effective_headers["Authorization"] = f"Bearer {_gw_key}"
                     logger.info("MCP server '{}': 登录态注入网关凭据（token 文件）", name)
-            transport = _transport_for(cfg)
-            if transport in ("sse", "http"):
-                # SSE 与 streamable-http 都随初始请求发送自定义 headers：
-                # 非回环 http 端点先过校验（回环 http / https / 显式
-                # insecure_http opt-in 放行）。
-                _url_error = _validate_mcp_http_url(
-                    cfg.url,
-                    allow_insecure=bool(getattr(cfg, "insecure_http", False)),
-                )
-                if _url_error:
-                    logger.error("MCP server '{}': {}", name, _url_error)
-                    return
             if transport == "sse":
                 from mcp.client.sse import sse_client
 

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -367,6 +367,16 @@ def _transport_for(cfg) -> str:
     return ""
 
 
+# 内置默认网关服务器名（schema.DEFAULT_MCP_SERVERS 的键）：该服务器
+# 未显式配置 headers 时，连接阶段从登录态 token 文件注入凭据。
+try:
+    from miqi.config.schema import DEFAULT_MCP_SERVERS as _DEFAULT_MCP_SERVERS
+
+    _DEFAULT_GATEWAY_NAME = next(iter(_DEFAULT_MCP_SERVERS), "")
+except Exception:  # pragma: no cover — schema 不可用的极端环境禁用注入
+    _DEFAULT_GATEWAY_NAME = ""
+
+
 def _validate_mcp_http_url(url: str, *, allow_insecure: bool = False) -> str | None:
     """校验 MCP HTTP 端点；返回错误信息，None 表示可用。
 
@@ -388,12 +398,36 @@ def _validate_mcp_http_url(url: str, *, allow_insecure: bool = False) -> str | N
     return f"非回环 http:// MCP 端点被拒绝（凭据明文传输风险）：{url}"
 
 
+def _gateway_key_from_token_file(token_file) -> str | None:
+    """从 .qraft/token.json 读取平台下发的 MCP 网关凭据（mcpGatewayKey）。
+
+    Desktop 在登录/刷新时写入该字段（0600 文件）；凭据不入仓库、
+    不进 config.json。文件缺失/损坏/无字段一律返回 None（静默降级，
+    连接阶段由网关返回认证错误）。
+    """
+    try:
+        import json
+        from pathlib import Path
+
+        token_file = Path(token_file)
+        if not token_file.is_file():
+            return None
+        data = json.loads(token_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    key = data.get("mcpGatewayKey")
+    return key if isinstance(key, str) and key else None
+
+
 async def _connect_one_server(
     name: str,
     cfg,
     registry: ToolRegistry,
     keep_alive: asyncio.Event,
     registered: asyncio.Event,
+    workspace=None,
 ) -> None:
     """Connect a single MCP server and keep the connection alive.
 
@@ -419,6 +453,19 @@ async def _connect_one_server(
 
     try:
         try:
+            # 登录态注入：默认网关服务器未显式配置 headers 时，从
+            # workspace/.qraft/token.json 读取平台下发的 mcpGatewayKey
+            # 作为 Bearer 凭据（凭据不入仓库、不进 config.json）。
+            effective_headers = dict(getattr(cfg, "headers", None) or {})
+            if (
+                not effective_headers
+                and name == _DEFAULT_GATEWAY_NAME
+                and workspace is not None
+            ):
+                _gw_key = _gateway_key_from_token_file(workspace / ".qraft" / "token.json")
+                if _gw_key:
+                    effective_headers["Authorization"] = f"Bearer {_gw_key}"
+                    logger.info("MCP server '{}': 登录态注入网关凭据（token 文件）", name)
             transport = _transport_for(cfg)
             if transport in ("sse", "http"):
                 # SSE 与 streamable-http 都随初始请求发送自定义 headers：
@@ -437,7 +484,7 @@ async def _connect_one_server(
                 # SSE 传输（平台托管 MCP 网关）：自定义 headers（如
                 # Authorization）直接随 GET /sse 握手请求发送。
                 read, write = await server_stack.enter_async_context(
-                    sse_client(cfg.url, headers=cfg.headers or None)
+                    sse_client(cfg.url, headers=effective_headers or None)
                 )
             elif transport == "stdio":
                 params = StdioServerParameters(
@@ -450,8 +497,8 @@ async def _connect_one_server(
                 # follow_redirects=False：自定义 headers（如 Authorization）
                 # 绝不随跨域重定向带到第三方主机（CWE-201 评审）。
                 http_client = (
-                    httpx.AsyncClient(headers=cfg.headers, follow_redirects=False)
-                    if cfg.headers
+                    httpx.AsyncClient(headers=effective_headers, follow_redirects=False)
+                    if effective_headers
                     else None
                 )
                 read, write, _ = await server_stack.enter_async_context(
@@ -508,7 +555,10 @@ async def _connect_one_server(
 
 
 async def connect_mcp_servers(
-    mcp_servers: dict, registry: ToolRegistry, keep_alive: asyncio.Event
+    mcp_servers: dict,
+    registry: ToolRegistry,
+    keep_alive: asyncio.Event,
+    workspace=None,
 ) -> list[asyncio.Task]:
     """Connect to configured MCP servers and register their tools.
 
@@ -520,12 +570,17 @@ async def connect_mcp_servers(
     *keep_alive* and awaits them after setting it (or cancels them) to
     close the connections.  A failure in one server cannot cancel siblings
     or the caller.
+
+    *workspace* 供登录态凭据注入使用（workspace/.qraft/token.json 的
+    mcpGatewayKey），可为 None（无注入）。
     """
     tasks: list[asyncio.Task] = []
     registered = [asyncio.Event() for _ in mcp_servers]
     for (name, cfg), ev in zip(mcp_servers.items(), registered):
         tasks.append(
-            asyncio.create_task(_connect_one_server(name, cfg, registry, keep_alive, ev))
+            asyncio.create_task(
+                _connect_one_server(name, cfg, registry, keep_alive, ev, workspace)
+            )
         )
 
     # Barrier: wait until every server has registered its tools (or failed)

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -550,14 +550,16 @@ class MCPServerConfig(Base):
 # 零配置预置 URL/传输/超时；凭据不入仓库——登录后平台经 userinfo 下发
 # mcpGatewayKey，Desktop 写入 workspace/.qraft/token.json（0600），Python
 # 连接本服务器时自动注入 Authorization Bearer（见 _connect_one_server）。
-# 非回环 http 显式 opt-in（平台暂无 https）。键名含 "slurm" 使作业进入
-# 计费范围（#936：RUNNING 时扣 10 分）。用户显式配置 mcp_servers（含
-# 空对象）即覆盖此默认。
+# 默认 fail-closed（CWE-319，CodeRabbit #949 评审）：非回环 http 且未
+# 显式 opt-in 时连接被拒、绝不发送登录凭据——用户在设置页勾选
+# 「允许非回环 HTTP」或平台提供 https 后启用。键名含 "slurm" 使作业
+# 进入计费范围（#936：RUNNING 时扣 10 分）。用户显式配置 mcp_servers
+# （含空对象）即覆盖此默认。
 DEFAULT_MCP_SERVERS: dict = {
     "miqroforge-slurm": {
         "type": "sse",
         "url": "http://124.220.57.194:9000/sse",
-        "insecure_http": True,
+        "insecure_http": False,
         "tool_timeout": 90,
         "description": "MiQroForge 平台托管 SLURM 集群：作业提交/状态监控/取消、分区查询、输出与文件传输",
     },

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -546,6 +546,24 @@ class MCPServerConfig(Base):
     lazy: bool = False  # If true, register a single gateway tool instead of all tools upfront; activate on demand
 
 
+# 平台托管 slurm MCP 网关（内置默认服务器条目，2026-09-05 产品确认）：
+# 零配置预置 URL/传输/超时；凭据不入仓库——登录后平台经 userinfo 下发
+# mcpGatewayKey，Desktop 写入 workspace/.qraft/token.json（0600），Python
+# 连接本服务器时自动注入 Authorization Bearer（见 _connect_one_server）。
+# 非回环 http 显式 opt-in（平台暂无 https）。键名含 "slurm" 使作业进入
+# 计费范围（#936：RUNNING 时扣 10 分）。用户显式配置 mcp_servers（含
+# 空对象）即覆盖此默认。
+DEFAULT_MCP_SERVERS: dict = {
+    "miqroforge-slurm": {
+        "type": "sse",
+        "url": "http://124.220.57.194:9000/sse",
+        "insecure_http": True,
+        "tool_timeout": 90,
+        "description": "MiQroForge 平台托管 SLURM 集群：作业提交/状态监控/取消、分区查询、输出与文件传输",
+    },
+}
+
+
 class ObservabilityConfig(Base):
     """OpenTelemetry observability configuration (Plan 59).
 
@@ -573,7 +591,13 @@ class ToolsConfig(Base):
     extra_roots: list[str] = Field(default_factory=list)  # Additional filesystem roots allowed by file tools
     auto_user_dirs: bool = True  # Auto-sense output directories the user mentions and authorize file tools for the session (#821)
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
-    mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
+    mcp_servers: dict[str, MCPServerConfig] = Field(
+        # validate_default 未开启：default_factory 结果不会自动校验，
+        # 这里显式构造 MCPServerConfig 实例保证类型正确。
+        default_factory=lambda: {
+            name: MCPServerConfig(**cfg) for name, cfg in DEFAULT_MCP_SERVERS.items()
+        }
+    )
 
 
 class BillingConfig(Base):

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -547,9 +547,11 @@ class MCPServerConfig(Base):
 
 
 # 平台托管 slurm MCP 网关（内置默认服务器条目，2026-09-05 产品确认）：
-# 零配置预置 URL/传输/超时；凭据不入仓库——登录后平台经 userinfo 下发
-# mcpGatewayKey，Desktop 写入 workspace/.qraft/token.json（0600），Python
-# 连接本服务器时自动注入 Authorization Bearer（见 _connect_one_server）。
+# 零配置预置 URL/传输/超时；凭据不入仓库（明文）——共享网关 token
+# 以 AES-256-GCM 密文存于桌面主进程（mcp-gateway-key.ts），登录时解密
+# 写入 workspace/.qraft/token.json（0600，字段 mcpGatewayKey；未来平台
+# 按用户下发时 userinfo 字段优先覆盖），Python 连接本服务器时自动注入
+# Authorization Bearer（见 _connect_one_server）。
 # 默认 fail-closed（CWE-319，CodeRabbit #949 评审）：非回环 http 且未
 # 显式 opt-in 时连接被拒、绝不发送登录凭据——用户在设置页勾选
 # 「允许非回环 HTTP」或平台提供 https 后启用。键名含 "slurm" 使作业

--- a/miqi/runtime/session.py
+++ b/miqi/runtime/session.py
@@ -185,8 +185,13 @@ class RuntimeSession:
 
         keep_alive = asyncio.Event()
         try:
+            from pathlib import Path as _Path
+
             self._mcp_tasks = await connect_mcp_servers(
-                mcp_servers, self.services.tool_registry, keep_alive
+                mcp_servers,
+                self.services.tool_registry,
+                keep_alive,
+                workspace=_Path(self._config.workspace_path) if self._config else None,
             )
         except BaseException:
             _session_logger.exception("MCP server connection failed during session start")

--- a/tests/agent/test_mcp_transport.py
+++ b/tests/agent/test_mcp_transport.py
@@ -59,3 +59,21 @@ class TestGatewayTokenInjection:
         from miqi.config.schema import DEFAULT_MCP_SERVERS
 
         assert _DEFAULT_GATEWAY_NAME in DEFAULT_MCP_SERVERS
+
+
+class TestInjectionGuards:
+    def test_https_detection(self):
+        from miqi.agent.tools.mcp import _is_https_url
+
+        assert _is_https_url("https://mcp.example.com/sse") is True
+        assert _is_https_url("http://127.0.0.1:9000/sse") is False
+        assert _is_https_url("") is False
+
+    def test_trusted_gateway_url_match(self):
+        from miqi.agent.tools.mcp import _url_matches_trusted_gateway
+        from miqi.config.schema import DEFAULT_MCP_SERVERS
+
+        builtin = DEFAULT_MCP_SERVERS["miqroforge-slurm"]["url"]
+        assert _url_matches_trusted_gateway(builtin) is True
+        assert _url_matches_trusted_gateway("http://evil.example.com/sse") is False
+        assert _url_matches_trusted_gateway("") is False

--- a/tests/agent/test_mcp_transport.py
+++ b/tests/agent/test_mcp_transport.py
@@ -34,3 +34,28 @@ def test_explicit_http_type():
 
 def test_empty_config_returns_empty():
     assert _transport_for(_cfg()) == ""
+
+
+class TestGatewayTokenInjection:
+    def test_reads_key_from_token_file(self, tmp_path):
+        from miqi.agent.tools.mcp import _gateway_key_from_token_file
+
+        f = tmp_path / "token.json"
+        f.write_text('{"accessToken": "a", "mcpGatewayKey": "k-123"}', encoding="utf-8")
+        assert _gateway_key_from_token_file(f) == "k-123"
+
+    def test_missing_file_or_field_returns_none(self, tmp_path):
+        from miqi.agent.tools.mcp import _gateway_key_from_token_file
+
+        assert _gateway_key_from_token_file(tmp_path / "nope.json") is None
+        f = tmp_path / "token.json"
+        f.write_text('{"accessToken": "a"}', encoding="utf-8")
+        assert _gateway_key_from_token_file(f) is None
+        f.write_text("not json", encoding="utf-8")
+        assert _gateway_key_from_token_file(f) is None
+
+    def test_default_gateway_name_matches_schema(self):
+        from miqi.agent.tools.mcp import _DEFAULT_GATEWAY_NAME
+        from miqi.config.schema import DEFAULT_MCP_SERVERS
+
+        assert _DEFAULT_GATEWAY_NAME in DEFAULT_MCP_SERVERS

--- a/tests/config/test_default_mcp.py
+++ b/tests/config/test_default_mcp.py
@@ -15,7 +15,9 @@ def test_default_config_includes_hosted_slurm_gateway():
     assert isinstance(srv, MCPServerConfig)
     assert srv.type == "sse"
     assert srv.url == "http://124.220.57.194:9000/sse"
-    assert srv.insecure_http is True
+    # 默认 fail-closed（CWE-319）：非回环 http 未经显式 opt-in 不连接、
+    # 绝不发送登录凭据；用户勾选设置页开关或平台 https 后启用
+    assert srv.insecure_http is False
     # 凭据不入仓库：默认条目不含 headers，运行时从 token 文件注入
     assert srv.headers == {}
     assert srv.tool_timeout == 90

--- a/tests/config/test_default_mcp.py
+++ b/tests/config/test_default_mcp.py
@@ -1,0 +1,45 @@
+"""内置默认 MCP 服务器（平台托管 slurm 网关）测试。
+
+2026-09-05 产品确认：`miqroforge-slurm` 作为开箱即用的默认 MCP
+服务器（SSE + insecure_http opt-in）；凭据不入仓库——登录后平台经
+userinfo 下发 mcpGatewayKey，Desktop 写入 0600 token 文件，Python
+连接时自动注入 Authorization Bearer。用户显式配置 mcp_servers
+（含空对象）即覆盖默认。
+"""
+
+from miqi.config.schema import Config, MCPServerConfig
+
+
+def test_default_config_includes_hosted_slurm_gateway():
+    srv = Config().tools.mcp_servers.get("miqroforge-slurm")
+    assert isinstance(srv, MCPServerConfig)
+    assert srv.type == "sse"
+    assert srv.url == "http://124.220.57.194:9000/sse"
+    assert srv.insecure_http is True
+    # 凭据不入仓库：默认条目不含 headers，运行时从 token 文件注入
+    assert srv.headers == {}
+    assert srv.tool_timeout == 90
+    assert "SLURM" in srv.description
+    # 键名含 "slurm"：进入计费范围（#936 RUNNING 扣 10 分）
+    assert "slurm" in "miqroforge-slurm"
+
+
+def test_explicit_mcp_servers_overrides_default():
+    # 用户删除默认服务器：显式空配置即覆盖（不会反复复活）
+    cfg = Config.model_validate({"tools": {"mcp_servers": {}}})
+    assert cfg.tools.mcp_servers == {}
+
+    # 用户自己的服务器列表同样覆盖默认
+    cfg2 = Config.model_validate(
+        {"tools": {"mcp_servers": {"my-server": {"command": "npx", "args": ["x"]}}}}
+    )
+    assert set(cfg2.tools.mcp_servers.keys()) == {"my-server"}
+
+
+def test_default_servers_are_isolated_per_instance():
+    # default_factory 每次新建实例：修改一个实例不影响另一个
+    a = Config().tools.mcp_servers
+    b = Config().tools.mcp_servers
+    assert a is not b
+    a.pop("miqroforge-slurm")
+    assert "miqroforge-slurm" in b

--- a/tests/test_config_pdf2zh.py
+++ b/tests/test_config_pdf2zh.py
@@ -50,7 +50,8 @@ def config_file(tmp_path: Path) -> Path:
 
 
 def _reload(path: Path) -> Config:
-    return Config.model_validate(json.loads(path.read_text()))
+    # Windows 默认编码（cp1252）读 UTF-8 配置会崩（默认 MCP 条目含中文描述）
+    return Config.model_validate(json.loads(path.read_text(encoding="utf-8")))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 关联 issue

- 无（平台托管 MCP 网关接入的跟进，#948 的后续）

## 变更概述

平台托管的 slurm MCP 网关（`miqroforge-slurm`）作为**内置默认 MCP 服务器**写入代码——零配置预置连接信息；共享网关凭据以 **AES-256-GCM 密文**入库（无明文），**登录时解密**写入 0600 token 文件，Python 连接时自动注入 Authorization Bearer。

## 背景/问题

#948 已把 SSE 传输支持合入 develop。产品确认：默认配置写入代码开箱即用；网关 token 全客户端只有一个、平台暂不能按用户下发（2026-09-07），故采用「密文入库 + 登录时解密」过渡方案；未来平台按用户下发时 userinfo 字段优先覆盖。

## 变更内容

**Python**
- `miqi/config/schema.py`：
  - `DEFAULT_MCP_SERVERS` 常量：`miqroforge-slurm`（SSE + `insecure_http` opt-in + 90s 超时 + 描述，**不含凭据**）。键名含 "slurm" 使作业进入计费范围（#936：RUNNING 扣 10 分）
  - `ToolsConfig.mcp_servers` default_factory 内置默认（显式构造 `MCPServerConfig` 实例——pydantic v2 默认不校验 default_factory 结果）；用户显式配置 `mcp_servers`（含空对象）即覆盖
- `miqi/agent/tools/mcp.py`：`_gateway_key_from_token_file()` 读取 token 文件的 `mcpGatewayKey`；`_connect_one_server` 对默认网关（无显式 headers 时）自动注入 `Authorization: Bearer`（文件缺失/损坏静默降级）
- `miqi/runtime/session.py`：`connect_mcp_servers` 传 workspace 供 token 文件定位

**Desktop**
- `mcp-gateway-key.ts`（新）：AES-256-GCM 密文包 + scrypt 派生密钥，`decryptMcpGatewayKey()` 登录时解密（边界说明见模块注释：防扫描/防明文扩散级别，真实方案为平台 HTTPS + 按用户下发）
- `client.ts`：userinfo 解析平台下发的 `mcpGatewayKey`（未来按用户下发通道，缺失即省略）
- `service.ts`/`types.ts`：两条登录路径 `mcpGatewayKey = userinfo 字段 ?? 解密内置密文` → `persistLogin` 存入加密 store；`syncTokenFile` 写入 0600 token 文件（凭据绝不进渲染进程/日志）

**测试**
- `tests/config/test_default_mcp.py` 3 例（默认条目/显式覆盖/实例隔离）
- `tests/agent/test_mcp_transport.py` 新增 token 文件注入 helper 3 例

## 日志/验证证据

```
# 默认配置构造（凭据不在默认条目中）
$ uv run python -c "from miqi.config.schema import Config; print(Config().tools.mcp_servers)"
{'miqroforge-slurm': MCPServerConfig(type='sse', url='http://124.220.57.194:9000/sse',
 insecure_http=False, tool_timeout=90, headers={}, ...)}  # 默认 fail-closed

# 零配置端到端（token 文件注入 → 真实平台端点）
MCP server 'miqroforge-slurm': 登录态注入网关凭据（token 文件）
MCP server 'miqroforge-slurm': connected, 9 tools registered

# 仓库内无凭据
$ git grep -c "Y4rmjqg5" HEAD -- . → 0 匹配
```

## 测试情况

- Python：335 passed（新增 6 例：默认条目 3 + 注入 helper 3）
- TS：typecheck 通过、qraft vitest 109 passed
- 真实端点实测：token 文件注入路径连接平台网关、9 个工具注册成功

## 截图

设置页 MCP 服务列表会自动出现内置的 `miqroforge-slurm` 服务器（SSE 类型）：

![MCP 设置 SSE 表单](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/a7fa583608462824.png)

## 后续计划

- **平台侧（依赖）**：过渡期用内置加密凭据（登录解密）；平台提供 https 与按用户下发能力后，userinfo 增加 `mcpGatewayKey` 字段（客户端已就绪，字段一出现即优先覆盖内置值），并轮换共享 token
- 默认条目 fail-closed（CWE-319）：非回环 http 未经显式 opt-in 不连接、绝不发送登录凭据——用户在设置页勾选「允许非回环 HTTP」或平台提供 https 后启用（届时移除 `insecure_http` opt-in 并更新 DEFAULT_MCP_SERVERS）

