### PR TITLE
chore(config): 清理 30 分计费闸门残留的死配置

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4620,9 +4620,11 @@ export function ChatConsole({
 
       // ── Platform points billing notices ─────────────────────────
       // 平台计费事件（当前仅 Slurm MCP 作业运行扣 10 分）通过 progress
-      // 事件推送结果：billed = 已扣费（安静的活动行）；blocked = 余额
-      // 不足/登录过期/计费服务不可用（醒目错误行，任务未执行）。渲染
-      // 逻辑与缓存回放共用 pointsEventToMessage，保证切会话后通知不丢。
+      // 事件推送结果：billed = 已扣费（安静的活动行）；blocked = 扣费
+      // 未完成（余额不足/登录过期/计费服务不可用，醒目错误行）——作业已
+      // 进入运行，扣费失败不阻断任务（见 main/ipc/index.ts 的
+      // slurm_job_running 处理）。渲染逻辑与缓存回放共用
+      // pointsEventToMessage，保证切会话后通知不丢。
       {
         const pointsMessage = pointsEventToMessage(data);
         if (pointsMessage) {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4619,10 +4619,10 @@ export function ChatConsole({
       }
 
       // ── Platform points billing notices ─────────────────────────
-      // 后端计费闸门（首次工具执行扣 30 分）通过 progress 事件推送结果：
-      // billed = 已扣费（安静的活动行）；blocked = 余额不足/登录过期/
-      // 计费服务不可用（醒目错误行，任务未执行）。渲染逻辑与缓存回放
-      // 共用 pointsEventToMessage，保证切会话后通知不丢。
+      // 平台计费事件（当前仅 Slurm MCP 作业运行扣 10 分）通过 progress
+      // 事件推送结果：billed = 已扣费（安静的活动行）；blocked = 余额
+      // 不足/登录过期/计费服务不可用（醒目错误行，任务未执行）。渲染
+      // 逻辑与缓存回放共用 pointsEventToMessage，保证切会话后通知不丢。
       {
         const pointsMessage = pointsEventToMessage(data);
         if (pointsMessage) {

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -576,20 +576,6 @@ class ToolsConfig(Base):
     mcp_servers: dict[str, MCPServerConfig] = Field(default_factory=dict)
 
 
-class BillingConfig(Base):
-    """Platform points billing (OAuth2 第三方接入 /oauth2/points/deduct).
-
-    When enabled, a logged-in session deducts ``cost_per_task`` points
-    before the first tool/skill execution of the session (one deduction
-    per session; plain conversation is free).  Deduction failures are
-    fail-closed — the task does not run.
-    """
-
-    enabled: bool = True
-    cost_per_task: int = 30
-    source: str = "desktop-agent-task"
-
-
 class Config(BaseSettings):
     """Root configuration for MiQi runtime."""
 
@@ -602,7 +588,6 @@ class Config(BaseSettings):
     cron: CronConfig = Field(default_factory=CronConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
-    billing: BillingConfig = Field(default_factory=BillingConfig)
     # Opaque Desktop-owned settings (e.g. theme, layout).  Not validated —
     # the Desktop UI reads/writes this via config/batchWrite desktop.* paths.
     desktop: dict[str, object] = Field(default_factory=dict)

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -616,6 +616,12 @@ class Config(BaseSettings):
     cron: CronConfig = Field(default_factory=CronConfig)
     tools: ToolsConfig = Field(default_factory=ToolsConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
+    # Inert passthrough for configs written by the removed #915 points-billing
+    # gate.  Config is a BaseSettings (extra keys are forbidden), so the field
+    # must stay to keep old config.json files loadable — deleting it made
+    # load_config silently fall back to a default config (providers lost,
+    # "尚未配置模型服务" on send).  Nothing reads this value (#960).
+    billing: dict[str, object] = Field(default_factory=dict)
     # Opaque Desktop-owned settings (e.g. theme, layout).  Not validated —
     # the Desktop UI reads/writes this via config/batchWrite desktop.* paths.
     desktop: dict[str, object] = Field(default_factory=dict)

--- a/tests/config/test_loader_migration.py
+++ b/tests/config/test_loader_migration.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from miqi.config.loader import _migrate_config
+import json
+
+from miqi.config.loader import _migrate_config, load_config
 
 
 def test_migrate_resets_custom_model_to_configured_provider_model():
@@ -48,3 +50,27 @@ def test_migrate_leaves_other_models_untouched():
     data = {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}}
     migrated = _migrate_config(data)
     assert migrated["agents"]["defaults"]["model"] == "deepseek/deepseek-v4-flash"
+
+
+def test_legacy_billing_key_does_not_break_config_load(tmp_path):
+    """#960：30 分计费闸门移除后，旧版写入的 billing 键仍必须可加载。
+
+    Config 继承 BaseSettings（extra 默认 forbid），把 billing 字段整个删掉
+    会让旧 config.json 校验失败，load_config 静默回退默认空配置——providers
+    全部丢失，表现为「尚未配置模型服务」。billing 字段须以透传 dict 保留。
+    """
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "billing": {"enabled": True, "costPerTask": 30, "source": "desktop-agent-task"},
+                "providers": {"deepseek": {"apiKey": "sk-ds-1234567890"}},
+                "agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_config(config_path)
+    # 关键断言：不是静默回退的默认空配置——providers 必须原样存活
+    assert cfg.providers.deepseek.api_key == "sk-ds-1234567890"
+    assert cfg.agents.defaults.model == "deepseek/deepseek-v4-flash"


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [x] 🔧 其他

## 变更概述

清理已移除的 30 分积分计费闸门残留：删除 schema.py 中无人读取的 BillingConfig 类，保留惰性 `billing` 透传字段兼容旧配置文件（E2E 实测抓到的回归），并修正 ChatConsole 的过时注释。

## 背景/问题

#915 的通用计费闸门（登录后会话首次执行工具/技能前扣 30 分）已随 #927/#936 从运行路径彻底移除，当前运行路径没有任何 30 分扣费。但 schema.py 仍保留 BillingConfig（默认 `enabled=True`、`cost_per_task=30`），全仓无任何代码读取它，属死配置，容易让人误以为扣费仍在生效；ChatConsole 的 points 事件注释也仍描述旧闸门。

**第一版直接删除字段被 mock E2E 抓到回归**：旧版应用会在 `~/.miqi/config.json` 写入 `billing` 键（本机真实配置实测存在）。`Config` 继承 BaseSettings，`extra` 默认 forbid——删掉字段后旧配置校验失败，`load_config` 静默回退默认空配置，providers 全部丢失，发送消息报「尚未配置模型服务」。修复：`billing` 改为惰性 `dict[str, object]` 透传字段（与 `desktop` 字段同模式），无任何代码读取，仅保证旧 config.json 可加载。

## 变更内容

- `miqi/config/schema.py`：删除强类型 `BillingConfig` 类（enabled/cost_per_task/source 定义不再存在，30 分语义彻底清除）；`Config.billing` 改为惰性 `dict` 透传字段，带注释说明存在原因（BaseSettings extra_forbid 兼容旧配置）。
- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`：过时注释更新为现状（points 事件当前仅由 Slurm MCP 作业运行扣 10 分使用）。
- `tests/config/test_loader_migration.py`：新增回归测试 `test_legacy_billing_key_does_not_break_config_load`——含 `billing` 键的旧配置必须正常加载且 providers 原样存活（先写测试复现失败，再修复）。

保留项：`QraftClient.deductPoints`、`chargeSlurmJob`、扣费历史与余额展示均为 Slurm 作业计费（10 分/次）复用，不动。

## 日志/验证证据

```
修复前（E2E 失败现场，页面快照）：
generic [ref=e100]: 尚未配置模型服务。请先配置 Provider/API Key 后再发送消息。
button "去配置模型" [ref=e101]

2026-09-07 16:50:48.246 | WARNING | miqi.config.loader:load_config:114 -
  Failed to load config ...: 1 validation error for Config
  billing
    Extra inputs are not permitted [type=extra_forbidden,
    input_value={'enabled': True, 'costPe...': 'desktop-agent-task'}]
  Using default configuration.

修复后：
$ uv run pytest tests/config/ tests/test_config_pdf2zh.py -q
...................................................                      [100%]
51 passed in 2.13s

$ npx playwright test --config=playwright.config.ts --project=electron     -g "cross-session read raises PermissionError"
[test] Sandbox ready after 0s
[tool-error-neutral] ✅ isolation message is visible mid-turn
[tool-error-neutral] ✅ no danger-colored element carries the message
[tool-error-neutral] ✅ turn completed normally
  1 passed (1.0m)
```

## 测试情况

- `tests/config/` + `tests/test_config_pdf2zh.py`：51 个用例全部通过（含新增回归测试）
- mock E2E 真实链路（`tool-error-neutral.spec.ts` Test A）：mock LLM 驱动模型真实调用 `read_file` 工具 → 会话隔离 PermissionError → ⚠️ 警示行 → 回合正常完成，全程无计费闸门/配置错误干扰；本用例在无沙箱标志的 CI 默认跳过，本地实跑通过
- 手动验证：本机真实 `~/.miqi/config.json`（含 `billing` 键）+ E2E patch 语义下 `Config.model_validate` 与 `make_provider` 均正常

## 截图

![E2E 实测通过](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/e034162548b3df9b.png)

