### PR TITLE
fix(desktop): 侧边栏拖拽调宽失效——usePanelResize 依赖内联 computeWidth 致拖拽中途被 reset (#977)

### DIFF
--- a/apps/desktop/src/renderer/hooks/usePanelResize.ts
+++ b/apps/desktop/src/renderer/hooks/usePanelResize.ts
@@ -16,6 +16,14 @@ export function usePanelResize(options: UsePanelResizeOptions) {
   const isResizing = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Keep the latest options in refs so the document listeners attach ONCE.
+  // Depending on computeWidth directly (#977): callers pass an inline arrow
+  // (new identity every render), so each setWidth re-render re-ran this
+  // effect — its cleanup resets isResizing mid-drag, and every mousemove
+  // after the first one was ignored. Only the first step of a drag applied.
+  const latestRef = useRef({ minWidth, maxWidth, computeWidth });
+  latestRef.current = { minWidth, maxWidth, computeWidth };
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     isResizing.current = true;
@@ -28,8 +36,9 @@ export function usePanelResize(options: UsePanelResizeOptions) {
       if (!isResizing.current) return;
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const newWidth = computeWidth(e, rect);
-      setWidth(Math.max(minWidth, Math.min(maxWidth, newWidth)));
+      const { minWidth: min, maxWidth: max, computeWidth: compute } = latestRef.current;
+      const newWidth = compute(e, rect);
+      setWidth(Math.max(min, Math.min(max, newWidth)));
     };
     const handleMouseUp = () => {
       if (isResizing.current) {
@@ -43,11 +52,12 @@ export function usePanelResize(options: UsePanelResizeOptions) {
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
+      // cleanup if unmounted during drag
       isResizing.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
-  }, [minWidth, maxWidth, computeWidth]);
+  }, []);
 
   return { width, containerRef, handleMouseDown };
 }

--- a/apps/desktop/tests/e2e/issue-977-sidebar-resize.spec.ts
+++ b/apps/desktop/tests/e2e/issue-977-sidebar-resize.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for #977: 左侧对话栏无法拖动调整大小.
+ *
+ * usePanelResize 的 effect 依赖了 computeWidth——调用方传内联箭头函数
+ * （每次渲染新身份），第一次 setWidth 重渲染即触发 cleanup，把
+ * isResizing 重置为 false，后续 mousemove 全部被忽略：拖拽只生效第一步
+ * 的几像素。真实鼠标事件密集，第一步位移常为 1-2px，用户感知即「拖不动」。
+ *
+ * 断言真实鼠标拖拽（多步 mousemove + mouseup）全程跟踪光标，并验证
+ * MIN_WIDTH/MAX_WIDTH 钳制。
+ */
+import { test, expect } from '@playwright/test';
+import { launchElectronApp, closeElectronApp } from './helpers/electron-setup';
+
+const MIN_WIDTH = 180;
+const MAX_WIDTH = 480;
+
+/** 从分隔条当前中心点开始，分 stepCount 步拖到目标 x（步进间留出事件投递时间）。 */
+async function dragHandle(page: import('@playwright/test').Page, handle: any, delta: number) {
+  const rect = await handle.evaluate((el: HTMLElement) => {
+    const r = el.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  });
+  const steps = 10;
+  await page.mouse.move(rect.x, rect.y);
+  await page.mouse.down();
+  for (let step = 1; step <= steps; step++) {
+    await page.mouse.move(rect.x + (delta * step) / steps, rect.y);
+    await page.waitForTimeout(30);
+  }
+  await page.mouse.up();
+}
+
+test('issue #977: sidebar drag-resize tracks the mouse', async () => {
+  const { electronApp, page, miqiHome } = await launchElectronApp();
+
+  const sidebar = page.locator('.sidebar-shell');
+  await expect(sidebar).toBeVisible({ timeout: 30_000 });
+  const handle = sidebar.locator('div.cursor-col-resize');
+
+  const getWidth = () => sidebar.evaluate((el) => el.getBoundingClientRect().width);
+
+  const before = await getWidth();
+  expect(before).toBe(260); // defaultWidth
+
+  // 右拖 150px：宽度必须跟随（原 bug 只生效第一步 ~13px）
+  await dragHandle(page, handle, 150);
+  const widened = await getWidth();
+  expect(widened).toBeGreaterThan(before + 130);
+  expect(widened).toBeLessThan(before + 170);
+
+  // 左拖超量：钳制在 MIN_WIDTH（拖拽距离按当前宽度计算，鼠标不越出视口）
+  await dragHandle(page, handle, -(widened - MIN_WIDTH + 40));
+  expect(await getWidth()).toBe(MIN_WIDTH);
+
+  // 右拖超量：钳制在 MAX_WIDTH
+  await dragHandle(page, handle, MAX_WIDTH - MIN_WIDTH + 40);
+  expect(await getWidth()).toBe(MAX_WIDTH);
+
+  await closeElectronApp(electronApp, miqiHome);
+});


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 #977：左侧对话栏（任务栏）无法拖动调整大小——拖动只生效第一步的几像素。

## 背景/问题

`usePanelResize` 的 effect 依赖数组包含 `computeWidth`，而调用方 Sidebar 传入内联箭头函数（每次渲染新身份）。第一次 mousemove → `setWidth` → 重渲染 → effect 清理函数执行 → `isResizing.current = false`（拖拽态被中途重置）→ 后续所有 mousemove 被 `if (!isResizing.current) return` 挡掉。

实测复现：10 步 × 15px 的合成拖拽只生效第一步（260 → 273，仅 13px）；真实鼠标事件密集，第一步位移常为 1-2px，用户感知即「完全拖不动」。

该缺陷是 #459 提取 hook 时引入的回归：重构前内联代码为 `useEffect(..., [])` 空依赖，监听器只挂载一次。

## 关联 issue

- Closes #977 左侧对话栏无法拖动调整大小

## 变更内容

- `apps/desktop/src/renderer/hooks/usePanelResize.ts`：用 ref 保存最新 `minWidth/maxWidth/computeWidth`，effect 恢复空依赖（回到 #459 重构前的稳定挂载语义），监听器整个生命周期只挂载一次
- `apps/desktop/tests/e2e/issue-977-sidebar-resize.spec.ts`：新增回归 E2E——真实 Electron + 鼠标事件验证拖拽全程跟随光标，并覆盖 MIN_WIDTH(180)/MAX_WIDTH(480) 钳制

## 日志/验证证据

```
修复前:  sidebar width before: 260 → after: 273   (150px 拖拽仅生效 13px)
修复后:  sidebar width before: 260 → after: 408   (完全跟随)
压测:    fast +200px → 458 / slow -100px → 356 / 边缘抓取 +100px → 452
（修复前后同一拖拽脚本：10 步 × 15px 真实鼠标事件）
```

## 测试情况

- 新增 E2E `issue-977-sidebar-resize.spec.ts`（electron project）：通过
- `npm run typecheck`：通过
- prettier check：通过

## 截图

（待补充：修复前后左侧任务栏拖拽对比截图，稍后添加）