### PR TITLE
fix(desktop): 桥进程父死看门狗——Electron 硬杀后不再遗留孤儿 bridge (#959)

### DIFF
--- a/apps/desktop/src/main/bridge.ts
+++ b/apps/desktop/src/main/bridge.ts
@@ -248,7 +248,19 @@ export class BridgeManager extends EventEmitter {
       const bridgeProcess = spawn(command, args, {
         cwd: this.projectRoot,
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, PYTHONUNBUFFERED: '1', PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8' },
+        // MIQI_PARENT_PID (#959): the bridge's parent-death watchdog watches
+        // this PID. On Windows the direct parent may be a `uv` shim that
+        // outlives Electron (and Windows never updates the parent PID), so
+        // the bridge must watch the real launcher. When Electron is killed
+        // hard (E2E force-kill / crash) the bridge hard-exits instead of
+        // lingering as an orphan that pollutes later runs.
+        env: {
+          ...process.env,
+          PYTHONUNBUFFERED: '1',
+          PYTHONUTF8: '1',
+          PYTHONIOENCODING: 'utf-8',
+          MIQI_PARENT_PID: String(process.pid),
+        },
         windowsHide: true,
       });
       this.process = bridgeProcess;

--- a/apps/desktop/tests/e2e/helpers/electron-setup.ts
+++ b/apps/desktop/tests/e2e/helpers/electron-setup.ts
@@ -11,6 +11,7 @@ import type { ElectronApplication, Page } from '@playwright/test';
 import { resolve } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdtempSync,
@@ -831,7 +832,21 @@ export async function closeElectronApp(
       (async () => {
         await new Promise((r) => setTimeout(r, 15_000));
         try {
-          app.process().kill();
+          if (process.platform === 'win32') {
+            // #959: Playwright launches Electron through a cmd.exe shell
+            // wrapper on Windows, so app.process() is the cmd wrapper —
+            // killing it alone leaves the real app main (window + bridge +
+            // children) running to pollute later runs (mcps.list hangs).
+            // taskkill /T kills the whole tree: cmd → electron main →
+            // bridge → its MCP/exec children.
+            spawnSync('taskkill', ['/F', '/T', '/PID', String(app.process().pid)], {
+              windowsHide: true,
+            });
+          } else {
+            // POSIX: no shell wrapper — the main dies, and the bridge's
+            // parent-death watchdog (#959) hard-exits within ~1-2s.
+            app.process().kill('SIGKILL');
+          }
         } catch {
           /* already gone */
         }

--- a/miqi/bridge/parent_watchdog.py
+++ b/miqi/bridge/parent_watchdog.py
@@ -1,0 +1,165 @@
+"""Parent-death watchdog — hard-exit the bridge when its launcher dies (#959).
+
+Electron spawns the bridge (directly or via ``uv run``) with a stdin pipe.
+When the launcher is killed hard (E2E force-kill path, crash), the bridge
+can linger as an orphan — stdin EOF may never arrive (Windows handle
+inheritance) and ``_graceful_shutdown`` can block on WSL sandbox teardown.
+Orphans pollute later runs: ``mcps.list`` hangs, the MCP server list never
+renders (#952 实测).
+
+The watchdog polls the launcher process chain from a daemon thread and
+hard-exits (``os._exit``) once it is dead, deliberately bypassing the
+hang-prone graceful shutdown path. Callers may pass ``on_death`` for fast
+cleanup that must complete before the exit (state-file clear, child reap).
+
+Watched targets:
+
+- the direct parent (always) — covers ``python server.py`` from a shell;
+- ``MIQI_PARENT_PID`` (set by the desktop BridgeManager) — required on
+  Windows when the direct parent is a launcher shim (``uv run`` / venv
+  redirector) that survives its own launcher and keeps waiting for the
+  child. Windows keeps the original parent PID forever, so getppid
+  polling cannot detect the launcher's death there.
+
+Death detection:
+
+- Windows: the process handle is opened ONCE and polled via
+  ``GetExitCodeProcess`` — the kernel process object stays queryable
+  through the pinned handle after death, so the check is exact (no
+  PID-reuse race). ``OpenProcess`` failing with ERROR_INVALID_PARAMETER
+  (pid did not exist) counts as dead; access-denied counts as alive
+  (never false-fire).
+- POSIX: getppid change for the direct parent (orphans reparent to init,
+  exact) plus ``kill(pid, 0)`` → ESRCH for ``MIQI_PARENT_PID`` (small
+  PID-reuse window; the direct-parent check remains exact).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable
+
+from loguru import logger
+
+WATCHDOG_ENV = "MIQI_PARENT_PID"
+
+_STILL_ACTIVE = 259
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_ERROR_ACCESS_DENIED = 5
+
+
+class _WindowsProcessHandle:
+    """Pinned handle to a target process; exact post-mortem liveness query."""
+
+    def __init__(self, pid: int) -> None:
+        import ctypes
+
+        self._kernel32 = ctypes.windll.kernel32
+        self._handle = self._kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        # OpenProcess fails with INVALID_PARAMETER when the pid does not
+        # exist (parent died before the watchdog attached) — treat as dead.
+        # ACCESS_DENIED means we cannot determine — treat as alive so the
+        # watchdog never false-fires.
+        self._unqueryable = bool(
+            not self._handle and ctypes.get_last_error() == _ERROR_ACCESS_DENIED
+        )
+
+    def is_alive(self) -> bool:
+        if not self._handle:
+            return self._unqueryable
+        import ctypes
+
+        exit_code = ctypes.c_ulong()
+        if not self._kernel32.GetExitCodeProcess(self._handle, ctypes.byref(exit_code)):
+            return self._unqueryable
+        return exit_code.value == _STILL_ACTIVE
+
+
+def _is_alive_posix(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Cannot determine — assume alive (never false-fire).
+        return True
+    return True
+
+
+def is_alive(pid: int) -> bool:
+    """True when the process exists (Windows: queryable exit code)."""
+    if os.name == "nt":
+        return _WindowsProcessHandle(pid).is_alive()
+    return _is_alive_posix(pid)
+
+
+def _env_watch_pid() -> int | None:
+    raw = os.environ.get(WATCHDOG_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        pid = int(raw)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def start_parent_watchdog(
+    on_death: Callable[[], None] | None = None,
+    interval_s: float = 1.0,
+) -> None:
+    """Start the parent-death watchdog in a daemon thread.
+
+    Once the launcher chain is dead the thread runs *on_death* (fast
+    cleanup only — never the hang-prone graceful shutdown) and calls
+    ``os._exit(0)``, bypassing atexit handlers.
+    """
+    direct_parent = os.getppid()
+    env_pid = _env_watch_pid()
+    logger.info(
+        "Parent watchdog armed: direct parent={} {}={}",
+        direct_parent,
+        WATCHDOG_ENV,
+        env_pid,
+    )
+
+    watched: list[int] = [direct_parent]
+    if env_pid is not None and env_pid != direct_parent:
+        watched.append(env_pid)
+
+    windows_handles: list[_WindowsProcessHandle] | None = None
+    if os.name == "nt":
+        windows_handles = [_WindowsProcessHandle(pid) for pid in watched]
+
+    def _parent_dead() -> bool:
+        if windows_handles is not None:
+            return any(not handle.is_alive() for handle in windows_handles)
+        if os.getppid() != direct_parent:
+            return True
+        return env_pid is not None and not _is_alive_posix(env_pid)
+
+    def _run() -> None:
+        try:
+            while not _parent_dead():
+                time.sleep(interval_s)
+        except Exception:
+            logger.exception("Parent watchdog thread failed")
+            return
+        logger.warning(
+            "Launcher process chain dead (direct parent={} {}={}) — hard-exiting bridge",
+            direct_parent,
+            WATCHDOG_ENV,
+            env_pid,
+        )
+        try:
+            if on_death is not None:
+                on_death()
+        except Exception:
+            logger.exception("Parent watchdog on_death cleanup failed")
+        os._exit(0)
+
+    threading.Thread(target=_run, name="bridge-parent-watchdog", daemon=True).start()

--- a/miqi/bridge/server.py
+++ b/miqi/bridge/server.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import asyncio
 import atexit
 import json
+import os
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -595,6 +597,21 @@ def _graceful_shutdown() -> None:
         _bridge_state = None
 
 
+def _clear_sandbox_state_file_fast() -> None:
+    """#959: 看门狗退出路径的状态文件快清理（不做 destroy_all —— 那正是
+    优雅关停的挂起向量）。防下一次启动读到 stale 条目。"""
+    global _bridge_state
+    if _bridge_state is None:
+        return
+    sandbox_mgr = getattr(_bridge_state, "_sandbox_manager", None)
+    if sandbox_mgr is None or sandbox_mgr == "disabled":
+        return
+    try:
+        sandbox_mgr._clear_state_file()
+    except Exception:
+        pass
+
+
 def main() -> None:
     global _bridge_state
 
@@ -658,6 +675,27 @@ def main() -> None:
     # instead of per-request asyncio.run(). Legacy handlers continue to
     # work via the _dispatch fallback path.
     from miqi.bridge.loop import BridgeRuntimeLoop
+
+    # #959: parent-death watchdog — Electron 被硬杀（E2E 15s 竞速超时/崩溃）
+    # 时 before-quit → BridgeManager.stop() 不会执行，桥若无此看门狗会成为
+    # 孤儿污染后续运行（mcps.list 挂起）。看门狗发现启动链死亡后硬退出
+    # （os._exit），故意绕过会挂起在 WSL teardown 的 _graceful_shutdown；
+    # 退出前只做状态文件快清理 + Windows 整树回收 MCP/exec 孙进程。
+    def _on_parent_death() -> None:
+        _clear_sandbox_state_file_fast()
+        if os.name == "nt":
+            try:
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(os.getpid())],
+                    capture_output=True,
+                    timeout=10,
+                )
+            except Exception:
+                pass
+
+    from miqi.bridge.parent_watchdog import start_parent_watchdog
+
+    start_parent_watchdog(on_death=_on_parent_death)
 
     bridge = BridgeRuntimeLoop(
         send_func=_send,

--- a/tests/bridge/test_parent_watchdog.py
+++ b/tests/bridge/test_parent_watchdog.py
@@ -1,0 +1,158 @@
+"""Parent-death watchdog tests (#959).
+
+The watchdog lives in spawned helper processes because its exit path is
+``os._exit`` — running it in-process would kill pytest. All tests spawn
+short-lived dummy processes and watch children that arm the watchdog.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from miqi.bridge.parent_watchdog import WATCHDOG_ENV, is_alive
+
+pytestmark = pytest.mark.subprocess
+
+POLL_INTERVAL = 0.2
+WAIT_TIMEOUT = 15.0
+WATCHDOG_CHILD = (
+    "import time\n"
+    "from miqi.bridge.parent_watchdog import start_parent_watchdog\n"
+    f"start_parent_watchdog(interval_s={POLL_INTERVAL})\n"
+    "print('watchdog-ready', flush=True)\n"
+    "time.sleep(120)\n"
+)
+
+
+def _spawn(code: str, env: dict[str, str] | None = None) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        env={**os.environ, "PYTHONUNBUFFERED": "1", **(env or {})},
+    )
+
+
+def _base_python() -> str:
+    """绕过 uv venv 的 redirector shim（Windows）。
+
+    shim 会在拉起真实 python 后存活等待，杀死 launcher 时 shim 仍在 ——
+    直接父进程（shim）不死，回退路径的看门狗永远不触发。用
+    sys._base_executable 直接 spawn 真实 python，使「launcher = 直接父进程」成立。
+    """
+    return getattr(sys, "_base_executable", None) or sys.executable
+
+
+def _wait_dead(proc: subprocess.Popen, timeout_s: float = WAIT_TIMEOUT) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.kill()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def test_watchdog_exits_when_env_parent_dies():
+    """MIQI_PARENT_PID 指向的进程死亡 → 看门狗子进程硬退出（跨平台）。"""
+    dummy = _spawn("import time; time.sleep(120)")
+    try:
+        assert dummy.poll() is None
+        child = _spawn(WATCHDOG_CHILD, env={WATCHDOG_ENV: str(dummy.pid)})
+        try:
+            assert child.stdout.readline().strip() == "watchdog-ready"
+            assert is_alive(dummy.pid)
+            dummy.kill()
+            dummy.wait(timeout=10)
+            assert _wait_dead(child), (
+                f"watchdog child (pid {child.pid}) should exit after the "
+                f"watched pid {dummy.pid} died"
+            )
+        finally:
+            _kill(child)
+    finally:
+        _kill(dummy)
+
+
+def test_watchdog_falls_back_to_direct_parent():
+    """无 MIQI_PARENT_PID 时监视直接父进程：launcher 自杀后子进程应退出。
+
+    Windows 上子进程必须用 base python 直接 spawn（绕过 venv redirector
+    shim —— shim 存活会掩盖 launcher 死亡，见 _base_python）。
+    """
+    base_py = _base_python()
+    launcher_code = (
+        "import os, subprocess, time\n"
+        # base python 直跑没有 venv 的 site-packages —— 把 launcher 的
+        # sys.path 透传给子进程（loguru 等依赖在 venv 里）
+        "venv_path = os.pathsep.join(p for p in __import__('sys').path if p)\n"
+        f"child = subprocess.Popen([{base_py!r}, '-c', {WATCHDOG_CHILD!r}],"
+        " stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,"
+        " env={**os.environ, 'PYTHONPATH': venv_path})\n"
+        "line = child.stdout.readline()\n"
+        "while line and line.strip() != 'watchdog-ready':\n"  # skip watchdog log line
+        "    line = child.stdout.readline()\n"
+        "print(child.pid, flush=True)\n"
+        "time.sleep(120)\n"
+    )
+    launcher = _spawn(launcher_code)
+    try:
+        child_pid = int(launcher.stdout.readline().strip())
+        assert is_alive(child_pid)
+        launcher.kill()
+        launcher.wait(timeout=10)
+        deadline = time.time() + WAIT_TIMEOUT
+        while time.time() < deadline and is_alive(child_pid):
+            time.sleep(0.1)
+        assert not is_alive(child_pid), (
+            f"watchdog child (pid {child_pid}) should exit after its direct "
+            "parent (launcher) died"
+        )
+    finally:
+        _kill(launcher)
+
+
+def test_watchdog_does_not_fire_while_parents_alive():
+    """被监视进程存活时看门狗不误触发。"""
+    dummy = _spawn("import time; time.sleep(120)")
+    try:
+        child = _spawn(WATCHDOG_CHILD, env={WATCHDOG_ENV: str(dummy.pid)})
+        try:
+            assert child.stdout.readline().strip() == "watchdog-ready"
+            # 数个轮询周期后子进程仍应存活（测试进程与 dummy 都活着）
+            time.sleep(POLL_INTERVAL * 5)
+            assert child.poll() is None, "watchdog fired while watched pids are alive"
+        finally:
+            _kill(child)
+    finally:
+        _kill(dummy)
+
+
+def test_is_alive_reports_death():
+    """is_alive：存活 True → 进程死亡（回收）后 False。"""
+    proc = _spawn("import time; time.sleep(120)")
+    try:
+        assert is_alive(proc.pid)
+        proc.kill()
+        proc.wait(timeout=10)
+        deadline = time.time() + WAIT_TIMEOUT
+        while time.time() < deadline and is_alive(proc.pid):
+            time.sleep(0.1)
+        assert not is_alive(proc.pid)
+    finally:
+        _kill(proc)


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

桥进程增加父死看门狗：Electron 被硬杀后桥不再遗留为孤儿进程，修复后续运行 mcps.list 挂起、MCP 服务器列表不渲染的假性失败。

## 背景/问题

失败/中断的 Electron E2E 运行会遗留孤儿 miqi/bridge/server.py 进程（#959，本机 2026-09-07 实测出现旧桥拉新桥双进程），导致后续本地 E2E 出现 mcps.list 挂起、MCP 设置页列表不渲染等假性失败。

根因：

1. closeElectronApp 15s 竞速超时强制 kill 时 before-quit → BridgeManager.stop() 不执行，桥收不到关停信号；
2. Windows 上桥的直接父进程是 uv shim（比 Electron 活得久），Windows 不更新父 PID，stdin EOF 也不保证送达，桥无从得知启动链已死；
3. _graceful_shutdown 的 WSL teardown 可能挂起，即使走到关停路径也可能卡住。

## 关联 issue

- Closes #959

## 变更内容

- 新增 miqi/bridge/parent_watchdog.py：daemon 线程轮询启动链（直接父进程 + MIQI_PARENT_PID），链死亡后 os._exit 硬退出，故意绕过会挂起的优雅关停路径；Windows 用 pinned handle + GetExitCodeProcess 精确检测（无 PID 复用竞态，access-denied 视为存活、绝不误杀），POSIX 用 getppid 变化 + kill(pid, 0)
- apps/desktop/src/main/bridge.ts：spawn 桥时注入 MIQI_PARENT_PID=Electron 主进程 PID
- miqi/bridge/server.py：接入看门狗；退出前状态文件快清理（不做 destroy_all——那正是挂起向量）+ Windows taskkill /T 整树回收 MCP/exec 孙进程
- apps/desktop/tests/e2e/helpers/electron-setup.ts：E2E 关闭路径 Windows 改用 taskkill /F /T /PID（Playwright 经 cmd shell 包装启动，只杀包装进程会留真身）；POSIX 维持 SIGKILL
- 新增 tests/bridge/test_parent_watchdog.py：4 个用例（env 父进程死亡退出/直接父进程回退/存活不触发/is_alive 死亡报告）

## 日志/验证证据

```
PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe -m pytest tests/bridge/test_parent_watchdog.py -v
============================= test session starts =============================
platform win32 -- Python 3.14.5, pytest-9.0.3, pluggy-1.6.0
rootdir: C:\Projects\PythonProjects\MiQi
configfile: pyproject.toml
collected 4 items

tests/bridge/test_parent_watchdog.py::test_watchdog_exits_when_env_parent_dies PASSED [ 25%]
tests/bridge/test_parent_watchdog.py::test_watchdog_falls_back_to_direct_parent PASSED [ 50%]
tests/bridge/test_parent_watchdog.py::test_watchdog_does_not_fire_while_parents_alive PASSED [ 75%]
tests/bridge/test_parent_watchdog.py::test_is_alive_reports_death PASSED [100%]

============================== 4 passed in 2.09s ==============================
```

## 测试情况

- pytest tests/bridge/test_parent_watchdog.py：4/4 通过（Windows 本机实测）
- E2E 全量（mcp.spec.ts 等）需登录态/mock 环境，本次未跑；修复效果待合入后由日常 E2E 运行验证

## 截图

无 UI 变更，无需截图

## 后续计划

无
