### PR TITLE
fix(desktop): 登录后 AI 网关可直接生效——保存门控对齐运行时网关路由并自动设置网关模型

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -591,7 +591,12 @@ export function registerIpcHandlers(bridge: BridgeManager): void {
       return writeLocalConfig(input.config);
     }
     try {
-      return await bridge.send('config.update', { config: input.config });
+      // 比较并设置（#991）：expectModel 原样转发给桥下 config.update，
+      // 后端在磁盘当前模型与期望不一致时跳过写入。
+      return await bridge.send('config.update', {
+        config: input.config,
+        ...(input.expectModel !== undefined ? { expect_model: input.expectModel } : {}),
+      });
     } catch (error) {
       if ((error as Error)?.message?.includes('Bridge not running')) {
         if (!isApprovalBypassUpdate(input.config)) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -220,8 +220,11 @@ const api = {
   // -- Config -----------------------------------------------------------------
   config: {
     get: (): Promise<Record<string, unknown>> => ipcRenderer.invoke(IPC.CONFIG_GET),
-    update: (config: Record<string, unknown>): Promise<unknown> =>
-      ipcRenderer.invoke(IPC.CONFIG_UPDATE, { config }),
+    update: (
+      config: Record<string, unknown>,
+      expectModel?: string
+    ): Promise<{ saved: boolean; skipped?: string } | unknown> =>
+      ipcRenderer.invoke(IPC.CONFIG_UPDATE, { config, expectModel }),
     // Issue #789: hot-reload broadcast after config.save. Payload:
     // { applied, newSessionsOnly, restartRequired, restartReasons }.
     onUpdated: (callback: (payload: ConfigUpdatedPayload) => void) => {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { ApprovalProvider } from './contexts/ApprovalContext';
 import { UserInputProvider } from './contexts/UserInputContext';
 import { RestartRequiredProvider } from './contexts/RestartRequiredContext';
 import { ConfigHotReloadListener } from './components/ConfigHotReloadListener';
+import { GatewayModelAutoSync } from './components/GatewayModelAutoSync';
 import { InstallWarningToaster } from './components/InstallWarningToaster';
 import { ApprovalModal } from './features/approvals/ApprovalModal';
 import { CronPage } from './features/cron/CronPage';
@@ -354,6 +355,7 @@ function AppShell() {
     <TooltipProvider>
       <RestartRequiredProvider>
         <ConfigHotReloadListener />
+        <GatewayModelAutoSync />
         <InstallWarningToaster
           onOpenSandboxSettings={() => {
             setSettingsTab('general');

--- a/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
+++ b/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
@@ -9,9 +9,7 @@ describe('gatewayModelToAutoSet', () => {
   });
 
   it('returns the gateway model id when the model field is missing', () => {
-    expect(gatewayModelToAutoSet({ agents: { defaults: {} } })).toBe(
-      'deepseek/deepseek-v4-flash'
-    );
+    expect(gatewayModelToAutoSet({ agents: { defaults: {} } })).toBe('deepseek/deepseek-v4-flash');
   });
 
   it('returns null when a non-empty model is already configured', () => {

--- a/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
+++ b/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { gatewayModelToAutoSet } from './GatewayModelAutoSync';
+
+describe('gatewayModelToAutoSet', () => {
+  it('returns the gateway model id when the default model is empty', () => {
+    expect(gatewayModelToAutoSet({ agents: { defaults: { model: '' } } })).toBe(
+      'deepseek/deepseek-v4-flash'
+    );
+  });
+
+  it('returns the gateway model id when the model field is missing', () => {
+    expect(gatewayModelToAutoSet({ agents: { defaults: {} } })).toBe(
+      'deepseek/deepseek-v4-flash'
+    );
+  });
+
+  it('returns null when a non-empty model is already configured', () => {
+    expect(
+      gatewayModelToAutoSet({ agents: { defaults: { model: 'deepseek/deepseek-v4-pro' } } })
+    ).toBeNull();
+  });
+
+  it('returns null for malformed config shapes', () => {
+    expect(gatewayModelToAutoSet(null)).toBeNull();
+    expect(gatewayModelToAutoSet({})).toBeNull();
+    expect(gatewayModelToAutoSet({ agents: null })).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
+++ b/apps/desktop/src/renderer/components/GatewayModelAutoSync.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { gatewayModelToAutoSet } from './GatewayModelAutoSync';
+import { describe, expect, it, vi } from 'vitest';
+import { gatewayModelToAutoSet, saveGatewayModelIfBlank } from './GatewayModelAutoSync';
 
 describe('gatewayModelToAutoSet', () => {
   it('returns the gateway model id when the default model is empty', () => {
@@ -22,5 +22,47 @@ describe('gatewayModelToAutoSet', () => {
     expect(gatewayModelToAutoSet(null)).toBeNull();
     expect(gatewayModelToAutoSet({})).toBeNull();
     expect(gatewayModelToAutoSet({ agents: null })).toBeNull();
+  });
+});
+
+describe('saveGatewayModelIfBlank', () => {
+  it('writes the gateway model with expectModel "" and invalidates cache on success', async () => {
+    const getConfig = vi.fn().mockResolvedValue({ agents: { defaults: { model: '' } } });
+    const updateConfig = vi.fn().mockResolvedValue({ saved: true });
+    const invalidate = vi.fn();
+
+    await saveGatewayModelIfBlank(getConfig, updateConfig, invalidate);
+
+    expect(updateConfig).toHaveBeenCalledWith(
+      { agents: { defaults: { model: 'deepseek/deepseek-v4-flash' } } },
+      ''
+    );
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it('does not call update when a model is already configured', async () => {
+    const getConfig = vi
+      .fn()
+      .mockResolvedValue({ agents: { defaults: { model: 'deepseek/deepseek-v4-flash' } } });
+    const updateConfig = vi.fn();
+    const invalidate = vi.fn();
+
+    await saveGatewayModelIfBlank(getConfig, updateConfig, invalidate);
+
+    expect(updateConfig).not.toHaveBeenCalled();
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it('keeps the newer user selection when the backend skips the compare-and-set', async () => {
+    const getConfig = vi.fn().mockResolvedValue({ agents: { defaults: { model: '' } } });
+    const updateConfig = vi
+      .fn()
+      .mockResolvedValue({ saved: false, skipped: 'expect_model_mismatch' });
+    const invalidate = vi.fn();
+
+    await saveGatewayModelIfBlank(getConfig, updateConfig, invalidate);
+
+    expect(updateConfig).toHaveBeenCalledOnce();
+    expect(invalidate).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/GatewayModelAutoSync.tsx
+++ b/apps/desktop/src/renderer/components/GatewayModelAutoSync.tsx
@@ -26,6 +26,37 @@ export function gatewayModelToAutoSet(config: unknown): string | null {
   return GATEWAY_MODEL_ID;
 }
 
+/** 保存结果：saved=false 表示后端因期望值不匹配跳过（用户已在间隙选了模型）。 */
+interface ConfigUpdateResult {
+  saved: boolean;
+  skipped?: string;
+}
+
+/**
+ * 自动同步的保存动作（独立导出以便无 DOM 单测，#991 review）。
+ *
+ * 用 expectModel: '' 做比较并设置：后端只在磁盘上的默认模型仍为空时写入。
+ * 配置快照读取与写入之间用户若已手动选了模型，后端返回 saved=false，
+ * 这里直接放弃，保留用户更新的选择。
+ */
+export async function saveGatewayModelIfBlank(
+  getConfig: () => Promise<unknown>,
+  updateConfig: (
+    config: Record<string, unknown>,
+    expectModel?: string
+  ) => Promise<ConfigUpdateResult | unknown>,
+  invalidate: () => void
+): Promise<void> {
+  const config = await getConfig();
+  const modelId = gatewayModelToAutoSet(config);
+  if (!modelId) return;
+  const result = await updateConfig({ agents: { defaults: { model: modelId } } }, '');
+  if (result && typeof result === 'object' && (result as ConfigUpdateResult).saved === false) {
+    return; // 被比较并设置拦截：用户的选择优先
+  }
+  invalidate();
+}
+
 export function GatewayModelAutoSync() {
   const { loggedIn, gatewayActive } = useQraftStatus();
   const { status } = useRuntime();
@@ -38,17 +69,13 @@ export function GatewayModelAutoSync() {
     }
     if (status.state !== 'running' || attemptedRef.current) return;
     attemptedRef.current = true;
-    void (async () => {
-      try {
-        const config = await window.miqi.config.get();
-        const modelId = gatewayModelToAutoSet(config);
-        if (!modelId) return;
-        await window.miqi.config.update({ agents: { defaults: { model: modelId } } });
-        invalidateConfigCache();
-      } catch {
-        attemptedRef.current = false; // 保存失败 → 等下一次状态变化重试
-      }
-    })();
+    void saveGatewayModelIfBlank(
+      () => window.miqi.config.get(),
+      (config, expectModel) => window.miqi.config.update(config, expectModel),
+      invalidateConfigCache
+    ).catch(() => {
+      attemptedRef.current = false; // 保存失败 → 等下一次状态变化重试
+    });
   }, [loggedIn, gatewayActive, status.state]);
 
   return null;

--- a/apps/desktop/src/renderer/components/GatewayModelAutoSync.tsx
+++ b/apps/desktop/src/renderer/components/GatewayModelAutoSync.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import { invalidateConfigCache } from '../lib/configCache';
+import { GATEWAY_MODEL_ID } from '../features/providers/components/ModelQuickPanel';
+import { useQraftStatus } from '../hooks/useQraftStatus';
+import { useRuntime } from '../contexts/RuntimeContext';
+
+/**
+ * 登录后 AI 网关自动生效（#922 收尾）。
+ *
+ * 网关不是登录即启用的开关：运行时只在默认模型恰好是网关实测模型时才会
+ * 把调用改道到平台网关（miqi/providers/factory.py）。登录本身不会写默认
+ * 模型，用户会卡在「已开通但模型未设置」的状态。本组件在登录 + 网关
+ * active 且默认模型为空时自动写入网关模型；已配置非空模型时不动它
+ * （可能是有意直连），仅在「未设置」时兜底。
+ */
+
+/** 默认模型为空（未设置）时返回要自动写入的网关模型 id，否则返回 null。 */
+export function gatewayModelToAutoSet(config: unknown): string | null {
+  if (!config || typeof config !== 'object') return null;
+  const agents = (config as Record<string, unknown>).agents;
+  if (!agents || typeof agents !== 'object') return null;
+  const defaults = (agents as Record<string, unknown>).defaults;
+  if (!defaults || typeof defaults !== 'object') return null;
+  const model = (defaults as Record<string, unknown>).model;
+  if (typeof model === 'string' && model.trim() !== '') return null;
+  return GATEWAY_MODEL_ID;
+}
+
+export function GatewayModelAutoSync() {
+  const { loggedIn, gatewayActive } = useQraftStatus();
+  const { status } = useRuntime();
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!loggedIn || !gatewayActive) {
+      attemptedRef.current = false; // 退出登录/网关不可用后，下次登录允许重试
+      return;
+    }
+    if (status.state !== 'running' || attemptedRef.current) return;
+    attemptedRef.current = true;
+    void (async () => {
+      try {
+        const config = await window.miqi.config.get();
+        const modelId = gatewayModelToAutoSet(config);
+        if (!modelId) return;
+        await window.miqi.config.update({ agents: { defaults: { model: modelId } } });
+        invalidateConfigCache();
+      } catch {
+        attemptedRef.current = false; // 保存失败 → 等下一次状态变化重试
+      }
+    })();
+  }, [loggedIn, gatewayActive, status.state]);
+
+  return null;
+}

--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
@@ -78,4 +78,19 @@ describe('sanitizeUiMessage', () => {
     expect(out).toContain('deepseek/deepseek-v4-flash');
     expect(out).not.toContain('[path]');
   });
+
+  it('masks credential URLs with uppercase schemes (#991 review)', () => {
+    const out = sanitizeUiMessage('boom at HTTPS://user:secret@example.com/path');
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('user');
+    expect(out).toContain('[url]');
+  });
+
+  it('masks credential URLs longer than 200 chars entirely (#991 review)', () => {
+    const longUrl = 'https://user:secret@example.com/' + 'a'.repeat(240);
+    const out = sanitizeUiMessage('boom at ' + longUrl);
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('aaaa');
+    expect(out).toContain('[url]');
+  });
 });

--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.test.ts
@@ -68,4 +68,14 @@ describe('sanitizeUiMessage', () => {
     expect(out).toContain('[url]');
     expect(out).toContain('[token]');
   });
+
+  it('keeps model ids intact instead of mangling them into [path]', () => {
+    // 实测：保存网关模型被 #929 门控拒绝时，/deepseek-v4-flash 曾被
+    // 路径正则打码成 [path]，报错显示成令人费解的 deepseek[path]。
+    const out = sanitizeUiMessage(
+      "Error invoking remote method 'config:update': Error: Unsupported model: deepseek/deepseek-v4-flash (INVALID_PARAMS)"
+    );
+    expect(out).toContain('deepseek/deepseek-v4-flash');
+    expect(out).not.toContain('[path]');
+  });
 });

--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
@@ -26,10 +26,12 @@ const RE_URL = /https?:\/\/[^\s"'<>]{1,200}/g;
  * Three alternatives (longest-first so UNC wins over drive-letter):
  *   1) UNC:  \\?\X:\dir\...\file
  *   2) Windows drive:  X:\dir\...\file
- *   3) Unix absolute:  /dir/.../file
+ *   3) Unix absolute:  /dir/.../file — 负向后顾要求斜杠前不是单词字符，
+ *      避免把 deepseek/deepseek-v4-flash 这类 provider/model id 误当路径
+ *      打码成 [path]（实测：保存网关模型报错被显示成 deepseek[path]）。
  */
 const RE_PATH =
-  /(?:\\\\\?\\[A-Za-z]:[\\/](?:[^\s"'<>|:]+[\\/])*[^\s"'<>|:]+)|(?:[A-Za-z]:[\\/](?:[^\s"'<>|:]+[\\/])*[^\s"'<>|:]+)|(?:\/(?:[^\s"'<>|:]+[\/])*[^\s"'<>|:]+)/g;
+  /(?:\\\\\?\\[A-Za-z]:[\\/](?:[^\s"'<>|:]+[\\/])*[^\s"'<>|:]+)|(?:[A-Za-z]:[\\/](?:[^\s"'<>|:]+[\\/])*[^\s"'<>|:]+)|(?:(?<![A-Za-z0-9_.-])\/(?:[^\s"'<>|:]+[\/])*[^\s"'<>|:]+)/g;
 
 /** Matches long Base64-like tokens (40+ contiguous base64 chars). */
 const RE_TOKEN = /\b[A-Za-z0-9+/=]{40,}\b/g;

--- a/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
+++ b/apps/desktop/src/renderer/lib/sanitizeUiMessage.ts
@@ -14,8 +14,10 @@ const MAX_LEN = 300;
  * Matches http(s) URLs.
  * Applied BEFORE the path regex so URLs are replaced as a whole unit,
  * rather than having their path segments fragmented into [path] markers.
+ * Case-insensitive (HTTPS:// … 同样整体替换)且不设长度上限 —— 截断在
+ * 上方先行执行,匹配长度天然有界（#991 review）。
  */
-const RE_URL = /https?:\/\/[^\s"'<>]{1,200}/g;
+const RE_URL = /https?:\/\/[^\s"'<>]+/gi;
 
 /**
  * Matches Unix / Windows absolute paths.

--- a/apps/desktop/src/shared/app-protocol.ts
+++ b/apps/desktop/src/shared/app-protocol.ts
@@ -46,6 +46,7 @@ export interface ConfigGetParams {}
 
 export interface ConfigUpdateParams {
   config: Record<string, unknown>;
+  expectModel?: null | string;
 }
 
 export interface ConfigBatchWriteParams {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -266,6 +266,8 @@ export interface SessionClaimLegacyResult {
 
 export const ConfigUpdateInput = z.object({
   config: z.record(z.unknown()),
+  // 比较并设置（#991）：期望当前默认模型仍为此值，后端不一致时跳过写入
+  expectModel: z.string().optional(),
 });
 
 export const ProviderTestInput = z.object({

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -266,8 +266,9 @@ export interface SessionClaimLegacyResult {
 
 export const ConfigUpdateInput = z.object({
   config: z.record(z.unknown()),
-  // 比较并设置（#991）：期望当前默认模型仍为此值，后端不一致时跳过写入
-  expectModel: z.string().optional(),
+  // 比较并设置（#991）：期望当前默认模型仍为此值，后端不一致时跳过写入。
+  // nullish：与 app-protocol.ts 契约（null | string）一致，null/缺省均放行
+  expectModel: z.string().nullish(),
 });
 
 export const ProviderTestInput = z.object({

--- a/apps/desktop/tests/e2e/tool-error-neutral.spec.ts
+++ b/apps/desktop/tests/e2e/tool-error-neutral.spec.ts
@@ -58,7 +58,9 @@ const DANGER_COLORS = ['rgb(255, 97, 97)', 'rgb(192, 64, 64)'];
 const ISOLATION_PHRASE = '会话隔离禁止跨会话访问';
 
 /** The exact ToolErrorEvent payload the backend sends for the session-
- *  isolation PermissionError (message shaped by _sanitize_exc_for_ui). */
+ *  isolation PermissionError (message shaped by _sanitize_exc_for_ui).
+ *  修复前 sessions/ 后的指导文字被路径正则吞成 [path]；负向后顾修复后
+ *  完整保留。 */
 const TOOL_ERROR_PAYLOAD = {
   event: 'ToolErrorEvent',
   data: {
@@ -66,7 +68,7 @@ const TOOL_ERROR_PAYLOAD = {
     tool_name: 'read_file',
     tool_call_id: 'call_cross_read',
     message:
-      'PermissionError: 路径位于其他会话的 files 目录内——会话隔离禁止跨会话访问。 不要重试或枚举 sessions[path]',
+      'PermissionError: 路径位于其他会话的 files 目录内——会话隔离禁止跨会话访问。 不要重试或枚举 sessions/；请使用当前会话的工作区，或请用户通过文件面板分享文件。',
     recoverable: true,
   },
 };

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -178,12 +178,15 @@ def _sanitize_exc_for_ui(exc: BaseException) -> str:
     # Truncate to a reasonable length
     if len(raw) > 300:
         raw = raw[:300] + "…"
-    # Strip common sensitive patterns (absolute paths, URLs with credentials)
+    # Strip common sensitive patterns (absolute paths, URLs with credentials).
+    # URL 必须先行替换成整体（前端 sanitizeUiMessage 同序）：先跑路径正则
+    # 会把 https://user:secret@host/path 里的路径段先打码，URL 正则随后
+    # 无法整体匹配，凭据 `secret` 泄漏（#991 review）。
     import re as _re
+    raw = _re.sub(r'https?://[^\s"\'<>]{1,200}', '[url]', raw)
     # 负向后顾：斜杠段前面不能紧跟单词字符，避免把 deepseek/deepseek-v4-flash
     # 这类 provider/model id 误当 Unix 路径打码（前端 sanitizeUiMessage 同款修复）。
     raw = _re.sub(r'(?<![A-Za-z0-9_.-])(?:/[^\s"\'<>|:]{1,200})+', '[path]', raw)
-    raw = _re.sub(r'https?://[^\s"\'<>]{1,200}', '[url]', raw)
     raw = _re.sub(r'\b[A-Za-z0-9+/=]{40,}\b', '[token]', raw)
     return f"{type(exc).__name__}: {raw}" if raw else type(exc).__name__
 

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -180,7 +180,9 @@ def _sanitize_exc_for_ui(exc: BaseException) -> str:
         raw = raw[:300] + "…"
     # Strip common sensitive patterns (absolute paths, URLs with credentials)
     import re as _re
-    raw = _re.sub(r'(?:/[^\s"\'<>|:]{1,200})+', '[path]', raw)
+    # 负向后顾：斜杠段前面不能紧跟单词字符，避免把 deepseek/deepseek-v4-flash
+    # 这类 provider/model id 误当 Unix 路径打码（前端 sanitizeUiMessage 同款修复）。
+    raw = _re.sub(r'(?<![A-Za-z0-9_.-])(?:/[^\s"\'<>|:]{1,200})+', '[path]', raw)
     raw = _re.sub(r'https?://[^\s"\'<>]{1,200}', '[url]', raw)
     raw = _re.sub(r'\b[A-Za-z0-9+/=]{40,}\b', '[token]', raw)
     return f"{type(exc).__name__}: {raw}" if raw else type(exc).__name__

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -182,8 +182,10 @@ def _sanitize_exc_for_ui(exc: BaseException) -> str:
     # URL 必须先行替换成整体（前端 sanitizeUiMessage 同序）：先跑路径正则
     # 会把 https://user:secret@host/path 里的路径段先打码，URL 正则随后
     # 无法整体匹配，凭据 `secret` 泄漏（#991 review）。
+    # 大小写不敏感 + 不设长度上限：HTTPS:// 大写 scheme 与超长凭据 URL 也
+    # 必须整体替换。raw 已在上方截断到 300 字符，匹配长度天然有界。
     import re as _re
-    raw = _re.sub(r'https?://[^\s"\'<>]{1,200}', '[url]', raw)
+    raw = _re.sub(r'https?://[^\s"\'<>]+', '[url]', raw, flags=_re.IGNORECASE)
     # 负向后顾：斜杠段前面不能紧跟单词字符，避免把 deepseek/deepseek-v4-flash
     # 这类 provider/model id 误当 Unix 路径打码（前端 sanitizeUiMessage 同款修复）。
     raw = _re.sub(r'(?<![A-Za-z0-9_.-])(?:/[^\s"\'<>|:]{1,200})+', '[path]', raw)

--- a/miqi/runtime/config_handlers.py
+++ b/miqi/runtime/config_handlers.py
@@ -225,6 +225,21 @@ async def config_update_handler(
     state = get_bridge_state(registry)
 
     current = state.load_config()
+
+    # 比较并设置（#991）：本次更新改写默认模型且调用方声明了期望的当前
+    # 模型值时，只在磁盘当前值仍与期望一致时写入。登录后的网关模型自动
+    # 同步（GatewayModelAutoSync）读取快照与写入之间用户可能已手动选了
+    # 别的模型 —— 不一致时跳过，保留用户更新的选择。
+    expected_model = getattr(typed, "expect_model", None)
+    if expected_model is not None and _update_touches_model(updates):
+        current_model = getattr(current.agents.defaults, "model", "") or ""
+        if current_model != expected_model:
+            logger.info(
+                "config.update: skipped, expect_model mismatch (current={!r}, expected={!r})",
+                current_model, expected_model,
+            )
+            return {"result": {"saved": False, "skipped": "expect_model_mismatch"}}
+
     # Merge in snake_case (by_alias=False): the wire format accepts both
     # snake_case and camelCase keys, but Pydantic's alias takes precedence
     # when both exist.  Dumping snake_case means a snake_case update wins

--- a/miqi/runtime/core_request_models.py
+++ b/miqi/runtime/core_request_models.py
@@ -201,6 +201,10 @@ class ConfigBatchWriteParams(_CoreParams):
 
 class ConfigUpdateParams(_CoreParams):
     config: dict[str, Any]
+    # 比较并设置（#991）：调用方声明「期望当前默认模型仍为此值」，与磁盘
+    # 当前值不一致时 handler 跳过写入 —— 自动同步（登录后兜底写网关模型）
+    # 用它在模型被并发修改时不覆盖用户更新的选择。
+    expect_model: str | None = Field(default=None, validation_alias="expectModel")
 
     @field_validator("config")
     @classmethod

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -83,6 +83,34 @@ def _pick_usable_default_model(config: Any, exclude: str | None = None) -> str:
     return ""
 
 
+def _qraft_gateway_routable(config: Any, model: str) -> bool:
+    """Whether the model is routed via the platform AI gateway at runtime.
+
+    镜像 factory.make_provider 的前置网关分支（#922）：登录凭据
+    （<workspace>/.qraft/token.json 的 aiGateway 块）active 且模型是网关
+    实测模型时，调用经平台网关转发（Anthropic Messages 兼容），不需要任何
+    本地 provider 凭据。保存门控必须认识这条路径，否则「已开通」状态下
+    唯一可用的网关模型会被拒之门外（实测复现：登录用户无任何本地 key，
+    保存 deepseek/deepseek-v4-flash 报 Unsupported model）。
+    """
+    if not model.startswith("deepseek/"):
+        return False
+    from miqi.providers.gateway import (
+        GATEWAY_MODEL,
+        gateway_origin,
+        gateway_token_file,
+        read_gateway_creds,
+    )
+
+    if model[len("deepseek/"):] != GATEWAY_MODEL:
+        return False
+    workspace = getattr(config, "workspace_path", None)
+    if not workspace:
+        return False
+    creds = read_gateway_creds(gateway_token_file(config))
+    return bool(creds and gateway_origin())
+
+
 def _model_provider_resolvable(config: Any, model: str) -> bool:
     """Whether the model resolves to a USABLE provider at runtime.
 
@@ -98,6 +126,10 @@ def _model_provider_resolvable(config: Any, model: str) -> bool:
         return False
     if model.lower().startswith("custom/"):
         return False  # custom provider 已移除（#835），网关兜底不得复活它（#933 review）
+    # 平台 AI 网关路由（#922）：登录凭据 active 时经平台网关转发，无需本地
+    # 凭据 —— 与 factory.make_provider 的路由前提保持一致。
+    if _qraft_gateway_routable(config, model):
+        return True
     model_prefix = model.split("/", 1)[0] if "/" in model else ""
     spec = find_by_name(model_prefix) if model_prefix else find_by_model(model)
     if spec is None:

--- a/tests/execution/test_orchestrator.py
+++ b/tests/execution/test_orchestrator.py
@@ -209,3 +209,46 @@ async def test_graph_render_receives_session_key_injection(orch, mock_orch_compo
     assert captured.get("_session_key") == "miqi-desktop:desktop:1787046883657"
     assert "_sandbox" in captured
     assert captured.get("path") == "graph-demo/bvse-mof-run/output"
+
+
+# ── _sanitize_exc_for_ui（#991 review）───────────────────────────────────
+
+
+class TestSanitizeExcForUi:
+    """错误消毒：URL 先整体打码、模型 id 不被误伤、真实路径仍打码。"""
+
+    def _sanitize(self, text: str) -> str:
+        from miqi.execution.orchestrator import _sanitize_exc_for_ui
+
+        return _sanitize_exc_for_ui(ValueError(text))
+
+    def test_model_id_not_mangled_by_path_regex(self):
+        """deepseek/deepseek-v4-flash 不得被误当 Unix 路径打码。"""
+        out = self._sanitize("Unsupported model: deepseek/deepseek-v4-flash (INVALID_PARAMS)")
+        assert "deepseek/deepseek-v4-flash" in out
+        assert "[path]" not in out
+
+    def test_credential_url_masked_as_whole_unit(self):
+        """带凭据的 URL 必须整体替换为 [url]，不得残留密码（URL 先于路径打码）。"""
+        out = self._sanitize("boom at https://user:secret@example.com/path")
+        assert "secret" not in out
+        assert "user" not in out
+        assert "[url]" in out
+
+    def test_real_paths_still_masked(self):
+        out = self._sanitize("boom at C:/Users/test/data.json and /home/user/file.py")
+        assert "Users" not in out
+        assert "/home/user/file.py" not in out
+        assert out.count("[path]") == 2
+
+    def test_sessions_guidance_not_swallowed(self):
+        """filesystem.py 会话隔离报文的指导文字不得整段被吞成 sessions[path]。"""
+        msg = (
+            "路径位于其他会话的 files 目录内——会话隔离禁止跨会话访问。 "
+            "不要重试或枚举 sessions/；请使用当前会话的工作区，"
+            "或请用户通过文件面板分享文件。"
+        )
+        out = self._sanitize(msg)
+        assert "sessions/；" in out
+        assert "工作区" in out
+        assert "[path]" not in out

--- a/tests/execution/test_orchestrator.py
+++ b/tests/execution/test_orchestrator.py
@@ -235,6 +235,21 @@ class TestSanitizeExcForUi:
         assert "user" not in out
         assert "[url]" in out
 
+    def test_credential_url_uppercase_scheme_masked(self):
+        """大写 scheme 的凭据 URL 也必须整体替换（#991 review）。"""
+        out = self._sanitize("boom at HTTPS://user:secret@example.com/path")
+        assert "secret" not in out
+        assert "user" not in out
+        assert "[url]" in out
+
+    def test_credential_url_over_200_chars_masked(self):
+        """超过 200 字符的凭据 URL 不再因长度上限漏掉尾部（#991 review）。"""
+        long_url = "https://user:secret@example.com/" + "a" * 240
+        out = self._sanitize("boom at " + long_url)
+        assert "secret" not in out
+        assert "aaaa" not in out
+        assert "[url]" in out
+
     def test_real_paths_still_masked(self):
         out = self._sanitize("boom at C:/Users/test/data.json and /home/user/file.py")
         assert "Users" not in out

--- a/tests/fixtures/protocol/app_protocol_snapshot.v1.json
+++ b/tests/fixtures/protocol/app_protocol_snapshot.v1.json
@@ -565,6 +565,17 @@
             "config": {
               "additionalProperties": true,
               "type": "object"
+            },
+            "expectModel": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
             }
           },
           "required": [
@@ -5593,7 +5604,7 @@
   "catalogVersion": 1,
   "generatedTypes": {
     "outputPath": "apps/desktop/src/shared/app-protocol.ts",
-    "sha256": "04a895db4f40f7c767a3628211a8f445cfb14aed53e4bb004d066ab1a04b743e",
+    "sha256": "b6d0d8780463370d4ed07b5638b72acdd18b6f856d86dc3598c7034457a4a25e",
     "source": "miqi.runtime.export_app_protocol_ts.render_typescript_contract"
   },
   "methodCounts": {

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -349,3 +349,79 @@ async def test_config_update_accepts_model_of_configured_provider(fake_config, f
         )
     assert result["result"]["saved"] is True
     assert registry.bridge_context["state"].config.agents.defaults.model == "deepseek/deepseek-v4-flash"
+
+
+# ── 比较并设置 expect_model（#991 review）────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_config_update_expect_model_match_saves(fake_config, fake_provider, tmp_path):
+    """期望值与磁盘当前模型一致时正常保存。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.providers.deepseek.api_key = "sk-ds-1234567890"
+    fake_config.agents.defaults.model = ""
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config") as save:
+        result = await config_update_handler(
+            "req-1",
+            {
+                "config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}},
+                "expect_model": "",
+            },
+            "client-1", None, registry,
+        )
+    assert result["result"]["saved"] is True
+    save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_config_update_expect_model_mismatch_skips(fake_config, fake_provider, tmp_path):
+    """快照读取后用户已选了别的模型 → 跳过写入，保留更新的选择。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.providers.deepseek.api_key = "sk-ds-1234567890"
+    fake_config.agents.defaults.model = "deepseek/deepseek-v4-pro"  # 间隙中被用户改写
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config") as save:
+        result = await config_update_handler(
+            "req-1",
+            {
+                "config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}},
+                "expect_model": "",
+            },
+            "client-1", None, registry,
+        )
+    assert result["result"] == {"saved": False, "skipped": "expect_model_mismatch"}
+    save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_config_update_expect_model_ignored_for_unrelated_fields(
+    fake_config, fake_provider, tmp_path,
+):
+    """不改写默认模型的更新不受期望值影响（只改名等字段时照常保存）。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    fake_config.agents.defaults.model = "deepseek/deepseek-v4-pro"  # 与期望不一致
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config") as save:
+        result = await config_update_handler(
+            "req-1",
+            {
+                "config": {"agents": {"defaults": {"name": "renamed"}}},
+                "expect_model": "",
+            },
+            "client-1", None, registry,
+        )
+    assert result["result"]["saved"] is True
+    save.assert_called_once()

--- a/tests/runtime/test_config_handlers.py
+++ b/tests/runtime/test_config_handlers.py
@@ -245,6 +245,92 @@ async def test_config_update_rejects_custom_model_even_with_gateway(fake_config,
     assert exc_info.value.code == "INVALID_PARAMS"
 
 
+# ── 平台 AI 网关路由与保存门控（#922 收尾） ─────────────────────────────
+
+
+def _write_qraft_gateway_token(config, *, status: str = "active") -> None:
+    """在 config 的 workspace 下写入带 aiGateway 块的 token 文件。"""
+    import json
+    from pathlib import Path
+
+    token_file = Path(config.agents.defaults.workspace) / ".qraft" / "token.json"
+    token_file.parent.mkdir(parents=True, exist_ok=True)
+    token_file.write_text(json.dumps({
+        "accessToken": "tok-123",
+        "aiGateway": {
+            "encryptedApiKey": "sk-test-gateway-secret",
+            "status": status,
+            "configVersion": 1,
+        },
+    }), encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_config_update_accepts_gateway_model_with_active_qraft_creds(
+    fake_config, fake_provider, tmp_path, monkeypatch,
+):
+    """平台网关凭据 active 时，网关实测模型可保存 —— 门控须与
+    factory.make_provider 的网关路由一致（#922）；登录用户无任何本地
+    provider 凭据时，这是唯一可用的模型。"""
+    from unittest import mock
+
+    from miqi.runtime.config_handlers import config_update_handler
+
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    _write_qraft_gateway_token(fake_config)
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with mock.patch("miqi.config.loader.save_config"):
+        result = await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}}},
+            "client-1", None, registry,
+        )
+    assert result["result"]["saved"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_gateway_model_without_qraft_creds(
+    fake_config, fake_provider, tmp_path, monkeypatch,
+):
+    """无网关凭据时，网关模型与其他模型一样必须由本地 provider 凭据背书。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-flash"}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "INVALID_PARAMS"
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_non_gateway_model_even_with_qraft_creds(
+    fake_config, fake_provider, tmp_path, monkeypatch,
+):
+    """网关凭据 active 只放行网关实测模型 —— 其余 deepseek 模型运行时仍走
+    直连（factory.make_provider），不能借网关凭据保存。"""
+    from miqi.runtime.app_server import AppServerError
+    from miqi.runtime.config_handlers import config_update_handler
+
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    _write_qraft_gateway_token(fake_config)
+    registry = _setup_registry(fake_config, tmp_path)
+
+    with pytest.raises(AppServerError) as exc_info:
+        await config_update_handler(
+            "req-1",
+            {"config": {"agents": {"defaults": {"model": "deepseek/deepseek-v4-pro"}}}},
+            "client-1", None, registry,
+        )
+    assert exc_info.value.code == "INVALID_PARAMS"
+
+
 @pytest.mark.asyncio
 async def test_config_update_accepts_model_of_configured_provider(fake_config, fake_provider, tmp_path):
     """#929 review：模型归属的 provider 持有凭据（或经网关路由）时放行。"""


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复「AI 网关已开通」状态下保存网关模型被拒、登录后网关不生效的问题，并修复报错打码误伤模型 id 的显示问题。

## 背景/问题

用户登录平台后 AI 网关显示「已开通」，但默认模型仍是「未设置」，手动选择 `deepseek/deepseek-v4-flash` 保存时报 `Unsupported model: deepseek[path] (INVALID_PARAMS)`。

根因有两层：

1. #929 收口的保存门控 `_model_provider_resolvable` 只认 provider 配置里的凭据（api_key / 已配置网关 provider），不认识 qraft 登录下发的平台 AI 网关凭据（`<workspace>/.qraft/token.json` 的 aiGateway 块）。而运行时 `factory.make_provider` 明确支持「登录 + 网关 active + 模型 = deepseek/deepseek-v4-flash」时经平台网关转发 —— 门控与运行时路由不一致，把当前唯一可用的模型拒之门外。且登录本身不会写默认模型（无任何 login→model 同步逻辑），用户被卡在「未设置 → 选模型保存 → 被拒」的死循环。
2. 报错里的 `[path]` 是假象：`sanitizeUiMessage` / `_sanitize_exc_for_ui` 的路径正则把 `deepseek/deepseek-v4-flash` 里的 `/deepseek-v4-flash` 当 Unix 路径打码。同类误伤还包括会话隔离报错中 `sessions/` 后的整段指导文字被吞成 `sessions[path]`。

## 变更内容

- `miqi/runtime/provider_handlers.py`：`_model_provider_resolvable` 新增 `_qraft_gateway_routable` 前置判定，镜像 `factory.make_provider` 的网关路由前提（deepseek/ + GATEWAY_MODEL + aiGateway active + origin 可用）；无凭据 / 非网关模型仍按原规则拒绝
- `apps/desktop/src/renderer/components/GatewayModelAutoSync.tsx`（新）：挂在 AppShell，登录 + 网关 active 且默认模型为空时自动写入网关模型并失效配置缓存；已有非空模型不打扰，避免覆盖有意的直连配置
- `apps/desktop/src/renderer/lib/sanitizeUiMessage.ts` + `miqi/execution/orchestrator.py`：路径正则的 Unix 分支加负向后顾（斜杠前不能紧跟单词字符），真实路径仍打码、模型 id 与指导文字完整保留
- `apps/desktop/tests/e2e/tool-error-neutral.spec.ts`：夹具同步为后端实际产出的新文案（已用真实 `_sanitize_exc_for_ui` 逐字验证）
- 测试：`tests/runtime/test_config_handlers.py` 新增 3 个门控用例；`sanitizeUiMessage.test.ts` / `GatewayModelAutoSync.test.ts` 新增用例

## 日志/验证证据

```
修复前 bridge 日志（保存网关模型被拒）：
[2026-09-08T16:14:56Z] [WARNING] [bridge] miqi.runtime.app_server:dispatch:376 | AppServer: error dispatching config.update ...: Unsupported model: deepseek/deepseek-v4-flash

修复前界面显示（[path] 误伤模型 id）：
Error invoking remote method 'config:update': Error: Unsupported model: deepseek[path] (INVALID_PARAMS)

修复后 _sanitize_exc_for_ui 实测输出：
ValueError: Unsupported model: deepseek/deepseek-v4-flash (INVALID_PARAMS)
ValueError: boom at C:[path] and [path]   # 真实路径仍打码
```

## 截图

模型页保存/激活态（smoke 截图）：

![模型保存成功](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/fd01ca0b701a1a89.png)
![编辑弹窗已激活](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/da8ca3d8f0d54930.png)

## 测试情况

- Python 全量：3587 passed / 20 skipped，ruff 通过（含新增 3 个门控用例）
- 前端单测：413 passed / 5 skipped，`typecheck:web` 通过
- Smoke（重建产物后）：issue-929-fixes-e2e / issue-929-model-consolidation-ui / issue-922-ai-gateway 共 8 个用例全过
