### PR TITLE
fix(desktop): 修复 #902 exec 命令展开 smoke 用例（#918 改版后注入失效）

### DIFF
--- a/apps/desktop/tests/smoke/issue-902-exec-command-expand.spec.ts
+++ b/apps/desktop/tests/smoke/issue-902-exec-command-expand.spec.ts
@@ -27,7 +27,11 @@ async function injectMockAndGoto(
 
 test.describe('Issue #902 exec command expand', () => {
   test('clicking an exec tool row expands to the full untruncated command', async ({ page }) => {
-    await injectMockAndGoto(page);
+    // hangChatSend：mock 的 chat.send 挂起直到 terminal 事件，镜像真实桥接
+    // （send promise 由 final/error/aborted 才 settle）。#918 改版后
+    // ChatConsole 在 send settle 时立即退订本轮 progress 监听器——立即
+    // resolve 会让发送后注入的事件被丢弃，工具行永远不渲染。
+    await injectMockAndGoto(page, { hangChatSend: true });
 
     const textarea = page.getByPlaceholder('请输入消息或拖入文件...');
     await expect(textarea).toBeVisible({ timeout: 5000 });
@@ -38,17 +42,28 @@ test.describe('Issue #902 exec command expand', () => {
     // the expanded block reveals the full text.
     const longCommand =
       'echo "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron" | tr -d " " | wc -c';
-    await page.evaluate((cmd) => {
-      (window as any).__miqiMock.progress({
-        text: 'exec("echo alpha beta …")',
-        tool_hint: true,
-        tool_call_id: 'call_902_1',
-        tool_args: { command: cmd },
-      });
-    }, longCommand);
 
+    // 回合 in-flight 时监听器已注册，但 Enter 到注册之间仍有异步窗口
+    // （网关/模型检查等）——在工具行出现前反复重试注入；同一 tool_call_id
+    // 的重复注入只会更新既有行，不会叠行。
     const label = page.getByRole('button', { name: /执行命令/ });
-    await expect(label).toBeVisible({ timeout: 5000 });
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate((cmd) => {
+            (window as any).__miqiMock.progress({
+              text: 'exec("echo alpha beta …")',
+              tool_hint: true,
+              tool_call_id: 'call_902_1',
+              tool_args: { command: cmd },
+            });
+          }, longCommand);
+          return label.isVisible();
+        },
+        { timeout: 10000 }
+      )
+      .toBe(true);
+
     // Collapsed summary is truncated — the full command is not on screen yet.
     await expect(page.getByText(longCommand)).toHaveCount(0);
 

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -25,6 +25,14 @@ export interface MockBridgeOptions {
   qraftLoggedInStatus?: Record<string, unknown>;
   /** qraft.pointsBalance 的返回结果。默认成功返回 270 可用积分。 */
   qraftPointsResult?: Record<string, unknown>;
+  /**
+   * 让 chat.send 挂起直到 mock 触发 terminal 事件（final/error/aborted），
+   * 保持回合 in-flight。真实桥接下 send promise 由 terminal 事件才 settle
+   * （src/main/bridge.ts TERMINAL_EVENT_TYPES），#918 改版后 ChatConsole 在
+   * send settle 时立即退订本轮监听器——立即 resolve 会让发送后注入的
+   * progress 事件被丢弃。默认关闭，保持其余用例的既有行为。
+   */
+  hangChatSend?: boolean;
 }
 
 /** Build a self-contained init script that installs the mock bridge on
@@ -110,6 +118,7 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       points: { availablePoints: 270, heldPoints: 0, totalEarned: 300, totalSpent: 30 },
     }
   );
+  const hangChatSendJson = opts.hangChatSend === true ? 'true' : 'false';
 
   return `
 (function() {
@@ -197,7 +206,31 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
     },
 
     chat: {
-      send: function() { return Promise.resolve({ accepted: true, req_id: 'req-test-001' }); },
+      // 默认立即 resolve（accepted）。hangChatSend 开启时挂起直到 terminal
+      // 事件，镜像真实桥接：主进程 bridge client 在 final/aborted 时 resolve、
+      // error 时 reject（src/main/bridge.ts TERMINAL_EVENT_TYPES）。只有挂起
+      // 时 ChatConsole 才会在整个回合期间保持 progress 监听器注册，测试才能
+      // 在发送后注入 progress 事件（#902 工具行渲染回归）。
+      send: function() {
+        if (!${hangChatSendJson}) {
+          return Promise.resolve({ accepted: true, req_id: 'req-test-001' });
+        }
+        return new Promise(function(resolve, reject) {
+          var settled = false;
+          var settleOk = function() {
+            if (settled) return;
+            settled = true;
+            resolve({ accepted: true, req_id: 'req-test-001' });
+          };
+          _on('final', settleOk);
+          _on('aborted', settleOk);
+          _on('error', function(data) {
+            if (settled) return;
+            settled = true;
+            reject(new Error((data && data.message) || 'Mock backend error'));
+          });
+        });
+      },
       abort: function() {
         _fire('aborted', {});
         return Promise.resolve({ aborted: true });


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复过期 smoke 用例 issue-902-exec-command-expand：mock 的 chat.send 挂起直到 terminal 事件，让 #918 改版后的 ChatConsole 在回合期间保持 progress 监听器注册，注入的工具行得以渲染。

## 背景/问题

用例在 develop tip 上确定性失败，CI smoke 步骤因 continue-on-error 未暴露。#918 会话/回合管道改版后，ChatConsole 的 progress 监听器按「每次发送」注册，并在 chat.send 的 promise settle 时立即退订（ChatConsole.tsx:5213-5228）。真实桥接下该 promise 由 terminal 事件（final/error/aborted）才 settle（src/main/bridge.ts TERMINAL_EVENT_TYPES）；而 smoke mock 的 send 立即 resolve `{accepted: true}`，监听器在注入到达前就被退订，`window.__miqiMock.progress()` 注入的事件无人接收——页面快照显示只有用户消息气泡和「停止生成」按钮，工具行从未渲染。

## 变更内容

- `apps/desktop/tests/smoke/mocks.ts`：新增 opt-in 选项 `hangChatSend`，开启后 chat.send 挂起直到 mock 触发 terminal 事件（final/aborted 时 resolve、error 时 reject），镜像真实桥接语义。默认关闭，其余用例行为不变。
- `apps/desktop/tests/smoke/issue-902-exec-command-expand.spec.ts`：启用 `hangChatSend: true`；事件注入改为「注入 + 轮询」直到工具行出现，自愈 Enter 与监听器注册之间的异步窗口（同一 tool_call_id 重复注入只更新既有行，不叠行）。

## 日志/验证证据

```
修复前（基线，确定性失败）：
Error: expect(locator).toBeVisible() failed
Locator: getByRole('button', { name: /执行命令/ })
Expected: visible
Timeout: 5000ms
Error: element(s) not found

修复后（重建 renderer 产物）：
npx playwright test --config=playwright.config.ts --project=smoke issue-902-exec-command-expand
  1 passed (4.9s)

# 防 flake 复跑
npx playwright test --config=playwright.config.ts --project=smoke issue-902-exec-command-expand --repeat-each=3
  3 passed (5.3s)
```

## 测试情况

- 目标用例 issue-902-exec-command-expand：通过（repeat-each=3 全过）
- 全量 smoke（合并 develop 后重建产物）：72 passed / 1 skipped / 0 failed

## 截图

本次为测试基础设施修复（仅改动 tests/smoke 的 mock 与用例），无界面变更，故不附截图。
