### PR TITLE
fix(e2e): 隔离 qraft 登录态——E2E 继承开发机真实平台凭据致模型调用走真实网关而非 mock (#952)

### DIFF
--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -501,6 +501,17 @@ export async function launchElectronApp(
   const env: Record<string, string | undefined> = { ...process.env };
   env.MIQI_HOME = miqiHome;
   delete env.ELECTRON_RUN_AS_NODE;
+  // Isolate the platform login store per run (#952): dev mode overrides
+  // app.getPath('userData') to a checkout-shared dir (index.ts ws-hash), so
+  // the developer machine's real qraft-auth.json leaks into every E2E app.
+  // A restored login re-syncs real gateway creds (encryptedApiKey) into the
+  // temp workspace's .qraft/token.json, which routes model calls to the real
+  // AI gateway — mock LLMs never receive a request.  Point MIQI_QRAFT_STORE
+  // at the temp home (the product already reads this env, see qraft/ipc.ts)
+  // unless a spec presets its own store (ai-gateway.spec.ts).
+  if (!env.MIQI_QRAFT_STORE) {
+    env.MIQI_QRAFT_STORE = join(miqiHome, 'qraft-auth.json');
+  }
   // E2E default: set MIQI_E2E so the main process skips the #837 privacy-consent
   // gate (fresh userData has no stored consent). The privacy-consent spec opts
   // out via noConsentBypass to exercise the gate itself.
@@ -644,6 +655,10 @@ export async function relaunchElectronApp(
   const env: Record<string, string | undefined> = { ...process.env };
   env.MIQI_HOME = miqiHome;
   delete env.ELECTRON_RUN_AS_NODE;
+  // Same #952 login-store isolation as launchElectronApp (see above).
+  if (!env.MIQI_QRAFT_STORE) {
+    env.MIQI_QRAFT_STORE = join(miqiHome, 'qraft-auth.json');
+  }
   // Same #837 consent-gate bypass logic as launchElectronApp (see above).
   if (opts?.noConsentBypass) {
     delete env.MIQI_E2E;

--- a/apps/desktop/tests/e2e/mcp.spec.ts
+++ b/apps/desktop/tests/e2e/mcp.spec.ts
@@ -244,6 +244,22 @@ test.describe('MCP 服务器集成', () => {
       await createNewConversation(page);
       await expect(page.locator('[data-testid="chat-input-container"]')).toBeVisible();
 
+      // #952 回归守卫：E2E 应用不得继承开发机的平台登录态。开发模式
+      // userData 按仓库隔离（index.ts），若 launchElectronApp 未隔离 qraft
+      // store，登录态会恢复 → 真实网关凭据同步进临时 workspace 的
+      // .qraft/token.json → 模型调用走真实网关、mock 收不到请求。
+      const qraftState = await page.evaluate(async () => {
+        try {
+          return await (window as any).miqi.qraft.status();
+        } catch {
+          return null;
+        }
+      });
+      expect(
+        qraftState?.loggedIn,
+        'E2E app must not inherit the developer machine platform login (see #952)'
+      ).toBeFalsy();
+
       // ── 发送任务 → mock 第一轮即调用 mcp_e2emcp_e2e_echo ──
       await sendMessage(page, 'MCP 测试：请调用 MCP 工具并返回结果');
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

隔离 E2E 应用的 qraft 登录态：`launchElectronApp`/`relaunchElectronApp` 通过产品预留的 `MIQI_QRAFT_STORE` 钩子把登录态 store 指向临时 MIQI_HOME，杜绝已登录开发机的真实平台凭据泄漏进测试环境、导致模型调用走真实 AI 网关而非 mock。

## 背景/问题

**现象**：`mcp.spec.ts` 用例「新建会话 → 模型调用 MCP 工具 → 最终回复含工具返回值标记」在已登录 MiqroForge 平台的机器上稳定失败——mock LLM 全程收不到请求，工具调用由真实模型发起，最终回复不含 mock 专属标记；CI（无登录）通过。

**根因**（实测定位，比 #952 技术分析更深一层，不是 patch 覆盖不到，而是登录态泄漏）：

1. 开发模式 `main/index.ts` 用 ws-hash 覆盖 `app.setPath('userData')` → Playwright 的 `--user-data-dir` 隔离对主进程文件失效，所有 E2E 实例共享 `%APPDATA%\miqi-desktop-dev\ws-<hash>\qraft-auth.json`
2. 实测：E2E 应用内 `qraft.status()` = `loggedIn: true, aiGateway: active`（开发机真实账号）
3. `QraftService` 启动恢复登录态 → `syncTokenFile` 把真实 encryptedApiKey 写进临时 MIQI_HOME 的 `workspace/.qraft/token.json`
4. 桥进程 `make_provider`（#922 网关路由）读到 active 凭据 + 默认模型 `deepseek-v4-flash`（GATEWAY_MODEL）→ 路由到真实 AI 网关
5. CI 无登录态 → 无 token 文件 → spec 的 apiBase patch 生效 → 用例通过

**影响**：本机跑 e2e 误报失败，且真实模型代答消耗平台配额；任何依赖 mock LLM 的用例在已登录机器上都有此隐患。

## 关联 issue

- Closes #952 MCP E2E 在已登录平台网关的机器上失败

## 变更内容

- `tests/e2e/helpers/electron-setup.ts`：`launchElectronApp` 与 `relaunchElectronApp` 设置 `MIQI_QRAFT_STORE=<miqiHome>/qraft-auth.json`——正是产品为 E2E 预留的钩子（`qraft/ipc.ts` 注释明确「E2E 通过 MIQI_QRAFT_STORE 环境变量指向临时目录，避免污染开发态并支持预置登录态」）；已设置时尊重 spec 自设值（`ai-gateway.spec.ts` 预置登录态不受影响）
- `tests/e2e/mcp.spec.ts` 用例 2：增加回归守卫，断言 E2E 应用未继承平台登录态——隔离再失效时直接报出明确原因（`E2E app must not inherit the developer machine platform login`），而非「真实模型应答」的迷惑症状

## 日志/验证证据

```
**修复前**（同一台已登录机器，两次运行均失败）：

- mock 全程零请求——两次失败运行日志中均只有启动行、无任何 R1/R2
- E2E 应用继承了开发机真实登录态：
[debug-952] qraft.status: {"loggedIn":true,"account":{"phone":"17365928436",...},"aiGateway":{"status":"active","configVersion":1}}

- 断言失败：真实模型代答并自行调用 MCP 工具（参数非 mock 写死的 `hello-mcp`），30 秒断言窗口内无 `MCP-E2E-PASS`

**修复后**（同一台已登录机器）：

[mock-mcp] R1 → tool_call mcp_e2emcp_e2e_echo
[mock-mcp] R2 → 工具返回含真实 MCP 标记 → PASS
2 passed (24.2s)
```

## 测试情况

- `mcp.spec.ts`：2/2 通过（修复前用例 2 稳定失败，修复后 24.2s）
- `ai-gateway.spec.ts`：2/2 通过（自预置 store 路径不受影响）
- `npm run typecheck:node`：通过

## 截图

无需截图

## 后续计划

- #959 孤儿 bridge 进程清理（E2E 基建，与本次修复无关）