### PR TITLE
feat(agent): DeepSeek 搜索不可用时 auto 链自动切换兜底 + 零配置搜索 E2E (#979)

### DIFF
--- a/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
+++ b/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #979 — 零配置搜索 DDGS 兜底链 E2E。
+ *
+ * 验证：清空全部搜索配置（无 Tavily/Brave key、无 DeepSeek 官方 key、
+ * 环境变量无搜索 key）时，agent 调用 web_search 走 auto 链回落 DDGS 并
+ * 真实返回结果。
+ *
+ * 驱动方式：mock OpenAI 服务器（scripts/mock_search_llm.py，确定性两轮
+ * 状态机）作为 LLM 提供方 —— 第 1 轮发起真实 web_search 工具调用（经
+ * 应用运行时真实执行，零配置 auto 链 → DDGS 真实网络请求），第 2 轮把
+ * 真实工具结果中的首个 URL 嵌进最终回复（SEARCH_OK|{url}）。断言最终
+ * 回复携带真实 URL，即证明零配置链在应用内端到端可用。
+ *
+ * 刻意不用 DeepSeek 作为 LLM 提供方：DeepSeek 模型 + 官方 base 会让
+ * auto 链自动启用 DeepSeek 官方搜索（#844 设计），测不到纯 DDGS 兜底。
+ *
+ * Run: cd apps/desktop && PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test \
+ *      --config=playwright.config.ts --project=electron issue-979-zero-config-search.spec.ts
+ */
+
+import { _electron as electron, test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  launchElectronApp,
+  closeElectronApp,
+  createNewConversation,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+
+// ── 真零配置：清除本机环境变量里的搜索 key ─────────────────────────────
+// WebSearchTool 构造时会把 DEEPSEEK_API_KEY/TAVILY_API_KEY/BRAVE_API_KEY
+// 环境变量当兜底配置（web.py）——不删掉它们，零配置就不成立。
+for (const k of ['DEEPSEEK_API_KEY', 'TAVILY_API_KEY', 'BRAVE_API_KEY']) {
+  delete process.env[k];
+}
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+
+/** 启动 scripts/mock_search_llm.py（stdlib only，ephemeral 端口）。 */
+async function startMockSearchLLM(): Promise<{ proc: ChildProcess; mockUrl: string }> {
+  const python = process.env.MIQI_PYTHON_PATH || 'python';
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_search_llm.py'), String(port)], {
+    cwd: REPO_ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+    windowsHide: true,
+  });
+
+  let readyUrl = '';
+  let stderrTail = '';
+  proc.stdout?.on('data', (d) => {
+    const t = String(d);
+    console.log(`[mock] ${t.trim()}`);
+    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => {
+    stderrTail = (stderrTail + String(d)).slice(-2000);
+    console.log(`[mock-err] ${String(d).trim()}`);
+  });
+  proc.on('exit', (code) => console.log(`[test] mock search server exited: ${code}`));
+
+  const deadline = Date.now() + 30_000;
+  while (!readyUrl && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      throw new Error(`mock search server exited early (code ${proc.exitCode}): ${stderrTail}`);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!readyUrl) {
+    proc.kill();
+    throw new Error(`mock search server startup line not seen in 30s: ${stderrTail}`);
+  }
+  console.log(`[test] mock search server ready at ${readyUrl}`);
+  return { proc, mockUrl: readyUrl };
+}
+
+test.describe('Issue #979 零配置搜索 DDGS 兜底', () => {
+  // macOS CI 连不上本地 mock 监听（与 confirm-card 同策略，见该 spec 注释）。
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server'
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+
+  test.beforeAll(async () => {
+    const mock = await startMockSearchLLM();
+    mockServer = mock.proc;
+
+    // 零配置搜索 + mock OpenAI 作为 LLM 提供方：
+    //  - providers.deepseek 必须不存在（否则 auto 链启用 DeepSeek 官方搜索）
+    //  - 模型用 openai/gpt-4o-mini（非 deepseek 模型 → 不启用对应模型搜索）
+    //  - tools.web.search 的 key 全部清除，provider 保持 auto
+    const fixture = await launchElectronApp((config: any) => {
+      config.providers = config.providers ?? {};
+      delete config.providers.deepseek;
+      config.providers.openai = { apiKey: 'mock-key', apiBase: mock.mockUrl };
+      config.agents = {
+        ...(config.agents ?? {}),
+        defaults: {
+          ...(config.agents?.defaults ?? {}),
+          model: 'openai/gpt-4o-mini',
+        },
+      };
+      const search = config.tools?.web?.search;
+      if (search && typeof search === 'object') {
+        delete search.apiKey;
+        delete search.tavilyApiKey;
+        delete search.braveApiKey;
+        search.provider = 'auto';
+      }
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    try {
+      mockServer?.kill();
+    } catch {
+      /* already gone */
+    }
+  });
+
+  test(
+    '零配置发起 web_search → auto 链回落 DDGS → 真实结果返回',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '请用网页搜索查一下今天北京的天气');
+
+      // 1. 工具行出现「网页搜索」——web_search 被真实执行（非错误短路上报）
+      await expect(page.locator('main').getByText('网页搜索').first()).toBeVisible({
+        timeout: 60_000,
+      });
+
+      // 2. mock 把真实工具结果的首个 URL 嵌进最终回复：DDGS 兜底返回了真实结果
+      await expect(
+        page
+          .getByTestId('chat-message-assistant')
+          .getByText(/SEARCH_OK\|https?:\/\//)
+          .first()
+      ).toBeVisible({ timeout: 180_000 });
+
+      // 3. 失败路径不得出现（零配置下整条链不应报网络/限流错误）
+      await waitForResponseComplete(page, 60_000);
+      const mainText = await page.locator('main').textContent();
+      expect(mainText).not.toContain('网络搜索失败');
+      expect(mainText).not.toContain('SEARCH_FAILED');
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        fullPage: true,
+      });
+    }
+  );
+});

--- a/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
+++ b/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
@@ -1,18 +1,24 @@
 /**
- * Issue #979 — 零配置搜索 DDGS 兜底链 E2E。
+ * Issue #979 — 搜索 auto 链兜底 E2E。
  *
- * 验证：清空全部搜索配置（无 Tavily/Brave key、无 DeepSeek 官方 key、
- * 环境变量无搜索 key）时，agent 调用 web_search 走 auto 链回落 DDGS 并
- * 真实返回结果。
+ * 场景 A（零配置）：清空全部搜索配置（无 Tavily/Brave key、无 DeepSeek
+ * 官方 key、环境变量无搜索 key）时，agent 调用 web_search 走 auto 链
+ * 回落 DDGS 并真实返回结果。
+ *
+ * 场景 B（DeepSeek 配置了但搜索不可用）：LLM 提供方为 DeepSeek（模型
+ * deepseek/deepseek-v4-flash）但 apiBase 是中转站（无 /responses 端点，
+ * 不支持官方联网搜索）→ auto 链跳过 DeepSeek 搜索、自动切换 DDGS 返回
+ * 真实结果（#979：DeepSeek 配置不能搜索也要自动切换）。
  *
  * 驱动方式：mock OpenAI 服务器（scripts/mock_search_llm.py，确定性两轮
  * 状态机）作为 LLM 提供方 —— 第 1 轮发起真实 web_search 工具调用（经
- * 应用运行时真实执行，零配置 auto 链 → DDGS 真实网络请求），第 2 轮把
- * 真实工具结果中的首个 URL 嵌进最终回复（SEARCH_OK|{url}）。断言最终
- * 回复携带真实 URL，即证明零配置链在应用内端到端可用。
+ * 应用运行时真实执行，auto 链 → DDGS 真实网络请求），第 2 轮把真实工具
+ * 结果中的首个 URL 嵌进最终回复（SEARCH_OK|{url}）。断言最终回复携带
+ * 真实 URL，即证明 auto 链在应用内端到端可用。
  *
- * 刻意不用 DeepSeek 作为 LLM 提供方：DeepSeek 模型 + 官方 base 会让
- * auto 链自动启用 DeepSeek 官方搜索（#844 设计），测不到纯 DDGS 兜底。
+ * 场景 A 刻意不用 DeepSeek 作为 LLM 提供方：DeepSeek 模型 + 官方 base
+ * 会让 auto 链自动启用 DeepSeek 官方搜索（#844 设计），测不到纯 DDGS
+ * 兜底路径。
  *
  * Run: cd apps/desktop && PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test \
  *      --config=playwright.config.ts --project=electron issue-979-zero-config-search.spec.ts
@@ -81,7 +87,30 @@ async function startMockSearchLLM(): Promise<{ proc: ChildProcess; mockUrl: stri
   return { proc, mockUrl: readyUrl };
 }
 
-test.describe('Issue #979 零配置搜索 DDGS 兜底', () => {
+/** 断言零配置/DeepSeek 不可用场景下 web_search 经 DDGS 真实返回结果。 */
+async function expectSearchOkViaDdgs(page: Page) {
+  // 1. 工具行出现「网页搜索」——web_search 被真实执行（非错误短路上报）
+  await expect(page.locator('main').getByText('网页搜索').first()).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // 2. mock 把真实工具结果的首个 URL 嵌进最终回复：DDGS 兜底返回了真实结果
+  await expect(
+    page
+      .getByTestId('chat-message-assistant')
+      .getByText(/SEARCH_OK\|https?:\/\//)
+      .first()
+  ).toBeVisible({ timeout: 180_000 });
+
+  // 3. 失败路径不得出现（auto 链不应报网络/限流/余额错误而中断）
+  await waitForResponseComplete(page, 60_000);
+  const mainText = await page.locator('main').textContent();
+  expect(mainText).not.toContain('网络搜索失败');
+  expect(mainText).not.toContain('SEARCH_FAILED');
+  expect(mainText).not.toContain('余额不足');
+}
+
+test.describe('Issue #979 场景 A：零配置搜索 DDGS 兜底', () => {
   // macOS CI 连不上本地 mock 监听（与 confirm-card 同策略，见该 spec 注释）。
   test.skip(
     process.platform === 'darwin' && !!process.env.CI,
@@ -141,24 +170,76 @@ test.describe('Issue #979 零配置搜索 DDGS 兜底', () => {
       await createNewConversation(page);
       await sendMessage(page, '请用网页搜索查一下今天北京的天气');
 
-      // 1. 工具行出现「网页搜索」——web_search 被真实执行（非错误短路上报）
-      await expect(page.locator('main').getByText('网页搜索').first()).toBeVisible({
-        timeout: 60_000,
+      await expectSearchOkViaDdgs(page);
+
+      await page.screenshot({
+        path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,
+        fullPage: true,
       });
+    }
+  );
+});
 
-      // 2. mock 把真实工具结果的首个 URL 嵌进最终回复：DDGS 兜底返回了真实结果
-      await expect(
-        page
-          .getByTestId('chat-message-assistant')
-          .getByText(/SEARCH_OK\|https?:\/\//)
-          .first()
-      ).toBeVisible({ timeout: 180_000 });
+test.describe('Issue #979 场景 B：DeepSeek 中转站 base（搜索不可用）自动切换 DDGS', () => {
+  // macOS CI 连不上本地 mock 监听（与 confirm-card 同策略，见该 spec 注释）。
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server'
+  );
 
-      // 3. 失败路径不得出现（零配置下整条链不应报网络/限流错误）
-      await waitForResponseComplete(page, 60_000);
-      const mainText = await page.locator('main').textContent();
-      expect(mainText).not.toContain('网络搜索失败');
-      expect(mainText).not.toContain('SEARCH_FAILED');
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let mockServer: ChildProcess;
+
+  test.beforeAll(async () => {
+    const mock = await startMockSearchLLM();
+    mockServer = mock.proc;
+
+    // DeepSeek 作为 LLM 提供方（模型 deepseek/deepseek-v4-flash），但
+    // apiBase 指向 mock（等价中转站：无 /responses 端点，_is_official_
+    // deepseek_base 判定失败）→ auto 链跳过 DeepSeek 官方搜索，自动
+    // 切换 DDGS。LLM 请求本身经 mock 正常驱动 web_search 工具调用。
+    const fixture = await launchElectronApp((config: any) => {
+      config.providers = config.providers ?? {};
+      config.providers.deepseek = { apiKey: 'mock-key', apiBase: mock.mockUrl };
+      config.agents = {
+        ...(config.agents ?? {}),
+        defaults: {
+          ...(config.agents?.defaults ?? {}),
+          model: 'deepseek/deepseek-v4-flash',
+        },
+      };
+      const search = config.tools?.web?.search;
+      if (search && typeof search === 'object') {
+        delete search.apiKey;
+        delete search.tavilyApiKey;
+        delete search.braveApiKey;
+        search.provider = 'auto';
+      }
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    try {
+      mockServer?.kill();
+    } catch {
+      /* already gone */
+    }
+  });
+
+  test(
+    'DeepSeek 中转站 base → 官方搜索不可用 → 自动切换 DDGS 返回真实结果',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      await createNewConversation(page);
+      await sendMessage(page, '请用网页搜索查一下今天北京的天气');
+
+      await expectSearchOkViaDdgs(page);
 
       await page.screenshot({
         path: `test-results/${test.info().title.replace(/\s+/g, '-')}.png`,

--- a/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
+++ b/apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts
@@ -26,7 +26,7 @@
 
 import { _electron as electron, test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { join } from 'node:path';
 import {
   LLM_TIMEOUT,
@@ -41,29 +41,58 @@ import {
 // ── 真零配置：清除本机环境变量里的搜索 key ─────────────────────────────
 // WebSearchTool 构造时会把 DEEPSEEK_API_KEY/TAVILY_API_KEY/BRAVE_API_KEY
 // 环境变量当兜底配置（web.py）——不删掉它们，零配置就不成立。
-for (const k of ['DEEPSEEK_API_KEY', 'TAVILY_API_KEY', 'BRAVE_API_KEY']) {
-  delete process.env[k];
+// 原值先保存，beforeAll 清除、afterAll 恢复：Playwright worker 会串行跑
+// 多个 spec 文件，模块级永久删除会污染同 worker 后续 spec；本 spec 被
+// skip 时 beforeAll 不执行，环境不受扰动（CodeRabbit #996）。
+const SEARCH_ENV_KEYS = ['DEEPSEEK_API_KEY', 'TAVILY_API_KEY', 'BRAVE_API_KEY'] as const;
+const _savedSearchEnv: Record<string, string | undefined> = {};
+for (const k of SEARCH_ENV_KEYS) _savedSearchEnv[k] = process.env[k];
+
+function clearSearchEnvKeys() {
+  for (const k of SEARCH_ENV_KEYS) delete process.env[k];
+}
+
+function restoreSearchEnvKeys() {
+  for (const k of SEARCH_ENV_KEYS) {
+    if (_savedSearchEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = _savedSearchEnv[k];
+  }
 }
 
 const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
 
-/** 启动 scripts/mock_search_llm.py（stdlib only，ephemeral 端口）。 */
+/** 启动 scripts/mock_search_llm.py（stdlib only，port 0 由 OS 分配）。 */
 async function startMockSearchLLM(): Promise<{ proc: ChildProcess; mockUrl: string }> {
-  const python = process.env.MIQI_PYTHON_PATH || 'python';
-  const port = 20000 + Math.floor(Math.random() * 20000);
-  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_search_llm.py'), String(port)], {
+  // MIQI_PYTHON_PATH 可能指向失效解释器——先探测，不可用回退 'python'
+  // （与 launchElectronApp 同策略），并挂 error 监听避免 spawn ENOENT
+  // 未处理异常（CodeRabbit #996）。
+  let python = process.env.MIQI_PYTHON_PATH || 'python';
+  const probe = spawnSync(python, ['-c', 'import sys; sys.exit(0)'], {
+    encoding: 'utf8',
+    timeout: 5000,
+    windowsHide: true,
+  });
+  if (probe.status !== 0) {
+    console.log(
+      `[test] MIQI_PYTHON_PATH unusable (status ${probe.status}) — mock falls back to 'python'`
+    );
+    python = 'python';
+  }
+  const proc = spawn(python, [join(REPO_ROOT, 'scripts', 'mock_search_llm.py'), '0'], {
     cwd: REPO_ROOT,
     stdio: ['ignore', 'pipe', 'pipe'],
     env: { ...process.env, PYTHONUNBUFFERED: '1' },
     windowsHide: true,
   });
+  proc.on('error', (e) => console.log(`[test] mock search server spawn error: ${e}`));
 
   let readyUrl = '';
+  let stdoutBuf = '';
   let stderrTail = '';
   proc.stdout?.on('data', (d) => {
-    const t = String(d);
-    console.log(`[mock] ${t.trim()}`);
-    const m = t.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    stdoutBuf += String(d); // 跨 chunk 累积匹配，URL 被拆包也能识别
+    console.log(`[mock] ${String(d).trim()}`);
+    const m = stdoutBuf.match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
     if (m) readyUrl = `http://127.0.0.1:${m[1]}/v1`;
   });
   proc.stderr?.on('data', (d) => {
@@ -123,6 +152,7 @@ test.describe('Issue #979 场景 A：零配置搜索 DDGS 兜底', () => {
   let mockServer: ChildProcess;
 
   test.beforeAll(async () => {
+    clearSearchEnvKeys();
     const mock = await startMockSearchLLM();
     mockServer = mock.proc;
 
@@ -161,6 +191,7 @@ test.describe('Issue #979 场景 A：零配置搜索 DDGS 兜底', () => {
     } catch {
       /* already gone */
     }
+    restoreSearchEnvKeys();
   });
 
   test(
@@ -193,6 +224,7 @@ test.describe('Issue #979 场景 B：DeepSeek 中转站 base（搜索不可用�
   let mockServer: ChildProcess;
 
   test.beforeAll(async () => {
+    clearSearchEnvKeys();
     const mock = await startMockSearchLLM();
     mockServer = mock.proc;
 
@@ -230,6 +262,7 @@ test.describe('Issue #979 场景 B：DeepSeek 中转站 base（搜索不可用�
     } catch {
       /* already gone */
     }
+    restoreSearchEnvKeys();
   });
 
   test(

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -165,7 +165,9 @@ class SearchResult:
 
 
 # Error categories that should trigger fallback in auto mode.
-_FALLBACK_ERRORS = {"RATE_LIMIT", "NETWORK", "SERVER_ERROR", "NO_RESULT"}
+# BALANCE_ERROR（余额不足）也回落——DeepSeek 配置了 key 但账户没钱时，
+# 用户仍应能得到搜索结果（#979：配置了不能搜索 → 自动切换兜底）。
+_FALLBACK_ERRORS = {"RATE_LIMIT", "NETWORK", "SERVER_ERROR", "NO_RESULT", "BALANCE_ERROR"}
 # Errors that must NOT silently fall back (config problems) — log, but
 # degrade to the keyless provider once so the user still gets an answer.
 _AUTH_ERRORS = {"AUTH_ERROR", "NO_KEY"}

--- a/scripts/mock_search_llm.py
+++ b/scripts/mock_search_llm.py
@@ -1,0 +1,176 @@
+"""Mock OpenAI-compatible server for zero-config search E2E (issue #979).
+
+Deterministic two-round flow that drives the REAL web_search tool through
+the desktop runtime:
+
+  Round 1: tool_call → web_search (real tool: auto chain → zero-config DDGS)
+  Round 2: web_search done → final text echoing the real result:
+           "SEARCH_OK|{first result URL}"  (success)
+           "SEARCH_FAILED|{error head}"    (the runtime reported failure)
+
+The spec asserts the final reply marker, so the URL in the reply is the
+URL the real DDGS backend actually returned — proof the zero-config chain
+worked end-to-end inside the app.
+
+Stdlib only (like mock_openai.py) — run with any python.
+Run:  python scripts/mock_search_llm.py [port]
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SEARCH_QUERY = "今天北京天气怎么样"
+SEARCH_COUNT = 3
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_sse(self, obj):
+        msg = obj["choices"][0]["message"]
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            delta = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "index": i,
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": tc["function"],
+                    }
+                    for i, tc in enumerate(tool_calls)
+                ],
+            }
+            finish = obj["choices"][0].get("finish_reason") or "tool_calls"
+        else:
+            delta = {"role": "assistant", "content": msg.get("content") or ""}
+            finish = obj["choices"][0].get("finish_reason") or "stop"
+        chunk1 = {
+            "id": obj.get("id", "mock"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-model"),
+            "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+        }
+        chunk2 = {
+            "id": obj.get("id", "mock"),
+            "object": "chat.completion.chunk",
+            "created": 0,
+            "model": obj.get("model", "mock-model"),
+            "choices": [{"index": 0, "delta": {}, "finish_reason": finish}],
+        }
+        body = (
+            "data: " + json.dumps(chunk1, ensure_ascii=False) + "\n\n"
+            "data: " + json.dumps(chunk2, ensure_ascii=False) + "\n\n"
+            "data: [DONE]\n\n"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _respond(self, obj, streamed):
+        if streamed:
+            self._send_sse(obj)
+        else:
+            self._send(200, obj)
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._send(200, {"object": "list", "data": [{"id": "mock-model", "object": "model"}]})
+        else:
+            self._send(404, {"error": {"message": "not found"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            req = json.loads(raw)
+        except Exception:
+            self._send(400, {"error": {"message": "bad json"}})
+            return
+        if not self.path.startswith("/v1/chat/completions"):
+            self._send(404, {"error": {"message": "not found"}})
+            return
+
+        streamed = bool(req.get("stream"))
+        messages = req.get("messages", [])
+
+        def tc(name, args, cid="call_search"):
+            return {
+                "id": cid,
+                "object": "chat.completion",
+                "created": 0,
+                "model": "mock-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": None, "tool_calls": [{
+                        "id": cid, "type": "function",
+                        "function": {"name": name, "arguments": json.dumps(args, ensure_ascii=False)},
+                    }]},
+                    "finish_reason": "tool_calls",
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+            }
+
+        def text(content):
+            return {
+                "id": "mock-final", "object": "chat.completion", "created": 0, "model": "mock-model",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+            }
+
+        # 流程进度只看 assistant 侧的 web_search 调用次数（可靠，不看结果内容）
+        n_search = 0
+        for m in messages:
+            if m.get("role") != "assistant" or not m.get("tool_calls"):
+                continue
+            for c in m["tool_calls"]:
+                if (c.get("function") or {}).get("name") == "web_search":
+                    n_search += 1
+
+        if n_search == 0:
+            print("  [mock-search] R1 → 真实执行 web_search", flush=True)
+            self._respond(tc("web_search", {"query": SEARCH_QUERY, "count": SEARCH_COUNT}), streamed)
+            return
+
+        # R2：解析真实 web_search 工具结果，把证据嵌进最终回复
+        tool_content = ""
+        for m in reversed(messages):
+            if m.get("role") == "tool":
+                tool_content = str(m.get("content", ""))
+                break
+        m = re.search(r"https?://[^\s\"'`]+", tool_content)
+        if tool_content.startswith("Error:") or "网络搜索失败" in tool_content:
+            head = tool_content[:120].replace("\n", " ")
+            print(f"  [mock-search] R2 → 搜索失败: {head}", flush=True)
+            self._respond(text(f"SEARCH_FAILED|{head}"), streamed)
+        elif m:
+            print(f"  [mock-search] R2 → 搜索成功，首个结果 {m.group(0)}", flush=True)
+            self._respond(text(f"SEARCH_OK|{m.group(0)}"), streamed)
+        else:
+            print(f"  [mock-search] R2 → 无 URL（内容: {tool_content[:80]}）", flush=True)
+            self._respond(text("SEARCH_NO_URL|" + tool_content[:120].replace("\n", " ")), streamed)
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8899
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    actual_port = server.server_address[1]
+    print(f"Mock search LLM server on http://127.0.0.1:{actual_port}/v1", flush=True)
+    server.serve_forever()

--- a/tests/agent/tools/test_web.py
+++ b/tests/agent/tools/test_web.py
@@ -682,6 +682,35 @@ async def test_auto_deepseek_falls_through(monkeypatch):
     assert result.success and calls == ["deepseek"]
 
 
+async def test_auto_deepseek_balance_error_falls_through(monkeypatch, caplog):
+    """auto 链：DeepSeek 余额不足（402）→ 自动切换兜底，不中断链（#979）。
+
+    DeepSeek 配置了 key 但账户余额耗尽时，搜索功能仍应可用——回落 ddgs。
+    """
+    calls = []
+
+    class _DS(DeepSeekSearchProvider):
+        async def search(self, query, count):
+            calls.append("deepseek")
+            return SearchResult(False, error_type="BALANCE_ERROR", provider="deepseek")
+
+    manager = SearchProviderManager(
+        "auto", model="deepseek/deepseek-v4-flash",
+        deepseek_api_key="ds-key",
+        deepseek_api_base="https://api.deepseek.com",
+    )
+    manager._chain = lambda: [_DS("ds-key"), DDGSProvider()]
+
+    async def _ok(self, query, count):
+        return SearchResult(True, [{"title": "ok", "url": "https://example.com", "snippet": "s"}])
+
+    monkeypatch.setattr(DDGSProvider, "search", _ok)
+    result = await manager.search("q", 5)
+    assert result.success
+    assert calls == ["deepseek"]
+    assert any("trying next provider" in r.message for r in caplog.records)
+
+
 async def test_execute_unsupported_exposes_message(monkeypatch):
     """显式 deepseek + 非官方 base → 透出\"不支持联网搜索\"（可操作文案）。"""
     tool = WebSearchTool(provider="deepseek", deepseek_api_key="k",


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

搜索 auto 链兜底补齐 + 零配置搜索 E2E：DeepSeek 配置了但搜索不可用（余额不足/中转站 base）时自动切换 DDGS；无任何搜索 key 时 web_search 经 DDGS 兜底真实返回结果。

## 背景/问题

#979 要求实测"完全无配置"场景下 DDGS 兜底链真实可用。源码级实测确认零配置可用，但发现一个缺口：auto 链中 DeepSeek 的 401/429/5xx/超时都会回落，唯独 **402 余额不足（BALANCE_ERROR）会中断整条链**——"配置了 key 但搜索不可用"时用户拿不到任何结果。本次补齐：余额不足也自动切换兜底（显式 `provider=deepseek` 模式仍透出「余额不足」文案，行为不变）。同时补应用内端到端 E2E（此前只有单元测试与源码级验证）。

## 关联 issue

- #979 零配置搜索可用性验证

## 变更内容

- `miqi/agent/tools/web.py`：`BALANCE_ERROR` 加入 `_FALLBACK_ERRORS`——DeepSeek 账户余额耗尽时 auto 链自动切换 Tavily/Brave/DDGS，不再中断
- `tests/agent/tools/test_web.py`：新增 `test_auto_deepseek_balance_error_falls_through`（TDD：先红后绿，46 个用例全绿）
- `apps/desktop/tests/e2e/issue-979-zero-config-search.spec.ts`：两个场景——A 零配置（清 env key + 清配置 key + 非 deepseek 模型）→ auto 链回落 DDGS；B DeepSeek 中转站 base（无 /responses 端点，官方搜索不可用）→ auto 链跳过 DeepSeek 自动切换 DDGS。mock LLM 驱动真实 web_search，断言最终回复携带真实 DDGS 结果 URL、无失败文案
- `scripts/mock_search_llm.py`：确定性两轮状态机（R1 发起 web_search 工具调用，R2 把真实工具结果首个 URL 嵌进最终回复），stdlib only，与 `mock_openai.py` 同构

## 日志/验证证据

```
[mock] [mock-search] R1 → 真实执行 web_search
[mock] [mock-search] R2 → 搜索成功，首个结果 http://www.nmc.cn/publish/forecast/ABJ/beijing.html
  ok 1 [electron] › issue-979-zero-config-search.spec.ts:166:7 › 场景 A：零配置搜索 DDGS 兜底 › 零配置发起 web_search → auto 链回落 DDGS → 真实结果返回 (23.2s)
  ok 2 [electron] › issue-979-zero-config-search.spec.ts:235:7 › 场景 B：DeepSeek 中转站 base（搜索不可用）自动切换 DDGS › … (23.2s)
  2 passed (34.5s)

pytest tests/agent/tools/test_web.py → 46 passed（含新增余额回落用例）
```

本地 Windows 实测（真实 DDGS 网络请求，结果来自 nmc.cn 中央气象台官网）：

场景 A 截图：

![零配置搜索 E2E 结果](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/1aa3c5552ad6d12f.png)

场景 B 截图：

![DeepSeek 中转站 base 自动切换 DDGS](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/0dd2f877f237f671.png)

## 测试情况

- 本地 E2E：`PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test --config=playwright.config.ts --project=electron issue-979-zero-config-search.spec.ts` — 2 passed（23.2s × 2）
- 单测：`pytest tests/agent/tools/test_web.py` — 46 passed
- 新文件通过 prettier 检查与 `tsc --noEmit -p tsconfig.web.json`
- 源码级实测（记录于 #979 评论）：零配置 DDGS 1.8~5.2s；有效 DeepSeek key 走官方搜索 7.6~11.3s；401 自动降级 DDGS 成功

## 截图

见「日志/验证证据」节内嵌两张截图（场景 A 零配置、场景 B DeepSeek 中转站 base 自动切换，均以 `SEARCH_OK|真实URL` 收尾）。

## 后续计划

- #979 结论已在 issue 评论中记录（源码级实测数据）；本 PR 合入后 E2E 回归保护两种兜底路径
