### PR TITLE
chore(desktop): add VS Code launch config for one-click dev startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "打开 App（dev 模式）",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/apps/desktop",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "windows": {
+        "runtimeExecutable": "npm.cmd"
+      },
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "调试主进程（dev + sourcemap）",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/apps/desktop",
+      "runtimeExecutable": "${workspaceFolder}/apps/desktop/node_modules/.bin/electron-vite",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/apps/desktop/node_modules/.bin/electron-vite.cmd"
+      },
+      "runtimeArgs": ["dev", "--sourcemap"],
+      "env": {
+        "REMOTE_DEBUGGING_PORT": "9222"
+      },
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
## 类型

- [x] 🔧 其他

## 变更概述

新增 VS Code 启动配置（launch.json），在 IDE 里一键启动/调试桌面应用，无需手动进 apps/desktop 跑命令。

## 背景/问题

开发时启动应用需要手动切到 apps/desktop 目录执行 npm run dev，且想打断点调试主进程时没有现成的调试配置。新增 .vscode/launch.json 后，按 F5 或点运行面板即可一键启动。

## 变更内容

- `.vscode/launch.json`（新增）：
  - 「打开 App（dev 模式）」：执行 `npm run dev`，自动触发 `predev`（uv sync 同步 Python 桥环境），Windows 下经 `npm.cmd` 启动避免 PATH 解析问题，集成终端输出便于 Ctrl+C 停止；
  - 「调试主进程（dev + sourcemap）」：按 electron-vite 官方调试文档写法，直接调用 `electron-vite` 二进制并带 `--sourcemap`，配置 `REMOTE_DEBUGGING_PORT=9222` 便于后续附加渲染进程调试器。

## 日志/验证证据

```
$ python -c "import json; json.load(open('.vscode/launch.json', encoding='utf-8')); print('JSON OK')"
JSON OK
```

## 测试情况

- 纯配置新增，无代码逻辑变更，未跑功能测试；
- launch.json 已通过 JSON 语法校验；
- 配置结构与 electron-vite 官方调试文档一致（cwd/runtimeExecutable 按 monorepo 路径调整为 apps/desktop）。

## 截图

无需截图
