### PR TITLE
fix(mcp): 编辑弹窗不回显已保存配置 + upsert schema 补 type/insecure_http (#950)

### DIFF
--- a/apps/desktop/src/renderer/features/mcps/MCPsPage.tsx
+++ b/apps/desktop/src/renderer/features/mcps/MCPsPage.tsx
@@ -5,12 +5,10 @@ import type { McpServerInfo, McpServerConfig } from '../../../shared/ipc';
 import { Modal } from '../../components/shared';
 
 function MCPServerModal({
-  open,
   onClose,
   onSave,
   initial,
 }: {
-  open: boolean;
   onClose: () => void;
   onSave: (name: string, config: McpServerConfig) => Promise<void>;
   initial?: McpServerInfo | null;
@@ -43,8 +41,6 @@ function MCPServerModal({
   const [lazy, setLazy] = useState(initial?.lazy ?? false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-
-  if (!open) return null;
 
   const handleSave = async () => {
     setError('');
@@ -90,13 +86,7 @@ function MCPServerModal({
   };
 
   return (
-    <Modal
-      open={open}
-      onOpenChange={(o) => {
-        if (!o) onClose();
-      }}
-      hideClose
-    >
+    <Modal open onOpenChange={onClose} hideClose>
       <div className="rounded-xl shadow-2xl w-full max-w-lg mx-4 bg-surface">
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 className="text-base font-semibold text-text">
@@ -395,65 +385,73 @@ export function MCPsPage() {
           </div>
         ) : (
           <div className="grid gap-3">
-            {servers.map((srv) => (
-              <div
-                key={srv.name}
-                className="settings-hover-card rounded-xl border p-4 transition-colors"
-                style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-mono text-sm font-semibold text-text">{srv.name}</span>
-                      <span
-                        className="px-1.5 py-0.5 rounded text-size-2xs font-medium uppercase"
-                        style={{
-                          background: srv.command ? 'var(--accent-bg)' : 'var(--info-bg)',
-                          color: srv.command ? 'var(--accent)' : 'var(--info)',
-                        }}
-                      >
-                        {srv.command ? 'stdio' : 'http'}
-                      </span>
+            {servers.map((srv) => {
+              const connType: 'stdio' | 'http' | 'sse' =
+                srv.type === 'sse' ? 'sse' : srv.command ? 'stdio' : 'http';
+              return (
+                <div
+                  key={srv.name}
+                  className="settings-hover-card rounded-xl border p-4 transition-colors"
+                  style={{ background: 'var(--surface)', borderColor: 'var(--border)' }}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="font-mono text-sm font-semibold text-text">
+                          {srv.name}
+                        </span>
+                        <span
+                          className="px-1.5 py-0.5 rounded text-size-2xs font-medium uppercase"
+                          style={{
+                            background:
+                              connType === 'stdio' ? 'var(--accent-bg)' : 'var(--info-bg)',
+                            color: connType === 'stdio' ? 'var(--accent)' : 'var(--info)',
+                          }}
+                        >
+                          {connType}
+                        </span>
+                      </div>
+                      {srv.description && (
+                        <p className="text-xs mb-2 text-text-muted">{srv.description}</p>
+                      )}
+                      <p className="text-xs font-mono truncate text-text-faint">
+                        {srv.command
+                          ? `${srv.command} ${(srv.args ?? []).join(' ')}`
+                          : (srv.url ?? '')}
+                      </p>
                     </div>
-                    {srv.description && (
-                      <p className="text-xs mb-2 text-text-muted">{srv.description}</p>
-                    )}
-                    <p className="text-xs font-mono truncate text-text-faint">
-                      {srv.command
-                        ? `${srv.command} ${(srv.args ?? []).join(' ')}`
-                        : (srv.url ?? '')}
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    <button
-                      onClick={() => handleEdit(srv)}
-                      className="p-1.5 rounded-lg transition-colors hover:bg-[var(--surface-muted)] text-text-muted"
-                      title="编辑"
-                    >
-                      <Pencil size={14} />
-                    </button>
-                    <button
-                      onClick={() => handleDelete(srv.name)}
-                      className="p-1.5 rounded-lg transition-colors hover:bg-[var(--danger-bg)]"
-                      style={{ color: 'var(--danger)' }}
-                      title="删除"
-                    >
-                      <Trash2 size={14} />
-                    </button>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => handleEdit(srv)}
+                        className="p-1.5 rounded-lg transition-colors hover:bg-[var(--surface-muted)] text-text-muted"
+                        title="编辑"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(srv.name)}
+                        className="p-1.5 rounded-lg transition-colors hover:bg-[var(--danger-bg)]"
+                        style={{ color: 'var(--danger)' }}
+                        title="删除"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
 
-      <MCPServerModal
-        open={modalOpen}
-        onClose={() => setModalOpen(false)}
-        onSave={handleSave}
-        initial={editingServer}
-      />
+      {modalOpen && (
+        <MCPServerModal
+          onClose={() => setModalOpen(false)}
+          onSave={handleSave}
+          initial={editingServer}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -798,11 +798,13 @@ export interface McpServerInfo extends McpServerConfig {
 
 export const McpUpsertInput = z.object({
   name: z.string().min(1),
+  type: z.string().optional(),
   command: z.string().optional(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string()).optional(),
   url: z.string().optional(),
   headers: z.record(z.string()).optional(),
+  insecure_http: z.boolean().optional(),
   tool_timeout: z.number().optional(),
   progress_interval_seconds: z.number().optional(),
   description: z.string().optional(),

--- a/apps/desktop/tests/e2e/mcp.spec.ts
+++ b/apps/desktop/tests/e2e/mcp.spec.ts
@@ -233,6 +233,38 @@ test.describe('MCP 服务器集成', () => {
       expect(entry.command).toBe(mcpCommand.command);
       const savedArgs = entry.args ?? [];
       expect(savedArgs).toContain(SERVER_SCRIPT);
+
+      // ── #950 回归：重新打开「编辑」弹窗应回显已保存配置 ──
+      const uimcpCard = page.locator('.settings-hover-card').filter({ hasText: uiName });
+      await uimcpCard.getByTitle('编辑').click();
+      await expect(page.getByRole('heading', { name: '编辑 MCP 服务器' })).toBeVisible();
+      await expect(page.getByPlaceholder('my-mcp-server')).toHaveValue(uiName);
+      await expect(page.getByPlaceholder('npx')).toHaveValue(mcpCommand.command);
+      await expect(
+        page.getByPlaceholder('-y, @modelcontextprotocol/server-filesystem')
+      ).toHaveValue(argsStr);
+      await page.getByRole('button', { name: '取消' }).click();
+
+      // ── #950 报告场景：添加 SSE 服务器 → 徽标显示 sse → 编辑回显 URL/Headers ──
+      await page.getByRole('button', { name: '添加服务器' }).click();
+      const sseName = 'uisse';
+      const sseUrl = 'http://127.0.0.1:9/mcp'; // 丢弃端口：连接快速失败，不影响会话启动
+      const sseHeaders = 'X-Api-Key: mock-key';
+      await page.getByPlaceholder('my-mcp-server').fill(sseName);
+      await page.getByRole('button', { name: 'SSE' }).click();
+      await page.getByPlaceholder('http://localhost:8080/mcp').fill(sseUrl);
+      await page.getByPlaceholder('Authorization: Bearer token').fill(sseHeaders);
+      await page.getByRole('button', { name: '保存', exact: true }).click();
+      await expect(page.getByText(sseName, { exact: true })).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByText('sse', { exact: true })).toBeVisible();
+
+      const sseCard = page.locator('.settings-hover-card').filter({ hasText: sseName });
+      await sseCard.getByTitle('编辑').click();
+      await expect(page.getByRole('heading', { name: '编辑 MCP 服务器' })).toBeVisible();
+      await expect(page.getByPlaceholder('my-mcp-server')).toHaveValue(sseName);
+      await expect(page.getByPlaceholder('http://localhost:8080/mcp')).toHaveValue(sseUrl);
+      await expect(page.getByPlaceholder('Authorization: Bearer token')).toHaveValue(sseHeaders);
+      await page.getByRole('button', { name: '取消' }).click();
     }
   );
 


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复

## 变更概述

<!-- 必填，一句话 -->

MCP 服务器「编辑」弹窗不回显已保存配置——弹窗改为按打开状态条件挂载、表单每次全新初始化；同时补齐 upsert schema 的 type/insecure_http、修正 SSE 连接类型徽标。

## 背景/问题

<!-- 必填。Bug：现象、根因、影响。Feature：需求背景、痛点 -->

- **现象（#950）**：添加/编辑 MCP 服务器并保存后，重新打开「编辑」弹窗，所有表单字段（含 URL、Headers）均为空白默认值。
- **根因**：`MCPServerModal` 在 `MCPsPage` 中无条件渲染（`open=false` 时仅提前 `return null`，组件从未卸载），`useState(initial?.xxx)` 初始化器只在首次挂载执行——「编辑」时传入的已保存数据从不生效。
- **同链路另两个问题**：① `McpUpsertInput` 缺 `type`/`insecure_http`，zod 默认剥离未知键——设置页保存的 SSE 服务器 `type: 'sse'` 从未落盘（#948 只给 TS interface 加了字段，未加 zod schema），重开后连接类型回退为 http；② 列表连接类型徽标 `srv.command ? 'stdio' : 'http'` 对 SSE 服务器误显示 `http`。

## 关联 issue

<!-- 可选。本 PR 解决的 issue。写 `Closes #xxx` / `Fixes #xxx` / `Resolves #xxx` 会在 PR 合入 develop 后自动关闭对应 issue；裸 `#xxx` 只生成链接、不会自动关闭。无关联 issue 可整节删除 -->
- Closes #950 MCP 服务器「编辑」弹窗不回显已保存配置

## 变更内容

<!-- 必填。列出关键改动文件和原因 -->

- `apps/desktop/src/renderer/features/mcps/MCPsPage.tsx`：`{modalOpen && <MCPServerModal … />}` 条件挂载（与 CronPage `CreateEditModal` 同约定），每次打开全新挂载、表单从 `initial` 正确初始化；移除 `open` prop 与 `if (!open) return null`。徽标按 `srv.type === 'sse' ? 'sse' : srv.command ? 'stdio' : 'http'` 推导。
- `apps/desktop/src/shared/ipc.ts`：`McpUpsertInput` 补 `type`/`insecure_http`，与 `McpServerConfig` 接口对齐，SSE 类型与明文 HTTP 开关可持久化。
- `apps/desktop/tests/e2e/mcp.spec.ts`：#950 回归断言——stdio 编辑回显（name/command/args）+ 报告场景（SSE 添加 → 徽标 `sse` → 编辑回显 URL/Headers）。

## 日志/验证证据

```
用真实配置副本（含 `miqroforge-slurm` SSE 服务器）驱动修复后构建实测：
[verify] headers on open: ""     ← 保存的数据本就为空（headers: {}），空白符合预期
[verify] headers echo OK         ← 填写 Headers 保存后重开编辑，完整回显
```

## 测试情况

<!-- 必填。跑过哪些测试？结果？ -->

- `npm run typecheck`（tsconfig.web / tsconfig.node）✓
- `prettier --check`（三个改动文件）✓
- `vitest run`：372 passed / 5 skipped ✓
- Playwright e2e（electron 项目）`mcp.spec.ts` 用例 1「设置页添加 stdio MCP 服务器 → 列表显示并持久化到 config.json」：通过（含全部新增回归断言）
- 说明：用例 2 在本机失败为已单独记录的环境问题（#952：已登录平台网关导致 mock LLM 未收到请求），baseline（未打补丁的 develop）同样失败，与本 PR 无关

## 截图
修改前
<img width="385" height="735" alt="image" src="https://github.com/user-attachments/assets/d53219ac-4d3e-4f0a-888b-668ddbf09333" />

修改后
<img width="396" height="716" alt="image" src="https://github.com/user-attachments/assets/cc88f9c9-29e3-4996-9cb3-47a53faa0e1e" />

## 后续计划

<!-- 可选。关联的后续 issue（一个功能一个 issue，一个 issue 一个 PR） -->
- #952 MCP e2e 用例 2 在已登录平台网关的机器上失败：mock LLM 收不到请求，调用走真实网关（fixture 未覆盖网关路由，另行修复）
