### PR TITLE
fix(chat): 用户消息去重前归一化附件占位符，避免带图/文件消息双显示 (#968)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -470,6 +470,39 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([true]);
   });
 
+  it('#968 复核：相同附件重复出现不得共用同一条持久化装饰（CodeRabbit #969 round 2）', () => {
+    // 30s 内先发 1 张图再发同文本 2 张相同图：1 条装饰的旧副本若同时满足两个
+    // identical 附件，第二气泡会被误认领 → 吞真实消息。每条装饰只认领一个附件。
+    const fpa = 'a'.repeat(64);
+    const two = [
+      { name: 'photo.png', type: 'image' as const, contentFp: fpa },
+      { name: 'photo.png', type: 'image' as const, contentFp: fpa },
+    ];
+    // 旧副本只有 1 条装饰 → 不认领
+    expect(
+      _markUserTwinMatches([u('看图', T, two)], [u(`看图\n\n[Image: photo.png (fp:${fpa})]`, T)])
+    ).toEqual([false]);
+    // 旧副本有 2 条相同装饰 → 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, two)],
+        [u(`看图\n\n[Image: photo.png (fp:${fpa})]\n\n[Image: photo.png (fp:${fpa})]`, T)]
+      )
+    ).toEqual([true]);
+    // document 占位同型：1 条占位不得满足 2 个同指纹附件
+    expect(
+      _markUserTwinMatches(
+        [
+          u('看', T, [
+            { name: 'scan.pdf', type: 'document', contentFp: fpa },
+            { name: 'scan.pdf', type: 'document', contentFp: fpa },
+          ]),
+        ],
+        [u(`看\n\n[scan.pdf: scanned PDF (fp:${fpa}) — OCR will be attempted by the server]`, T)]
+      )
+    ).toEqual([false]);
+  });
+
   it('#968 复核：SHA-256 覆盖全量内容——同名同首尾、仅中段不同的大附件指纹不同', async () => {
     // CodeRabbit #969 回归要求：>8192 字符、长度与首尾 4KB 相同、中段不同的
     // dataBase64 必须产生不同指纹（采样方案会被构造性绕过，全量摘要不会）

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -304,6 +304,15 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
       },
     ]);
     expect(ui2.find((m) => m.role === 'user')?.attachments?.[0]?.name).toBe('photo.png');
+    // 文件名含 ] + 指纹尾：以 fp 为锚反推名称，不得在名字内的 ] 截断（CodeRabbit）
+    const ui3 = sessionMsgsToUi([
+      {
+        role: 'user',
+        content: `看图\n\n[Image: IMG[1].png (fp:${fpa})]`,
+        timestamp: '2026-09-01T00:00:00Z',
+      },
+    ]);
+    expect(ui3.find((m) => m.role === 'user')?.attachments?.[0]?.name).toBe('IMG[1].png');
   });
 
   it('#968 复核：文档解析失败占位（[name: 大小 — parsing on server]）可剥离', () => {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -248,6 +248,14 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([false]);
   });
 
+  it('#968 复核：文档解析失败占位（[name: 大小 — parsing on server]）可剥离', () => {
+    // handleSend catch 分支：冒号后先带 formatFileSize，再是 parsing on server——
+    // 早期规则要求 phrase 紧跟冒号导致永不匹配（CodeRabbit 阻塞项）
+    expect(
+      _markUserTwinMatches([u('看')], [u('看\n\n[a.pdf: 1.2 MB — parsing on server]')])
+    ).toEqual([true]);
+  });
+
   it('#968 复核：同图真实副本可认领（装饰名守卫通过）', () => {
     expect(
       _markUserTwinMatches(

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -20,6 +20,7 @@ import {
   shouldRenderThinkingGroup,
   sessionMsgsToUi,
   insertInterruptedTurns,
+  _markUserTwinMatches,
 } from './ChatConsole';
 
 describe('ChatConsole thinking block regression (#858 → #905)', () => {
@@ -132,5 +133,58 @@ describe('ChatConsole thinking block regression (#858 → #905)', () => {
     const card = cards.find((m) => m.interrupted);
     expect(card?.reasoningMode).toBe('fast');
     expect(card?.reasoningElapsedS).toBe(4);
+  });
+});
+
+describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', () => {
+  const T = 1_700_000_000_000;
+  const u = (content: string, ts = T) => ({ role: 'user' as const, content, timestamp: ts });
+
+  it('纯文本：持久化副本认领同内容乐观气泡', () => {
+    expect(_markUserTwinMatches([u('你好')], [u('你好')])).toEqual([true]);
+  });
+
+  it('#968 图片消息：persisted 带 [Image: …] 占位符也能互认（归一化后比对）', () => {
+    // 乐观气泡 content 只有输入文本；落库 content 追加了图片占位符（handleSend payload）
+    expect(
+      _markUserTwinMatches([u('看看这张图')], [u('看看这张图\n\n[Image: photo.png]')])
+    ).toEqual([true]);
+  });
+
+  it('#968 文件附件：persisted 带 [File: …] 代码块也能互认', () => {
+    expect(
+      _markUserTwinMatches([u('帮我看看')], [u('帮我看看\n\n[File: a.txt]\n```\nhello\n```')])
+    ).toEqual([true]);
+  });
+
+  it('#968 文档附件：--- Document: --- 段被剥离后互认', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('解析这个 pdf')],
+        [u('解析这个 pdf\n\n--- Document: report.pdf ---\n正文\n--- End of report.pdf ---')]
+      )
+    ).toEqual([true]);
+  });
+
+  it('内容不同不互认', () => {
+    expect(_markUserTwinMatches([u('问题 A')], [u('问题 B')])).toEqual([false]);
+  });
+
+  it('#891 复核：同文本两条气泡只有最早一条被一对一认领', () => {
+    // 用户 30s 内连发同一句、快照只含第一条的持久化副本——第二条必须判为
+    // 未落盘（保留），不能再被同一条副本同时满足（.some() 的旧缺陷）
+    expect(
+      _markUserTwinMatches([u('再来一次', T), u('再来一次', T + 10_000)], [u('再来一次')])
+    ).toEqual([true, false]);
+  });
+
+  it('时间相近限定：30s 外的同文本旧副本不误认', () => {
+    expect(_markUserTwinMatches([u('再来一次', T)], [u('再来一次', T - 60_000)])).toEqual([false]);
+  });
+
+  it('#968 + #891 复核组合：同文本两条、persisted 带图 → 归一化后仍只认领最早一条', () => {
+    expect(
+      _markUserTwinMatches([u('看图', T), u('看图', T + 5_000)], [u('看图\n\n[Image: a.png]', T)])
+    ).toEqual([true, false]);
   });
 });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -236,23 +236,74 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
   });
 
   it('#968 复核：纯附件无文本发送（live "(attachment)" ↔ 纯装饰副本）', () => {
+    const fpa = 'a'.repeat(64);
     expect(
       _markUserTwinMatches(
-        [u('(attachment)', T, [{ name: 'photo.png', type: 'image' }])],
-        [u('\n\n[Image: photo.png]', T)]
+        [u('(attachment)', T, [{ name: 'photo.png', type: 'image', contentFp: fpa }])],
+        [u(`\n\n[Image: photo.png (fp:${fpa})]`, T)]
       )
     ).toEqual([true]);
   });
 
-  it('#968 复核：图片装饰名守卫——旧图副本不得认领换图后的新气泡（重新生成）', () => {
-    // 重新生成换了图：live 气泡带 B.png，merged 只有旧回合 A.png 的副本。
-    // key 相同（看图），但旧副本不含 [Image: B.png] → 不得认领（否则新问题被吞）
+  it('#968 复核：图片内容指纹守卫——同名异字节图片不得互认、同字节可认领（CodeRabbit #969）', () => {
+    const fpa = 'a'.repeat(64);
+    const fpb = 'b'.repeat(64);
+    // 重新生成换了图（同名异字节）：live 带 fpB，merged 只有旧副本 fpA → 不认领
     expect(
       _markUserTwinMatches(
-        [u('看图', T, [{ name: 'B.png', type: 'image' }])],
-        [u('看图\n\n[Image: A.png]', T - 2_000)]
+        [u('看图', T, [{ name: 'B.png', type: 'image', contentFp: fpb }])],
+        [u(`看图\n\n[Image: A.png (fp:${fpa})]`, T - 2_000)]
       )
     ).toEqual([false]);
+    // 同名同字节 → 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'A.png', type: 'image', contentFp: fpa }])],
+        [u(`看图\n\n[Image: A.png (fp:${fpa})]`, T)]
+      )
+    ).toEqual([true]);
+    // 同名异字节 → 不认领（CodeRabbit 主场景）
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'photo.png', type: 'image', contentFp: fpb }])],
+        [u(`看图\n\n[Image: photo.png (fp:${fpa})]`, T)]
+      )
+    ).toEqual([false]);
+    // 旧版无指纹装饰 → 不认领（无法验证内容，方向安全）
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'photo.png', type: 'image', contentFp: fpa }])],
+        [u('看图\n\n[Image: photo.png]', T)]
+      )
+    ).toEqual([false]);
+    // live 无 contentFp → 不认领（方向安全）
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'photo.png', type: 'image' }])],
+        [u(`看图\n\n[Image: photo.png (fp:${fpa})]`, T)]
+      )
+    ).toEqual([false]);
+  });
+
+  it('#968 复核：图片名称解析向后兼容——带 (fp:…) 尾的装饰还原纯文件名', () => {
+    const fpa = 'a'.repeat(64);
+    const ui = sessionMsgsToUi([
+      {
+        role: 'user',
+        content: `看图\n\n[Image: photo.png (fp:${fpa})]`,
+        timestamp: '2026-09-01T00:00:00Z',
+      },
+    ]);
+    expect(ui.find((m) => m.role === 'user')?.attachments?.[0]?.name).toBe('photo.png');
+    // 旧版无指纹装饰照常解析
+    const ui2 = sessionMsgsToUi([
+      {
+        role: 'user',
+        content: '看图\n\n[Image: photo.png]',
+        timestamp: '2026-09-01T00:00:00Z',
+      },
+    ]);
+    expect(ui2.find((m) => m.role === 'user')?.attachments?.[0]?.name).toBe('photo.png');
   });
 
   it('#968 复核：文档解析失败占位（[name: 大小 — parsing on server]）可剥离', () => {
@@ -263,11 +314,12 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([true]);
   });
 
-  it('#968 复核：同图真实副本可认领（装饰名守卫通过）', () => {
+  it('#968 复核：同图真实副本可认领（内容指纹一致）', () => {
+    const fpa = 'a'.repeat(64);
     expect(
       _markUserTwinMatches(
-        [u('看图', T, [{ name: 'A.png', type: 'image' }])],
-        [u('看图\n\n[Image: A.png]', T)]
+        [u('看图', T, [{ name: 'A.png', type: 'image', contentFp: fpa }])],
+        [u(`看图\n\n[Image: A.png (fp:${fpa})]`, T)]
       )
     ).toEqual([true]);
   });
@@ -403,15 +455,17 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
   });
 
   it('#968 复核：纯附件两张图 + 无文本（迭代剥离到空）', () => {
+    const fpa = 'a'.repeat(64);
+    const fpb = 'b'.repeat(64);
     expect(
       _markUserTwinMatches(
         [
           u('(attachment)', T, [
-            { name: 'A.png', type: 'image' },
-            { name: 'B.png', type: 'image' },
+            { name: 'A.png', type: 'image', contentFp: fpa },
+            { name: 'B.png', type: 'image', contentFp: fpb },
           ]),
         ],
-        [u('\n\n[Image: A.png]\n\n[Image: B.png]', T)]
+        [u(`\n\n[Image: A.png (fp:${fpa})]\n\n[Image: B.png (fp:${fpb})]`, T)]
       )
     ).toEqual([true]);
   });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -21,7 +21,7 @@ import {
   sessionMsgsToUi,
   insertInterruptedTurns,
   _markUserTwinMatches,
-  _docFingerprint,
+  _sha256HexOfBase64,
 } from './ChatConsole';
 
 describe('ChatConsole thinking block regression (#858 → #905)', () => {
@@ -147,6 +147,7 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
       type: 'image' | 'text' | 'document';
       content?: string;
       dataBase64?: string;
+      contentFp?: string;
     }[]
   ) => ({
     role: 'user' as const,
@@ -325,41 +326,59 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
   });
 
   it('#968 复核：占位装饰指纹守卫——同名不同字节的不可提取附件不得互认（CodeRabbit #969）', () => {
-    const b64a = btoa('binary payload A');
-    const b64b = btoa('binary payload B');
-    const fpa = _docFingerprint(b64a);
-    const fpb = _docFingerprint(b64b);
-    expect(fpa).not.toBe(fpb); // 指纹本身能区分
+    // 守卫只比对装饰内 (fp:…) 与 live 附件暂存的 contentFp（SHA-256 由发送前
+    // 预计算写入附件），此处用合成的 64 位 hex 直接构造配对
+    const fpa = 'a'.repeat(64);
+    const fpb = 'b'.repeat(64);
+    expect(fpa).not.toBe(fpb);
     const placeA = `看\n\n[scan.pdf: scanned PDF (fp:${fpa}) — OCR will be attempted by the server]`;
     const placeB = `看\n\n[scan.pdf: scanned PDF (fp:${fpb}) — OCR will be attempted by the server]`;
-    // 内容不同 → 不认领
+    // 指纹不同 → 不认领
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64b }])],
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', contentFp: fpb }])],
         [u(placeA, T)]
       )
     ).toEqual([false]);
-    // 内容一致（指纹相同）→ 认领
+    // 指纹一致 → 认领
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64a }])],
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', contentFp: fpa }])],
         [u(placeA, T)]
       )
     ).toEqual([true]);
     // 旧版无指纹占位 → 不认领（无法验证内容，方向安全）
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64a }])],
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', contentFp: fpa }])],
         [u('看\n\n[scan.pdf: scanned PDF — OCR will be attempted by the server]', T)]
       )
+    ).toEqual([false]);
+    // live 附件无 contentFp → 不认领（方向安全）
+    expect(
+      _markUserTwinMatches([u('看', T, [{ name: 'scan.pdf', type: 'document' }])], [u(placeA, T)])
     ).toEqual([false]);
     // 解析失败占位（带大小 + 指纹）→ 指纹一致认领
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'a.pdf', type: 'document', dataBase64: b64a }])],
+        [u('看', T, [{ name: 'a.pdf', type: 'document', contentFp: fpa }])],
         [u(`看\n\n[a.pdf: 1.2 MB — parsing on server (fp:${fpa})]`, T)]
       )
     ).toEqual([true]);
+  });
+
+  it('#968 复核：SHA-256 覆盖全量内容——同名同首尾、仅中段不同的大附件指纹不同', async () => {
+    // CodeRabbit #969 回归要求：>8192 字符、长度与首尾 4KB 相同、中段不同的
+    // dataBase64 必须产生不同指纹（采样方案会被构造性绕过，全量摘要不会）
+    const s1 = 'a'.repeat(4096) + '1'.repeat(1024) + 'b'.repeat(4096); // 长度 9216
+    const s2 = 'a'.repeat(4096) + '2'.repeat(1024) + 'b'.repeat(4096);
+    expect(s1.length).toBe(s2.length);
+    const f1 = await _sha256HexOfBase64(s1);
+    const f2 = await _sha256HexOfBase64(s2);
+    expect(f1).toMatch(/^[0-9a-f]{64}$/);
+    expect(f1).not.toBe(f2);
+    // 同一内容 → 同一指纹
+    expect(await _sha256HexOfBase64(s1)).toBe(f1);
   });
 
   it('#968 复核：纯附件两张图 + 无文本（迭代剥离到空）', () => {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -449,6 +449,27 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([false]);
   });
 
+  it('#968 复核：同名不可提取文档占位扫描全部出现点（CodeRabbit #969 Major）', () => {
+    // 同一条消息带两张同名异字节的扫描 PDF：占位各带 (fp:…)，守卫须逐个出现点
+    // 比对——旧实现只看第一个占位，第二个附件对到第一个的 fp → 误拒 → 持久化
+    // 副本不被认领 → 双显示（#968 同类回归）
+    const fpa = 'a'.repeat(64);
+    const fpb = 'b'.repeat(64);
+    const pmBoth = `看\n\n[report.pdf: scanned PDF (fp:${fpa}) — OCR will be attempted by the server]\n\n[report.pdf: scanned PDF (fp:${fpb}) — OCR will be attempted by the server]`;
+    // live 两张同名附件（fpA + fpB）→ 第二张必须扫到自己的占位，整条消息认领
+    expect(
+      _markUserTwinMatches(
+        [
+          u('看', T, [
+            { name: 'report.pdf', type: 'document', contentFp: fpa },
+            { name: 'report.pdf', type: 'document', contentFp: fpb },
+          ]),
+        ],
+        [u(pmBoth, T)]
+      )
+    ).toEqual([true]);
+  });
+
   it('#968 复核：SHA-256 覆盖全量内容——同名同首尾、仅中段不同的大附件指纹不同', async () => {
     // CodeRabbit #969 回归要求：>8192 字符、长度与首尾 4KB 相同、中段不同的
     // dataBase64 必须产生不同指纹（采样方案会被构造性绕过，全量摘要不会）

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -407,4 +407,13 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
       _markUserTwinMatches([u('看图', T), u('看图', T + 5_000)], [u('看图\n\n[Image: a.png]', T)])
     ).toEqual([true, false]);
   });
+
+  it('#968 复核：未知/未来扩展附件类型——守卫默认不认领（不能仅凭 key 吞消息）', () => {
+    // type 联合目前闭合于 image/text/document；若未来扩展（audio/video/archive/…）
+    // 而 _persistedCoversAttachments 漏补对应分支，default 必须回落「不认领」——
+    // 正文/key 完全一致时旧实现 default:true 会直接认领（吞掉真实新消息）。
+    // as never 绕过闭合联合，模拟扩展后的运行时形态。
+    const frontend = u('听这段', T, [{ name: 'clip.wav', type: 'audio' } as never]);
+    expect(_markUserTwinMatches([frontend], [u('听这段', T)])).toEqual([false]);
+  });
 });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -367,6 +367,27 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([true]);
   });
 
+  it('#968 复核：占位文件名含 ] 时指纹不被截断（CodeRabbit #969 Minor）', () => {
+    // 守卫切段此前从 phIdx 起找第一个 ]——文件名含 ]（report].pdf）会把段截在
+    // 文件名内、丢掉 (fp:…)，合法同文件重发也被误拒 → 双显示。须从段头 + 长度起找收尾 ]。
+    const fpa = 'a'.repeat(64);
+    const placeA = `看\n\n[report].pdf: scanned PDF (fp:${fpa}) — OCR will be attempted by the server]`;
+    // 指纹一致 → 认领（修复前因 ] 截断 seg 丢 fp 而误拒）
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'report].pdf', type: 'document', contentFp: fpa }])],
+        [u(placeA, T)]
+      )
+    ).toEqual([true]);
+    // 指纹不同 → 依旧不认领（修复不放松内容校验）
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'report].pdf', type: 'document', contentFp: 'b'.repeat(64) }])],
+        [u(placeA, T)]
+      )
+    ).toEqual([false]);
+  });
+
   it('#968 复核：SHA-256 覆盖全量内容——同名同首尾、仅中段不同的大附件指纹不同', async () => {
     // CodeRabbit #969 回归要求：>8192 字符、长度与首尾 4KB 相同、中段不同的
     // dataBase64 必须产生不同指纹（采样方案会被构造性绕过，全量摘要不会）

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -257,6 +257,60 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([true]);
   });
 
+  it('#968 复核：文本附件守卫——旧回合的 a.py 副本不得认领换了 b.py 的新气泡', () => {
+    // key 剥离会去掉嵌入的文件内容，text 附件同文本不同文件一样碰撞 → 必须守卫
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'b.py', type: 'text' }])],
+        [u('看\n\n[File: a.py]\n```\nprint(1)\n```', T - 2_000)]
+      )
+    ).toEqual([false]);
+    // 同名同文件 → 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'a.py', type: 'text' }])],
+        [u('看\n\n[File: a.py]\n```\nprint(1)\n```', T)]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：文档附件守卫——旧回合 A.pdf 副本不得认领换了 B.pdf 的新气泡', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'B.pdf', type: 'document' }])],
+        [u('看\n\n--- Document: A.pdf ---\n内容\n--- End of A.pdf ---', T - 2_000)]
+      )
+    ).toEqual([false]);
+    // 扫描 PDF（占位装饰 [name: …]）同名 → 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'scan.pdf', type: 'document' }])],
+        [u('看\n\n[scan.pdf: scanned PDF — OCR will be attempted by the server]', T)]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：纯附件两张图 + 无文本（迭代剥离到空）', () => {
+    expect(
+      _markUserTwinMatches(
+        [
+          u('(attachment)', T, [
+            { name: 'A.png', type: 'image' },
+            { name: 'B.png', type: 'image' },
+          ]),
+        ],
+        [u('\n\n[Image: A.png]\n\n[Image: B.png]', T)]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：[File:] 内嵌内容以 ``` 结尾紧邻收尾围栏时仍正确剥离', () => {
+    // 文件内容为 'code\n```' → 块形如 [File: x.py]\n```\ncode\n```\n```（连续两个收尾围栏）
+    expect(_markUserTwinMatches([u('看')], [u('看\n\n[File: x.py]\n```\ncode\n```\n```')])).toEqual(
+      [true]
+    );
+  });
+
   it('#968 + #891 复核组合：同文本两条、persisted 带图 → 归一化后仍只认领最早一条', () => {
     expect(
       _markUserTwinMatches([u('看图', T), u('看图', T + 5_000)], [u('看图\n\n[Image: a.png]', T)])

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -138,7 +138,16 @@ describe('ChatConsole thinking block regression (#858 → #905)', () => {
 
 describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', () => {
   const T = 1_700_000_000_000;
-  const u = (content: string, ts = T) => ({ role: 'user' as const, content, timestamp: ts });
+  const u = (
+    content: string,
+    ts = T,
+    attachments?: { name: string; type: 'image' | 'text' | 'document' }[]
+  ) => ({
+    role: 'user' as const,
+    content,
+    timestamp: ts,
+    ...(attachments ? { attachments: attachments.map((a) => ({ ...a, size: 0 })) } : {}),
+  });
 
   it('纯文本：持久化副本认领同内容乐观气泡', () => {
     expect(_markUserTwinMatches([u('你好')], [u('你好')])).toEqual([true]);
@@ -180,6 +189,72 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
 
   it('时间相近限定：30s 外的同文本旧副本不误认', () => {
     expect(_markUserTwinMatches([u('再来一次', T)], [u('再来一次', T - 60_000)])).toEqual([false]);
+  });
+
+  it('#968 复核：正文内嵌 ``` 围栏的 [File:] 块不截断剥离（尾锚定回溯）', () => {
+    // 文件内容含 ``` 行时旧惰性正则在内部围栏截断留下残留；尾锚定 + 回溯
+    // 必须剥到真正的收尾围栏
+    expect(
+      _markUserTwinMatches(
+        [u('帮我看看')],
+        [u('帮我看看\n\n[File: a.py]\n```\nline1\n```\nline3\n```')]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：正文含 --- End of … --- 行的 Document 段不截断剥离', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('解析这个')],
+        [
+          u(
+            '解析这个\n\n--- Document: report.pdf ---\n第一段\n--- End of report.pdf ---\n第二段\n--- End of report.pdf ---'
+          ),
+        ]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：文件名含 ] 的图片装饰（贪婪捕获回溯容忍）', () => {
+    expect(_markUserTwinMatches([u('看图')], [u('看图\n\n[Image: IMG[1].png]')])).toEqual([true]);
+  });
+
+  it('#968 复核：重试回合（persisted 带 [系统提示：…] 尾）可互认', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('再来一次')],
+        [u('再来一次\n\n[系统提示：这是重试请求。请换一个角度重新回答，不要复述之前的答案。]')]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：纯附件无文本发送（live "(attachment)" ↔ 纯装饰副本）', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('(attachment)', T, [{ name: 'photo.png', type: 'image' }])],
+        [u('\n\n[Image: photo.png]', T)]
+      )
+    ).toEqual([true]);
+  });
+
+  it('#968 复核：图片装饰名守卫——旧图副本不得认领换图后的新气泡（重新生成）', () => {
+    // 重新生成换了图：live 气泡带 B.png，merged 只有旧回合 A.png 的副本。
+    // key 相同（看图），但旧副本不含 [Image: B.png] → 不得认领（否则新问题被吞）
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'B.png', type: 'image' }])],
+        [u('看图\n\n[Image: A.png]', T - 2_000)]
+      )
+    ).toEqual([false]);
+  });
+
+  it('#968 复核：同图真实副本可认领（装饰名守卫通过）', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('看图', T, [{ name: 'A.png', type: 'image' }])],
+        [u('看图\n\n[Image: A.png]', T)]
+      )
+    ).toEqual([true]);
   });
 
   it('#968 + #891 复核组合：同文本两条、persisted 带图 → 归一化后仍只认领最早一条', () => {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -141,7 +141,12 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
   const u = (
     content: string,
     ts = T,
-    attachments?: { name: string; type: 'image' | 'text' | 'document' }[]
+    attachments?: {
+      name: string;
+      type: 'image' | 'text' | 'document';
+      content?: string;
+      dataBase64?: string;
+    }[]
   ) => ({
     role: 'user' as const,
     content,
@@ -265,31 +270,58 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
     ).toEqual([true]);
   });
 
-  it('#968 复核：文本附件守卫——旧回合的 a.py 副本不得认领换了 b.py 的新气泡', () => {
-    // key 剥离会去掉嵌入的文件内容，text 附件同文本不同文件一样碰撞 → 必须守卫
+  it('#968 复核：文本附件内容守卫——同文本同文件名、内容不同不得互认（CodeRabbit #969）', () => {
+    // 用户迭代工作流：改完 main.py 再发同文本——旧副本(print(1))认领新气泡
+    // (print(2)) 会吞掉新消息，名字级校验不够，必须逐字校验嵌入内容
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'b.py', type: 'text' }])],
-        [u('看\n\n[File: a.py]\n```\nprint(1)\n```', T - 2_000)]
+        [u('检查这个', T, [{ name: 'main.py', type: 'text', content: 'print(2)' }])],
+        [u('检查这个\n\n[File: main.py]\n```\nprint(1)\n```', T)]
       )
     ).toEqual([false]);
-    // 同名同文件 → 认领
+    // 内容一致 → 认领
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'a.py', type: 'text' }])],
-        [u('看\n\n[File: a.py]\n```\nprint(1)\n```', T)]
+        [u('检查这个', T, [{ name: 'main.py', type: 'text', content: 'print(1)' }])],
+        [u('检查这个\n\n[File: main.py]\n```\nprint(1)\n```', T)]
       )
     ).toEqual([true]);
   });
 
-  it('#968 复核：文档附件守卫——旧回合 A.pdf 副本不得认领换了 B.pdf 的新气泡', () => {
+  it('#968 复核：文本附件守卫——不同文件名不认领', () => {
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'b.py', type: 'text', content: 'print(1)' }])],
+        [u('看\n\n[File: a.py]\n```\nprint(1)\n```', T - 2_000)]
+      )
+    ).toEqual([false]);
+  });
+
+  it('#968 复核：文档附件内容守卫——同文件名内容不同不得互认（CodeRabbit #969）', () => {
+    const b64v1 = btoa('hello doc v1');
+    const b64v2 = btoa('hello doc v2');
+    // 内容不同 → 不认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'note.txt', type: 'document', dataBase64: b64v2 }])],
+        [u('看\n\n--- Document: note.txt ---\nhello doc v1\n--- End of note.txt ---', T)]
+      )
+    ).toEqual([false]);
+    // 内容一致 → 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'note.txt', type: 'document', dataBase64: b64v1 }])],
+        [u('看\n\n--- Document: note.txt ---\nhello doc v1\n--- End of note.txt ---', T)]
+      )
+    ).toEqual([true]);
+    // 不同文件名 → 不认领
     expect(
       _markUserTwinMatches(
         [u('看', T, [{ name: 'B.pdf', type: 'document' }])],
         [u('看\n\n--- Document: A.pdf ---\n内容\n--- End of A.pdf ---', T - 2_000)]
       )
     ).toEqual([false]);
-    // 扫描 PDF（占位装饰 [name: …]）同名 → 认领
+    // 扫描 PDF 占位装饰（无内容可承载）→ 名字 + 短语校验通过即认领
     expect(
       _markUserTwinMatches(
         [u('看', T, [{ name: 'scan.pdf', type: 'document' }])],

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.test.ts
@@ -21,6 +21,7 @@ import {
   sessionMsgsToUi,
   insertInterruptedTurns,
   _markUserTwinMatches,
+  _docFingerprint,
 } from './ChatConsole';
 
 describe('ChatConsole thinking block regression (#858 → #905)', () => {
@@ -321,11 +322,42 @@ describe('_markUserTwinMatches 一对一去重匹配（#891 复核 + #968）', (
         [u('看\n\n--- Document: A.pdf ---\n内容\n--- End of A.pdf ---', T - 2_000)]
       )
     ).toEqual([false]);
-    // 扫描 PDF 占位装饰（无内容可承载）→ 名字 + 短语校验通过即认领
+  });
+
+  it('#968 复核：占位装饰指纹守卫——同名不同字节的不可提取附件不得互认（CodeRabbit #969）', () => {
+    const b64a = btoa('binary payload A');
+    const b64b = btoa('binary payload B');
+    const fpa = _docFingerprint(b64a);
+    const fpb = _docFingerprint(b64b);
+    expect(fpa).not.toBe(fpb); // 指纹本身能区分
+    const placeA = `看\n\n[scan.pdf: scanned PDF (fp:${fpa}) — OCR will be attempted by the server]`;
+    const placeB = `看\n\n[scan.pdf: scanned PDF (fp:${fpb}) — OCR will be attempted by the server]`;
+    // 内容不同 → 不认领
     expect(
       _markUserTwinMatches(
-        [u('看', T, [{ name: 'scan.pdf', type: 'document' }])],
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64b }])],
+        [u(placeA, T)]
+      )
+    ).toEqual([false]);
+    // 内容一致（指纹相同）→ 认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64a }])],
+        [u(placeA, T)]
+      )
+    ).toEqual([true]);
+    // 旧版无指纹占位 → 不认领（无法验证内容，方向安全）
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'scan.pdf', type: 'document', dataBase64: b64a }])],
         [u('看\n\n[scan.pdf: scanned PDF — OCR will be attempted by the server]', T)]
+      )
+    ).toEqual([false]);
+    // 解析失败占位（带大小 + 指纹）→ 指纹一致认领
+    expect(
+      _markUserTwinMatches(
+        [u('看', T, [{ name: 'a.pdf', type: 'document', dataBase64: b64a }])],
+        [u(`看\n\n[a.pdf: 1.2 MB — parsing on server (fp:${fpa})]`, T)]
       )
     ).toEqual([true]);
   });

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -191,7 +191,9 @@ interface FileChip {
   category: ReturnType<typeof getDocCategory>;
 }
 
-const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\]]+)\]/g;
+// 名称捕获容忍可选的内容指纹尾（(fp:64hex)，#968 复核 CodeRabbit #969）——
+// 旧版无指纹占位仍能解析（向后兼容）；惰性名称 + 回溯使带指纹的名字只取真名。
+const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\]]+?)(?:\s*\(fp:[0-9a-f]{64}\))?\]/g;
 
 /** Extract image attachments from the "[Image: name]" placeholder the sender
  *  embeds. dataUrl stays undefined — it is re-read from the session files dir
@@ -1431,16 +1433,27 @@ function _decodeDocData(dataBase64: string, name: string): { extracted: string; 
   return { extracted, ext };
 }
 
+export async function _sha256HexOfBytes(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
 // #968 复核（CodeRabbit #969）：附件内容指纹——全量 SHA-256（采样首尾会被
 // 「同名同首尾、仅中段不同」的附件构造性绕过）。渲染线程没有同步摘要，故：
 // 发送前由 handleSend 在 await 段调用本函数预计算，结果暂存到附件
-// contentFp 并写进占位装饰 (fp:…)；守卫侧只比对暂存值（load() 合并是同步
-// 路径，不能做摘要）。atob 解码失败会抛错，由调用方捕获（fp 缺失 → 占位
-// 无指纹 → 守卫不认领，方向安全）。
+// contentFp 并写进装饰 (fp:…)（doc 占位/图片）；守卫侧只比对暂存值（load()
+// 合并是同步路径，不能做摘要）。atob 解码失败会抛错，由调用方捕获（fp 缺失
+// → 装饰无指纹 → 守卫不认领，方向安全）。图片 dataUrl 不是纯 base64
+// （data:image/…;base64, 前缀），走 _sha256HexOfText 直接哈希整个字符串。
 export async function _sha256HexOfBase64(dataBase64: string): Promise<string> {
-  const raw = Uint8Array.from(atob(dataBase64), (c) => c.charCodeAt(0));
-  const digest = await crypto.subtle.digest('SHA-256', raw);
-  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
+  // new Uint8Array(…) 拷贝定型为 Uint8Array<ArrayBuffer>（TS 5.7 泛型数组：
+  // Uint8Array.from 返回 ArrayBufferLike，不满足 BufferSource）
+  const raw = new Uint8Array(Uint8Array.from(atob(dataBase64), (c) => c.charCodeAt(0)));
+  return _sha256HexOfBytes(raw);
+}
+
+export async function _sha256HexOfText(text: string): Promise<string> {
+  return _sha256HexOfBytes(new TextEncoder().encode(text));
 }
 
 // #968 复核：附件装饰内容守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，
@@ -1463,8 +1476,23 @@ function _persistedCoversAttachments(
   if (!attachments || attachments.length === 0) return true;
   return attachments.every((a) => {
     switch (a.type) {
-      case 'image':
-        return pmContent.includes(`[Image: ${a.name}]`);
+      case 'image': {
+        // 图片装饰 [Image: name (fp:…)]：发送侧内嵌内容指纹，这里比对区分同名
+        // 异字节图片（CodeRabbit #969）。无指纹的旧版装饰 / live 无 contentFp
+        // → 不认领（方向安全）。文件名可含 ]，故收尾 ] 从名字后找起；同名装饰
+        // 可能出现多次（同消息两张同名图 / 嵌入文本撞串）→ 扫描全部出现点。
+        const open = `[Image: ${a.name}`;
+        if (!a.contentFp) return false;
+        let searchFrom = 0;
+        for (;;) {
+          const openIdx = pmContent.indexOf(open, searchFrom);
+          if (openIdx < 0) return false;
+          const rest = pmContent.slice(openIdx + open.length, openIdx + open.length + 90);
+          const fpMatch = rest.match(/^ \(fp:([0-9a-f]{64})\)\]/);
+          if (fpMatch && fpMatch[1] === a.contentFp) return true;
+          searchFrom = openIdx + open.length;
+        }
+      }
       case 'text': {
         const c = a.content ?? '';
         if (!c) return false;
@@ -4429,6 +4457,14 @@ export function ChatConsole({
         } catch {
           /* 保留 undefined */
         }
+      } else if (att.type === 'image' && att.dataUrl && !att.contentFp) {
+        // 图片字节以 dataUrl 形式存在（#968 复核 CodeRabbit #969）：装饰只带
+        // 文件名无法区分同名异字节，同样预计算指纹写进 [Image: name (fp:…)]
+        try {
+          att.contentFp = await _sha256HexOfText(att.dataUrl);
+        } catch {
+          /* 保留 undefined */
+        }
       }
     }
 
@@ -4437,7 +4473,10 @@ export function ChatConsole({
       if (att.type === 'text' && att.content) {
         content += `\n\n[File: ${att.name}]\n\`\`\`\n${att.content}\n\`\`\``;
       } else if (att.type === 'image' && att.dataUrl) {
-        content += `\n\n[Image: ${att.name}]`;
+        // 图片装饰内嵌内容指纹 (fp:…)（CodeRabbit #969）——同名异字节图片
+        // 不得互认；IMAGE_PLACEHOLDER_RES 名称解析已容忍该尾（向后兼容）
+        const fpTag = att.contentFp ? ` (fp:${att.contentFp})` : '';
+        content += `\n\n[Image: ${att.name}${fpTag}]`;
       } else if (att.type === 'document' && att.dataBase64) {
         // Decode and extract text client-side（解码逻辑与去重守卫共用 _decodeDocData，
         // 见上——守卫需按相同规则重解以逐字校验内容，单一实现防漂移 #968 复核）

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1392,11 +1392,55 @@ function _userContentDedupKey(content: string): string {
   return trimmed === '(attachment)' ? '' : trimmed;
 }
 
-// #968 复核：附件装饰名守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，所以
-// 「同文本 + 不同附件」的消息 key 必然碰撞——重新生成换附件后，旧回合副本会与
-// 新一轮在途气泡 key 相同。若被旧副本认领，新问题会被吞（消失而非重复，比双显示
-// 更糟）。守卫要求：气泡的每个附件在持久化副本里有同名的装饰标记，否则不认领。
-// 校验用原始 content 的子串匹配（不经过 key 剥离），文件名含 "]" 也不受影响。
+// #968 复核（CodeRabbit #969）：文档附件内容解码的单一实现——handleSend 拼
+// Document 装饰段与去重守卫校验内容都用它，避免两侧解码逻辑漂移（ext 白名单、
+// atob/TextDecoder/extractPdfText 与 50k 截断必须完全一致，守卫才能逐字比对）。
+function _decodeDocData(dataBase64: string, name: string): { extracted: string; ext: string } {
+  const raw = Uint8Array.from(atob(dataBase64), (c) => c.charCodeAt(0));
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  let extracted = '';
+  if (ext === 'pdf') {
+    extracted = extractPdfText(raw.buffer);
+  } else if (
+    ext === 'md' ||
+    ext === 'markdown' ||
+    ext === 'mdown' ||
+    ext === 'txt' ||
+    ext === 'text' ||
+    ext === 'html' ||
+    ext === 'htm' ||
+    ext === 'csv' ||
+    ext === 'json' ||
+    ext === 'yaml' ||
+    ext === 'yml' ||
+    ext === 'xml' ||
+    ext === 'env' ||
+    ext === 'log' ||
+    ext === 'sql' ||
+    ext === 'ini' ||
+    ext === 'toml' ||
+    ext === 'htaccess' ||
+    ext === 'sh' ||
+    ext === 'bash'
+  ) {
+    extracted = new TextDecoder().decode(raw);
+  }
+  return { extracted, ext };
+}
+
+// #968 复核：附件装饰内容守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，
+// 「同文本 + 同附件名」的消息 key 必然碰撞，名字级校验不足以区分内容差异
+// （CodeRabbit #969：同文本 + main.py 但 print(1)/print(2) 两种内容时，旧副本
+// 会误认领新气泡 → 新消息被吞）。守卫对每个附件做内容级验证：
+// - text：payload 原样嵌入 att.content → 要求持久化副本含完整的
+//   `[File: name]\n```\n${content}\n```` 段（逐字，含围栏锚点，长度/重叠不误判）
+// - document：`--- Document: name ---` 块正文须与 att.dataBase64 重新解码结果
+//   （同一 _decodeDocData，50k 截断一致）逐字相等；占位装饰（扫描/二进制/解析
+//   失败）不承载内容 → 名字 + 类型短语校验（内容本就不可见）
+// - image：装饰只携带文件名（字节不走 content）→ 名字校验（同名异字节需名字+
+//   文本+30s+旧行已消失四重巧合，记为已知限制）
+// 校验失败一律不认领（方向安全：可能双显示，绝不吞消息）。空内容 text 附件在
+// 发送侧不产生装饰 → 同样不认领（安全方向）。
 function _persistedCoversAttachments(
   pmContent: string,
   attachments: Attachment[] | undefined
@@ -1406,15 +1450,32 @@ function _persistedCoversAttachments(
     switch (a.type) {
       case 'image':
         return pmContent.includes(`[Image: ${a.name}]`);
-      case 'text':
-        // text 附件装饰仅当 att.content 非空时追加；空内容附件装饰缺失 → 不认领
-        // （方向安全：气泡保留 → 潜在双显示，绝不吞消息）
-        return pmContent.includes(`[File: ${a.name}]`);
-      case 'document':
-        // 可提取正文 → --- Document: name ---；扫描/二进制/失败 → [name: …] 占位
-        return (
-          pmContent.includes(`--- Document: ${a.name} ---`) || pmContent.includes(`[${a.name}: `)
-        );
+      case 'text': {
+        const c = a.content ?? '';
+        if (!c) return false;
+        return pmContent.includes(`[File: ${a.name}]\n\`\`\`\n${c}\n\`\`\``);
+      }
+      case 'document': {
+        const blockOpen = `--- Document: ${a.name} ---`;
+        if (pmContent.includes(blockOpen)) {
+          // Document 块嵌内容 → 内容必须逐字一致才认领（CodeRabbit #969）
+          if (!a.dataBase64) return false;
+          try {
+            const { extracted } = _decodeDocData(a.dataBase64, a.name);
+            const body = extracted && extracted.trim() ? extracted.slice(0, 50000) : '';
+            if (!body) return false; // 空提取发送侧会走占位分支，不应出现块
+            return pmContent.includes(`${blockOpen}\n${body}\n--- End of ${a.name} ---`);
+          } catch {
+            return false; // 解码异常 → 发送侧走占位分支，不可能有 Document 块
+          }
+        }
+        // 占位装饰（scanned PDF / binary file / parsing on server）：名字 + 短语
+        const ph = `[${a.name}: `;
+        const phIdx = pmContent.indexOf(ph);
+        if (phIdx < 0) return false;
+        const phTail = pmContent.slice(phIdx, phIdx + 400);
+        return /(?:scanned PDF|binary file|parsing on server)/.test(phTail);
+      }
       default:
         return true; // 未知类型装饰规则不明 → 交由 key 决定
     }
@@ -4335,39 +4396,10 @@ export function ChatConsole({
       } else if (att.type === 'image' && att.dataUrl) {
         content += `\n\n[Image: ${att.name}]`;
       } else if (att.type === 'document' && att.dataBase64) {
-        // Decode and extract text client-side
+        // Decode and extract text client-side（解码逻辑与去重守卫共用 _decodeDocData，
+        // 见上——守卫需按相同规则重解以逐字校验内容，单一实现防漂移 #968 复核）
         try {
-          const raw = Uint8Array.from(atob(att.dataBase64), (c) => c.charCodeAt(0));
-          let extracted = '';
-          const ext = att.name.split('.').pop()?.toLowerCase() ?? '';
-
-          if (ext === 'pdf') {
-            extracted = extractPdfText(raw.buffer);
-          } else if (
-            ext === 'md' ||
-            ext === 'markdown' ||
-            ext === 'mdown' ||
-            ext === 'txt' ||
-            ext === 'text' ||
-            ext === 'html' ||
-            ext === 'htm' ||
-            ext === 'csv' ||
-            ext === 'json' ||
-            ext === 'yaml' ||
-            ext === 'yml' ||
-            ext === 'xml' ||
-            ext === 'env' ||
-            ext === 'log' ||
-            ext === 'sql' ||
-            ext === 'ini' ||
-            ext === 'toml' ||
-            ext === 'htaccess' ||
-            ext === 'sh' ||
-            ext === 'bash'
-          ) {
-            extracted = new TextDecoder().decode(raw);
-          }
-
+          const { extracted, ext } = _decodeDocData(att.dataBase64, att.name);
           if (extracted && extracted.trim()) {
             content += `\n\n--- Document: ${att.name} ---\n${extracted.slice(0, 50000)}\n--- End of ${att.name} ---`;
           } else if (ext === 'pdf') {

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1392,15 +1392,33 @@ function _userContentDedupKey(content: string): string {
   return trimmed === '(attachment)' ? '' : trimmed;
 }
 
-// #968 复核：图片装饰名守卫。图片装饰只携带文件名（不嵌入文件内容），是跨轮
-// 「同文本 + 不同图」消息唯一能让 key 碰撞的向量（重新生成换图后，旧图副本会
-// 与新一轮在途气泡 key 相同）——若被旧副本认领，新问题会被吞（消失而非重复）。
-// 文本/文档附件把文件内容嵌进 content，key 本身即可区分，无需守卫。
-function _persistedCoversImages(pmContent: string, attachments: Attachment[] | undefined): boolean {
+// #968 复核：附件装饰名守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，所以
+// 「同文本 + 不同附件」的消息 key 必然碰撞——重新生成换附件后，旧回合副本会与
+// 新一轮在途气泡 key 相同。若被旧副本认领，新问题会被吞（消失而非重复，比双显示
+// 更糟）。守卫要求：气泡的每个附件在持久化副本里有同名的装饰标记，否则不认领。
+// 校验用原始 content 的子串匹配（不经过 key 剥离），文件名含 "]" 也不受影响。
+function _persistedCoversAttachments(
+  pmContent: string,
+  attachments: Attachment[] | undefined
+): boolean {
   if (!attachments || attachments.length === 0) return true;
-  const images = attachments.filter((a) => a.type === 'image');
-  if (images.length === 0) return true;
-  return images.every((img) => pmContent.includes(`[Image: ${img.name}]`));
+  return attachments.every((a) => {
+    switch (a.type) {
+      case 'image':
+        return pmContent.includes(`[Image: ${a.name}]`);
+      case 'text':
+        // text 附件装饰仅当 att.content 非空时追加；空内容附件装饰缺失 → 不认领
+        // （方向安全：气泡保留 → 潜在双显示，绝不吞消息）
+        return pmContent.includes(`[File: ${a.name}]`);
+      case 'document':
+        // 可提取正文 → --- Document: name ---；扫描/二进制/失败 → [name: …] 占位
+        return (
+          pmContent.includes(`--- Document: ${a.name} ---`) || pmContent.includes(`[${a.name}: `)
+        );
+      default:
+        return true; // 未知类型装饰规则不明 → 交由 key 决定
+    }
+  });
 }
 
 // #891 深度审阅 #11：删 flag 门控与保留块须用同一匹配（两处不再手写漂移）。
@@ -1410,7 +1428,7 @@ function _persistedCoversImages(pmContent: string, attachments: Attachment[] | u
 // 化而漏掉第二条。返回数组与 frontend 等长：matched[i]===true 表示该条乐观气泡
 // 已有专属持久化副本。匹配条件（按代价排序）：①时间相近 O(1) ②归一化 key（#968，
 // key 惰性缓存、每行只算一次——load() 在 UI 线程跑，避免每对候选做全文正则）
-// ③图片装饰名守卫。内容比对经 _userContentDedupKey 归一化（#968）。
+// ③附件装饰名守卫（#968 复核：图片/文本/文档三类都查，见 _persistedCoversAttachments）。内容比对经 _userContentDedupKey 归一化（#968）。
 export function _markUserTwinMatches(frontend: Message[], merged: Message[]): boolean[] {
   const matched = new Array<boolean>(frontend.length).fill(false);
   const keyCache = new Array<string | undefined>(frontend.length).fill(undefined);
@@ -1426,7 +1444,7 @@ export function _markUserTwinMatches(frontend: Message[], merged: Message[]): bo
       if (!_isPersistedCopyOf(m.timestamp, pm.timestamp)) continue;
       if (keyCache[i] === undefined) keyCache[i] = _userContentDedupKey(String(m.content ?? ''));
       if (keyCache[i] !== pmKey) continue;
-      if (!_persistedCoversImages(pmContent, m.attachments)) continue;
+      if (!_persistedCoversAttachments(pmContent, m.attachments)) continue;
       matched[i] = true;
       break;
     }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1499,7 +1499,10 @@ function _persistedCoversAttachments(
         return fpMatch[1] === a.contentFp;
       }
       default:
-        return true; // 未知类型装饰规则不明 → 交由 key 决定
+        // 未知/未来扩展类型（audio/video/archive/…）无法验证内容 → 不认领。
+        // 与全守卫「宁可双显、绝不吞消息」的安全方向一致：若扩展 attachment type
+        // 而漏补分支，仅凭 key（文本+时间+文件名）认领可能吞掉真实新消息。
+        return false;
     }
   });
 }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -109,6 +109,9 @@ interface Attachment {
   status?: 'pending' | 'parsing' | 'done' | 'error';
   /** Server-parsed text content, shown inline after send */
   parsedContent?: string;
+  /** Client-side content fingerprint (SHA-256 hex of bytes, #968 复核)：发送前
+   * 由 handleSend 预计算暂存，占位装饰 (fp:…) 与去重守卫据此区分同名异内容附件 */
+  contentFp?: string;
   /** Parse error message if status === 'error' */
   parseError?: string;
 }
@@ -1428,27 +1431,16 @@ function _decodeDocData(dataBase64: string, name: string): { extracted: string; 
   return { extracted, ext };
 }
 
-function _fnv1a(body: string, seed: number): number {
-  let h = seed >>> 0;
-  for (let i = 0; i < body.length; i += 1) {
-    h = Math.imul(h ^ body.charCodeAt(i), 0x01000193) >>> 0;
-  }
-  return h;
-}
-
-// #968 复核（CodeRabbit #969）：占位装饰的内容指纹——渲染线程内没有同步的
-// crypto 摘要，占位场景（扫描/二进制/解析失败）用它区分「同名不同内容」的
-// 附件（防误认领，非对抗场景）：对 b64 的 长度+首尾各 4KB 跑双种子 FNV-1a
-// 并拼成 16 位 hex。发送侧写占位与守卫校验共用，避免两侧算法漂移。
-export function _docFingerprint(dataBase64: string): string {
-  const head = dataBase64.slice(0, 4096);
-  const tail = dataBase64.length > 8192 ? dataBase64.slice(-4096) : dataBase64;
-  const body = `${dataBase64.length}:${head}:${tail}`;
-  const h1 = _fnv1a(body, 0x811c9dc5).toString(16).padStart(8, '0');
-  const h2 = _fnv1a(body, 0x811c9dc5 ^ 0x9e3779b9)
-    .toString(16)
-    .padStart(8, '0');
-  return h1 + h2;
+// #968 复核（CodeRabbit #969）：附件内容指纹——全量 SHA-256（采样首尾会被
+// 「同名同首尾、仅中段不同」的附件构造性绕过）。渲染线程没有同步摘要，故：
+// 发送前由 handleSend 在 await 段调用本函数预计算，结果暂存到附件
+// contentFp 并写进占位装饰 (fp:…)；守卫侧只比对暂存值（load() 合并是同步
+// 路径，不能做摘要）。atob 解码失败会抛错，由调用方捕获（fp 缺失 → 占位
+// 无指纹 → 守卫不认领，方向安全）。
+export async function _sha256HexOfBase64(dataBase64: string): Promise<string> {
+  const raw = Uint8Array.from(atob(dataBase64), (c) => c.charCodeAt(0));
+  const digest = await crypto.subtle.digest('SHA-256', raw);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 // #968 复核：附件装饰内容守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，
@@ -1493,18 +1485,18 @@ function _persistedCoversAttachments(
           }
         }
         // 占位装饰（scanned PDF / binary file / parsing on server）不承载内容，
-        // 同名不同字节的文件会生成相同的占位 → 发送侧在占位内写入内容指纹
-        // （_docFingerprint），此处比对指纹区分（CodeRabbit #969）。无指纹的
-        // 旧版占位无法验证内容 → 一律不认领（方向安全）。
+        // 同名不同字节的文件会生成相同的占位 → 发送侧把全量 SHA-256 写进占位
+        // （(fp:…)），此处与 live 附件暂存的 contentFp 比对（CodeRabbit #969）。
+        // 无指纹的旧版占位 / live 附件无法验证内容 → 一律不认领（方向安全）。
         const ph = `[${a.name}: `;
         const phIdx = pmContent.indexOf(ph);
         if (phIdx < 0) return false;
         const closeIdx = pmContent.indexOf(']', phIdx);
         if (closeIdx < 0 || closeIdx - phIdx > 400) return false;
         const seg = pmContent.slice(phIdx, closeIdx + 1);
-        const fpMatch = seg.match(/\(fp:([0-9a-f]{16})\)/);
-        if (!fpMatch || !a.dataBase64) return false;
-        return fpMatch[1] === _docFingerprint(a.dataBase64);
+        const fpMatch = seg.match(/\(fp:([0-9a-f]{64})\)/);
+        if (!fpMatch || !a.contentFp) return false;
+        return fpMatch[1] === a.contentFp;
       }
       default:
         return true; // 未知类型装饰规则不明 → 交由 key 决定
@@ -4419,6 +4411,21 @@ export function ChatConsole({
 
     let content = text + retryHint;
 
+    // #968 复核（CodeRabbit #969）：先为 document 附件预计算全量 SHA-256 内容
+    // 指纹并暂存到附件（contentFp）——渲染线程无同步摘要，只能在此 await 段算；
+    // 拼装饰与去重守卫都读暂存值（守卫在 load() 同步合并路径，不能做摘要）。
+    // 重试回合的附件已带 contentFp → 跳过重算。解码失败 → fp 缺失 → 占位无指纹
+    // → 守卫不认领（方向安全）。
+    for (const att of atts) {
+      if (att.type === 'document' && att.dataBase64 && !att.contentFp) {
+        try {
+          att.contentFp = await _sha256HexOfBase64(att.dataBase64);
+        } catch {
+          /* 保留 undefined */
+        }
+      }
+    }
+
     // Build message content with embedded document text
     for (const att of atts) {
       if (att.type === 'text' && att.content) {
@@ -4435,15 +4442,16 @@ export function ChatConsole({
           } else {
             // 占位装饰内嵌内容指纹 (fp:…) —— 守卫按指纹区分同名不同内容的附件
             //（CodeRabbit #969）；key 剥离的占位规则仍可整段移除。
-            const fp = `(fp:${_docFingerprint(att.dataBase64)})`;
+            const fpTag = att.contentFp ? ` (fp:${att.contentFp})` : '';
             if (ext === 'pdf') {
-              content += `\n\n[${att.name}: scanned PDF ${fp} — OCR will be attempted by the server]`;
+              content += `\n\n[${att.name}: scanned PDF${fpTag} — OCR will be attempted by the server]`;
             } else {
-              content += `\n\n[${att.name}: binary file, server will parse ${fp}]`;
+              content += `\n\n[${att.name}: binary file, server will parse${fpTag}]`;
             }
           }
         } catch {
-          content += `\n\n[${att.name}: ${formatFileSize(att.size)} — parsing on server (fp:${_docFingerprint(att.dataBase64)})]`;
+          const fpTag = att.contentFp ? ` (fp:${att.contentFp})` : '';
+          content += `\n\n[${att.name}: ${formatFileSize(att.size)} — parsing on server${fpTag}]`;
         }
       }
     }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1518,19 +1518,28 @@ function _persistedCoversAttachments(
         // 占位装饰（scanned PDF / binary file / parsing on server）不承载内容，
         // 同名不同字节的文件会生成相同的占位 → 发送侧把全量 SHA-256 写进占位
         // （(fp:…)），此处与 live 附件暂存的 contentFp 比对（CodeRabbit #969）。
-        // 无指纹的旧版占位 / live 附件无法验证内容 → 一律不认领（方向安全）。
+        // 同名占位可出现多次（同消息两张同名不同字节的不可提取文档）→ 扫描全部
+        // 出现点，任一 fp 一致即认领（CodeRabbit #969 Major：旧实现只看第一个，
+        // 第二个附件对到第一个的 fp → 误拒 → 双显示）。无指纹的旧版占位 / live
+        // 附件无法验证内容 → 一律不认领（方向安全）。
+        if (!a.contentFp) return false;
         const ph = `[${a.name}: `;
-        const phIdx = pmContent.indexOf(ph);
-        if (phIdx < 0) return false;
-        // 收尾 ] 须从 phIdx + ph.length 起找：文件名可含 ]（report].pdf），从
-        // phIdx 起找会命中文件名内的 ]、把段截在文件名里丢掉 (fp:…)（CodeRabbit
-        // #969 Minor：合法同文件重发被误拒 → 双显示）
-        const closeIdx = pmContent.indexOf(']', phIdx + ph.length);
-        if (closeIdx < 0 || closeIdx - phIdx > 400) return false;
-        const seg = pmContent.slice(phIdx, closeIdx + 1);
-        const fpMatch = seg.match(/\(fp:([0-9a-f]{64})\)/);
-        if (!fpMatch || !a.contentFp) return false;
-        return fpMatch[1] === a.contentFp;
+        let searchFrom = 0;
+        for (;;) {
+          const phIdx = pmContent.indexOf(ph, searchFrom);
+          if (phIdx < 0) return false;
+          // 收尾 ] 须从 phIdx + ph.length 起找：文件名可含 ]（report].pdf），从
+          // phIdx 起找会命中文件名内的 ]、把段截在文件名里丢掉 (fp:…)（CodeRabbit
+          // #969 Minor：合法同文件重发被误拒 → 双显示）。畸形段（无收尾/超长）
+          // 视为非装饰跳过，继续搜后续出现点。
+          const closeIdx = pmContent.indexOf(']', phIdx + ph.length);
+          if (closeIdx >= 0 && closeIdx - phIdx <= 400) {
+            const seg = pmContent.slice(phIdx, closeIdx + 1);
+            const fpMatch = seg.match(/\(fp:([0-9a-f]{64})\)/);
+            if (fpMatch && fpMatch[1] === a.contentFp) return true;
+          }
+          searchFrom = phIdx + ph.length;
+        }
       }
       default:
         // 未知/未来扩展类型（audio/video/archive/…）无法验证内容 → 不认领。

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -191,9 +191,12 @@ interface FileChip {
   category: ReturnType<typeof getDocCategory>;
 }
 
-// 名称捕获容忍可选的内容指纹尾（(fp:64hex)，#968 复核 CodeRabbit #969）——
-// 旧版无指纹占位仍能解析（向后兼容）；惰性名称 + 回溯使带指纹的名字只取真名。
-const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\]]+?)(?:\s*\(fp:[0-9a-f]{64}\))?\]/g;
+// #968 复核（CodeRabbit #969）：图片占位符解析——两分支交替：
+// ① 带内容指纹尾 (fp:64hex) 的新装饰：以 fp 尾为锚点反推名称（名称可含 "]"，
+//    如 IMG[1].png——旧式从首个 ] 截断会把整条装饰匹配崩坏、图片恢复丢失）；
+// ② 旧版无指纹装饰：回到 [^\]]+ 语义（名称含 ] 的旧版装饰维持历史限制）。
+// 名称与装饰均不含换行，捕获用 [^\n] 限定。
+const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\n]*?)\s*\(fp:[0-9a-f]{64}\)\]|\[Image:\s*([^\]]+)\]/g;
 
 /** Extract image attachments from the "[Image: name]" placeholder the sender
  *  embeds. dataUrl stays undefined — it is re-read from the session files dir
@@ -203,7 +206,7 @@ const IMAGE_PLACEHOLDER_RES = /\[Image:\s*([^\]]+?)(?:\s*\(fp:[0-9a-f]{64}\))?\]
 export const INSTALL_WARNING_EVENT = 'miqi:system-install-warning';
 export type InstallWarningKind = 'persist' | 'runtime';
 function extractImageAttachmentsFromContent(content: string): Attachment[] | undefined {
-  const names = [...content.matchAll(IMAGE_PLACEHOLDER_RES)].map((m) => m[1].trim());
+  const names = [...content.matchAll(IMAGE_PLACEHOLDER_RES)].map((m) => (m[1] ?? m[2]).trim());
   if (names.length === 0) return undefined;
   return names.map((name) => ({
     name,

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1491,7 +1491,10 @@ function _persistedCoversAttachments(
         const ph = `[${a.name}: `;
         const phIdx = pmContent.indexOf(ph);
         if (phIdx < 0) return false;
-        const closeIdx = pmContent.indexOf(']', phIdx);
+        // 收尾 ] 须从 phIdx + ph.length 起找：文件名可含 ]（report].pdf），从
+        // phIdx 起找会命中文件名内的 ]、把段截在文件名里丢掉 (fp:…)（CodeRabbit
+        // #969 Minor：合法同文件重发被误拒 → 双显示）
+        const closeIdx = pmContent.indexOf(']', phIdx + ph.length);
         if (closeIdx < 0 || closeIdx - phIdx > 400) return false;
         const seg = pmContent.slice(phIdx, closeIdx + 1);
         const fpMatch = seg.match(/\(fp:([0-9a-f]{64})\)/);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1428,6 +1428,29 @@ function _decodeDocData(dataBase64: string, name: string): { extracted: string; 
   return { extracted, ext };
 }
 
+function _fnv1a(body: string, seed: number): number {
+  let h = seed >>> 0;
+  for (let i = 0; i < body.length; i += 1) {
+    h = Math.imul(h ^ body.charCodeAt(i), 0x01000193) >>> 0;
+  }
+  return h;
+}
+
+// #968 复核（CodeRabbit #969）：占位装饰的内容指纹——渲染线程内没有同步的
+// crypto 摘要，占位场景（扫描/二进制/解析失败）用它区分「同名不同内容」的
+// 附件（防误认领，非对抗场景）：对 b64 的 长度+首尾各 4KB 跑双种子 FNV-1a
+// 并拼成 16 位 hex。发送侧写占位与守卫校验共用，避免两侧算法漂移。
+export function _docFingerprint(dataBase64: string): string {
+  const head = dataBase64.slice(0, 4096);
+  const tail = dataBase64.length > 8192 ? dataBase64.slice(-4096) : dataBase64;
+  const body = `${dataBase64.length}:${head}:${tail}`;
+  const h1 = _fnv1a(body, 0x811c9dc5).toString(16).padStart(8, '0');
+  const h2 = _fnv1a(body, 0x811c9dc5 ^ 0x9e3779b9)
+    .toString(16)
+    .padStart(8, '0');
+  return h1 + h2;
+}
+
 // #968 复核：附件装饰内容守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，
 // 「同文本 + 同附件名」的消息 key 必然碰撞，名字级校验不足以区分内容差异
 // （CodeRabbit #969：同文本 + main.py 但 print(1)/print(2) 两种内容时，旧副本
@@ -1469,12 +1492,19 @@ function _persistedCoversAttachments(
             return false; // 解码异常 → 发送侧走占位分支，不可能有 Document 块
           }
         }
-        // 占位装饰（scanned PDF / binary file / parsing on server）：名字 + 短语
+        // 占位装饰（scanned PDF / binary file / parsing on server）不承载内容，
+        // 同名不同字节的文件会生成相同的占位 → 发送侧在占位内写入内容指纹
+        // （_docFingerprint），此处比对指纹区分（CodeRabbit #969）。无指纹的
+        // 旧版占位无法验证内容 → 一律不认领（方向安全）。
         const ph = `[${a.name}: `;
         const phIdx = pmContent.indexOf(ph);
         if (phIdx < 0) return false;
-        const phTail = pmContent.slice(phIdx, phIdx + 400);
-        return /(?:scanned PDF|binary file|parsing on server)/.test(phTail);
+        const closeIdx = pmContent.indexOf(']', phIdx);
+        if (closeIdx < 0 || closeIdx - phIdx > 400) return false;
+        const seg = pmContent.slice(phIdx, closeIdx + 1);
+        const fpMatch = seg.match(/\(fp:([0-9a-f]{16})\)/);
+        if (!fpMatch || !a.dataBase64) return false;
+        return fpMatch[1] === _docFingerprint(a.dataBase64);
       }
       default:
         return true; // 未知类型装饰规则不明 → 交由 key 决定
@@ -4402,13 +4432,18 @@ export function ChatConsole({
           const { extracted, ext } = _decodeDocData(att.dataBase64, att.name);
           if (extracted && extracted.trim()) {
             content += `\n\n--- Document: ${att.name} ---\n${extracted.slice(0, 50000)}\n--- End of ${att.name} ---`;
-          } else if (ext === 'pdf') {
-            content += `\n\n[${att.name}: scanned PDF — OCR will be attempted by the server]`;
           } else {
-            content += `\n\n[${att.name}: binary file, server will parse]`;
+            // 占位装饰内嵌内容指纹 (fp:…) —— 守卫按指纹区分同名不同内容的附件
+            //（CodeRabbit #969）；key 剥离的占位规则仍可整段移除。
+            const fp = `(fp:${_docFingerprint(att.dataBase64)})`;
+            if (ext === 'pdf') {
+              content += `\n\n[${att.name}: scanned PDF ${fp} — OCR will be attempted by the server]`;
+            } else {
+              content += `\n\n[${att.name}: binary file, server will parse ${fp}]`;
+            }
           }
         } catch {
-          content += `\n\n[${att.name}: ${formatFileSize(att.size)} — parsing on server]`;
+          content += `\n\n[${att.name}: ${formatFileSize(att.size)} — parsing on server (fp:${_docFingerprint(att.dataBase64)})]`;
         }
       }
     }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1547,8 +1547,9 @@ function _persistedCoversAttachments(
         } else {
           // 占位装饰：同名不同字节的不可提取文档生成相同占位 + 各自 (fp:…)，
           // 按 name+fp 分组数出现条数（同名字同 fp 的重复附件不得共用一条）。
+          // key 分隔符用 \x1f（任何 OS 文件名都不合法），避免文件名含 | 解析错位。
           if (!a.contentFp) return false;
-          const key = `${a.name}|${a.contentFp}`;
+          const key = `${a.name}\x1f${a.contentFp}`;
           fpNeed.set(key, (fpNeed.get(key) ?? 0) + 1);
         }
         break;
@@ -1564,7 +1565,7 @@ function _persistedCoversAttachments(
     if (_countOccurrences(pmContent, sig) < n) return false;
   }
   for (const [key, n] of fpNeed) {
-    const sep = key.indexOf('|');
+    const sep = key.indexOf('\x1f');
     const name = key.slice(0, sep);
     const fp = key.slice(sep + 1);
     if (_countPlaceholderFp(pmContent, name, fp) < n) return false;

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1369,35 +1369,67 @@ function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | und
   return Math.abs(copyTs - frontendTs) < _PERSISTED_COPY_TS_TOLERANCE_MS;
 }
 
-// #968: 附件消息的 content 归一化。发送侧把附件占位符/内嵌文本拼进 content 后
-// 落库（handleSend payload 构造：图片 [Image: name]、文件 [File: …] 块、
-// --- Document: … --- 段），而乐观气泡的 content 只有原始输入文本——直接字符串
-// 比对必失配，快照截住在途附件消息时会把它当"未落盘"保留 → 同一条消息渲染两遍。
-// 与渲染层共用同一套剥离规则（extractFileChips），两侧一致变换后即可正确互认；
-// 用户手打的形似占位符文本同样被剥离，与展示层语义一致。
-function _normalizeUserContentForMatch(content: string): string {
-  return extractFileChips(content).cleanContent;
+// #968: 用户消息去重 key——剥离发送侧追加进 content 的装饰段。handleSend 把
+// 每类附件/重试提示都追加在 content 尾部，故这里每条规则都「尾锚定」（节头
+// 限定为字符串头或前导 \n\n、节尾锚定 $）并迭代剥离：内嵌文件正文里的 ``` 围栏
+// 或 "--- End of … ---" 行无法再提前截断惰性匹配（回溯必须抵达真正的尾部），
+// 文件名含 "]" 也由贪婪捕获的回溯容忍。若某条剥离失手（如手打的形似装饰文本），
+// 后果是 key 不相等 → 气泡与其副本并存（#968 双显示，方向安全），绝不会让
+// 不同消息的 key 意外相等而吞掉真实消息（方向危险）。
+const _DEDUP_TAIL_SECTION_RES =
+  /(?:^|\n\n)(?:\[系统提示：[^\]]*\]|\[Image: [^\n]+\]|\[File: [^\n]+\]\n```\n[\s\S]*?\n```|--- Document: [^\n]+ ---\n[\s\S]*?\n--- End of [^\n]+ ---|\[[^\n]+?: (?:scanned PDF|binary file|parsing on server)[^\]]*\])\s*$/;
+
+function _userContentDedupKey(content: string): string {
+  let s = content;
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(_DEDUP_TAIL_SECTION_RES, '');
+  } while (s !== prev);
+  // 无文本纯附件发送：乐观气泡显示 '(attachment)' 占位符，落库副本剥离装饰后
+  // 为空串——两侧统一映射到空串才能互认（#968 复核）。
+  const trimmed = s.trim();
+  return trimmed === '(attachment)' ? '' : trimmed;
+}
+
+// #968 复核：图片装饰名守卫。图片装饰只携带文件名（不嵌入文件内容），是跨轮
+// 「同文本 + 不同图」消息唯一能让 key 碰撞的向量（重新生成换图后，旧图副本会
+// 与新一轮在途气泡 key 相同）——若被旧副本认领，新问题会被吞（消失而非重复）。
+// 文本/文档附件把文件内容嵌进 content，key 本身即可区分，无需守卫。
+function _persistedCoversImages(pmContent: string, attachments: Attachment[] | undefined): boolean {
+  if (!attachments || attachments.length === 0) return true;
+  const images = attachments.filter((a) => a.type === 'image');
+  if (images.length === 0) return true;
+  return images.every((img) => pmContent.includes(`[Image: ${img.name}]`));
 }
 
 // #891 深度审阅 #11：删 flag 门控与保留块须用同一匹配（两处不再手写漂移）。
-// 唯一匹配改为一对一：merged 里每条持久化用户行只认领最早一条同内容、时间相近
+// 唯一匹配改为一对一：merged 里每条持久化用户行只认领最早一条同 key、时间相近
 // 的乐观气泡。此前 .some() 会让同一条持久化副本同时满足多条相同文本的气泡——
 // 用户 30s 内两次发送同一句、恢复快照时第二条尚未落盘，两条都会被误判为已持久
 // 化而漏掉第二条。返回数组与 frontend 等长：matched[i]===true 表示该条乐观气泡
-// 已有专属持久化副本。内容比对经 _normalizeUserContentForMatch 归一化（#968）。
+// 已有专属持久化副本。匹配条件（按代价排序）：①时间相近 O(1) ②归一化 key（#968，
+// key 惰性缓存、每行只算一次——load() 在 UI 线程跑，避免每对候选做全文正则）
+// ③图片装饰名守卫。内容比对经 _userContentDedupKey 归一化（#968）。
 export function _markUserTwinMatches(frontend: Message[], merged: Message[]): boolean[] {
   const matched = new Array<boolean>(frontend.length).fill(false);
+  const keyCache = new Array<string | undefined>(frontend.length).fill(undefined);
   for (const pm of merged) {
     if (pm.role !== 'user') continue;
-    const idx = frontend.findIndex(
-      (m, i) =>
-        !matched[i] &&
-        m.role === 'user' &&
-        _normalizeUserContentForMatch(String(pm.content)) ===
-          _normalizeUserContentForMatch(String(m.content)) &&
-        _isPersistedCopyOf(m.timestamp, pm.timestamp)
-    );
-    if (idx >= 0) matched[idx] = true;
+    const pmContent = String(pm.content ?? '');
+    const pmKey = _userContentDedupKey(pmContent);
+    for (let i = 0; i < frontend.length; i += 1) {
+      if (matched[i]) continue;
+      const m = frontend[i];
+      if (m.role !== 'user') continue;
+      // 时间门控最先（O(1)）——内容剥离是 O(content)，只对时间相近的候选执行
+      if (!_isPersistedCopyOf(m.timestamp, pm.timestamp)) continue;
+      if (keyCache[i] === undefined) keyCache[i] = _userContentDedupKey(String(m.content ?? ''));
+      if (keyCache[i] !== pmKey) continue;
+      if (!_persistedCoversImages(pmContent, m.attachments)) continue;
+      matched[i] = true;
+      break;
+    }
   }
   return matched;
 }

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1377,7 +1377,7 @@ function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | und
 // 后果是 key 不相等 → 气泡与其副本并存（#968 双显示，方向安全），绝不会让
 // 不同消息的 key 意外相等而吞掉真实消息（方向危险）。
 const _DEDUP_TAIL_SECTION_RES =
-  /(?:^|\n\n)(?:\[系统提示：[^\]]*\]|\[Image: [^\n]+\]|\[File: [^\n]+\]\n```\n[\s\S]*?\n```|--- Document: [^\n]+ ---\n[\s\S]*?\n--- End of [^\n]+ ---|\[[^\n]+?: (?:scanned PDF|binary file|parsing on server)[^\]]*\])\s*$/;
+  /(?:^|\n\n)(?:\[系统提示：[^\]]*\]|\[Image: [^\n]+\]|\[File: [^\n]+\]\n```\n[\s\S]*?\n```|--- Document: [^\n]+ ---\n[\s\S]*?\n--- End of [^\n]+ ---|\[[^\n]+?: [^\]]*?(?:scanned PDF|binary file|parsing on server)[^\]]*\])\s*$/;
 
 function _userContentDedupKey(content: string): string {
   let s = content;

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1462,44 +1462,73 @@ export async function _sha256HexOfText(text: string): Promise<string> {
 // #968 复核：附件装饰内容守卫。key 会把装饰段（含嵌入的文件内容）整体剥掉，
 // 「同文本 + 同附件名」的消息 key 必然碰撞，名字级校验不足以区分内容差异
 // （CodeRabbit #969：同文本 + main.py 但 print(1)/print(2) 两种内容时，旧副本
-// 会误认领新气泡 → 新消息被吞）。守卫对每个附件做内容级验证：
-// - text：payload 原样嵌入 att.content → 要求持久化副本含完整的
-//   `[File: name]\n```\n${content}\n```` 段（逐字，含围栏锚点，长度/重叠不误判）
+// 会误认领新气泡 → 新消息被吞）。守卫采用「签名计数」语义：每条 live 附件
+// 换算成一条唯一装饰签名（相同签名 = 同名字同内容/同指纹的重复附件），持久化
+// 副本里每种签名的出现次数必须 ≥ live 条数——一条装饰只认领一个附件，杜绝
+// 重复附件共用同一条旧装饰（CodeRabbit #969 round 2：30s 内先发 1 张图再发
+// 同文本 2 张相同图时，1 条装饰的旧副本会误认领 2 附件气泡 → 吞真实消息）。
+// - text：payload 原样嵌入 att.content → 签名 = 完整 `[File: name]\n```\n
+//   ${content}\n```` 段（逐字，含围栏锚点，长度/重叠不误判）
 // - document：`--- Document: name ---` 块正文须与 att.dataBase64 重新解码结果
-//   （同一 _decodeDocData，50k 截断一致）逐字相等；占位装饰（扫描/二进制/解析
-//   失败）不承载内容 → 名字 + 类型短语校验（内容本就不可见）
-// - image：装饰只携带文件名（字节不走 content）→ 名字校验（同名异字节需名字+
-//   文本+30s+旧行已消失四重巧合，记为已知限制）
-// 校验失败一律不认领（方向安全：可能双显示，绝不吞消息）。空内容 text 附件在
-// 发送侧不产生装饰 → 同样不认领（安全方向）。
+//   （同一 _decodeDocData，50k 截断一致）逐字相等，签名 = 完整块；占位装饰
+//   （扫描/二进制/解析失败）无法构造完整文本 → 按 [name: 前缀定位、逐段数
+//   (fp:contentFp) 出现次数
+// - image：签名 = `[Image: name (fp:hex)]` 完整装饰（字节不走 content，内容
+//   以发送侧预计算的全量 SHA-256 指纹代偿）
+// 任一签名次数不足 / 无法换算（无指纹、空内容、解码失败）→ 一律不认领
+// （方向安全：可能双显示，绝不吞消息）。
+function _countOccurrences(haystack: string, needle: string): number {
+  let n = 0;
+  let from = 0;
+  for (;;) {
+    const i = haystack.indexOf(needle, from);
+    if (i < 0) return n;
+    n += 1;
+    from = i + needle.length;
+  }
+}
+
+// 数 [name: 前缀占位中出现指定 fp 的段数。收尾 ] 从段头+长度起找（文件名可含
+// ]，report].pdf 不会在文件名内部截断，CodeRabbit #969 Minor）；畸形段（无
+// 收尾/超长）跳过。
+function _countPlaceholderFp(pmContent: string, name: string, fp: string): number {
+  const ph = `[${name}: `;
+  let n = 0;
+  let searchFrom = 0;
+  for (;;) {
+    const phIdx = pmContent.indexOf(ph, searchFrom);
+    if (phIdx < 0) return n;
+    const closeIdx = pmContent.indexOf(']', phIdx + ph.length);
+    if (closeIdx >= 0 && closeIdx - phIdx <= 400) {
+      const seg = pmContent.slice(phIdx, closeIdx + 1);
+      if (seg.includes(`(fp:${fp})`)) n += 1;
+    }
+    searchFrom = phIdx + ph.length;
+  }
+}
+
 function _persistedCoversAttachments(
   pmContent: string,
   attachments: Attachment[] | undefined
 ): boolean {
   if (!attachments || attachments.length === 0) return true;
-  return attachments.every((a) => {
+  const need = new Map<string, number>();
+  const fpNeed = new Map<string, number>(); // `name|fp` → 需要条数（占位装饰）
+  for (const a of attachments) {
     switch (a.type) {
       case 'image': {
-        // 图片装饰 [Image: name (fp:…)]：发送侧内嵌内容指纹，这里比对区分同名
-        // 异字节图片（CodeRabbit #969）。无指纹的旧版装饰 / live 无 contentFp
-        // → 不认领（方向安全）。文件名可含 ]，故收尾 ] 从名字后找起；同名装饰
-        // 可能出现多次（同消息两张同名图 / 嵌入文本撞串）→ 扫描全部出现点。
-        const open = `[Image: ${a.name}`;
+        // 无指纹旧版 live 附件无法验证内容 → 不认领（方向安全）
         if (!a.contentFp) return false;
-        let searchFrom = 0;
-        for (;;) {
-          const openIdx = pmContent.indexOf(open, searchFrom);
-          if (openIdx < 0) return false;
-          const rest = pmContent.slice(openIdx + open.length, openIdx + open.length + 90);
-          const fpMatch = rest.match(/^ \(fp:([0-9a-f]{64})\)\]/);
-          if (fpMatch && fpMatch[1] === a.contentFp) return true;
-          searchFrom = openIdx + open.length;
-        }
+        const sig = `[Image: ${a.name} (fp:${a.contentFp})]`;
+        need.set(sig, (need.get(sig) ?? 0) + 1);
+        break;
       }
       case 'text': {
         const c = a.content ?? '';
         if (!c) return false;
-        return pmContent.includes(`[File: ${a.name}]\n\`\`\`\n${c}\n\`\`\``);
+        const sig = `[File: ${a.name}]\n\`\`\`\n${c}\n\`\`\``;
+        need.set(sig, (need.get(sig) ?? 0) + 1);
+        break;
       }
       case 'document': {
         const blockOpen = `--- Document: ${a.name} ---`;
@@ -1510,36 +1539,19 @@ function _persistedCoversAttachments(
             const { extracted } = _decodeDocData(a.dataBase64, a.name);
             const body = extracted && extracted.trim() ? extracted.slice(0, 50000) : '';
             if (!body) return false; // 空提取发送侧会走占位分支，不应出现块
-            return pmContent.includes(`${blockOpen}\n${body}\n--- End of ${a.name} ---`);
+            const sig = `${blockOpen}\n${body}\n--- End of ${a.name} ---`;
+            need.set(sig, (need.get(sig) ?? 0) + 1);
           } catch {
             return false; // 解码异常 → 发送侧走占位分支，不可能有 Document 块
           }
+        } else {
+          // 占位装饰：同名不同字节的不可提取文档生成相同占位 + 各自 (fp:…)，
+          // 按 name+fp 分组数出现条数（同名字同 fp 的重复附件不得共用一条）。
+          if (!a.contentFp) return false;
+          const key = `${a.name}|${a.contentFp}`;
+          fpNeed.set(key, (fpNeed.get(key) ?? 0) + 1);
         }
-        // 占位装饰（scanned PDF / binary file / parsing on server）不承载内容，
-        // 同名不同字节的文件会生成相同的占位 → 发送侧把全量 SHA-256 写进占位
-        // （(fp:…)），此处与 live 附件暂存的 contentFp 比对（CodeRabbit #969）。
-        // 同名占位可出现多次（同消息两张同名不同字节的不可提取文档）→ 扫描全部
-        // 出现点，任一 fp 一致即认领（CodeRabbit #969 Major：旧实现只看第一个，
-        // 第二个附件对到第一个的 fp → 误拒 → 双显示）。无指纹的旧版占位 / live
-        // 附件无法验证内容 → 一律不认领（方向安全）。
-        if (!a.contentFp) return false;
-        const ph = `[${a.name}: `;
-        let searchFrom = 0;
-        for (;;) {
-          const phIdx = pmContent.indexOf(ph, searchFrom);
-          if (phIdx < 0) return false;
-          // 收尾 ] 须从 phIdx + ph.length 起找：文件名可含 ]（report].pdf），从
-          // phIdx 起找会命中文件名内的 ]、把段截在文件名里丢掉 (fp:…)（CodeRabbit
-          // #969 Minor：合法同文件重发被误拒 → 双显示）。畸形段（无收尾/超长）
-          // 视为非装饰跳过，继续搜后续出现点。
-          const closeIdx = pmContent.indexOf(']', phIdx + ph.length);
-          if (closeIdx >= 0 && closeIdx - phIdx <= 400) {
-            const seg = pmContent.slice(phIdx, closeIdx + 1);
-            const fpMatch = seg.match(/\(fp:([0-9a-f]{64})\)/);
-            if (fpMatch && fpMatch[1] === a.contentFp) return true;
-          }
-          searchFrom = phIdx + ph.length;
-        }
+        break;
       }
       default:
         // 未知/未来扩展类型（audio/video/archive/…）无法验证内容 → 不认领。
@@ -1547,7 +1559,17 @@ function _persistedCoversAttachments(
         // 而漏补分支，仅凭 key（文本+时间+文件名）认领可能吞掉真实新消息。
         return false;
     }
-  });
+  }
+  for (const [sig, n] of need) {
+    if (_countOccurrences(pmContent, sig) < n) return false;
+  }
+  for (const [key, n] of fpNeed) {
+    const sep = key.indexOf('|');
+    const name = key.slice(0, sep);
+    const fp = key.slice(sep + 1);
+    if (_countPlaceholderFp(pmContent, name, fp) < n) return false;
+  }
+  return true;
 }
 
 // #891 深度审阅 #11：删 flag 门控与保留块须用同一匹配（两处不再手写漂移）。

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -1369,13 +1369,23 @@ function _isPersistedCopyOf(frontendTs: number | undefined, copyTs: number | und
   return Math.abs(copyTs - frontendTs) < _PERSISTED_COPY_TS_TOLERANCE_MS;
 }
 
+// #968: 附件消息的 content 归一化。发送侧把附件占位符/内嵌文本拼进 content 后
+// 落库（handleSend payload 构造：图片 [Image: name]、文件 [File: …] 块、
+// --- Document: … --- 段），而乐观气泡的 content 只有原始输入文本——直接字符串
+// 比对必失配，快照截住在途附件消息时会把它当"未落盘"保留 → 同一条消息渲染两遍。
+// 与渲染层共用同一套剥离规则（extractFileChips），两侧一致变换后即可正确互认；
+// 用户手打的形似占位符文本同样被剥离，与展示层语义一致。
+function _normalizeUserContentForMatch(content: string): string {
+  return extractFileChips(content).cleanContent;
+}
+
 // #891 深度审阅 #11：删 flag 门控与保留块须用同一匹配（两处不再手写漂移）。
 // 唯一匹配改为一对一：merged 里每条持久化用户行只认领最早一条同内容、时间相近
 // 的乐观气泡。此前 .some() 会让同一条持久化副本同时满足多条相同文本的气泡——
 // 用户 30s 内两次发送同一句、恢复快照时第二条尚未落盘，两条都会被误判为已持久
 // 化而漏掉第二条。返回数组与 frontend 等长：matched[i]===true 表示该条乐观气泡
-// 已有专属持久化副本。
-function _markUserTwinMatches(frontend: Message[], merged: Message[]): boolean[] {
+// 已有专属持久化副本。内容比对经 _normalizeUserContentForMatch 归一化（#968）。
+export function _markUserTwinMatches(frontend: Message[], merged: Message[]): boolean[] {
   const matched = new Array<boolean>(frontend.length).fill(false);
   for (const pm of merged) {
     if (pm.role !== 'user') continue;
@@ -1383,7 +1393,8 @@ function _markUserTwinMatches(frontend: Message[], merged: Message[]): boolean[]
       (m, i) =>
         !matched[i] &&
         m.role === 'user' &&
-        String(pm.content) === String(m.content) &&
+        _normalizeUserContentForMatch(String(pm.content)) ===
+          _normalizeUserContentForMatch(String(m.content)) &&
         _isPersistedCopyOf(m.timestamp, pm.timestamp)
     );
     if (idx >= 0) matched[idx] = true;


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #968：会话加载窗口内发送带图片/文件附件的消息可能显示两遍——去重比对前缺失附件占位符归一化所致。

## 背景/问题

#891 合入的 load() 保留逻辑用 `_markUserTwinMatches`（ChatConsole.tsx）判断乐观气泡是否已有持久化副本，比对条件是 content 字符串相等。但带附件的消息两侧 content 必然不相等：

- **乐观气泡**：`content = text`（纯输入文本，附件在独立 `attachments` 字段）
- **发送 payload**（handleSend）：图片追加 `\n\n[Image: 文件名]` 占位符、文本/文件追加 `[File: 名]\n```\n…\n```` 块、文档追加 `--- Document: 名 ---` 段 → 后端落库的就是这份带附件段的内容
- **恢复时**（`sessionMsgsToUi`）：只把占位符提取成 attachments，content 原文保留

→ 持久化副本与乐观气泡字符串不等 → 快照截住在途附件消息时，气泡被误判「未落盘」保留 → **同一条消息渲染两遍**（纯文本消息收发 content 一致，不受影响）。触发需「慢加载 + 附件发送 + 快照时机」组合，罕见但属 #891 修复目标的同类回归。

## 关联 issue

- Closes #968

## 变更内容

- `apps/desktop/src/renderer/features/chat/ChatConsole.tsx`
  - 新增 `_userContentDedupKey`：尾锚定（`$`）+ 节头限定的迭代剥离，去除 handleSend 追加在 content 尾部的全部装饰段（`[Image:]`、`[File:]` 代码块、`--- Document: ---` 段、扫描/二进制占位、重试 `[系统提示：…]` 尾）并映射 `(attachment)` 占位符为空串——内嵌 ``` 围栏、`--- End of … ---` 行、文件名含 `]` 均不截断
  - 新增 `_decodeDocData`：文档附件解码/提取的单一实现（handleSend 拼装饰与守卫校验共用，ext 白名单与 50k 截断不漂移）
  - 新增 `_sha256HexOfBase64`：不可提取附件（扫描 PDF / binary / parsing on server）发送前预计算**全量 SHA-256**（采样会被「同首尾、仅中段不同」构造性绕过），写入占位装饰 `(fp:…)`
  - 新增 `_persistedCoversAttachments` 内容级附件守卫：text 要求持久化副本含完整逐字 `[File:]` 代码块、document 块正文与 `dataBase64` 重解码逐字比对（不可提取则比对 `fp`）、image 按装饰名 + 内嵌 SHA-256 指纹（[Image: name (fp:…)]，同名异字节不再互认，CodeRabbit #969 阻塞项落地）；未知/未来扩展类型 default **回落不认领**——守卫整体遵循「内容无法确认 → 不认领」的防吞消息安全方向；旧版无 `fp` 占位一律不认领（兼容优先，宁可双显不吞消息）
  - `_markUserTwinMatches` 重构：时间门控 O(1) 提前 + 归一化 key 每行惰性缓存（load() 在 UI 线程跑，避免每对候选全文正则）+ 一对一认领（#891 复核语义不回退）
- `apps/desktop/src/renderer/features/chat/ChatConsole.test.ts`
  - 新增 28 条单测（本文件净增，基线 7 条 → 35 条）：附件各格式归一化互认（含内嵌围栏/End 行/含 `]` 文件名/重试尾/纯附件 `(attachment)`）、一对一认领不回退（#891 复核行为）、图片换图守卫、文本/文档同名异内容守卫（CodeRabbit #969 构造）、不可提取附件 `fp` 一致/不一致/旧版无 `fp`、SHA-256 全量覆盖回归（同首尾异中段 9KB 输入指纹必须不同）、未知附件类型回落不认领

## 日志/验证证据

```
# vitest（7 既有 + 28 新增 = 35 条）
$ npx vitest run src/renderer/features/chat/ChatConsole.test.ts
 ✓ src/renderer/features/chat/ChatConsole.test.ts (35 tests)
 Test Files  1 passed (1)
      Tests  33 passed (33)

# typecheck
$ npm run typecheck:web   # tsc --noEmit -p tsconfig.web.json，无错误输出

# prettier
ChatConsole.tsx / ChatConsole.test.ts — All matched files use Prettier code style!
```

## 测试情况

- 单元测试：`ChatConsole.test.ts` 35 passed（7 既有 + 28 新增）
- 类型检查：`typecheck:web` 通过
- 格式：prettier 通过
- CI：最新 head 复跑后 typecheck / check-format / check-title / quick / CodeQL / GitGuardian / Analyze 全绿后合入
- 未跑完整 electron e2e 套件（本改动为纯函数级去重逻辑，单测已覆盖谓词行为；e2e 由 CI 兜底）

## 截图

无需截图（纯数据层去重逻辑修复，无 UI 变化）

## 后续计划

- image/text/document 三类附件一致性校验已统一为内容级（image 与 doc 均走全量 SHA-256 contentFp，#980 随本 PR 闭合）
- #968 修复后随下个版本发布
