### PR TITLE
feat(desktop): 状态栏点击积分弹出扣费历史明细

### DIFF
--- a/apps/desktop/src/renderer/components/StatusBar.tsx
+++ b/apps/desktop/src/renderer/components/StatusBar.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/utils';
 import { useRuntime } from '../contexts/RuntimeContext';
 import { useRestartRequired } from '../contexts/RestartRequiredContext';
 import { useQraftStatus } from '../hooks/useQraftStatus';
 import { Coins, Loader2, RefreshCw } from 'lucide-react';
+import type { QraftBillingHistoryEntry } from '../../shared/ipc';
 
 const STATES: Record<string, { label: string; color: string }> = {
   stopped: { label: '已停止', color: 'var(--text-faint)' },
@@ -13,6 +14,13 @@ const STATES: Record<string, { label: string; color: string }> = {
   error: { label: '错误', color: 'var(--danger)' },
 };
 
+function fmtDateTime(epochMs?: number): string {
+  if (!epochMs) return '—';
+  const d = new Date(epochMs);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export function StatusBar({ onOpenPoints }: { onOpenPoints?: () => void }) {
   const { status, start, stop } = useRuntime();
   const { restartRequired, restartReasons, clearRestartRequired } = useRestartRequired();
@@ -20,6 +28,57 @@ export function StatusBar({ onOpenPoints }: { onOpenPoints?: () => void }) {
   const s = STATES[status.state] ?? STATES.stopped;
   const [restarting, setRestarting] = useState(false);
   const [restartError, setRestartError] = useState<string | null>(null);
+  /** 积分按钮弹层：打开时展示本地扣费历史（issue #927 明细入口）。 */
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [billingHistory, setBillingHistory] = useState<QraftBillingHistoryEntry[] | null>(null);
+  const [historyError, setHistoryError] = useState(false);
+  const pointsWrapRef = useRef<HTMLDivElement>(null);
+
+  // 弹层打开时拉取扣费历史；打开期间余额变化（新扣费推送状态事件）时重拉，
+  // 保证刚扣完费的记录即时可见。
+  useEffect(() => {
+    if (!historyOpen) return;
+    let cancelled = false;
+    try {
+      window.miqi.qraft
+        .billingHistory()
+        .then((entries) => {
+          if (!cancelled) {
+            setBillingHistory(entries);
+            setHistoryError(false);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setHistoryError(true);
+        });
+    } catch {
+      // preload 存在但无 billingHistory 方法（旧版 preload）：同样落错误态，
+      // 不能停在「加载中…」。
+      if (!cancelled) setHistoryError(true);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [historyOpen, qraftStatus?.points?.availablePoints]);
+
+  // 点击弹层外部或按 Escape 关闭。
+  useEffect(() => {
+    if (!historyOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (pointsWrapRef.current && !pointsWrapRef.current.contains(e.target as Node)) {
+        setHistoryOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setHistoryOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [historyOpen]);
 
   // 登录后拉取一次积分余额：主进程（QraftService.fetchPointsBalance）成功
   // 缓存后会推送 statusChanged，此处经 useQraftStatus 自动收到带 points
@@ -131,18 +190,106 @@ export function StatusBar({ onOpenPoints }: { onOpenPoints?: () => void }) {
 
       <div className="ml-auto flex items-center gap-3">
         {loggedIn && qraftStatus?.points && (
-          <button
-            type="button"
-            onClick={onOpenPoints}
-            disabled={!onOpenPoints}
-            className="flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors disabled:cursor-default"
-            style={{ color: 'var(--text-muted)' }}
-            data-testid="statusbar-points"
-            title={`可用积分 ${qraftStatus.points.availablePoints} · 累计获得 ${qraftStatus.points.totalEarned} · 累计支出 ${qraftStatus.points.totalSpent}${onOpenPoints ? '（点击查看明细）' : ''}`}
-          >
-            <Coins size={12} style={{ color: 'var(--accent)' }} />
-            积分 {qraftStatus.points.availablePoints}
-          </button>
+          <div className="relative" ref={pointsWrapRef}>
+            <button
+              type="button"
+              onClick={() => setHistoryOpen((open) => !open)}
+              aria-expanded={historyOpen}
+              className={cn(
+                'flex items-center gap-1 rounded px-1 py-0.5 text-xs transition-colors',
+                historyOpen && 'bg-[var(--surface-raised)]'
+              )}
+              style={{ color: 'var(--text-muted)' }}
+              data-testid="statusbar-points"
+              title={`可用积分 ${qraftStatus.points.availablePoints} · 累计获得 ${qraftStatus.points.totalEarned} · 累计支出 ${qraftStatus.points.totalSpent}（点击查看明细）`}
+            >
+              <Coins size={12} style={{ color: 'var(--accent)' }} />
+              积分 {qraftStatus.points.availablePoints}
+            </button>
+            {historyOpen && (
+              <div
+                className="absolute bottom-full right-0 z-50 mb-1.5 w-80 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] shadow-lg"
+                data-testid="statusbar-points-popover"
+              >
+                <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-3 py-2">
+                  <span className="text-xs font-medium text-[var(--text)]">积分明细</span>
+                  <span className="text-size-2xs text-[var(--text-faint)]">
+                    累计获得 {qraftStatus.points.totalEarned} · 累计支出{' '}
+                    {qraftStatus.points.totalSpent}
+                  </span>
+                </div>
+                {historyError ? (
+                  <p className="px-3 py-3 text-size-2xs text-[var(--text-faint)]">
+                    扣费历史加载失败
+                  </p>
+                ) : billingHistory === null ? (
+                  <p className="px-3 py-3 text-size-2xs text-[var(--text-faint)]">加载中…</p>
+                ) : billingHistory.length === 0 ? (
+                  <p
+                    className="px-3 py-3 text-size-2xs text-[var(--text-faint)]"
+                    data-testid="statusbar-billing-empty"
+                  >
+                    暂无扣费记录
+                  </p>
+                ) : (
+                  <ul
+                    className="flex max-h-64 flex-col gap-1.5 overflow-y-auto px-3 py-2"
+                    data-testid="statusbar-billing-history"
+                  >
+                    {billingHistory.map((entry) => (
+                      <li
+                        key={entry.chargeId}
+                        className="flex items-center justify-between gap-2 text-size-2xs"
+                      >
+                        <div className="min-w-0">
+                          <p className="flex items-center text-[var(--text)]">
+                            <span className="min-w-0 truncate">
+                              {entry.jobId
+                                ? `作业 ${entry.jobId}`
+                                : `${entry.serverName ?? ''}.${entry.toolName ?? ''}`}
+                            </span>
+                            <span className="ml-2 shrink-0 text-[var(--text-faint)]">
+                              {fmtDateTime(Date.parse(entry.deductedAt))}
+                            </span>
+                          </p>
+                          {entry.argsSummary && (
+                            <p className="truncate text-[var(--text-faint)]">{entry.argsSummary}</p>
+                          )}
+                        </div>
+                        <div className="shrink-0 text-right">
+                          {entry.status === 'billed' ? (
+                            <>
+                              <span className="text-[var(--danger)]">-{entry.cost}</span>
+                              {entry.balanceAfter !== undefined && (
+                                <span className="ml-1 text-[var(--text-faint)]">
+                                  余额 {entry.balanceAfter}
+                                </span>
+                              )}
+                            </>
+                          ) : (
+                            <span className="text-[var(--warning)]">
+                              {entry.status === 'insufficient' ? '余额不足' : '扣费失败'}
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setHistoryOpen(false);
+                    onOpenPoints?.();
+                  }}
+                  className="w-full border-t border-[var(--border-subtle)] px-3 py-2 text-center text-xs text-[var(--accent)]"
+                  data-testid="statusbar-points-open-settings"
+                >
+                  在设置中查看全部
+                </button>
+              </div>
+            )}
+          </div>
         )}
         <span className="text-text-faint">
           MiQroForge Desktop v{typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'}

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -25,6 +25,8 @@ export interface MockBridgeOptions {
   qraftLoggedInStatus?: Record<string, unknown>;
   /** qraft.pointsBalance 的返回结果。默认成功返回 270 可用积分。 */
   qraftPointsResult?: Record<string, unknown>;
+  /** qraft.billingHistory 的返回结果。默认空列表。 */
+  qraftBillingHistoryResult?: Array<Record<string, unknown>>;
 }
 
 /** Build a self-contained init script that installs the mock bridge on
@@ -110,6 +112,7 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       points: { availablePoints: 270, heldPoints: 0, totalEarned: 300, totalSpent: 30 },
     }
   );
+  const qraftBillingHistoryJson = JSON.stringify(opts.qraftBillingHistoryResult || []);
 
   return `
 (function() {
@@ -426,7 +429,9 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
         }
         return Promise.resolve(result);
       },
-      billingHistory: function() { return Promise.resolve([]); },
+      billingHistory: function() {
+        return Promise.resolve(JSON.parse(JSON.stringify(${qraftBillingHistoryJson})));
+      },
       onStatusChanged: function(cb) { return _on('qraftStatus', cb); },
     },
   };

--- a/apps/desktop/tests/smoke/smoke.spec.ts
+++ b/apps/desktop/tests/smoke/smoke.spec.ts
@@ -153,6 +153,85 @@ test.describe('Status Bar', () => {
 
     await expect(page.getByTestId('statusbar-points')).toHaveCount(0);
   });
+
+  test('shows billing history popover when clicking points', async ({ page }) => {
+    await injectMockAndGoto(page, {
+      qraftStatus: {
+        loggedIn: true,
+        account: { phone: '18500000000', sub: '19', nickname: 'MiQi测试' },
+      },
+      qraftBillingHistoryResult: [
+        {
+          chargeId: 'charge-001',
+          deductedAt: new Date(Date.now() - 3600_000).toISOString(),
+          cost: 10,
+          balanceAfter: 260,
+          status: 'billed',
+          jobId: 'slurm-123',
+          serverName: 'slurm',
+          toolName: 'submit_job',
+          argsSummary: 'sbatch run.sh',
+        },
+        {
+          chargeId: 'charge-002',
+          deductedAt: new Date(Date.now() - 7200_000).toISOString(),
+          cost: 10,
+          status: 'insufficient',
+          jobId: 'slurm-124',
+        },
+      ],
+    });
+
+    await expect(page.getByTestId('statusbar-points')).toHaveText(/积分 270/);
+    await page.getByTestId('statusbar-points').click();
+
+    const popover = page.getByTestId('statusbar-points-popover');
+    await expect(popover).toBeVisible();
+    // 明细：作业、扣费金额、扣后余额、失败状态
+    await expect(popover).toContainText('作业 slurm-123');
+    await expect(popover).toContainText('sbatch run.sh');
+    await expect(popover).toContainText('-10');
+    await expect(popover).toContainText('余额 260');
+    await expect(popover).toContainText('作业 slurm-124');
+    await expect(popover).toContainText('余额不足');
+
+    // 再次点击关闭弹层
+    await page.getByTestId('statusbar-points').click();
+    await expect(popover).toHaveCount(0);
+  });
+
+  test('shows empty billing history popover when no charges', async ({ page }) => {
+    await injectMockAndGoto(page, {
+      qraftStatus: {
+        loggedIn: true,
+        account: { phone: '18500000000', sub: '19', nickname: 'MiQi测试' },
+      },
+    });
+
+    await expect(page.getByTestId('statusbar-points')).toHaveText(/积分 270/);
+    await page.getByTestId('statusbar-points').click();
+    await expect(page.getByTestId('statusbar-points-popover')).toContainText('暂无扣费记录');
+
+    // 点击弹层外关闭
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId('statusbar-points-popover')).toHaveCount(0);
+  });
+
+  test('closes popover and navigates to settings via footer link', async ({ page }) => {
+    await injectMockAndGoto(page, {
+      qraftStatus: {
+        loggedIn: true,
+        account: { phone: '18500000000', sub: '19', nickname: 'MiQi测试' },
+      },
+    });
+
+    await expect(page.getByTestId('statusbar-points')).toHaveText(/积分 270/);
+    await page.getByTestId('statusbar-points').click();
+    await page.getByTestId('statusbar-points-open-settings').click();
+    await expect(page.getByTestId('statusbar-points-popover')).toHaveCount(0);
+    // 跳转到设置 → Qraft 平台账号页（含扣费历史区块）
+    await expect(page.getByText('MiQroForge 平台账号')).toBeVisible();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/docs/dev-notes/slurm-mcp-billing-map.md
+++ b/docs/dev-notes/slurm-mcp-billing-map.md
@@ -9,7 +9,7 @@ Slurm MCP 作业计费（issue #927，PR #936）：计费触发点为「slurm MC
 **架构**：
 - Python 握手桥 `miqi/agent/billing_resolver.py`（镜像 user_input_resolver 模式）：slurm MCP 工具（服务器名含 "slurm"）执行前，MCPToolWrapper 经会话发射器发 `slurm_job_charge_request`（charge_id/工具名/参数摘要/会话上下文）→ 等 Desktop 决议（25s 超时 fail-closed）→ 放行或「[计费阻止]」；无 Desktop 通道（headless/CLI）阻止。作业提交成功后从输出提取作业 ID（Submitted batch job N / JobId=N / slurm-N 3+ 位）经 `slurm_job_charge_enrich` 回传
 - bridge/loop.py：drain 注册 `set_billing_charge_emitter`；`billing.slurmResolve` 方法（带会话归属鉴权 + protocol_specs.BILLING_SLURM_RESOLVE，注意新增方法必须带 spec，否则 phase72 audit 的 legacy 计数会超）
-- Desktop：`QraftService.chargeSlurmJob`（10 分、source=slurm-job、memo={jobId,tool,args,session,turn}；charge_id 去重 + 历史文件跨重启不重复扣；token 失效先 refreshNow 重试一次）；历史 `userData/qraft-billing-history.json`（200 条上限，billed/insufficient/error），设置页展示；聊天区提示复用 points 事件流（「本次任务已扣 N 积分 · 可用余额 M」）
+- Desktop：`QraftService.chargeSlurmJob`（10 分、source=slurm-job、memo={jobId,tool,args,session,turn}；charge_id 去重 + 历史文件跨重启不重复扣；token 失效先 refreshNow 重试一次）；历史 `userData/qraft-billing-history.json`（200 条上限，billed/insufficient/error），设置页展示 + 状态栏积分按钮点击弹层展示（弹层内「在设置中查看全部」跳设置页）；聊天区提示复用 points 事件流（「本次任务已扣 N 积分 · 可用余额 M」）
 - orchestrator 对 `mcp_` 工具注入 `_session_key/_turn_id/_tool_call_id`（MCPToolWrapper pop 掉，不传给 MCP 服务端）
 
 **关键坑（#936 live E2E 暴露，已修）**：桌面主路径 `miqi/runtime/` 的 TurnRunner 经 `CapabilityResolver.resolve` 按 agent 静态白名单（agent_registry 的 available_tools）过滤 registry——用户配置的 MCP 工具（`mcp_<server>_<tool>`）**从未进入模型请求**，DeepSeek 只能幻觉裸名调用（submit_slurm_job）。修复：capabilities.py 放行 `mcp_`/`use_` 前缀（用户 opt-in 能力不受白名单约束），tests/runtime/test_capabilities.py 有穿透用例。注意 KUN runtime（kun_runtime/loop.py）不经过这个白名单，但桌面不用 KUN。


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] ✨ 新功能

## 变更概述

状态栏积分余额按钮点击后直接弹出扣费历史明细弹层，底部「在设置中查看全部」跳转设置页。

## 背景/问题

Slurm 作业计费（#927/#936）的扣费历史此前只展示在设置 → Qraft 平台账号页底部：用户点状态栏「积分 X」按钮（提示文案是「点击查看明细」）只会跳到设置页，还要在账号信息、网关状态、积分余额之后往下翻才能看到明细。本 PR 把明细直接放到点击处：状态栏按钮点击弹出本地扣费历史（作业 ID、时间、扣费金额、扣后余额、余额不足/扣费失败状态），需要完整列表（最多 200 条）时再进设置页。

## 关联 issue

无

## 变更内容

- `apps/desktop/src/renderer/components/StatusBar.tsx`：积分按钮改为 toggle 弹层（`data-testid="statusbar-points-popover"`）。弹层打开时经 preload `qraft.billingHistory()` 拉取历史（未登录/旧 preload 安全降级）；打开期间余额变化（新扣费推送 `qraft:statusChanged`）自动重拉，刚扣完费的记录即时可见。明细行与设置页一致：作业 ID（超长截断，时间不截断）+ `sbatch` 参数摘要 + `-10 余额 N` / 「余额不足」/「扣费失败」。点击弹层外或 Escape 关闭；底部「在设置中查看全部」走原 `onOpenPoints` 跳转。拉取失败显示「扣费历史加载失败」而非停在加载态
- `apps/desktop/tests/smoke/mocks.ts`：新增 `qraftBillingHistoryResult` 注入项，`billingHistory` mock 返回可配置列表
- `apps/desktop/tests/smoke/smoke.spec.ts`：Status Bar 套件新增 3 个用例（弹层展示 billed/insufficient 条目、空历史提示、点外部关闭与底部链接跳转设置页）
- `docs/dev-notes/slurm-mcp-billing-map.md`：历史展示位置补充状态栏弹层入口

## 日志/验证证据

```
npx tsc --noEmit -p tsconfig.web.json   → 0 error
npx tsc --noEmit -p tsconfig.node.json  → 0 error
npx vitest run                          → 374 passed | 5 skipped
npx playwright test --project=smoke     → 71 passed | 1 skipped | 1 failed（见测试情况）
```

## 测试情况

- 类型检查（web + node）通过
- vitest 单测 374 通过 0 失败
- smoke：Status Bar 套件 7 个用例全部通过（含新增 3 个）；全量 71 通过 0 新增失败
- 已知既有失败（与本次改动无关，已单独验证在 develop tip 基线同样失败，并拆出独立任务）：`issue-902-exec-command-expand.spec.ts` —— #918 会话/回合管道改版后该用例的 progress 事件注入方式失效（页面快照中「执行命令」工具行不再出现），CI smoke 步骤因 `continue-on-error` 未暴露

## 截图

状态栏积分按钮点击后的扣费历史弹层（含成功扣费与余额不足条目）：

![状态栏积分弹层-扣费历史](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/836f984a5a8824a7.png)

## 后续计划

无