### PR TITLE
docs: 在 README 中补充 winget 安装 uv 与 nvm-windows 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ MiQroForge Desktop is an Electron-based desktop application that provides a mode
 - **Node.js 20+** — to run Electron frontend
 - **uv** — Python package manager (recommended)
 
+> **Windows users** can install `uv` and Node.js with winget (included in Windows 10 1709+ / Windows 11; if missing, install "App Installer" from the Microsoft Store first):
+>
+> ```bash
+> # Install uv
+> winget install --id astral-sh.uv -e
+>
+> # Install nvm-windows, then Node.js 22
+> winget install --id CoreyButler.NVMforWindows -e
+> nvm install 22
+> ```
+>
+> After installing nvm-windows, open a new terminal before running `nvm`.
+
 ### Installation
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -68,6 +68,19 @@ MiQroForge 是一个个人 AI 代理框架，将强大的 **Python 运行时引�
 - **Node.js 20+** — 运行 Electron 前端
 - **uv** — Python 包管理器（推荐）
 
+> **Windows 用户**可通过 winget 一键安装 uv 和 Node.js（Windows 10 1709+ / Windows 11 自带 winget；若没有，请先从 Microsoft Store 安装「应用安装程序」）：
+>
+> ```bash
+> # 安装 uv
+> winget install --id astral-sh.uv -e
+>
+> # 安装 nvm-windows，并安装 Node.js 22
+> winget install --id CoreyButler.NVMforWindows -e
+> nvm install 22
+> ```
+>
+> 安装 nvm-windows 后请新开一个终端窗口再执行 `nvm`。
+
 ### 安装步骤
 
 ```bash


### PR DESCRIPTION
## 类型

- [x] 📝 文档

## 变更概述

README 快速开始章节补充 Windows 下用 winget 一键安装 uv 与 nvm-windows（含 Node.js 22）的说明。

## 背景/问题

新开发者或 Windows 用户按 README 快速开始搭建环境时，前置依赖只列出了 Python、Node.js、uv 三项，没有给出安装命令；首次接触者不知道用什么方式装，也容易踩两个坑：机器没有 winget，以及 nvm-windows 装完后当前终端 PATH 未刷新导致 `nvm` 命令不可用。

## 变更内容

- `README_zh.md`：前置依赖节新增 Windows 用户 winget 安装 uv 与 nvm-windows 的命令，注明没有 winget 时需先从 Microsoft Store 安装「应用安装程序」，并提示 nvm-windows 安装后需新开终端再执行 `nvm`
- `README.md`：英文版同步更新

## 日志/验证证据

```
$ git show --stat HEAD
 README.md    | 13 +++++++++++++
 README_zh.md | 13 +++++++++++++
 2 files changed, 26 insertions(+)
```

README 新增内容（中文版）：

```
> **Windows 用户**可通过 winget 一键安装 uv 和 Node.js（Windows 10 1709+ / Windows 11 自带 winget；若没有，请先从 Microsoft Store 安装「应用安装程序」）：
>
> # 安装 uv
> winget install --id astral-sh.uv -e
>
> # 安装 nvm-windows，并安装 Node.js 22
> winget install --id CoreyButler.NVMforWindows -e
> nvm install 22
```

## 测试情况

纯文档改动，无代码变更；未运行自动化测试。

## 截图

无需截图
