### PR TITLE
feat(desktop): 模型设置页显示 Qraft AI 网关使用状态

### DIFF
--- a/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.test.ts
+++ b/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.test.ts
@@ -52,10 +52,10 @@ function loggedInGatewayUnknown() {
   };
 }
 
-const render = () =>
+const render = (activeModel = 'deepseek/deepseek-v4-flash') =>
   renderToStaticMarkup(
     createElement(ModelQuickPanel, {
-      activeModel: 'deepseek/deepseek-v4-flash',
+      activeModel,
       onSaved: () => {},
       onGoToQraft: () => {},
     })
@@ -99,5 +99,41 @@ describe('ModelQuickPanel（#835/#922 门控）', () => {
     const html = render();
     expect(html).toContain('保存');
     expect(html).not.toContain('AI 网关未就绪');
+  });
+
+  describe('AI 网关使用状态展示（#922）', () => {
+    it('未登录：显示「未登录」', () => {
+      const html = render();
+      expect(html).toContain('AI 网关');
+      expect(html).toContain('未登录');
+      expect(html).not.toContain('使用中');
+    });
+
+    it('登录 + 网关 active + 当前模型为网关模型：显示「使用中」', () => {
+      mockedStatus.mockReturnValue(loggedInGatewayActive());
+      const html = render('deepseek/deepseek-v4-flash');
+      expect(html).toContain('使用中');
+      expect(html).not.toContain('已开通');
+    });
+
+    it('登录 + 网关 active + 当前模型非网关模型：显示「已开通」并提示不走网关', () => {
+      mockedStatus.mockReturnValue(loggedInGatewayActive());
+      const html = render('deepseek/deepseek-v4-pro');
+      expect(html).toContain('已开通');
+      expect(html).not.toContain('使用中');
+      expect(html).toContain('deepseek/deepseek-v4-pro');
+    });
+
+    it('登录但网关非 active：显示平台下发状态（开通中）', () => {
+      mockedStatus.mockReturnValue(loggedInGatewayNotReady('provisioning'));
+      const html = render();
+      expect(html).toContain('开通中');
+    });
+
+    it('登录但网关状态未下发：显示「未下发」', () => {
+      mockedStatus.mockReturnValue(loggedInGatewayUnknown());
+      const html = render();
+      expect(html).toContain('未下发');
+    });
   });
 });

--- a/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.tsx
+++ b/apps/desktop/src/renderer/features/providers/components/ModelQuickPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Check, Loader2, LogIn, Save } from 'lucide-react';
+import { Check, Loader2, LogIn, Save, ShieldCheck } from 'lucide-react';
 import { invalidateConfigCache } from '../../../lib/configCache';
 import { sanitizeUiMessage } from '../../../lib/sanitizeUiMessage';
+import { gatewayStatusText } from '../../../lib/qraftGateway';
 import { useQraftStatus } from '../../../hooks/useQraftStatus';
 import { ModelSelect } from './ModelSelect';
 
@@ -10,6 +11,68 @@ import { ModelSelect } from './ModelSelect';
  * 仅保留「默认模型」下拉；移除 Provider 凭据（API Key / Base URL）配置。
  * 未登录时禁用模型选择并引导去 Qraft 登录。
  */
+
+/** 经平台 AI 网关路由的模型（须与 miqi/providers/gateway.py 的 GATEWAY_MODEL 一致）。 */
+export const GATEWAY_MODEL_ID = 'deepseek/deepseek-v4-flash';
+
+const BADGE_BASE =
+  'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium';
+const BADGE_MUTED = `${BADGE_BASE} bg-[var(--surface-muted)] text-[var(--text-muted)]`;
+const BADGE_SUCCESS = `${BADGE_BASE} bg-[var(--success-bg)] text-[var(--success-text)]`;
+const BADGE_INFO = `${BADGE_BASE} bg-[var(--info-bg)] text-[var(--info)]`;
+const BADGE_WARNING = `${BADGE_BASE} bg-[var(--warning-bg)] text-[var(--warning)]`;
+
+interface GatewayUsageDisplay {
+  label: string;
+  hint: string;
+  badgeClass: string;
+}
+
+/**
+ * 「是否使用 Qraft AI 网关」的展示状态（#922）。
+ * 网关路由的前提（miqi/providers/factory.py）：deepseek + 网关实测模型 +
+ * 登录凭据 active。渲染侧无法看到凭据文件与网关 origin，用登录态 +
+ * aiGateway.status + 当前默认模型近似判定；凭据/origin 异常时运行时
+ * 会落回直连，此处展示的是平台下发状态。
+ */
+function gatewayUsageDisplay(
+  loggedIn: boolean,
+  gatewayActive: boolean,
+  aiGatewayKnown: boolean,
+  aiGatewayStatus: string | undefined,
+  activeModel: string
+): GatewayUsageDisplay {
+  if (!loggedIn) {
+    return {
+      label: '未登录',
+      hint: '登录平台账号后，模型调用经平台 AI 网关转发。',
+      badgeClass: BADGE_MUTED,
+    };
+  }
+  if (gatewayActive) {
+    if (activeModel === GATEWAY_MODEL_ID) {
+      return {
+        label: '使用中',
+        hint: '当前默认模型经平台 AI 网关转发，计入平台消费组配额。',
+        badgeClass: BADGE_SUCCESS,
+      };
+    }
+    return {
+      label: '已开通',
+      hint: `当前默认模型 ${activeModel || '未设置'} 不走网关（仅 ${GATEWAY_MODEL_ID} 经平台网关路由）。`,
+      badgeClass: BADGE_INFO,
+    };
+  }
+  if (aiGatewayKnown && aiGatewayStatus) {
+    const gw = gatewayStatusText(aiGatewayStatus);
+    return { label: gw.label, hint: gw.hint, badgeClass: BADGE_WARNING };
+  }
+  return {
+    label: '未下发',
+    hint: '平台未下发网关状态，模型调用走直连。',
+    badgeClass: BADGE_MUTED,
+  };
+}
 
 interface ModelQuickPanelProps {
   activeModel: string;
@@ -22,11 +85,18 @@ export function ModelQuickPanel({ activeModel, onSaved, onGoToQraft }: ModelQuic
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { loggedIn, gatewayActive, aiGatewayKnown } = useQraftStatus();
+  const { loggedIn, gatewayActive, aiGatewayKnown, aiGatewayStatus } = useQraftStatus();
   // 可改模型 = 未登录时引导登录（现状）；登录时需网关 active；平台未下发网关
   // 状态（aiGatewayKnown=false）视为可用，避免误锁存量账号。
   const canUseModel = loggedIn && (gatewayActive || !aiGatewayKnown);
   const gatewayBlocked = loggedIn && aiGatewayKnown && !gatewayActive;
+  const gatewayDisplay = gatewayUsageDisplay(
+    loggedIn,
+    gatewayActive,
+    aiGatewayKnown,
+    aiGatewayStatus,
+    activeModel
+  );
 
   useEffect(() => {
     if (activeModel) setModelValue(activeModel);
@@ -70,6 +140,19 @@ export function ModelQuickPanel({ activeModel, onSaved, onGoToQraft }: ModelQuic
       </div>
 
       <div className="flex flex-col gap-3">
+        {/* 是否使用 Qraft AI 网关（#922）：始终可见，便于确认模型调用走网关还是直连 */}
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-3 py-2"
+          data-testid="model-gateway-status"
+        >
+          <ShieldCheck size={13} className="shrink-0 text-[var(--text-faint)]" />
+          <span className="text-xs text-[var(--text-muted)]">AI 网关</span>
+          <span className={gatewayDisplay.badgeClass}>{gatewayDisplay.label}</span>
+          <span className="min-w-0 text-xs leading-relaxed text-[var(--text-faint)]">
+            {gatewayDisplay.hint}
+          </span>
+        </div>
+
         <div className="flex flex-col gap-1.5">
           <label className="text-xs font-medium text-[var(--text-muted)] uppercase tracking-wide">
             默认模型

--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from '../../../components/ui/Button';
 import { Input } from '../../../components/ui/Input';
 import { cn } from '../../../lib/utils';
+import { gatewayStatusText } from '../../../lib/qraftGateway';
 import type {
   QraftBillingHistoryEntry,
   QraftErrorCode,
@@ -73,25 +74,6 @@ function errorText(result: QraftLoginResult | null, fallback: string): string {
   if (!result) return fallback;
   if (result.message) return result.message;
   return ERROR_GUIDANCE[result.code ?? 'INTERNAL'] ?? fallback;
-}
-
-/** AI 网关状态展示文案（#922）。 */
-function gatewayStatusText(status: string): { label: string; hint: string } {
-  switch (status) {
-    case 'active':
-      return {
-        label: '可用',
-        hint: 'AI 网关已开通：模型调用将走平台网关，计入平台消费组配额与计费。',
-      };
-    case 'provisioning':
-      return { label: '开通中', hint: 'AI 网关正在开通，暂时无法发起会话。请稍后刷新查看。' };
-    case 'failed':
-      return { label: '开通失败', hint: 'AI 网关开通失败，请联系平台处理后再试。' };
-    case 'disabled':
-      return { label: '已停用', hint: 'AI 网关已停用，请联系平台启用后再试。' };
-    default:
-      return { label: status || '未知', hint: 'AI 网关状态未知，请联系平台确认。' };
-  }
 }
 
 const ModeBtn = ({

--- a/apps/desktop/src/renderer/lib/qraftGateway.ts
+++ b/apps/desktop/src/renderer/lib/qraftGateway.ts
@@ -1,0 +1,27 @@
+/**
+ * Qraft 平台 AI 网关状态展示文案（#922）。
+ * QraftPage（平台账号页）与 ModelQuickPanel（模型设置页）共用。
+ */
+
+export interface GatewayStatusText {
+  label: string;
+  hint: string;
+}
+
+export function gatewayStatusText(status: string): GatewayStatusText {
+  switch (status) {
+    case 'active':
+      return {
+        label: '可用',
+        hint: 'AI 网关已开通：模型调用将走平台网关，计入平台消费组配额与计费。',
+      };
+    case 'provisioning':
+      return { label: '开通中', hint: 'AI 网关正在开通，暂时无法发起会话。请稍后刷新查看。' };
+    case 'failed':
+      return { label: '开通失败', hint: 'AI 网关开通失败，请联系平台处理后再试。' };
+    case 'disabled':
+      return { label: '已停用', hint: 'AI 网关已停用，请联系平台启用后再试。' };
+    default:
+      return { label: status || '未知', hint: 'AI 网关状态未知，请联系平台确认。' };
+  }
+}

--- a/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
+++ b/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
@@ -61,6 +61,11 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
     await expect(page.getByText('查看平台账号')).toBeVisible();
     await expect(page.getByText('登录后使用平台内置模型')).not.toBeVisible();
     await expect(page.getByRole('button', { name: '保存' })).not.toBeVisible();
+
+    // 模型设置页展示网关使用状态：透出平台下发的状态文案（开通中）
+    const gatewayBadge = page.getByTestId('model-gateway-status');
+    await expect(gatewayBadge).toBeVisible();
+    await expect(gatewayBadge).toContainText('开通中');
   });
 
   test('登录且网关 active：模型 tab 可正常选择与保存', async ({ page }) => {
@@ -79,6 +84,8 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
           baseUrl: 'https://test.forge.miqroera.com/api',
           aiGateway: { status: 'active', configVersion: 1 },
         },
+        // 默认模型为网关模型 → 状态行应显示「使用中」
+        activeModel: 'deepseek/deepseek-v4-flash',
       }),
     });
     await gotoModelTab(page);
@@ -87,6 +94,11 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
     await expect(page.getByRole('button', { name: '保存' })).toBeVisible({ timeout: 10_000 });
     // ModelSelect 已渲染（select 元素存在，含内置 DeepSeek 兜底预设）
     await expect(page.locator('select').first()).toBeVisible();
+
+    // 模型设置页展示网关使用状态：active + 网关模型 → 「使用中」
+    const gatewayBadge = page.getByTestId('model-gateway-status');
+    await expect(gatewayBadge).toBeVisible();
+    await expect(gatewayBadge).toContainText('使用中');
   });
 
   test('登录且网关非 active（failed）：聊天发送被拦截，chat.send 不被调用', async ({ page }) => {


### PR DESCRIPTION
## 类型

- [x] ✨ 新功能

## 变更概述

模型设置页显示是否使用 Qraft AI 网关：新增始终可见的「AI 网关」状态行，按登录态 + 网关开通状态 + 当前默认模型判定展示使用状态。

## 背景/问题

模型设置页此前只在网关未就绪时显示拦截提示，网关 active 时没有任何「正在使用网关」的显示，用户无法确认模型调用走的是平台 AI 网关还是直连。需要一眼可辨的网关使用状态展示。

## 变更内容

- `ModelQuickPanel.tsx`：新增「AI 网关」状态行（badge + 提示），`gatewayUsageDisplay` 按登录态 + `aiGateway.status` + 当前默认模型判定：使用中（active 且默认模型为网关模型 `deepseek/deepseek-v4-flash`，与 `miqi/providers/gateway.py` 的 GATEWAY_MODEL 一致）/ 已开通（当前模型不走网关）/ 平台下发状态（开通中、失败、停用）/ 未下发 / 未登录；原有登录/网关门禁逻辑不变
- `lib/qraftGateway.ts`（新增）：抽出 QraftPage 的网关状态文案映射 `gatewayStatusText`，两页共用，避免重复
- `QraftPage.tsx`：改用共享映射，展示行为不变
- `ModelQuickPanel.test.ts`：新增 5 个状态展示用例
- `tests/smoke/issue-922-ai-gateway.spec.ts`：既有两条用例补「使用中」「开通中」断言（经 data-testid 限定，避免与门禁文案撞车）

## 日志/验证证据

```
$ npx vitest run（渲染层全量）
Test Files  33 passed | 2 skipped (35)
      Tests  379 passed | 5 skipped (384)

$ npx tsc --noEmit -p tsconfig.web.json
（无输出，通过）

$ npx playwright test --project=smoke issue-922-ai-gateway.spec.ts
5 passed (5.6s)
```

## 测试情况

- 渲染层全量单测 379 通过（含 ModelQuickPanel 新增 5 例：未登录/使用中/已开通/开通中/未下发）
- issue-922 smoke 5 条全过（含新断言）
- `tsc --noEmit -p tsconfig.web.json` 通过
- smoke 截屏人工核对两种状态布局，无溢出/错位

## 截图

网关 active + 默认模型为网关模型 → 「使用中」：

![网关使用中](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/d2d27064c02925bb.png)

网关 provisioning → 「开通中」，原有未就绪门禁保留：

![网关开通中](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/08b040e946f9fef8.png)
