### PR TITLE
fix(desktop): 堵住 openExternal/openContainingFolder 的路径校验绕过 (#955)

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, unlinkSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { randomUUID } from 'crypto';
-import { isAbsolute, join } from 'path';
+import { join } from 'path';
 import type { BrowserWindow } from 'electron';
 import type { BridgeManager } from '../bridge';
 import {
@@ -62,6 +62,13 @@ import {
   wslPackageInstalled,
   wslStatusWorks,
 } from './wsl-state';
+import {
+  getConfigDir,
+  getConfigPath,
+  getWorkspacePath,
+  readLocalConfig,
+  resolveWorkspacePath,
+} from './workspace-path';
 
 const { ipcMain, dialog, shell, app } = electron;
 
@@ -89,90 +96,8 @@ function readWorkspaceLogLines(
   return lines;
 }
 
-function getConfigDir(): string {
-  const miqiHome = process.env['MIQI_HOME']?.trim();
-  return miqiHome ? miqiHome : join(homedir(), '.miqi');
-}
-
-function getConfigPath(): string {
-  return join(getConfigDir(), 'config.json');
-}
-
-/** Strip sandbox prefix and resolve against the host workspace.
- *
- *  The bwrap sandbox mounts at /home/miqi/workspace/.  Paths reported
- *  by the agent (e.g. /home/miqi/workspace/report.md) are normalised
- *  to workspace-relative form and then joined with the host workspace
- *  root.  Absolute paths outside the workspace are rejected.
- */
-function resolveWorkspacePath(raw: string): string {
-  // Convert WSL /mnt/<drive>/ paths to Windows <drive>:\ paths
-  // (e.g. /mnt/c/Users/... -> C:\Users\...)
-  const mntMatch = raw.match(/^\/mnt\/([a-zA-Z])\/?(.*)$/);
-  if (mntMatch) {
-    return mntMatch[1].toUpperCase() + ':\\' + mntMatch[2];
-  }
-
-  const SANDBOX_WS = '/home/miqi/workspace';
-  let normalised = raw;
-  if (normalised === SANDBOX_WS) {
-    normalised = '.';
-  } else if (normalised.startsWith(SANDBOX_WS + '/')) {
-    normalised = normalised.slice(SANDBOX_WS.length + 1);
-  } else if (normalised.startsWith(SANDBOX_WS + '\\')) {
-    normalised = normalised.slice(SANDBOX_WS.length + 1);
-  }
-
-  const wsRoot = getWorkspacePath();
-  let resolved: string;
-  if (isAbsolute(normalised)) {
-    resolved = normalised;
-  } else {
-    resolved = join(wsRoot, normalised);
-  }
-
-  // Enforce workspace containment — prevent escape via .. or absolute
-  // paths that land outside the workspace root.
-  const rel = resolved.replace(/\\/g, '/');
-  const wsNorm = wsRoot.replace(/\\/g, '/');
-  if (!(rel + '/').startsWith(wsNorm + '/') && rel !== wsNorm) {
-    throw new Error(`Path outside workspace: ${raw}`);
-  }
-
-  return resolved;
-}
-
-export function getWorkspacePath(): string {
-  const config = readLocalConfig();
-  const agents = (config['agents'] as Record<string, unknown> | undefined) ?? {};
-  const defaults = (agents['defaults'] as Record<string, unknown> | undefined) ?? {};
-  const raw = (defaults['workspace'] as string) || '~/.miqi/workspace';
-
-  // When using the default path but MIQI_HOME is set, rebase like the Python side does
-  if (raw === '~/.miqi/workspace') {
-    const miqiHome = process.env['MIQI_HOME']?.trim();
-    if (miqiHome) return join(miqiHome, 'workspace');
-  }
-
-  // Expand ~ to home directory
-  if (raw.startsWith('~')) {
-    const stripSep = raw.startsWith('~/') || raw.startsWith('~\\');
-    return join(homedir(), raw.slice(stripSep ? 2 : 1));
-  }
-
-  return raw;
-}
-
-function readLocalConfig(): Record<string, unknown> {
-  const configPath = getConfigPath();
-  try {
-    if (!existsSync(configPath)) return {};
-    const raw = readFileSync(configPath, 'utf8');
-    return JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
+// Re-exported for consumers that import from this module (e.g. qraft/ipc.ts).
+export { getWorkspacePath };
 
 function deepMergeConfig(
   base: Record<string, unknown>,
@@ -2019,17 +1944,12 @@ for m in ("pydantic", "httpx", "loguru"):
     const raw = p.path;
     // Session metadata may store workspace as a string (Path str) —
     // resolve "Path('...')" wrapper to a plain path string before opening.
-    const { existsSync: fsExistsSync2 } = await import('node:fs');
     const clean = raw.replace(/^Path\(['"]/, '').replace(/['"]\)$/, '');
-    if (isAbsolute(clean) && fsExistsSync2(clean)) {
-      try {
-        shell.showItemInFolder(clean);
-        return { revealed: true, path: raw };
-      } catch (e: any) {
-        return { revealed: false, path: raw, error: e?.message ?? String(e) };
-      }
-    }
-    const absolutePath = resolveWorkspacePath(raw);
+    // Security: route through resolveWorkspacePath so the workspace-containment
+    // check always applies.  A previous fast path here (isAbsolute(clean) &&
+    // existsSync(clean) → showItemInFolder) skipped that check entirely, letting
+    // the renderer reveal any host directory (security regression #955).
+    const absolutePath = resolveWorkspacePath(clean);
     try {
       if (!existsSync(absolutePath)) {
         return { revealed: false, path: raw, error: `File not found: ${absolutePath}` };

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -66,6 +66,7 @@ import {
   getConfigDir,
   getConfigPath,
   getWorkspacePath,
+  isWithinCanonicalWorkspace,
   readLocalConfig,
   resolveWorkspacePath,
 } from './workspace-path';
@@ -1891,6 +1892,12 @@ for m in ("pydantic", "httpx", "loguru"):
     for (const candidate of candidates) {
       try {
         if (!existsSync(candidate)) continue;
+        // WSL UNC paths live inside the sandbox distro, not on the host — skip
+        // the host-workspace canonical check (relPath was vetted above).
+        const isWslUnc = candidate.startsWith('\\\\wsl$');
+        if (!isWslUnc && !isWithinCanonicalWorkspace(candidate, getWorkspacePath())) {
+          continue;
+        }
         const error = await shell.openPath(candidate);
         if (!error) {
           opened = true;
@@ -1953,6 +1960,11 @@ for m in ("pydantic", "httpx", "loguru"):
     try {
       if (!existsSync(absolutePath)) {
         return { revealed: false, path: raw, error: `File not found: ${absolutePath}` };
+      }
+      // Follow symlinks/junctions so a link pointing outside the workspace can't
+      // reveal a host directory through the lexical containment check (#955).
+      if (!isWithinCanonicalWorkspace(absolutePath, getWorkspacePath())) {
+        return { revealed: false, path: raw, error: `Path outside workspace: ${raw}` };
       }
       shell.showItemInFolder(absolutePath);
       return { revealed: true, path: raw };

--- a/apps/desktop/src/main/ipc/workspace-path.test.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { getWorkspacePath, resolveWorkspacePath } from './workspace-path';
+import {
+  getWorkspacePath,
+  isWithinCanonicalWorkspace,
+  resolveWorkspacePath,
+} from './workspace-path';
 
 const isWin = process.platform === 'win32';
 
@@ -83,5 +88,35 @@ describe('resolveWorkspacePath', () => {
       const escaped = toMnt(`${wsRoot}\\..\\..\\Windows\\System32\\calc.exe`);
       expect(() => resolveWorkspacePath(escaped)).toThrow(/outside workspace/);
     });
+  });
+});
+
+describe('isWithinCanonicalWorkspace', () => {
+  let wsRoot: string;
+
+  beforeEach(() => {
+    const home = join(
+      tmpdir(),
+      `miqi-ws-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    process.env['MIQI_HOME'] = home;
+    wsRoot = getWorkspacePath();
+    mkdirSync(wsRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    delete process.env['MIQI_HOME'];
+  });
+
+  it('accepts a path inside the workspace', () => {
+    expect(isWithinCanonicalWorkspace(wsRoot, wsRoot)).toBe(true);
+  });
+
+  it('rejects a path outside the workspace', () => {
+    expect(isWithinCanonicalWorkspace(tmpdir(), wsRoot)).toBe(false);
+  });
+
+  it('accepts a non-existent path (lexical check covers it)', () => {
+    expect(isWithinCanonicalWorkspace(join(wsRoot, 'no-such-file.txt'), wsRoot)).toBe(true);
   });
 });

--- a/apps/desktop/src/main/ipc/workspace-path.test.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.test.ts
@@ -73,5 +73,15 @@ describe('resolveWorkspacePath', () => {
       const target = join(lowerWs, 'report.md');
       expect(norm(resolveWorkspacePath(toMnt(target)))).toBe(norm(target));
     });
+
+    it('rejects an absolute path with literal .. traversal', () => {
+      const escaped = `${wsRoot}\\..\\..\\Windows\\System32\\calc.exe`;
+      expect(() => resolveWorkspacePath(escaped)).toThrow(/outside workspace/);
+    });
+
+    it('rejects a /mnt path with .. traversal escaping the workspace', () => {
+      const escaped = toMnt(`${wsRoot}\\..\\..\\Windows\\System32\\calc.exe`);
+      expect(() => resolveWorkspacePath(escaped)).toThrow(/outside workspace/);
+    });
   });
 });

--- a/apps/desktop/src/main/ipc/workspace-path.test.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getWorkspacePath, resolveWorkspacePath } from './workspace-path';
+
+const isWin = process.platform === 'win32';
+
+/** Normalise a path for comparison: forward slashes + lowercase. */
+function norm(p: string): string {
+  return p.replace(/\\/g, '/').toLowerCase();
+}
+
+/** Turn a Windows path like C:\a\b into a WSL /mnt/c/a/b path. */
+function toMnt(winPath: string): string {
+  return '/mnt/' + winPath[0].toLowerCase() + winPath.slice(2).replace(/\\/g, '/');
+}
+
+describe('resolveWorkspacePath', () => {
+  let wsRoot: string;
+
+  beforeEach(() => {
+    // Point MIQI_HOME at a fresh temp dir (no config.json) so the default
+    // workspace rebases to <tmp>/workspace and never reads the real ~/.miqi.
+    const home = join(
+      tmpdir(),
+      `miqi-ws-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    process.env['MIQI_HOME'] = home;
+    wsRoot = getWorkspacePath();
+  });
+
+  afterEach(() => {
+    delete process.env['MIQI_HOME'];
+  });
+
+  it('resolves a workspace-relative path', () => {
+    expect(resolveWorkspacePath('report.md')).toBe(join(wsRoot, 'report.md'));
+  });
+
+  it('resolves a /home/miqi/workspace sandbox path', () => {
+    expect(resolveWorkspacePath('/home/miqi/workspace/report.md')).toBe(join(wsRoot, 'report.md'));
+  });
+
+  it('rejects .. traversal escaping the workspace', () => {
+    expect(() => resolveWorkspacePath('../secret.txt')).toThrow(/outside workspace/);
+  });
+
+  it('rejects an absolute path outside the workspace', () => {
+    const outside = join(wsRoot, '..');
+    expect(() => resolveWorkspacePath(outside)).toThrow(/outside workspace/);
+  });
+
+  // /mnt conversion is Windows-specific (WSL mount paths).
+  const winOnly = isWin ? describe : describe.skip;
+  winOnly('Windows /mnt handling (#955)', () => {
+    it('resolves a /mnt path that stays inside the workspace', () => {
+      const target = join(wsRoot, 'report.md');
+      expect(norm(resolveWorkspacePath(toMnt(target)))).toBe(norm(target));
+    });
+
+    it('rejects a /mnt path outside the workspace', () => {
+      expect(() => resolveWorkspacePath('/mnt/c/Windows/System32/calc.exe')).toThrow(
+        /outside workspace/
+      );
+    });
+
+    it('matches /mnt paths case-insensitively (lowercase drive workspace)', () => {
+      // Configure a workspace with a lowercase drive letter, then resolve a
+      // /mnt path (which uppercases the drive) — must not be rejected.
+      const lowerHome = 'c' + tmpdir().slice(1);
+      process.env['MIQI_HOME'] = join(lowerHome, 'miqi-ws-lower');
+      const lowerWs = getWorkspacePath();
+      const target = join(lowerWs, 'report.md');
+      expect(norm(resolveWorkspacePath(toMnt(target)))).toBe(norm(target));
+    });
+  });
+});

--- a/apps/desktop/src/main/ipc/workspace-path.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.ts
@@ -8,10 +8,12 @@ export function getConfigDir(): string {
   return miqiHome ? miqiHome : join(homedir(), '.miqi');
 }
 
+/** Path to the config JSON file (inside the MIQI_HOME config dir). */
 export function getConfigPath(): string {
   return join(getConfigDir(), 'config.json');
 }
 
+/** Read and parse the local config JSON, returning `{}` when absent or malformed. */
 export function readLocalConfig(): Record<string, unknown> {
   const configPath = getConfigPath();
   try {
@@ -23,6 +25,7 @@ export function readLocalConfig(): Record<string, unknown> {
   }
 }
 
+/** Resolve the configured workspace root (default `~/.miqi/workspace`, rebased to MIQI_HOME). */
 export function getWorkspacePath(): string {
   const config = readLocalConfig();
   const agents = (config['agents'] as Record<string, unknown> | undefined) ?? {};

--- a/apps/desktop/src/main/ipc/workspace-path.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.ts
@@ -1,0 +1,95 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { isAbsolute, join } from 'path';
+
+/** Directory holding the local config file (`~/.miqi` by default, overridable via MIQI_HOME). */
+export function getConfigDir(): string {
+  const miqiHome = process.env['MIQI_HOME']?.trim();
+  return miqiHome ? miqiHome : join(homedir(), '.miqi');
+}
+
+export function getConfigPath(): string {
+  return join(getConfigDir(), 'config.json');
+}
+
+export function readLocalConfig(): Record<string, unknown> {
+  const configPath = getConfigPath();
+  try {
+    if (!existsSync(configPath)) return {};
+    const raw = readFileSync(configPath, 'utf8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function getWorkspacePath(): string {
+  const config = readLocalConfig();
+  const agents = (config['agents'] as Record<string, unknown> | undefined) ?? {};
+  const defaults = (agents['defaults'] as Record<string, unknown> | undefined) ?? {};
+  const raw = (defaults['workspace'] as string) || '~/.miqi/workspace';
+
+  // When using the default path but MIQI_HOME is set, rebase like the Python side does
+  if (raw === '~/.miqi/workspace') {
+    const miqiHome = process.env['MIQI_HOME']?.trim();
+    if (miqiHome) return join(miqiHome, 'workspace');
+  }
+
+  // Expand ~ to home directory
+  if (raw.startsWith('~')) {
+    const stripSep = raw.startsWith('~/') || raw.startsWith('~\\');
+    return join(homedir(), raw.slice(stripSep ? 2 : 1));
+  }
+
+  return raw;
+}
+
+/** Strip sandbox prefix and resolve against the host workspace.
+ *
+ *  The bwrap sandbox mounts at /home/miqi/workspace/.  Paths reported
+ *  by the agent (e.g. /home/miqi/workspace/report.md) are normalised
+ *  to workspace-relative form and then joined with the host workspace
+ *  root.  Absolute paths outside the workspace are rejected.
+ */
+export function resolveWorkspacePath(raw: string): string {
+  // Convert WSL /mnt/<drive>/ paths to Windows <drive>:\ paths
+  // (e.g. /mnt/c/Users/... -> C:\Users\...).  Fold the result into
+  // `normalised` instead of returning early, so the workspace-containment
+  // check below still applies — an early return here let the renderer
+  // escape the workspace via /mnt (security regression #955).
+  const mntMatch = raw.match(/^\/mnt\/([a-zA-Z])\/?(.*)$/);
+
+  const SANDBOX_WS = '/home/miqi/workspace';
+  let normalised = raw;
+  if (mntMatch) {
+    normalised = mntMatch[1].toUpperCase() + ':\\' + mntMatch[2];
+  } else if (normalised === SANDBOX_WS) {
+    normalised = '.';
+  } else if (normalised.startsWith(SANDBOX_WS + '/')) {
+    normalised = normalised.slice(SANDBOX_WS.length + 1);
+  } else if (normalised.startsWith(SANDBOX_WS + '\\')) {
+    normalised = normalised.slice(SANDBOX_WS.length + 1);
+  }
+
+  const wsRoot = getWorkspacePath();
+  let resolved: string;
+  if (isAbsolute(normalised)) {
+    resolved = normalised;
+  } else {
+    resolved = join(wsRoot, normalised);
+  }
+
+  // Enforce workspace containment — prevent escape via .. or absolute
+  // paths that land outside the workspace root.  Case-fold on Windows
+  // (its filesystem is case-insensitive) so a workspace configured with a
+  // lowercase drive letter still matches a /mnt/<DRIVE>/ path.
+  const rel = resolved.replace(/\\/g, '/');
+  const wsNorm = wsRoot.replace(/\\/g, '/');
+  const relCmp = process.platform === 'win32' ? rel.toLowerCase() : rel;
+  const wsCmp = process.platform === 'win32' ? wsNorm.toLowerCase() : wsNorm;
+  if (!(relCmp + '/').startsWith(wsCmp + '/') && relCmp !== wsCmp) {
+    throw new Error(`Path outside workspace: ${raw}`);
+  }
+
+  return resolved;
+}

--- a/apps/desktop/src/main/ipc/workspace-path.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
-import { isAbsolute, join } from 'path';
+import { isAbsolute, join, normalize } from 'path';
 
 /** Directory holding the local config file (`~/.miqi` by default, overridable via MIQI_HOME). */
 export function getConfigDir(): string {
@@ -78,6 +78,12 @@ export function resolveWorkspacePath(raw: string): string {
   } else {
     resolved = join(wsRoot, normalised);
   }
+
+  // Collapse any ".." segments before the containment check.  An absolute
+  // path like C:\ws\..\..\Windows\calc.exe would otherwise pass the
+  // string-prefix check below (its literal ".." looks like it stays inside
+  // ws) while the filesystem resolves it outside the workspace (#955).
+  resolved = normalize(resolved);
 
   // Enforce workspace containment — prevent escape via .. or absolute
   // paths that land outside the workspace root.  Case-fold on Windows

--- a/apps/desktop/src/main/ipc/workspace-path.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
-import { isAbsolute, join, normalize } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 
 /** Directory holding the local config file (`~/.miqi` by default, overridable via MIQI_HOME). */
 export function getConfigDir(): string {
@@ -74,19 +74,18 @@ export function resolveWorkspacePath(raw: string): string {
     normalised = normalised.slice(SANDBOX_WS.length + 1);
   }
 
-  const wsRoot = getWorkspacePath();
+  // Resolve both the workspace root and the candidate to normalized absolute
+  // paths so ".." segments are collapsed before the prefix comparison.  An
+  // absolute path like C:\ws\..\..\Windows\calc.exe would otherwise keep its
+  // literal ".." (which looks like it stays inside ws) while the filesystem
+  // resolves it outside the workspace (#955).
+  const wsRoot = resolve(getWorkspacePath());
   let resolved: string;
   if (isAbsolute(normalised)) {
-    resolved = normalised;
+    resolved = resolve(normalised);
   } else {
-    resolved = join(wsRoot, normalised);
+    resolved = resolve(wsRoot, normalised);
   }
-
-  // Collapse any ".." segments before the containment check.  An absolute
-  // path like C:\ws\..\..\Windows\calc.exe would otherwise pass the
-  // string-prefix check below (its literal ".." looks like it stays inside
-  // ws) while the filesystem resolves it outside the workspace (#955).
-  resolved = normalize(resolved);
 
   // Enforce workspace containment — prevent escape via .. or absolute
   // paths that land outside the workspace root.  Case-fold on Windows

--- a/apps/desktop/src/main/ipc/workspace-path.ts
+++ b/apps/desktop/src/main/ipc/workspace-path.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import { homedir } from 'os';
 import { isAbsolute, join, resolve } from 'path';
 
@@ -100,4 +100,24 @@ export function resolveWorkspacePath(raw: string): string {
   }
 
   return resolved;
+}
+
+/**
+ * Whether an existing host path resolves (symlinks/junctions followed) to a
+ * location inside the workspace root.  Returns true when the path cannot be
+ * resolved (e.g. it does not exist) — those are already covered by the lexical
+ * containment check in resolveWorkspacePath.
+ */
+export function isWithinCanonicalWorkspace(candidate: string, wsRoot: string): boolean {
+  try {
+    const realCandidate = realpathSync.native(candidate);
+    const realRoot = realpathSync.native(wsRoot);
+    const rel = realCandidate.replace(/\\/g, '/');
+    const root = realRoot.replace(/\\/g, '/');
+    const relCmp = process.platform === 'win32' ? rel.toLowerCase() : rel;
+    const rootCmp = process.platform === 'win32' ? root.toLowerCase() : root;
+    return relCmp === rootCmp || relCmp.startsWith(rootCmp + '/');
+  } catch {
+    return true;
+  }
 }

--- a/apps/desktop/tests/e2e/open-external-path-security.spec.ts
+++ b/apps/desktop/tests/e2e/open-external-path-security.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * E2E: files.openExternal / openContainingFolder 拒绝 workspace 外路径 (#955)
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts --project=electron open-external-path-security.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+import { launchElectronApp, closeElectronApp } from './helpers/electron-setup';
+
+test.skip(process.platform !== 'win32', 'Windows-only: /mnt path conversion');
+
+test('rejects host paths outside the workspace (#955)', async () => {
+  const { electronApp, page } = await launchElectronApp((config) => {
+    // Force the default workspace (rebased to MIQI_HOME) so C:\Windows is
+    // guaranteed outside it, regardless of the developer's config.
+    if (config.agents?.defaults) delete (config.agents.defaults as any).workspace;
+  });
+
+  try {
+    // Wait for the preload bridge to expose window.miqi.
+    await page.evaluate(async () => {
+      for (let i = 0; i < 120; i++) {
+        try {
+          if ((window as any).miqi?.runtime) return;
+        } catch {
+          /* preload not injected yet */
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    });
+
+    // 1. /mnt/c/... escape → resolveWorkspacePath throws → invoke rejects.
+    const openExternal = await page.evaluate(async () => {
+      try {
+        const r = await (window as any).miqi.files.openExternal('/mnt/c/Windows/System32/calc.exe');
+        return { threw: false, result: r };
+      } catch (e: any) {
+        return { threw: true, message: String(e?.message ?? e) };
+      }
+    });
+    expect(
+      openExternal.threw,
+      `openExternal should reject, got: ${JSON.stringify(openExternal)}`
+    ).toBe(true);
+
+    // 2. Absolute path outside workspace → the isAbsolute+exists fast path is
+    //    gone, so resolveWorkspacePath rejects it too.
+    const openFolder = await page.evaluate(async () => {
+      try {
+        const r = await (window as any).miqi.files.openContainingFolder('C:\\Windows\\System32');
+        return { threw: false, result: r };
+      } catch (e: any) {
+        return { threw: true, message: String(e?.message ?? e) };
+      }
+    });
+    expect(openFolder.threw).toBe(true);
+  } finally {
+    await closeElectronApp(electronApp);
+  }
+});


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 openExternal/openContainingFolder 的 workspace 包含性校验可被 /mnt 路径与绝对路径快速通道绕过的问题。

## 背景/问题

`files:openExternal` 与 `files:openContainingFolder` 的 workspace 包含性校验可被绕过，渲染进程可借此打开/执行宿主任意文件（issue #955）：

1. `resolveWorkspacePath` 的 `/mnt` 分支提前 `return`，把 `/mnt/c/...` 转成 `C:\...` 后直接返回，跳过了下方的 workspace 包含性校验 → `openExternal` 可 `shell.openPath` 打开宿主任意 exe。
2. `openContainingFolder` 的「绝对路径 + 存在」快速通道（`isAbsolute(clean) && existsSync(clean)` → `showItemInFolder`）完全绕过校验，可定位宿主任意目录。
3. 包含性校验用字符串前缀比较，绝对路径含字面 `..` 时（如 `C:\ws\..\..\Windows\calc.exe`）会通过前缀判断，但文件系统解析后逃出 workspace。

## 关联 issue

- Closes #955

## 变更内容

- 将 `resolveWorkspacePath` / `getWorkspacePath` / `readLocalConfig` / `getConfigDir` / `getConfigPath` 抽到纯函数模块 `workspace-path.ts`（无 electron 依赖，便于单测）；`index.ts` re-export `getWorkspacePath` 保持对外 API 不变（qraft/ipc.ts 仍从 `../ipc` import）。
- `/mnt` 转换不再提前 `return`，而是融入 `normalised` 继续走下方包含性校验。
- 删除 `openContainingFolder` 的「绝对路径 + 存在」快速通道，统一走 `resolveWorkspacePath(clean)`。
- 包含性校验前先 `normalize` 折叠 `..` 段，堵住绝对路径遍历绕过。
- Windows 下包含性校验做大小写折叠，避免误拒 `/mnt/<DRIVE>/` 路径。

## 日志/验证证据

```
$ npx vitest run src/main/ipc/workspace-path.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)

$ npx vitest run
Test Files  37 passed | 2 skipped (39)
     Tests  465 passed | 5 skipped (470)

$ npm run typecheck   # node + web 均通过
$ npm run build       # ✓ built in 9.19s

$ npx playwright test --config=playwright.config.ts --project=electron open-external-path-security.spec.ts
  1 passed (5.2s)
```

## 测试情况

- 单测 `workspace-path.test.ts` 9 个用例，覆盖 /mnt 逃逸、绝对路径、`..` 遍历（含绝对路径字面 `..`）、大小写折叠；全量单测 465 passed / 0 failed。
- E2E `open-external-path-security.spec.ts`（Windows-only）端到端验证两条恶意路径被拒绝，1 passed。
- `npm run typecheck`（node + web）、`npm run build` 均通过。

## 截图

![#955 安全验证：workspace 外路径已被拒绝](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/955-evidence-fd53ec0f101e.png)