### PR TITLE
feat(desktop): 登录页仅保留 OAuth 浏览器登录入口

### DIFF
--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -94,30 +94,6 @@ function gatewayStatusText(status: string): { label: string; hint: string } {
   }
 }
 
-const ModeBtn = ({
-  value,
-  current,
-  set,
-  label,
-}: {
-  value: 'test' | 'prod';
-  current: 'test' | 'prod';
-  set: (v: 'test' | 'prod') => void;
-  label: string;
-}) => (
-  <button
-    onClick={() => set(value)}
-    className={cn(
-      'settings-hover-tab px-3 py-1.5 rounded-lg text-body-sm border',
-      current === value
-        ? 'bg-[var(--accent-soft)] text-[var(--accent)] border-[var(--accent)]'
-        : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)] hover:border-[var(--accent)]'
-    )}
-  >
-    {label}
-  </button>
-);
-
 export function QraftPage() {
   const [status, setStatus] = useState<QraftStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -125,7 +101,6 @@ export function QraftPage() {
   const [phone, setPhone] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [env, setEnv] = useState<'test' | 'prod'>('test');
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [baseUrl, setBaseUrl] = useState('');
   const [clientId, setClientId] = useState('');
@@ -184,7 +159,7 @@ export function QraftPage() {
         return;
       }
       const result = await window.miqi.qraft.login(phone.trim(), password, {
-        env,
+        env: 'test',
         baseUrl: baseUrl.trim() || undefined,
         clientId: clientId.trim() || undefined,
         clientSecret: clientSecret.trim() || undefined,
@@ -210,7 +185,7 @@ export function QraftPage() {
     setBrowserNotice(null);
     try {
       const result = await window.miqi.qraft.browserLogin({
-        env,
+        env: 'test',
         baseUrl: baseUrl.trim() || undefined,
         clientId: clientId.trim() || undefined,
         clientSecret: clientSecret.trim() || undefined,
@@ -357,15 +332,6 @@ export function QraftPage() {
             <div className="h-px flex-1 bg-[var(--border-subtle)]" />
           </div>
 
-          {/* 环境选择 */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-size-sm font-medium text-[var(--text-muted)]">环境</label>
-            <div className="flex gap-2">
-              <ModeBtn value="test" current={env} set={setEnv} label="测试环境" />
-              <ModeBtn value="prod" current={env} set={setEnv} label="生产环境" />
-            </div>
-          </div>
-
           <div className="flex flex-col gap-1.5">
             <label
               htmlFor="qraft-phone"
@@ -497,7 +463,7 @@ export function QraftPage() {
                   />
                 </div>
                 <p className="text-size-2xs text-[var(--text-faint)]">
-                  生产环境必须使用在 MiQroForge 平台注册的回调地址；测试环境不校验注册值。
+                  当前为测试环境，不校验注册值。生产环境上线后再开放环境选择。
                 </p>
               </div>
             )}

--- a/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
+++ b/apps/desktop/src/renderer/features/settings/components/QraftPage.tsx
@@ -1,21 +1,17 @@
 /**
  * MiQroForge 平台账号登录（issue #726）。
  *
- * 设置页内的登录入口：手机号 + 密码（密码仅经 IPC 提交给主进程，
- * 前端不落任何存储、不打日志）→ 主进程完成平台登录 + 授权码流程 +
- * token 换取与安全存储。登录后展示账号信息与 token 到期/刷新时间，
- * 刷新失败时引导重新登录。
+ * 设置页内的登录入口：浏览器 OAuth 登录 —— 主进程打开 MiQroForge 授权页，
+ * 用户在平台页面完成登录并点击「同意」，授权码由 IPC 层拦截后换 token，
+ * 凭据安全存储。登录后展示账号信息与 token 到期/刷新时间，刷新失败时
+ * 引导重新登录。
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import {
   CloudCog,
-  LogIn,
   LogOut,
   RefreshCw,
-  Eye,
-  EyeOff,
-  ChevronDown,
   UserRound,
   ShieldCheck,
   TriangleAlert,
@@ -25,8 +21,6 @@ import {
   Coins,
 } from 'lucide-react';
 import { Button } from '../../../components/ui/Button';
-import { Input } from '../../../components/ui/Input';
-import { cn } from '../../../lib/utils';
 import { gatewayStatusText } from '../../../lib/qraftGateway';
 import type {
   QraftBillingHistoryEntry,
@@ -80,16 +74,6 @@ export function QraftPage() {
   const [status, setStatus] = useState<QraftStatus | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const [phone, setPhone] = useState('');
-  const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [baseUrl, setBaseUrl] = useState('');
-  const [clientId, setClientId] = useState('');
-  const [clientSecret, setClientSecret] = useState('');
-  const [redirectUri, setRedirectUri] = useState('');
-
-  const [loggingIn, setLoggingIn] = useState(false);
   const [browserLoggingIn, setBrowserLoggingIn] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
@@ -128,38 +112,6 @@ export function QraftPage() {
     return () => unsubscribe?.();
   }, [loadStatus]);
 
-  const handleLogin = async () => {
-    setLoggingIn(true);
-    setLoginError(null);
-    try {
-      if (!phone.trim()) {
-        setLoginError('请输入手机号');
-        return;
-      }
-      if (!password) {
-        setLoginError('请输入密码');
-        return;
-      }
-      const result = await window.miqi.qraft.login(phone.trim(), password, {
-        env: 'test',
-        baseUrl: baseUrl.trim() || undefined,
-        clientId: clientId.trim() || undefined,
-        clientSecret: clientSecret.trim() || undefined,
-        redirectUri: redirectUri.trim() || undefined,
-      });
-      if (result.ok) {
-        setPassword('');
-        setStatus(await window.miqi.qraft.status());
-      } else {
-        setLoginError(errorText(result, '登录失败'));
-      }
-    } catch (e) {
-      setLoginError(e instanceof Error ? e.message : 'IPC 调用失败');
-    } finally {
-      setLoggingIn(false);
-    }
-  };
-
   /** 浏览器登录：打开 MiQroForge 授权页，用户在页面完成登录并点击"同意"。 */
   const handleBrowserLogin = async () => {
     setBrowserLoggingIn(true);
@@ -168,13 +120,8 @@ export function QraftPage() {
     try {
       const result = await window.miqi.qraft.browserLogin({
         env: 'test',
-        baseUrl: baseUrl.trim() || undefined,
-        clientId: clientId.trim() || undefined,
-        clientSecret: clientSecret.trim() || undefined,
-        redirectUri: redirectUri.trim() || undefined,
       });
       if (result.ok) {
-        setPassword('');
         setStatus(await window.miqi.qraft.status());
       } else if (result.code === 'LOGIN_CANCELLED') {
         setBrowserNotice(errorText(result, '已取消浏览器登录'));
@@ -269,22 +216,17 @@ export function QraftPage() {
         <div className="min-w-0">
           <h3 className="text-subheading text-[var(--text)]">MiQroForge 平台账号</h3>
           <p className="mt-1 text-xs leading-relaxed text-[var(--text-faint)]">
-            登录后 MiQroForge 将以你的身份调用 MiQroForge 平台接口（授权码流程，凭据安全存储，
-            到期自动刷新）。推荐使用浏览器登录：打开 MiQroForge 平台页面完成登录并点击
-            「同意」，MiQroForge 自动完成授权。
+            登录后 MiQroForge 将以你的身份调用 MiQroForge 平台接口（OAuth 授权码流程，
+            凭据安全存储，到期自动刷新）。点击下方按钮打开 MiQroForge 平台页面完成登录
+            并点击「同意」，MiQroForge 自动完成授权。
           </p>
         </div>
       </div>
 
       {!loggedIn ? (
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void handleLogin();
-          }}
-        >
-          {/* 浏览器登录（MiQroForge 授权页修复后可用：用户在页面点击"同意"） */}
+        <div className="flex flex-col gap-4">
+          {/* 浏览器登录（OAuth）：当前唯一的登录入口 —— 手机号/密码表单、
+              环境选择与高级设置已隐藏，待后续需要时恢复。 */}
           <div className="flex flex-col gap-1.5">
             <Button
               type="button"
@@ -299,156 +241,11 @@ export function QraftPage() {
               ) : (
                 <Globe size={14} />
               )}
-              {browserLoggingIn
-                ? '等待授权中…（请在 MiQroForge 页面完成登录）'
-                : '浏览器登录（推荐）'}
+              {browserLoggingIn ? '等待授权中…（请在 MiQroForge 页面完成登录）' : '浏览器登录'}
             </Button>
             <p className="text-size-2xs text-[var(--text-faint)]">
               将打开 MiQroForge 平台授权页，在页面完成登录并点击「同意」后自动回到 MiQroForge。
             </p>
-          </div>
-
-          <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-[var(--border-subtle)]" />
-            <span className="text-size-2xs text-[var(--text-faint)]">或使用手机号登录</span>
-            <div className="h-px flex-1 bg-[var(--border-subtle)]" />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="qraft-phone"
-              className="text-size-sm font-medium text-[var(--text-muted)]"
-            >
-              手机号
-            </label>
-            <Input
-              id="qraft-phone"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              placeholder="MiQroForge 平台账号手机号"
-              autoComplete="username"
-              inputMode="numeric"
-              data-testid="qraft-phone-input"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="qraft-password"
-              className="text-size-sm font-medium text-[var(--text-muted)]"
-            >
-              密码
-            </label>
-            <div className="flex gap-2">
-              <Input
-                id="qraft-password"
-                type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="MiQroForge 平台密码"
-                autoComplete="current-password"
-                className="flex-1"
-                data-testid="qraft-password-input"
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                type="button"
-                onClick={() => setShowPassword((v) => !v)}
-                aria-label={showPassword ? '隐藏密码' : '显示密码'}
-              >
-                {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
-              </Button>
-            </div>
-          </div>
-
-          {/* 高级设置 */}
-          <div className="border-t border-[var(--border-subtle)] pt-3">
-            <button
-              type="button"
-              onClick={() => setAdvancedOpen((v) => !v)}
-              className="flex w-full items-center gap-1.5 text-xs font-medium text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
-            >
-              <ChevronDown
-                size={12}
-                className={cn('transition-transform duration-150', advancedOpen && 'rotate-180')}
-              />
-              高级设置（接入配置，默认按环境预填）
-            </button>
-            {advancedOpen && (
-              <div className="mt-3 flex flex-col gap-3">
-                <div className="flex flex-col gap-1.5">
-                  <label
-                    htmlFor="qraft-baseurl"
-                    className="text-size-xs font-medium text-[var(--text-faint)]"
-                  >
-                    API 基础地址（留空用环境默认）
-                  </label>
-                  <Input
-                    id="qraft-baseurl"
-                    value={baseUrl}
-                    onChange={(e) => setBaseUrl(e.target.value)}
-                    placeholder="https://test.forge.miqroera.com/api"
-                    className="font-mono text-xs"
-                    data-testid="qraft-baseurl-input"
-                  />
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex flex-col gap-1.5">
-                    <label
-                      htmlFor="qraft-client-id"
-                      className="text-size-xs font-medium text-[var(--text-faint)]"
-                    >
-                      client_id
-                    </label>
-                    <Input
-                      id="qraft-client-id"
-                      value={clientId}
-                      onChange={(e) => setClientId(e.target.value)}
-                      placeholder="miqi"
-                      className="font-mono text-xs"
-                      data-testid="qraft-client-id-input"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1.5">
-                    <label
-                      htmlFor="qraft-client-secret"
-                      className="text-size-xs font-medium text-[var(--text-faint)]"
-                    >
-                      client_secret
-                    </label>
-                    <Input
-                      id="qraft-client-secret"
-                      type={showPassword ? 'text' : 'password'}
-                      value={clientSecret}
-                      onChange={(e) => setClientSecret(e.target.value)}
-                      placeholder="留空用默认值（测试阶段）"
-                      className="font-mono text-xs"
-                      data-testid="qraft-client-secret-input"
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <label
-                    htmlFor="qraft-redirect-uri"
-                    className="text-size-xs font-medium text-[var(--text-faint)]"
-                  >
-                    redirect_uri（留空自动生成 loopback 地址）
-                  </label>
-                  <Input
-                    id="qraft-redirect-uri"
-                    value={redirectUri}
-                    onChange={(e) => setRedirectUri(e.target.value)}
-                    placeholder="http://localhost:<随机端口>/callback"
-                    className="font-mono text-xs"
-                    data-testid="qraft-redirect-uri-input"
-                  />
-                </div>
-                <p className="text-size-2xs text-[var(--text-faint)]">
-                  当前为测试环境，不校验注册值。生产环境上线后再开放环境选择。
-                </p>
-              </div>
-            )}
           </div>
 
           {browserNotice && (
@@ -470,17 +267,7 @@ export function QraftPage() {
               <span className="min-w-0">{loginError}</span>
             </div>
           )}
-
-          <Button
-            type="submit"
-            disabled={loggingIn}
-            className="self-start"
-            data-testid="qraft-login-btn"
-          >
-            {loggingIn ? <RefreshCw size={14} className="animate-spin" /> : <LogIn size={14} />}
-            {loggingIn ? '登录中…（含授权流程，请稍候）' : '登录'}
-          </Button>
-        </form>
+        </div>
       ) : (
         <div className="flex flex-col gap-4">
           {needsRelogin && (

--- a/apps/desktop/tests/e2e/ai-gateway-live.spec.ts
+++ b/apps/desktop/tests/e2e/ai-gateway-live.spec.ts
@@ -10,7 +10,7 @@
  *   npx playwright test --config=playwright.config.ts --project=electron ai-gateway-live.spec.ts
  *
  * 覆盖真实全链路（issue #922 / PR #946）：
- *   真实 Electron 应用 → QraftPage 手机号登录 → /oauth2/userinfo 下发
+ *   真实 Electron 应用 → QraftPage 浏览器登录（OAuth）→ /oauth2/userinfo 下发
  *   encryptedApiKey（网关状态行"可用"+ 配置版本）→ 聊天发消息
  *   → 主进程写 token.json → Python make_provider 路由 AnthropicProvider
  *   → 平台 AI 网关真实回复。
@@ -20,6 +20,7 @@ import { test, expect } from '@playwright/test';
 import {
   launchElectronApp,
   closeElectronApp,
+  browserLogin,
   createNewConversation,
   sendMessage,
   type ElectronFixture,
@@ -48,17 +49,9 @@ describeFn('AI 网关真实账号 live E2E (opt-in)', () => {
     const page = fixture.page;
 
     // 1. 设置页真实登录（幂等：dev userData 可能残留上次登录态）
-    await page.getByText(/^(System Settings|系统设置)$/).click();
-    await page
-      .getByRole('tab')
-      .filter({ hasText: /MiQroForge/ })
-      .first()
-      .click();
     const loggedInBadge = page.getByText('已登录');
     if (!(await loggedInBadge.isVisible({ timeout: 5000 }).catch(() => false))) {
-      await page.getByTestId('qraft-phone-input').fill(PHONE);
-      await page.getByTestId('qraft-password-input').fill(PASSWORD);
-      await page.getByTestId('qraft-login-btn').click();
+      await browserLogin(page, fixture.electronApp, PHONE, PASSWORD);
     }
     await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
 

--- a/apps/desktop/tests/e2e/billing-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-live.spec.ts
@@ -21,6 +21,7 @@ import {
   createNewConversation,
   launchElectronApp,
   closeElectronApp,
+  browserLogin,
   type ElectronFixture,
 } from './helpers/electron-setup';
 
@@ -85,17 +86,14 @@ describeFn('Billing live E2E — slurm MCP RUNNING 扣分 (opt-in)', () => {
     { timeout: 360_000 },
     async () => {
       // 1. 设置页真实登录（dev userData 可能残留上次运行的登录态，幂等处理）
-      await page.getByText(/^(System Settings|系统设置)$/).click();
-      await page
-        .getByRole('tab')
-        .filter({ hasText: /MiQroForge/ })
-        .first()
-        .click();
       const loggedInBadge = page.getByText('已登录');
       if (!(await loggedInBadge.isVisible({ timeout: 5000 }).catch(() => false))) {
-        await page.getByTestId('qraft-phone-input').fill(process.env.QRAFT_PHONE!);
-        await page.getByTestId('qraft-password-input').fill(process.env.QRAFT_PASSWORD!);
-        await page.getByTestId('qraft-login-btn').click();
+        await browserLogin(
+          page,
+          electronApp,
+          process.env.QRAFT_PHONE!,
+          process.env.QRAFT_PASSWORD!
+        );
       }
       await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
 

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -439,6 +439,48 @@ export interface ElectronFixture {
   miqiSessionsDir: string;
 }
 
+/**
+ * 设置页「浏览器登录」真实链路：点按钮 → 主进程打开 MiQroForge 授权窗口
+ * （独立 partition）→ 未登录被 302 到平台登录页 → 填测试账号登录 →
+ * 服务端 302 回调 redirect_uri?code → 主进程拦截 code 换 token →
+ * 应用内出现「已登录」。
+ *
+ * 凭据经环境变量注入（QRAFT_PHONE / QRAFT_PASSWORD），调用方在未登录时
+ * 才调用（dev userData 可能残留上次登录态，须先判断「已登录」徽标）。
+ * 返回授权窗口的 Page（完成时主进程会自动关闭它）。
+ */
+export async function browserLogin(
+  page: Page,
+  electronApp: ElectronApplication,
+  phone: string,
+  password: string
+): Promise<Page> {
+  await page.getByText(/^(System Settings|系统设置)$/).click();
+  await page
+    .getByRole('tab')
+    .filter({ hasText: /MiQroForge/ })
+    .first()
+    .click();
+  await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 15_000 });
+
+  const loginWindowPromise = electronApp.waitForEvent('window');
+  await page.getByTestId('qraft-browser-login-btn').click();
+  const loginWin = await loginWindowPromise;
+  await loginWin.waitForLoadState('domcontentloaded');
+
+  // 未登录 → 服务端 302 到平台登录页；已有登录态时直接进授权流程
+  await loginWin.waitForURL(/\/login/, { timeout: 30_000 }).catch(() => {
+    /* 已有登录态时直接进授权流程 */
+  });
+  await expect(loginWin.locator('#login_phone')).toBeVisible({ timeout: 30_000 });
+  await loginWin.fill('#login_phone', phone);
+  await loginWin.fill('#login_password', password);
+  await loginWin.getByRole('button', { name: /登\s*录/ }).click();
+
+  await expect(page.getByText('已登录')).toBeVisible({ timeout: 120_000 });
+  return loginWin;
+}
+
 /** Launch Electron app, wait for bridge ready, return { electronApp, page, miqiHome, miqiSessionsDir }.
  *
  *  - Creates a unique temporary MIQI_HOME so parallel test workers are fully isolated.

--- a/apps/desktop/tests/e2e/qraft-browser-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-browser-login.spec.ts
@@ -19,6 +19,7 @@ import { existsSync, rmSync } from 'node:fs';
 import {
   launchElectronApp,
   closeElectronApp,
+  browserLogin,
   type ElectronFixture,
 } from './helpers/electron-setup';
 
@@ -26,14 +27,6 @@ const PHONE = process.env.QRAFT_PHONE ?? '';
 const PASSWORD = process.env.QRAFT_PASSWORD ?? '';
 
 const STORE_ENV = 'MIQI_QRAFT_STORE';
-
-async function gotoQraftTab(page: Page): Promise<void> {
-  await page.getByText(/^(System Settings|系统设置)$/).click();
-  await page
-    .getByRole('tab')
-    .filter({ hasText: /MiQroForge/ })
-    .click();
-}
 
 let storePath: string;
 
@@ -61,28 +54,11 @@ test.describe('MiQroForge 浏览器登录 E2E（真实测试环境）', () => {
   test('浏览器登录：MiQroForge 页面完成登录 → 自动回到授权 → 应用内完成登录', async () => {
     test.setTimeout(300_000);
 
-    await gotoQraftTab(page);
-    await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 15_000 });
+    // 点浏览器登录 → 主进程打开 MiQroForge 授权窗口 → 填测试账号登录 →
+    // 拦截回调 code 换 token → 设置页出现已登录账号信息（helper 全链路）
+    const loginWin = await browserLogin(page, electronApp, PHONE, PASSWORD);
 
-    // 点浏览器登录 → 主进程打开 MiQroForge 授权窗口（标题「MiQroForge 平台登录」）
-    const loginWindowPromise = electronApp.waitForEvent('window');
-    await page.getByTestId('qraft-browser-login-btn').click();
-    const loginWin = await loginWindowPromise;
-    await loginWin.waitForLoadState('domcontentloaded');
-
-    // 未登录 → 服务端 302 到平台登录页；填入测试账号登录
-    await loginWin.waitForURL(/\/login/, { timeout: 30_000 }).catch(() => {
-      /* 已有登录态时直接进授权流程 */
-    });
-    await expect(loginWin.locator('#login_phone')).toBeVisible({ timeout: 30_000 });
-    await loginWin.fill('#login_phone', PHONE);
-    await loginWin.fill('#login_password', PASSWORD);
-    await loginWin.getByRole('button', { name: /登\s*录/ }).click();
-
-    // 主进程检测到登录态 cookie → 带回授权流程 → 拦截回调 code →
-    // 换 token + userinfo → 设置页出现已登录账号信息
     await expect(page.getByText('MiQi测试').first()).toBeVisible({ timeout: 120_000 });
-    await expect(page.getByText('已登录')).toBeVisible();
     await expect(page.getByTestId('qraft-logout-btn')).toBeVisible();
 
     // 授权窗口已在完成时自动关闭
@@ -93,8 +69,8 @@ test.describe('MiQroForge 浏览器登录 E2E（真实测试环境）', () => {
       fullPage: true,
     });
 
-    // 退出登录：回到登录表单，磁盘凭据清空
+    // 退出登录：回到登录入口，磁盘凭据清空
     await page.getByTestId('qraft-logout-btn').click();
-    await expect(page.getByTestId('qraft-login-btn')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -86,7 +86,7 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
     if (existsSync(storePath)) rmSync(storePath, { force: true });
   });
 
-  test('登录表单渲染：手机号/密码（掩码）/环境/高级设置默认折叠', async () => {
+  test('登录表单渲染：手机号/密码（掩码）/高级设置默认折叠', async () => {
     await gotoQraftTab(page);
 
     const phoneInput = page.getByTestId('qraft-phone-input');
@@ -95,8 +95,9 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
     await expect(passwordInput).toBeVisible();
     await expect(passwordInput).toHaveAttribute('type', 'password');
     await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
-    await expect(page.getByRole('button', { name: '测试环境' })).toBeVisible();
-    await expect(page.getByRole('button', { name: '生产环境' })).toBeVisible();
+    // 环境选择已隐藏（生产域名未上线，仅测试环境可用）
+    await expect(page.getByRole('button', { name: '测试环境' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '生产环境' })).toHaveCount(0);
     // 高级设置默认折叠，展开后出现接入配置输入框
     await expect(page.getByTestId('qraft-baseurl-input')).not.toBeVisible();
     await page.getByText('高级设置（接入配置，默认按环境预填）').click();

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -2,13 +2,12 @@
  * MiQroForge 平台 OAuth2 登录 — Electron E2E（issue #726）。
  *
  * 覆盖真实主进程链路（qraft IPC → QraftService → QraftStore 落盘）：
- *   1. 登录表单渲染、密码掩码、高级设置折叠
- *   2. 登录失败的错误分类提示（不可路由 baseUrl 强制网络失败，无外部依赖）
- *   3. 预置登录态（MIQI_QRAFT_STORE 指向临时文件）→ 账号信息展示 →
+ *   1. 登录页只渲染浏览器登录（OAuth）入口（手机号表单/高级设置已隐藏）
+ *   2. 预置登录态（MIQI_QRAFT_STORE 指向临时文件）→ 账号信息展示 →
  *      退出登录 → 磁盘文件被清空（验证真实持久化路径）
  *
- * 不依赖 MiQroForge 网络：登录态由测试预置（plain 信封），错误路径用
- * TEST-NET-1（192.0.2.1）强制请求失败，任何平台（含 macOS CI）行为一致。
+ * 不依赖 MiQroForge 网络：登录态由测试预置（plain 信封），行为在任何
+ * 平台（含 macOS CI）一致。
  */
 
 import { test, expect } from '@playwright/test';
@@ -25,7 +24,6 @@ import {
 } from './helpers/electron-setup';
 
 const STORE_ENV = 'MIQI_QRAFT_STORE';
-const TEST_BASE_URL = 'https://192.0.2.1/api'; // TEST-NET-1，永远不可达
 
 /** 构造 plain 信封的预置登录态文件内容（QraftStore 支持无 safeStorage 降级读取）。 */
 function buildSeededStoreContent(overrides: { baseUrl?: string; expiresAt?: number } = {}): string {
@@ -86,45 +84,16 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
     if (existsSync(storePath)) rmSync(storePath, { force: true });
   });
 
-  test('登录表单渲染：手机号/密码（掩码）/高级设置默认折叠', async () => {
+  test('登录页只渲染浏览器登录（OAuth）入口', async () => {
     await gotoQraftTab(page);
 
-    const phoneInput = page.getByTestId('qraft-phone-input');
-    const passwordInput = page.getByTestId('qraft-password-input');
-    await expect(phoneInput).toBeVisible({ timeout: 15_000 });
-    await expect(passwordInput).toBeVisible();
-    await expect(passwordInput).toHaveAttribute('type', 'password');
-    await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
-    // 环境选择已隐藏（生产域名未上线，仅测试环境可用）
-    await expect(page.getByRole('button', { name: '测试环境' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: '生产环境' })).toHaveCount(0);
-    // 高级设置默认折叠，展开后出现接入配置输入框
-    await expect(page.getByTestId('qraft-baseurl-input')).not.toBeVisible();
-    await page.getByText('高级设置（接入配置，默认按环境预填）').click();
-    await expect(page.getByTestId('qraft-baseurl-input')).toBeVisible();
-    await expect(page.getByTestId('qraft-client-secret-input')).toBeVisible();
-  });
-
-  test('登录失败展示分类错误提示（不可达 baseUrl → 网络类错误）', async () => {
-    await gotoQraftTab(page);
-
-    await page.getByTestId('qraft-phone-input').fill('18500000000');
-    await page.getByTestId('qraft-password-input').fill('not-a-real-password');
-    await page.getByText('高级设置（接入配置，默认按环境预填）').click();
-    await page.getByTestId('qraft-baseurl-input').fill(TEST_BASE_URL);
-    await page.getByTestId('qraft-login-btn').click();
-
-    // 主进程对 192.0.2.1 重试 3 次后失败 → 错误框给出分类提示。
-    // 用户可感知结果：错误提示出现且包含网络类文案，而不是空白/崩溃。
-    const errorBox = page.getByTestId('qraft-login-error');
-    await expect(errorBox).toBeVisible({ timeout: 120_000 });
-    const text = (await errorBox.textContent()) ?? '';
-    expect(/网络请求失败|网络请求|请检查网络/.test(text)).toBe(true);
-
-    await page.screenshot({
-      path: 'test-results/qraft-e2e-login-error.png',
-      fullPage: true,
-    });
+    // 浏览器登录入口可见；手机号/密码表单、提交按钮与高级设置均不渲染
+    await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('qraft-phone-input')).toHaveCount(0);
+    await expect(page.getByTestId('qraft-password-input')).toHaveCount(0);
+    await expect(page.getByTestId('qraft-login-btn')).toHaveCount(0);
+    await expect(page.getByTestId('qraft-baseurl-input')).toHaveCount(0);
+    await expect(page.getByText('高级设置（接入配置，默认按环境预填）')).toHaveCount(0);
   });
 
   test('预置登录态展示账号信息，退出登录清空状态与磁盘文件', async () => {
@@ -178,11 +147,10 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
       fullPage: true,
     });
 
-    // 退出登录：界面回到登录表单，磁盘凭据清空（store 文件与 token 文件）
+    // 退出登录：界面回到登录入口，磁盘凭据清空（store 文件与 token 文件）
     // IPC 返回与磁盘写入存在竞态，轮询文件直到为空。
     await page.getByTestId('qraft-logout-btn').click();
-    await expect(page.getByTestId('qraft-phone-input')).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
+    await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 15_000 });
     await expect
       .poll(() => (existsSync(storePath) ? readFileSync(storePath, 'utf8') : ''), {
         timeout: 10_000,

--- a/apps/desktop/tests/smoke/issue-726-qraft.spec.ts
+++ b/apps/desktop/tests/smoke/issue-726-qraft.spec.ts
@@ -1,8 +1,8 @@
 /**
  * Issue #726 — MiQroForge 平台 OAuth2 登录设置页（smoke，mock bridge）。
  *
- * 覆盖：未登录表单、密码输入脱敏（type=password）、登录成功展示账号、
- * 登录失败错误提示、requiresRelogin 横幅、退出登录回到表单。
+ * 覆盖：未登录时只展示浏览器登录（OAuth）入口、登录成功展示账号、
+ * 登录失败错误提示、requiresRelogin 横幅、退出登录回到登录入口。
  */
 
 import { expect, test } from '@playwright/test';
@@ -23,27 +23,21 @@ async function gotoQraftTab(
 }
 
 test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
-  test('未登录时显示登录表单：浏览器登录入口、手机号、密码（掩码输入）与高级设置', async ({
+  test('未登录时只展示浏览器登录（OAuth）入口，手机号/密码表单与高级设置已隐藏', async ({
     page,
   }) => {
     await gotoQraftTab(page);
 
-    const phoneInput = page.getByTestId('qraft-phone-input');
-    const passwordInput = page.getByTestId('qraft-password-input');
-    await expect(phoneInput).toBeVisible();
-    await expect(passwordInput).toBeVisible();
-    // 密码输入必须为掩码类型（凭据不在界面明文展示）
-    await expect(passwordInput).toHaveAttribute('type', 'password');
-    // 浏览器登录入口（MiQroForge 授权页修复后：页面点击"同意"）
+    // 浏览器登录入口（MiQroForge 授权页：用户在页面点击"同意"）
     await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible();
     await expect(page.getByTestId('qraft-browser-login-btn')).toContainText('浏览器登录');
-    await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
-    // 环境选择已隐藏（生产域名未上线，仅测试环境可用）
+    // 手机号/密码表单、提交按钮、环境选择与高级设置均不渲染
+    await expect(page.getByTestId('qraft-phone-input')).toHaveCount(0);
+    await expect(page.getByTestId('qraft-password-input')).toHaveCount(0);
+    await expect(page.getByTestId('qraft-login-btn')).toHaveCount(0);
     await expect(page.getByRole('button', { name: '测试环境' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: '生产环境' })).toHaveCount(0);
-    // 高级设置默认折叠
-    await expect(page.getByText('高级设置（接入配置，默认按环境预填）')).toBeVisible();
-    await expect(page.getByText('client_id')).not.toBeVisible();
+    await expect(page.getByText('高级设置（接入配置，默认按环境预填）')).toHaveCount(0);
 
     await page.screenshot({ path: 'test-results/issue-726/qraft-login-form.png', fullPage: true });
   });
@@ -79,9 +73,7 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
   test('登录成功展示账号信息（nickname/username/脱敏手机号）与退出按钮', async ({ page }) => {
     await gotoQraftTab(page);
 
-    await page.getByTestId('qraft-phone-input').fill('18500000000');
-    await page.getByTestId('qraft-password-input').fill('test-password');
-    await page.getByTestId('qraft-login-btn').click();
+    await page.getByTestId('qraft-browser-login-btn').click();
 
     // 账号信息（nickname 来自 mock userinfo）
     await expect(page.getByText('MiQi测试').first()).toBeVisible({ timeout: 5000 });
@@ -106,9 +98,7 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
       },
     });
 
-    await page.getByTestId('qraft-phone-input').fill('18500000000');
-    await page.getByTestId('qraft-password-input').fill('test-password');
-    await page.getByTestId('qraft-login-btn').click();
+    await page.getByTestId('qraft-browser-login-btn').click();
 
     await expect(page.getByTestId('qraft-points-balance')).toBeVisible({ timeout: 5000 });
     await expect(page.getByTestId('qraft-points-value')).toHaveText('270');
@@ -155,9 +145,7 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
       },
     });
 
-    await page.getByTestId('qraft-phone-input').fill('18500000000');
-    await page.getByTestId('qraft-password-input').fill('x');
-    await page.getByTestId('qraft-login-btn').click();
+    await page.getByTestId('qraft-browser-login-btn').click();
 
     const errorBox = page.getByTestId('qraft-login-error');
     await expect(errorBox).toBeVisible({ timeout: 5000 });
@@ -187,7 +175,7 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
     await expect(page.getByTestId('qraft-logout-btn')).toBeVisible();
   });
 
-  test('退出登录清除状态并回到登录表单', async ({ page }) => {
+  test('退出登录清除状态并回到登录入口', async ({ page }) => {
     await gotoQraftTab(page, {
       qraftStatus: {
         loggedIn: true,
@@ -206,7 +194,6 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
     await expect(page.getByTestId('qraft-logout-btn')).toBeVisible();
     await page.getByTestId('qraft-logout-btn').click();
 
-    await expect(page.getByTestId('qraft-phone-input')).toBeVisible({ timeout: 5000 });
-    await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
+    await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible({ timeout: 5000 });
   });
 });

--- a/apps/desktop/tests/smoke/issue-726-qraft.spec.ts
+++ b/apps/desktop/tests/smoke/issue-726-qraft.spec.ts
@@ -23,7 +23,7 @@ async function gotoQraftTab(
 }
 
 test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
-  test('未登录时显示登录表单：浏览器登录入口、手机号、密码（掩码输入）、环境与高级设置', async ({
+  test('未登录时显示登录表单：浏览器登录入口、手机号、密码（掩码输入）与高级设置', async ({
     page,
   }) => {
     await gotoQraftTab(page);
@@ -38,8 +38,9 @@ test.describe('Issue #726 MiQroForge 平台登录设置页', () => {
     await expect(page.getByTestId('qraft-browser-login-btn')).toBeVisible();
     await expect(page.getByTestId('qraft-browser-login-btn')).toContainText('浏览器登录');
     await expect(page.getByTestId('qraft-login-btn')).toBeVisible();
-    await expect(page.getByRole('button', { name: '测试环境' })).toBeVisible();
-    await expect(page.getByRole('button', { name: '生产环境' })).toBeVisible();
+    // 环境选择已隐藏（生产域名未上线，仅测试环境可用）
+    await expect(page.getByRole('button', { name: '测试环境' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: '生产环境' })).toHaveCount(0);
     // 高级设置默认折叠
     await expect(page.getByText('高级设置（接入配置，默认按环境预填）')).toBeVisible();
     await expect(page.getByText('client_id')).not.toBeVisible();


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

登录页只保留 OAuth 浏览器登录入口，隐藏手机号/密码表单、环境选择与高级设置。

## 背景/问题

按产品要求（2026-09-08）：登录方式收敛为 OAuth 授权一条路径。手机号/密码表单、环境选择（生产域名尚未上线，无意义）与高级设置（接入配置）对用户不再展示，避免误用与界面噪音。浏览器登录打开 MiQroForge 授权页，用户在平台页面完成登录并点击「同意」后自动回到应用内完成授权。

## 变更内容

- `apps/desktop/src/renderer/features/settings/components/QraftPage.tsx`
  - 删除手机号/密码输入、密码显隐切换、提交按钮、环境选择器（`ModeBtn`）与高级设置区块，及对应 state/handler
  - 未登录视图只保留「浏览器登录」按钮（`browserLogin` 只传 `env: 'test'`）
- `apps/desktop/tests/smoke/issue-726-qraft.spec.ts` / `apps/desktop/tests/e2e/qraft-login.spec.ts`
  - 表单渲染用例改为断言手机号/密码/提交/高级设置均不渲染；手机号登录类用例改用浏览器登录入口
- `apps/desktop/tests/e2e/helpers/electron-setup.ts`
  - 新增共享 `browserLogin()` helper（设置页点按钮 → 授权窗口填账号 → 应用内完成登录），供 live 用例复用
- `apps/desktop/tests/e2e/qraft-browser-login.spec.ts` / `ai-gateway-live.spec.ts` / `billing-live.spec.ts`
  - 改用共享 `browserLogin()` helper；退出登录断言回到浏览器登录入口

主进程手机号登录 IPC（`qraft.login`）保留不动，仅隐藏 UI 入口，后续需要时可恢复。

## 日志/验证证据

```
$ npx playwright test --config=playwright.config.ts --project=smoke tests/smoke/issue-726-qraft.spec.ts
  9 passed (5.8s)

$ PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test --config=playwright.config.ts --project=electron tests/e2e/qraft-login.spec.ts
  3 passed (22.5s)

$ npx tsc --noEmit -p tsconfig.web.json
  （无输出，通过）
```

## 测试情况

- typecheck（tsconfig.web）：通过
- smoke `issue-726-qraft.spec.ts`：9 passed
- E2E `qraft-login.spec.ts`（真实 Electron 应用）：3 passed（原「不可达 baseUrl 错误分类」用例随高级设置隐藏移除）
- prettier：通过
- live 用例（`qraft-browser-login` / `ai-gateway-live` / `billing-live`）改为共享 helper，需真实凭据，本地未跑（CI 无凭据自动跳过）

## 截图

登录页（仅浏览器登录 OAuth 入口，手机号表单/环境选择/高级设置已隐藏）：

![qraft-login-oauth-only](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/75d7cbaebf24a05c.png)
