### PR TITLE
fix(session): 文件夹绑定会话切换后历史丢失、输入框卡生成中，重启后侧栏消失（#956）

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -3463,6 +3463,31 @@ export function ChatConsole({
           if (_inFlight.length > 0) merged.push(..._inFlight);
         }
         setMessages(merged);
+        // #956: the persisted history is the authoritative answer.  When it
+        // ends with a completed reply and nothing is in flight (no live send
+        // for this session, no progress-without-final cached while we were
+        // away), the switch-back "生成中" state must not survive — otherwise a
+        // folder session whose reply was restored from the bound workspace
+        // root keeps the send button stuck as "中断当前生成并发送" forever.
+        const _histEndsComplete = (() => {
+          for (let _i = uiMsgs.length - 1; _i >= 0; _i -= 1) {
+            const _m = uiMsgs[_i];
+            if (_m.role === 'user') return false; // last turn has no reply yet
+            if (_m.role === 'assistant' && String(_m.content ?? '').trim().length > 0) {
+              return true;
+            }
+          }
+          return false;
+        })();
+        const _cacheStillLive =
+          !!cached &&
+          cached.events.some((e) => e.type === 'progress') &&
+          !cached.events.some(
+            (e) => e.type === 'final' || e.type === 'error' || e.type === 'aborted'
+          );
+        if (_histEndsComplete && !streamingBySession.has(sessionKey) && !_cacheStillLive) {
+          setStreaming(false);
+        }
         // Snapshot is now reconciled into `merged` — clear it so a later
         // load() (loadTrigger refresh) doesn't re-append stale transient
         // progress on top of history.

--- a/apps/desktop/tests/e2e/issue-956-folder-session.spec.ts
+++ b/apps/desktop/tests/e2e/issue-956-folder-session.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * #956 — folder-bound session persistence E2E.
+ *
+ * Repro of the reported bug: a session bound to a custom folder loses its
+ * user/assistant messages after switching dialogs (only transient thinking
+ * remains, send button stuck as "中断当前生成并发送"), and the session
+ * vanishes from the sidebar entirely after a full app restart.
+ *
+ * Root cause (backend): the write side mirrors the conversation under the
+ * bound folder root while sessions.get / sessions.list only read the
+ * app-home root, where the folder session has just an empty stub.
+ *
+ * Flow (real user path):
+ *   1. Seed a workspace binding via the bridge so the workspace picker's
+ *      "最近使用" list offers the folder.
+ *   2. Open the picker from the inline "更换" button and pick the folder —
+ *      this creates the folder-bound session through the real
+ *      pendingWorkspace → sessions.get(key, { workspace }) flow.
+ *   3. Chat with a real LLM, then switch away/back (test 1) or fully
+ *      restart the app on the same MIQI_HOME (test 2) and verify the
+ *      history, the send button state, and no duplicate sidebar entry.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { mkdtempSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  LLM_TIMEOUT,
+  waitForInputReady,
+  createNewConversation,
+  sendMessage,
+  waitForResponseComplete,
+  launchElectronApp,
+  closeElectronApp,
+  relaunchElectronApp,
+  switchToSessionWithMarker,
+  waitForBridgeInitialized,
+} from './helpers/electron-setup';
+
+const SIDEBAR = 'div.flex.flex-col.shrink-0.border-r';
+
+/** Register a binding the same way the frontend persists a workspace pick —
+ *  sessions.get(key, { workspace }) writes the app-home stub + metadata. */
+async function seedWorkspace(page: Page, folderRoot: string) {
+  await waitForBridgeInitialized(page);
+  const seedKey = `e2e-956-seed-${Date.now()}`;
+  await page.evaluate(
+    async ({ key, ws }) => {
+      return await (window as any).miqi.sessions.get(key, { workspace: ws });
+    },
+    { key: seedKey, ws: folderRoot }
+  );
+  return seedKey;
+}
+
+/** Create a folder-bound session through the real UI: inline "更换" →
+ *  workspace picker → click the folder in "最近使用". */
+async function createFolderSessionViaPicker(page: Page, folderMarker: string) {
+  await page.getByTestId('inline-workspace-change-btn').click();
+  await expect(page.getByTestId('workspace-picker-modal')).toBeVisible({
+    timeout: 10_000,
+  });
+  const recentEntry = page
+    .locator('[data-testid^="workspace-picker-recent-"]', { hasText: folderMarker })
+    .first();
+  await expect(recentEntry).toBeVisible({ timeout: 15_000 });
+  await recentEntry.click();
+  await waitForInputReady(page, 30_000);
+  // The pill confirms the session resolved its workspace to the folder.
+  await expect(page.getByTestId('inline-workspace-path')).toContainText(folderMarker, {
+    timeout: 15_000,
+  });
+}
+
+/** Assert the send button is in the normal "发送" state, not stuck generating. */
+async function expectSendButtonNotStuck(page: Page) {
+  await expect(page.getByLabel('发送')).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByLabel('中断当前生成并发送')).toHaveCount(0);
+  await expect(page.getByLabel('停止生成')).toHaveCount(0);
+}
+
+/** Assert the conversation is visible: question + reply, input sendable. */
+async function expectConversationVisible(page: Page, marker: string, reply: string) {
+  await expect(page.locator('main').getByText(marker, { exact: false }).first()).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.locator('main').getByText(reply, { exact: false }).first()).toBeVisible({
+    timeout: 60_000,
+  });
+  await expectSendButtonNotStuck(page);
+}
+
+test.describe('#956 folder-bound session', () => {
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+
+  test('switch-back keeps folder-session history and the input is sendable', async () => {
+    test.setTimeout(LLM_TIMEOUT + 240_000);
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+
+    const folderRoot = mkdtempSync(join(tmpdir(), 'miqi-956a-'));
+    const folderMarker = 'miqi-956a';
+    const question = 'Q956A-请只回复两个字：收到';
+
+    try {
+      await seedWorkspace(page, folderRoot);
+      await createFolderSessionViaPicker(page, folderMarker);
+
+      await sendMessage(page, question);
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      await expect(page.locator('main').getByText('收到', { exact: false }).first()).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // #956 invariant: the real conversation lives under the BOUND FOLDER,
+      // while the app-home entry stays a binding-only stub.
+      const folderSessionsDir = join(folderRoot, 'sessions');
+      const convFiles: string[] = [];
+      for (const entry of readdirSync(folderSessionsDir)) {
+        const conv = join(folderSessionsDir, entry, 'conversation.jsonl');
+        if (existsSync(conv)) convFiles.push(conv);
+      }
+      expect(convFiles.length).toBeGreaterThan(0);
+      expect(readFileSync(convFiles[0], 'utf-8')).toContain('Q956A');
+
+      // After the turn completes, the folder session must appear EXACTLY once
+      // in the sidebar (the active registry + folder-scan must not duplicate it).
+      await expect(
+        page.locator(`${SIDEBAR} button.rounded-xl`, { hasText: 'Q956A' }).first()
+      ).toBeVisible({ timeout: 60_000 });
+      await expect(page.locator(`${SIDEBAR} button.rounded-xl`, { hasText: 'Q956A' })).toHaveCount(
+        1
+      );
+
+      // Switch away and back — the reported bug lost the history here.
+      await createNewConversation(page);
+      const switched = await switchToSessionWithMarker(page, 'Q956A');
+      expect(switched, 'folder session must be found in the sidebar').toBe(true);
+      await expectConversationVisible(page, 'Q956A', '收到');
+
+      await page.screenshot({
+        path: 'test-results/issue-956-switch-back.png',
+        fullPage: true,
+      });
+    } finally {
+      await closeElectronApp(electronApp, miqiHome);
+    }
+  });
+
+  test('folder session survives a full app restart with its history', async () => {
+    test.setTimeout(LLM_TIMEOUT + 360_000);
+    const fixture = await launchElectronApp();
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+
+    const folderRoot = mkdtempSync(join(tmpdir(), 'miqi-956b-'));
+    const folderMarker = 'miqi-956b';
+    const question = 'Q956B-请只回复两个字：好的';
+
+    try {
+      await seedWorkspace(page, folderRoot);
+      await createFolderSessionViaPicker(page, folderMarker);
+
+      await sendMessage(page, question);
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+      await expect(page.locator('main').getByText('好的', { exact: false }).first()).toBeVisible({
+        timeout: 30_000,
+      });
+
+      // Full restart on the SAME MIQI_HOME.
+      await closeElectronApp(electronApp, miqiHome, true);
+      const relaunched = await relaunchElectronApp(miqiHome);
+      electronApp = relaunched.electronApp;
+      page = relaunched.page;
+
+      // Pre-fix: the folder session vanished from the sidebar after restart.
+      // Its title now comes from the folder copy's first user message.
+      await expect(page.locator(SIDEBAR).getByText('Q956B', { exact: false }).first()).toBeVisible({
+        timeout: 90_000,
+      });
+      await expect(page.locator(`${SIDEBAR} button.rounded-xl`, { hasText: 'Q956B' })).toHaveCount(
+        1
+      );
+
+      const switched = await switchToSessionWithMarker(page, 'Q956B');
+      expect(switched, 'folder session must be clickable after restart').toBe(true);
+      await expectConversationVisible(page, 'Q956B', '好的');
+
+      await page.screenshot({
+        path: 'test-results/issue-956-restart.png',
+        fullPage: true,
+      });
+    } finally {
+      await closeElectronApp(electronApp, miqiHome);
+    }
+  });
+});

--- a/apps/desktop/tests/e2e/issue-956-folder-session.spec.ts
+++ b/apps/desktop/tests/e2e/issue-956-folder-session.spec.ts
@@ -23,7 +23,7 @@
 
 import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
-import { mkdtempSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -127,7 +127,9 @@ test.describe('#956 folder-bound session', () => {
         if (existsSync(conv)) convFiles.push(conv);
       }
       expect(convFiles.length).toBeGreaterThan(0);
-      expect(readFileSync(convFiles[0], 'utf-8')).toContain('Q956A');
+      // readdirSync order is not guaranteed — assert on ANY collected file
+      // rather than convFiles[0] (a stray seed file could sort first).
+      expect(convFiles.some((f) => readFileSync(f, 'utf-8').includes('Q956A'))).toBe(true);
 
       // After the turn completes, the folder session must appear EXACTLY once
       // in the sidebar (the active registry + folder-scan must not duplicate it).
@@ -150,6 +152,8 @@ test.describe('#956 folder-bound session', () => {
       });
     } finally {
       await closeElectronApp(electronApp, miqiHome);
+      // Clean up the temp folder root (mkdtempSync'd outside miqiHome).
+      rmSync(folderRoot, { recursive: true, force: true });
     }
   });
 
@@ -199,6 +203,8 @@ test.describe('#956 folder-bound session', () => {
       });
     } finally {
       await closeElectronApp(electronApp, miqiHome);
+      // Clean up the temp folder root (mkdtempSync'd outside miqiHome).
+      rmSync(folderRoot, { recursive: true, force: true });
     }
   });
 });

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -46,6 +46,85 @@ def _client_session_id(client_id: str, session_key: str) -> str:
     return f"{client_id}:{session_key}"
 
 
+def _candidate_workspace_roots(
+    sm: Any,
+    client_id: str,
+    *,
+    extra: list[str] | None = None,
+) -> list[Path]:
+    """Candidate folder roots that may hold real session data (#956).
+
+    A folder-bound session writes its conversation under the bound workspace
+    root while the app-home root keeps only a stub.  Collect every known
+    folder root: the explicitly requested workspace plus workspaces recorded
+    in other sessions' metadata (the recent-workspace list).  The default
+    workspace is always excluded.
+    """
+    from miqi.session.manager import SessionManager
+
+    raw_roots: list[str] = list(extra or [])
+    raw_roots.extend(sm.list_recent_workspaces(limit=25, client_id=client_id))
+
+    default_ws = str(Path(sm.workspace).expanduser().resolve())
+    roots: list[Path] = []
+    seen: set[str] = set()
+    for raw in raw_roots:
+        if not raw:
+            continue
+        try:
+            resolved = SessionManager._validate_workspace(Path(raw))
+        except Exception:
+            continue
+        key = str(resolved)
+        if key == default_ws or key in seen:
+            continue
+        seen.add(key)
+        roots.append(resolved)
+    return roots
+
+
+def _find_folder_session(
+    sm: Any,
+    session_key: str,
+    client_id: str,
+    *,
+    extra_workspace: str | None = None,
+) -> tuple[Any, Path] | None:
+    """Locate the authoritative folder-root copy of a session.
+
+    Returns (folder_session, folder_root) for the first known root that holds
+    real messages for ``session_key``, or None.  Sessions owned by a different
+    client are skipped — never leak another client's data.
+    """
+    from miqi.session.manager import SessionManager
+
+    for root in _candidate_workspace_roots(
+        sm, client_id, extra=[extra_workspace] if extra_workspace else None,
+    ):
+        try:
+            folder_sm = SessionManager(root)
+            folder_session = folder_sm.load_existing(session_key)
+        except Exception:
+            continue
+        if folder_session is None or not folder_session.messages:
+            continue
+        owner = folder_session.metadata.get("owner_client_id")
+        if owner is not None and owner != client_id:
+            continue
+        return folder_session, root
+    return None
+
+
+def _folder_session_manager(sm: Any, session_key: str, client_id: str) -> Any | None:
+    """SessionManager for the authoritative folder-root copy, if one exists."""
+    from miqi.session.manager import SessionManager
+
+    found = _find_folder_session(sm, session_key, client_id)
+    if found is None:
+        return None
+    return SessionManager(found[1])
+
+
 # ── sessions.list ──────────────────────────────────────────────────────────
 
 
@@ -121,6 +200,61 @@ async def sessions_list_handler(
                 "updated_at": None,
                 "agent_count": len(getattr(getattr(runtime.services, "agent_control", None), "_agents", {})) if runtime else 0,
             })
+
+    # #956: folder-bound sessions write their real conversation under the
+    # bound workspace root — their app-home stub is empty, so exclude_empty
+    # above hides them and they would vanish from the sidebar after a restart.
+    # Surface them from the known folder roots, title/updated_at taken from
+    # the authoritative folder copy.
+    try:
+        from miqi.session.manager import SessionManager
+
+        folder_copies: dict[str, dict[str, Any]] = {}
+        for root in _candidate_workspace_roots(sm, client_id):
+            try:
+                folder_sm = SessionManager(root)
+                for entry in folder_sm.list_sessions(
+                    client_id=client_id, exclude_empty=True,
+                ):
+                    fkey = entry.get("key", "")
+                    if fkey:
+                        entry["workspace"] = str(root)
+                        folder_copies.setdefault(fkey, entry)
+            except Exception as exc:
+                logger.debug(
+                    "sessions.list: folder scan failed for {}: {}", root, exc,
+                )
+
+        # Enrich active "not on disk" entries (the active loop above used a
+        # generic title=key and created_at=None) with the folder copy's real
+        # title/updated_at, then consume them so they are not added twice.
+        for entry in result_sessions:
+            fcopy = folder_copies.get(entry.get("key", ""))
+            if fcopy is None:
+                continue
+            if entry.get("created_at") is None:
+                entry["title"] = fcopy["title"]
+                entry["created_at"] = fcopy["created_at"]
+                entry["updated_at"] = fcopy["updated_at"]
+                entry["workspace"] = fcopy["workspace"]
+            folder_copies.pop(entry.get("key", ""), None)
+
+        # Remaining folder copies are folder-only sessions — their app-home
+        # stub was hidden by exclude_empty and they are not active.  Surface
+        # them with the folder copy's title/updated_at.
+        for fkey, fcopy in folder_copies.items():
+            if fkey in seen_keys:
+                continue
+            fsid = _client_session_id(client_id, fkey)
+            if fsid in active_sids:
+                continue  # safety net — already represented by the active loop
+            fstatus = (
+                "unowned" if fcopy.get("ownership") == "unowned" else "inactive"
+            )
+            result_sessions.append({**fcopy, "status": fstatus})
+            seen_keys.add(fkey)
+    except Exception as exc:
+        logger.warning("sessions.list: folder-session resolution failed: {}", exc)
 
     return {"result": {"sessions": result_sessions}}
 
@@ -201,29 +335,56 @@ async def sessions_get_handler(
     updated_at: str | None = None
     metadata: dict[str, Any] = {}
     ownership: str = "owned"
+    # #956: folder root holding the authoritative copy (set when adopted).
+    authoritative_ws: Path | None = None
 
     try:
         sm = _get_session_manager()
         ws = Path(typed.workspace) if typed.workspace else None
         disk_session = sm.get_or_create(session_key, client_id=client_id, workspace=ws)
-        # 空会话是临时的：首条消息写入前不进 sessions.list（左端不残留默认会话）。
-        # 但显式带 workspace 的空会话仍要落盘——用户先切工作目录、后发首条消息时，
-        # workspace 元数据需跨 get/重启存活（workspace E2E 依赖该契约）。
-        # 保留条件要覆盖"已落盘的 workspace 绑定"：切目录后的一次裸 get（无 workspace
-        # 参数，如历史重载/列表刷新）不能把空会话当残留 GC 掉，否则首条消息会落在
-        # 丢失 workspace 的会话上。仅当空会话既无显式 workspace、磁盘上也没有任何
-        # workspace 元数据时，才把它当作旧版本无条件 save 留下的空白残留删除。
+
+        # #956: folder-bound sessions write their real conversation under the
+        # bound workspace root while the app-home copy is an empty stub.  When
+        # the stub is empty, resolve the authoritative copy (explicit workspace
+        # → recent-workspace scan) and backfill the binding so later reads and
+        # sessions.list resolve without another scan.
         if not disk_session.messages:
-            existing_ws = disk_session.metadata.get("workspace")
-            if ws is not None or existing_ws is not None:
+            found = _find_folder_session(
+                sm, session_key, client_id, extra_workspace=str(ws) if ws else None,
+            )
+            if found is not None:
+                folder_session, authoritative_ws = found
+                disk_session = folder_session
+                try:
+                    stub = sm.get_or_create(
+                        session_key, client_id=client_id, workspace=authoritative_ws,
+                    )
+                    # Binding-only stub: never copy the folder's messages into
+                    # the app-home root — the folder stays authoritative.
+                    sm.save(stub)
+                except Exception as exc:
+                    logger.debug("sessions.get: binding backfill failed: {}", exc)
+
+        if authoritative_ws is None:
+            # 空会话是临时的：首条消息写入前不进 sessions.list（左端不残留默认会话）。
+            # 但显式带 workspace 的空会话仍要落盘——用户先切工作目录、后发首条消息时，
+            # workspace 元数据需跨 get/重启存活（workspace E2E 依赖该契约）。
+            # 保留条件要覆盖"已落盘的 workspace 绑定"：切目录后的一次裸 get（无 workspace
+            # 参数，如历史重载/列表刷新）不能把空会话当残留 GC 掉，否则首条消息会落在
+            # 丢失 workspace 的会话上。仅当空会话既无显式 workspace、磁盘上也没有任何
+            # workspace 元数据时，才把它当作旧版本无条件 save 留下的空白残留删除。
+            if not disk_session.messages:
+                existing_ws = disk_session.metadata.get("workspace")
+                if ws is not None or existing_ws is not None:
+                    sm.save(disk_session)
+                elif sm.get_session_dir(session_key).exists():
+                    sm.delete(session_key, client_id=client_id)
+                    disk_session = sm.get_or_create(
+                        session_key, client_id=client_id, workspace=ws
+                    )
+            else:
                 sm.save(disk_session)
-            elif sm.get_session_dir(session_key).exists():
-                sm.delete(session_key, client_id=client_id)
-                disk_session = sm.get_or_create(
-                    session_key, client_id=client_id, workspace=ws
-                )
-        else:
-            sm.save(disk_session)
+
         messages = disk_session.messages
         created_at = disk_session.created_at.isoformat()
         updated_at = disk_session.updated_at.isoformat()
@@ -245,7 +406,11 @@ async def sessions_get_handler(
         logger.warning("Failed to load session {}: {}", session_key, exc)
         raise AppServerError("Failed to get session", code="INTERNAL") from exc
 
-    ws_result = metadata.get("workspace")
+    ws_result = (
+        str(authoritative_ws)
+        if authoritative_ws is not None
+        else metadata.get("workspace")
+    )
 
     if runtime is not None:
         return {
@@ -335,15 +500,29 @@ async def sessions_delete_handler(
                 session_key, client_id, exc,
             )
 
-    # 3. Remove disk files (client-scoped)
+    # 3. Remove disk files (client-scoped).  A folder-bound session's real
+    # conversation lives under its bound workspace root — locate it BEFORE
+    # deleting the app-home entry (which carries the binding), then delete both.
     sm = _get_session_manager()
     try:
+        folder_sm = _folder_session_manager(sm, session_key, client_id)
         disk_deleted = sm.delete(session_key, client_id=client_id)
+        folder_deleted = False
+        if folder_sm is not None:
+            try:
+                folder_deleted = folder_sm.delete(session_key, client_id=client_id)
+            except OwnershipError as exc:
+                # An unowned legacy folder copy is not deletable by this client —
+                # keep it and let the app-home deletion stand.
+                logger.debug(
+                    "sessions.delete: folder copy {} not deleted: {}",
+                    session_key, exc,
+                )
     except OwnershipError as exc:
         raise AppServerError(exc.args[0], code=exc.code) from exc
 
     # Success if runtime was stopped (session may not have been on disk)
-    deleted = runtime_was_active or disk_deleted
+    deleted = runtime_was_active or disk_deleted or folder_deleted
 
     # Clean up AppServer event subscriptions for the deleted session.
     # stop_session() cleans _sessions/_client_sessions/_session_clients but
@@ -405,10 +584,21 @@ async def sessions_archive_handler(
                 session_key, client_id, exc,
             )
 
-    # 3. Mark archived on disk (client-scoped)
+    # 3. Mark archived on disk (client-scoped).  A folder-bound session must be
+    # archived under its workspace root too, or the folder scan would keep
+    # surfacing it in the active list (#956).
     sm = _get_session_manager()
     try:
         sm.archive(session_key, client_id=client_id)
+        folder_sm = _folder_session_manager(sm, session_key, client_id)
+        if folder_sm is not None:
+            try:
+                folder_sm.archive(session_key, client_id=client_id)
+            except OwnershipError as exc:
+                logger.debug(
+                    "sessions.archive: folder copy {} not archived: {}",
+                    session_key, exc,
+                )
     except OwnershipError as exc:
         raise AppServerError(exc.args[0], code=exc.code) from exc
 
@@ -432,6 +622,15 @@ async def sessions_unarchive_handler(
     sm = _get_session_manager()
     try:
         sm.unarchive(session_key, client_id=client_id)
+        folder_sm = _folder_session_manager(sm, session_key, client_id)
+        if folder_sm is not None:
+            try:
+                folder_sm.unarchive(session_key, client_id=client_id)
+            except OwnershipError as exc:
+                logger.debug(
+                    "sessions.unarchive: folder copy {} not unarchived: {}",
+                    session_key, exc,
+                )
     except OwnershipError as exc:
         raise AppServerError(exc.args[0], code=exc.code) from exc
 
@@ -465,6 +664,32 @@ async def sessions_list_archived_handler(
         marker = sm.sessions_dir / safe_key / ".archived"
         if marker.exists():
             archived.append(s)
+
+    # #956: folder-bound sessions archived under their workspace root must
+    # stay reachable here or unarchive would have no way to find them.
+    try:
+        from miqi.session.manager import SessionManager
+
+        for root in _candidate_workspace_roots(sm, client_id):
+            try:
+                folder_sm = SessionManager(root)
+                for s in folder_sm.list_sessions(
+                    include_archived=True, client_id=client_id,
+                ):
+                    fkey = s.get("key", "")
+                    if any(a.get("key") == fkey for a in archived):
+                        continue
+                    safe_key = safe_filename(fkey.replace(":", "_"))
+                    marker = folder_sm.sessions_dir / safe_key / ".archived"
+                    if marker.exists():
+                        archived.append({**s, "workspace": str(root)})
+            except Exception as exc:
+                logger.debug(
+                    "sessions.list_archived: folder scan failed for {}: {}",
+                    root, exc,
+                )
+    except Exception as exc:
+        logger.warning("sessions.list_archived: folder resolution failed: {}", exc)
 
     return {"result": {"sessions": archived}}
 
@@ -537,6 +762,17 @@ async def sessions_rename_handler(
     sm = _get_session_manager()
     try:
         effective_title = sm.rename(session_key, title, client_id=client_id)
+        folder_sm = _folder_session_manager(sm, session_key, client_id)
+        if folder_sm is not None:
+            try:
+                effective_title = folder_sm.rename(
+                    session_key, title, client_id=client_id,
+                )
+            except OwnershipError as exc:
+                logger.debug(
+                    "sessions.rename: folder copy {} not renamed: {}",
+                    session_key, exc,
+                )
     except OwnershipError as exc:
         raise AppServerError(exc.args[0], code=exc.code) from exc
 

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -315,6 +315,15 @@ class SessionManager:
             logger.warning("Failed to load session {}: {}", key, exc)
             return None
 
+    def load_existing(self, key: str) -> Session | None:
+        """Load a session from disk without creating it or touching the cache.
+
+        Unlike get_or_create, a missing/corrupt session returns None with no
+        side effects — used by read-side probing of other workspace roots
+        (#956 folder-bound session resolution).
+        """
+        return self._load(key)
+
     def save(self, session: Session) -> None:
         """Persist session changes with append-only writes when possible."""
         with self._get_session_lock(session.key):

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -248,11 +248,17 @@ class SessionManager:
         self._cache[key] = session
         return session
 
-    def _load(self, key: str) -> Session | None:
-        """Load a session from disk."""
-        self._migrate_flat_to_dir(key)
+    def _load(self, key: str, *, migrate: bool = True) -> Session | None:
+        """Load a session from disk.
+
+        When ``migrate`` is False, neither the flat-file nor the legacy-path
+        migration runs — used by read-only probing (``load_existing``) so a
+        scan across candidate workspace roots never mutates the filesystem.
+        """
+        if migrate:
+            self._migrate_flat_to_dir(key)
         path = self._get_session_path(key)
-        if not path.exists():
+        if migrate and not path.exists():
             legacy_path = self._get_legacy_session_path(key)
             if legacy_path.exists():
                 try:
@@ -320,9 +326,10 @@ class SessionManager:
 
         Unlike get_or_create, a missing/corrupt session returns None with no
         side effects — used by read-side probing of other workspace roots
-        (#956 folder-bound session resolution).
+        (#956 folder-bound session resolution).  Disables legacy/flat-file
+        migration so probing never mutates the filesystem.
         """
-        return self._load(key)
+        return self._load(key, migrate=False)
 
     def save(self, session: Session) -> None:
         """Persist session changes with append-only writes when possible."""

--- a/tests/runtime/test_session_handlers_956.py
+++ b/tests/runtime/test_session_handlers_956.py
@@ -47,6 +47,32 @@ def _write_app_home_stub(app_home, key, client_id, workspace=None):
     return sm
 
 
+def test_load_existing_does_not_migrate_legacy_flat_file(tmp_path):
+    """load_existing must not migrate a legacy flat session file (#956 review).
+
+    _find_folder_session probes candidate workspace roots via load_existing;
+    if that mutated legacy files, a scan could silently move a session into
+    the wrong root.  load_existing must leave flat .jsonl files untouched.
+    """
+    from miqi.session.manager import SessionManager
+
+    sm = SessionManager(tmp_path)
+    key = "legacy-flat"
+    safe_key = "legacy-flat"  # no colon → dir/file name unchanged
+    flat = sm.sessions_dir / f"{safe_key}.jsonl"
+    flat.write_text(
+        '{"_type": "metadata", "metadata": {}, "owner_client_id": "client-1"}\n'
+        '{"role": "user", "content": "hi", "timestamp": "2026-01-01T00:00:00"}\n',
+        encoding="utf-8",
+    )
+
+    # Probing must not migrate: the directory-based path does not exist yet,
+    # so load_existing returns None and leaves the flat file alone.
+    assert sm.load_existing(key) is None
+    assert flat.exists()
+    assert not (sm.sessions_dir / safe_key).exists()
+
+
 # ── sessions.get ───────────────────────────────────────────────────────────
 
 

--- a/tests/runtime/test_session_handlers_956.py
+++ b/tests/runtime/test_session_handlers_956.py
@@ -1,0 +1,255 @@
+"""Tests for #956 — folder-bound session resolution.
+
+Folder-bound sessions write their real conversation under the bound workspace
+root while the app-home root keeps only a stub.  These tests cover the
+read-side resolution (sessions.get / sessions.list), ownership isolation, and
+the mutation handlers' folder-copy cleanup, on top of the #918 exclude_empty
+empty-session filtering.
+"""
+
+import pytest
+
+
+def _install_app_home(monkeypatch, app_home):
+    """Point the bridge state's config at a per-test app-home workspace."""
+    from unittest.mock import MagicMock
+
+    from miqi.bridge import server as bridge_module
+    from miqi.config.schema import Config
+
+    config = Config()
+    config.agents.defaults.workspace = str(app_home)
+    state = MagicMock()
+    state.load_config.return_value = config
+    monkeypatch.setattr(bridge_module, "_state", state)
+    return config
+
+
+def _write_folder_session(folder_root, key, client_id):
+    """Write a session conversation under a folder root (write-side mirror)."""
+    from miqi.session.manager import SessionManager
+
+    sm = SessionManager(folder_root)
+    session = sm.get_or_create(key, client_id=client_id)
+    session.add_message("user", "folder question")
+    session.add_message("assistant", "folder answer")
+    sm.save(session)
+    return sm
+
+
+def _write_app_home_stub(app_home, key, client_id, workspace=None):
+    """Write an app-home stub for a session (optionally with a workspace binding)."""
+    from miqi.session.manager import SessionManager
+
+    sm = SessionManager(app_home)
+    session = sm.get_or_create(key, client_id=client_id, workspace=workspace)
+    sm.save(session)
+    return sm
+
+
+# ── sessions.get ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sessions_get_resolves_folder_session_via_metadata(monkeypatch, tmp_path):
+    """sessions.get returns the folder-root copy for a workspace-bound stub."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    # Write side: real conversation lives under the bound folder root
+    _write_folder_session(folder_root, "folder-session", "client-1")
+    # Read side: app-home keeps a binding-only stub (empty + workspace metadata)
+    _write_app_home_stub(app_home, "folder-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_handler(
+        "req-1", {"session_key": "folder-session"}, "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["workspace"] == str(folder_root)
+    contents = [m.get("content") for m in r["messages"]]
+    assert "folder question" in contents
+    assert "folder answer" in contents
+
+
+@pytest.mark.asyncio
+async def test_sessions_get_folder_fallback_via_recent_workspace(monkeypatch, tmp_path):
+    """A binding-less folder session is found by scanning known workspace roots."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    # No app-home stub for folder-session — only another session's metadata
+    # records the folder root (legacy registration path).
+    _write_folder_session(folder_root, "folder-session", "client-1")
+    _write_app_home_stub(app_home, "other-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_handler(
+        "req-1", {"session_key": "folder-session"}, "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["workspace"] == str(folder_root)
+    assert any(m.get("content") == "folder answer" for m in r["messages"])
+
+
+@pytest.mark.asyncio
+async def test_sessions_get_does_not_adopt_other_clients_folder(monkeypatch, tmp_path):
+    """A folder copy owned by another client is never adopted or leaked."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    _write_folder_session(folder_root, "folder-session", "client-2")
+    _write_app_home_stub(app_home, "folder-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_handler(
+        "req-1", {"session_key": "folder-session"}, "client-1", None, registry,
+    )
+    r = result["result"]
+    assert not any(m.get("content") == "folder answer" for m in r["messages"])
+
+
+@pytest.mark.asyncio
+async def test_sessions_get_unowned_stub_does_not_crash(monkeypatch, tmp_path):
+    """REQUIRES_CLAIM fallback path must not crash on folder-resolution vars."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_handler
+    from miqi.session.manager import SessionManager
+
+    app_home = tmp_path / "app-home"
+    app_home.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    # Legacy unowned session (created without client_id → no owner)
+    sm = SessionManager(app_home)
+    legacy = sm.get_or_create("legacy-session")
+    legacy.add_message("user", "legacy hello")
+    sm.save(legacy)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_handler(
+        "req-1", {"session_key": "legacy-session"}, "client-1", None, registry,
+    )
+    r = result["result"]
+    assert r["ownership"] == "unowned"
+    assert any(m.get("content") == "legacy hello" for m in r["messages"])
+    assert r["workspace"] is None
+
+
+# ── sessions.list ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_surfaces_folder_sessions(monkeypatch, tmp_path):
+    """sessions.list surfaces folder sessions hidden by exclude_empty."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_list_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    _write_folder_session(folder_root, "folder-session", "client-1")
+    # Empty app-home stub with a workspace binding (exclude_empty hides it)
+    _write_app_home_stub(app_home, "folder-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_list_handler("req-1", {}, "client-1", None, registry)
+    sessions = result["result"]["sessions"]
+    folder_entries = [s for s in sessions if s.get("key") == "folder-session"]
+    assert len(folder_entries) == 1
+    entry = folder_entries[0]
+    assert entry["workspace"] == str(folder_root)
+    # Title derived from the folder copy's first user message, not the key
+    assert entry["title"] and entry["title"] != "folder-session"
+    assert entry["status"] == "inactive"
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_no_duplicate_for_active_folder_session(
+    monkeypatch, tmp_path, fake_config, fake_provider,
+):
+    """An active folder-bound session appears exactly once in the list."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_list_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    _write_folder_session(folder_root, "folder-session", "client-1")
+    _write_app_home_stub(app_home, "folder-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    try:
+        await registry.create_session(
+            client_id="client-1",
+            session_key="folder-session",
+            config=fake_config,
+            provider=fake_provider,
+            workspace=folder_root,
+        )
+        result = await sessions_list_handler("req-1", {}, "client-1", None, registry)
+        entries = [
+            s for s in result["result"]["sessions"] if s.get("key") == "folder-session"
+        ]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["status"] == "running"
+        # Title resolved from the folder copy, not the generic active-loop key
+        assert entry["title"] and entry["title"] != "folder-session"
+    finally:
+        await registry.stop_all()
+
+
+# ── sessions.delete ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sessions_delete_removes_folder_copy(monkeypatch, tmp_path):
+    """sessions.delete removes the folder-root copy so it cannot resurrect."""
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_delete_handler, sessions_list_handler
+
+    app_home = tmp_path / "app-home"
+    folder_root = tmp_path / "task-folder"
+    app_home.mkdir(parents=True)
+    folder_root.mkdir(parents=True)
+    _install_app_home(monkeypatch, app_home)
+
+    folder_sm = _write_folder_session(folder_root, "folder-session", "client-1")
+    _write_app_home_stub(app_home, "folder-session", "client-1", folder_root)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_delete_handler(
+        "req-1", {"session_key": "folder-session"}, "client-1", None, registry,
+    )
+    assert result["result"]["deleted"] is True
+    # Both copies gone — the folder scan cannot resurrect the session
+    assert folder_sm.load_existing("folder-session") is None
+    list_result = await sessions_list_handler("req-1", {}, "client-1", None, registry)
+    assert not [
+        s for s in list_result["result"]["sessions"] if s.get("key") == "folder-session"
+    ]


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复


## 变更概述

修复#956：切换对话框后文件夹会话回复丢失，输入框卡生成中，重启后从侧栏消失的问题；顺带修复了引入folder扫描后出现“新建会话在侧栏出现两条的情况


## 背景/问题

会话绑定到非默认工作文件夹后：
--写侧：TaskRunner._save_to_session_manager（miqi/runtime/task_runner.py）用 SessionManager(services.workspace) 把会话镜像写到**绑定文件夹根**下的 sessions/<key>/conversation.jsonl。
-- 读侧：sessions_get_handler / sessions_list_handler（miqi/runtime/session_handlers.py）用 SessionManager(config.workspace_path)（app-home，即 ~/.miqi/workspace）**只读 app-home 根**。
--文件夹会话在 app-home 只有**空 stub**（仅 metadata 行、无消息），读侧因此返回 0 条消息 → 前端只渲染瞬时快照的思考行，回复丢失、streaming 状态残留。
-- key→workspace 绑定从未可靠持久化（只靠前端一次性 sessions.get(key, {workspace}) 传参，bridge 未就绪重试时参数丢失）。
-- #918 引入 exclude_empty 空会话过滤后，空 stub 被隐藏 → **重启后文件夹会话从侧栏彻底消失**。


## 变更内容

1、SessionManager：新增 load_existing() 无副作用加载，供读侧跨根探测。
2、sessions.get / sessions.list：app-home 空 stub 时，按「显式 workspace → recent-workspace 扫描」解析文件夹根下的权威副本并回填绑定；列表补回被 exclude_empty 隐藏的文件夹会话、补全标题并去重（修复新建会话出现两条）。
3、写操作（delete / archive / unarchive / rename / list_archived）：同步作用于文件夹副本，防删除后复活。
4、ChatConsole：历史完整且无进行中 turn 时清理卡死的 streaming 态。
5、测试：7 个 pytest + 2 个 E2E。

## 日志/验证证据

```
修复前（issue #956 复现）：文件夹会话切换后 sessions.get 返回 0 条消息、重启后侧栏消失。

修复后 E2E 实测：
$ npx playwright test tests/e2e/issue-956-folder-session.spec.ts --config=playwright.config.ts --project=electron --reporter=list
Running 2 tests using 2 workers
ok 2 [electron] › switch-back keeps folder-session history and the input is sendable (1.1m)
ok 1 [electron] › folder session survives a full app restart with its history (1.2m)
2 passed (1.2m)
```

## 测试情况

- pytest（后端）：7 新增用例 + 完整 runtime 1356 passed, 5 skipped
- vitest（前端）：379 passed, 5 skipped
-  typecheck / prettier：无错误
- E2E（issue-956 spec）：2 passed（切换 / 重启）

## 截图
<img width="1258" height="851" alt="2" src="https://github.com/user-attachments/assets/3464dfd4-b0a9-45fd-86dc-6a4d4ecc1db1" />
<img width="1265" height="856" alt="3" src="https://github.com/user-attachments/assets/c2339136-c1a3-4acb-8c2c-ff451d3c3c96" />
<img width="1266" height="853" alt="4" src="https://github.com/user-attachments/assets/588c0bfd-8b98-41ef-b4e6-e502ae36f0f5" />


