### PR TITLE
fix(#983): skill 产物进任务附件——tracked 存储根解耦 + store key 统一 + 下载产物登记 + 面板级 e2e

### DIFF
--- a/apps/desktop/tests/e2e/fixtures/create_pdf_mock.py
+++ b/apps/desktop/tests/e2e/fixtures/create_pdf_mock.py
@@ -26,7 +26,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 # The filename the spec puts into the user message (ASCII or CJK, one path
 # segment).  \w is Unicode-aware in Python, so 报告.pdf matches too.
-_PDF_RE = re.compile(r"[\w.\-]+\.pdf")
+# Bounded quantifier and NO '.' inside the class: the class cannot overlap the
+# literal '\.pdf' that follows, so scanning is linear on arbitrary message
+# text (CodeQL py/polynomial-redos).  A dotted name like a.v2.pdf still
+# resolves to its last segment — fine, the spec owns the filename.
+_PDF_RE = re.compile(r"[\w-]{1,64}\.pdf")
 
 _TOOL_NAME = "create_pdf"
 

--- a/apps/desktop/tests/e2e/fixtures/create_pdf_mock.py
+++ b/apps/desktop/tests/e2e/fixtures/create_pdf_mock.py
@@ -1,0 +1,180 @@
+"""Minimal deterministic OpenAI-compatible mock that drives ONE create_pdf call.
+
+Round 1 — the LATEST user message names a ``*.pdf`` file and no create_pdf
+call is in the request history yet: answer with a single ``create_pdf``
+tool_call for that filename (the filename travels in the user message, so the
+spec never has to tell the mock anything out of band).
+
+Every other request (no ``*.pdf`` in the latest user message, or the call
+already happened) answers with plain text ``created <file> (mock complete).``.
+
+ASCII-only on purpose: the spec asserts on this string, and CI runners may
+lack a CJK font, so neither the reply text nor the PDF title carries CJK.
+
+Answers GET /v1/models and POST /v1/chat/completions in both wire formats —
+``stream: true`` is served as SSE, exactly like scripts/mock_openai.py (a
+plain JSON body to a streaming request yields zero chunks and the turn ends
+empty).  Prints its bound URL as "http://127.0.0.1:<port>/v1".
+
+Self-contained on purpose: exercising the doc-tool tracked store must not
+depend on the confirm-card state machine in scripts/mock_openai.py.
+"""
+import json
+import re
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# The filename the spec puts into the user message (ASCII or CJK, one path
+# segment).  \w is Unicode-aware in Python, so 报告.pdf matches too.
+_PDF_RE = re.compile(r"[\w.\-]+\.pdf")
+
+_TOOL_NAME = "create_pdf"
+
+
+def _last_user(messages):
+    return next(
+        (str(m.get("content") or "") for m in reversed(messages) if m.get("role") == "user"),
+        "",
+    )
+
+
+def _already_called(messages):
+    """True when the conversation already carries a create_pdf tool_call."""
+    for m in messages:
+        if m.get("role") != "assistant":
+            continue
+        for tc in m.get("tool_calls") or []:
+            if ((tc.get("function") or {}).get("name") or "") in (_TOOL_NAME, "pdf_write"):
+                return True
+    return False
+
+
+def _reply(messages):
+    """Pick the response for this request: tool_call or plain text."""
+    filename = None
+    m = _PDF_RE.search(_last_user(messages))
+    if m:
+        # Must be set BEFORE the tool-call branch: round 2 (tool already in
+        # history) takes the text branch and reports the same filename back.
+        filename = m.group(0)
+    if m and not _already_called(messages):
+        args = {
+            "filename": filename,
+            "title": "#983 panel e2e",
+            "content": [{"type": "paragraph", "text": "created by create_pdf_mock.py"}],
+        }
+        return {
+            "id": "chatcmpl-mock-tool",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "mock",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_create_pdf",
+                        "type": "function",
+                        "function": {
+                            "name": _TOOL_NAME,
+                            "arguments": json.dumps(args, ensure_ascii=False),
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+        }
+    text = f"created {filename} (mock complete)." if filename else "ok."
+    return {
+        "id": "chatcmpl-mock-final",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "mock",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": text},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_GET(self):
+        if self.path.startswith("/v1/models"):
+            self._json({"object": "list", "data": [{"id": "mock", "object": "model"}]})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            req = json.loads(raw or b"{}")
+        except ValueError:
+            self._json({"error": {"message": "bad json"}})
+            return
+        obj = _reply(req.get("messages") or [])
+        if req.get("stream"):
+            self._sse(obj)
+        else:
+            self._json(obj)
+
+    def _sse(self, obj):
+        """Streaming response: one full-message chunk + finish chunk + [DONE]."""
+        msg = obj["choices"][0]["message"]
+        tool_calls = msg.get("tool_calls")
+        if tool_calls:
+            delta = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "index": i,
+                        "id": tc["id"],
+                        "type": "function",
+                        "function": tc["function"],
+                    }
+                    for i, tc in enumerate(tool_calls)
+                ],
+            }
+            finish = "tool_calls"
+        else:
+            delta = {"role": "assistant", "content": msg.get("content") or ""}
+            finish = "stop"
+        chunks = [
+            {"choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
+            {"choices": [{"index": 0, "delta": {}, "finish_reason": finish}]},
+        ]
+        body = "".join(
+            "data: " + json.dumps(c, ensure_ascii=False) + "\n\n" for c in chunks
+        ) + "data: [DONE]\n\n"
+        self._send(body.encode("utf-8"), "text/event-stream")
+
+    def _json(self, obj):
+        self._send(json.dumps(obj, ensure_ascii=False).encode("utf-8"), "application/json")
+
+    def _send(self, body, content_type):
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    port = int(sys.argv[1])
+    srv = ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    print(f"http://127.0.0.1:{port}/v1", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/desktop/tests/e2e/issue-983-doc-tool-assets.spec.ts
+++ b/apps/desktop/tests/e2e/issue-983-doc-tool-assets.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * Issue #983 — 文档工具（create_pdf）产物必须落进「本会话」的 tracked 存储，
+ * 不能落成 <sessionDir>/files/sessions/<key>/tracked_files.json 这条孤儿路径。
+ *
+ * 背景：create_pdf/docx/pptx/xlsx 注册时的 workspace 是 <ws>/sessions/<key>/files，
+ * 而 _persist_tracked_file 直接把它当存储根喂给 SessionManager → 条目写到
+ * <files>/sessions/<key>/tracked_files.json，资产面板永远读不到。#1003 把存储根
+ * 剥回 <ws>（_tracked_store_root）+ store key 与目录名派生同源（_session_files_dir_key）。
+ *
+ * 本 spec 用本地确定性 mock（fixtures/create_pdf_mock.py）驱动一次真实
+ * create_pdf 工具调用，再分别从磁盘与 IPC 两条读端验证落点。
+ *
+ * 断言分层（判别性只认 ④-a/④-b/④-c）：
+ *   ④-a canonical：<sessionDir>/tracked_files.json 存在且 files 键含该文件
+ *   ④-b 孤儿：<sessionDir>/files 下递归找不到任何 tracked_files.json
+ *   ④-c 面板读端同源：sessions.getTrackedFiles(真实 IPC) 返回该文件
+ *   ①  smoke：资产面板出现卡片 —— ChatConsole 对 create_pdf 无条件 trackFile
+ *      （_FILE_WRITE_TOOLS），未修复的 develop 上也会绿，故只作 smoke，不作证据。
+ *
+ * 前提：本 spec 仅在 session_workspace_enabled=true 下有效（关掉后产物落
+ * <ws>/<file>、findSessionDirWithFile 返回 null → 假红）。本机 ~/.miqi/config.json
+ * 为 true；CI 未设 → 默认 True（miqi/config/schema.py:237）。下方有显式 guard。
+ *
+ * Run: cd apps/desktop && npx playwright test --config=playwright.config.ts \
+ *      --project=electron --workers=1 issue-983-doc-tool-assets.spec.ts
+ *      (--workers=1: one Electron app + one Python mock per run — no reason to
+ *      contend for CPU with sibling specs, and it keeps the mock port single.)
+ */
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  waitForBridgeInitialized,
+  launchElectronApp,
+  closeElectronApp,
+  ensurePersistedSession,
+  APPS_DESKTOP,
+} from './helpers/electron-setup';
+
+const REPO_ROOT = join(APPS_DESKTOP, '..', '..');
+
+// ─── Mock ─────────────────────────────────────────────────────────────
+
+/** Start the deterministic create_pdf mock and wait for its bound URL. */
+async function startCreatePdfMock(): Promise<{ proc: ChildProcess; url: string }> {
+  // Windows venv 用 Scripts/python.exe，posix 用 bin/python（同 regression-delete-all-focus）。
+  const python =
+    process.platform === 'win32'
+      ? join(REPO_ROOT, '.venv', 'Scripts', 'python.exe')
+      : join(REPO_ROOT, '.venv', 'bin', 'python');
+  // 随机端口：避免 workers 并发碰撞（同 regression-delete-all-focus:47）。
+  const port = 20000 + Math.floor(Math.random() * 20000);
+  const proc = spawn(
+    python,
+    [join(APPS_DESKTOP, 'tests', 'e2e', 'fixtures', 'create_pdf_mock.py'), String(port)],
+    {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, PYTHONUNBUFFERED: '1' },
+      windowsHide: true,
+    }
+  );
+  let url = '';
+  let errTail = '';
+  proc.stdout?.on('data', (d) => {
+    const m = String(d).match(/http:\/\/127\.0\.0\.1:(\d+)\/v1/);
+    if (m) url = `http://127.0.0.1:${m[1]}/v1`;
+  });
+  proc.stderr?.on('data', (d) => (errTail = (errTail + String(d)).slice(-2000)));
+  const deadline = Date.now() + 30_000;
+  while (!url && Date.now() < deadline) {
+    if (proc.exitCode !== null) {
+      proc.kill();
+      throw new Error(`create_pdf mock exited early: ${errTail}`);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!url) {
+    proc.kill();
+    throw new Error(`create_pdf mock startup line not seen in 30s: ${errTail}`);
+  }
+  return { proc, url };
+}
+
+// ─── Disk helpers ─────────────────────────────────────────────────────
+
+/**
+ * First session directory under *sessionsDir* whose files/ holds *filename*.
+ *
+ * Returns the SESSION DIRECTORY (`<sessionsDir>/<key>`), NOT the file path —
+ * ④-b joins 'files' onto it, and returning the file path would make that
+ * join a nonexistent dir (always empty ⇒ ④-b green even on unfixed develop).
+ * The sibling helper findFileInSessionDirs (delivery-path-truth.spec.ts)
+ * returns a file path and must NOT be copied here.
+ */
+function findSessionDirWithFile(sessionsDir: string, filename: string): string | null {
+  if (!existsSync(sessionsDir)) return null;
+  for (const entry of readdirSync(sessionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sessionDir = join(sessionsDir, entry.name);
+    if (existsSync(join(sessionDir, 'files', filename))) return sessionDir;
+  }
+  return null;
+}
+
+/** Every tracked_files.json under *root* (recursive) — the orphan hunt. */
+function findTrackedFilesJson(root: string): string[] {
+  const found: string[] = [];
+  if (!existsSync(root)) return found;
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const p = join(root, entry.name);
+    if (entry.isDirectory()) found.push(...findTrackedFilesJson(p));
+    else if (entry.name === 'tracked_files.json') found.push(p);
+  }
+  return found;
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────
+
+test.describe('Issue #983 — doc-tool artifacts land in the session tracked store', () => {
+  // Same localhost restriction as confirm-card.spec: the macOS CI runner's
+  // undici fetch cannot reach a local 127.0.0.1 listener.
+  test.skip(
+    process.platform === 'darwin' && !!process.env.CI,
+    'macOS CI cannot reach the local mock server'
+  );
+
+  let electronApp: ElectronApplication;
+  let page: Page;
+  let miqiHome: string;
+  let miqiSessionsDir: string;
+  let mock: ChildProcess;
+
+  test.beforeAll(async () => {
+    const m = await startCreatePdfMock();
+    mock = m.proc;
+    const fixture = await launchElectronApp((config: any) => {
+      // Point EVERY configured provider at the mock (provider resolution is
+      // driven by agents.defaults.model) — the mock ignores model names/keys.
+      const providers = config.providers ?? {};
+      for (const [name, p] of Object.entries(providers)) {
+        if (p && typeof p === 'object') {
+          (p as any).apiBase = m.url;
+          if (!(p as any).apiKey) (p as any).apiKey = 'mock-key';
+        }
+      }
+      config.providers = providers;
+      // Deterministic native paths: no WSL sandbox in this spec.
+      config.tools = { ...config.tools, sandbox: { ...config.tools?.sandbox, enabled: false } };
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+    miqiHome = fixture.miqiHome;
+    miqiSessionsDir = fixture.miqiSessionsDir;
+    await waitForBridgeInitialized(page);
+  }, 180_000);
+
+  test.afterAll(async () => {
+    await closeElectronApp(electronApp, miqiHome);
+    mock?.kill();
+  });
+
+  test(
+    'create_pdf 产物落 canonical tracked 存储、无孤儿存储、面板读端同源',
+    { timeout: LLM_TIMEOUT },
+    async () => {
+      // Precondition guard: with per-session workspace isolation OFF the
+      // artifact lands at <ws>/<file> and every disk assertion below becomes
+      // a false red. Skip loudly instead of blaming #983.
+      const wsEnabled = await page.evaluate(async () => {
+        const c: any = await (window as any).miqi.config.get();
+        const sessions = c?.agents?.sessions ?? c?.agents?.defaults?.sessionConfig;
+        return sessions?.sessionWorkspaceEnabled ?? sessions?.session_workspace_enabled ?? null;
+      });
+      test.skip(
+        wsEnabled === false,
+        'session_workspace_enabled=false — this spec only covers the session-workspace layout'
+      );
+
+      // ≤30 chars on purpose: TrackedFileCard.tsx:73 renders
+      // `name.length > 30 ? slice(0,28)+'…' : name`, so a longer filename
+      // never appears verbatim in the panel DOM and the smoke card
+      // assertion below could never match.
+      const filename = `p983_${Date.now()}.pdf`;
+      // ASCII-only turn: the mock keys off the *.pdf filename alone, and CI
+      // runners may lack a CJK font — nothing here may depend on CJK glyphs.
+      const userText = `Please use create_pdf to create a PDF named ${filename}.`;
+
+      await sendMessage(page, userText);
+
+      // Session key from the live list. ensurePersistedSession() is the
+      // documented accessor (#774: list[0] is not necessarily the CURRENT
+      // session, empty sessions never persist). Wait for the user message to
+      // persist FIRST so the helper cannot fall back to seeding a second
+      // message — that seed would race this turn and flip the mock to text.
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(async () => {
+              const all = await (window as any).miqi.sessions.list();
+              return (all?.sessions ?? []).length;
+            }),
+          { timeout: 60_000 }
+        )
+        .toBeGreaterThan(0);
+      const sessionKey = await ensurePersistedSession(page);
+      console.log(`[test] session key = ${sessionKey}`);
+
+      // Turn end: the panel's backend refresh hangs off the turn-end handler.
+      // Wait for the mock's final text (unique per turn) before the generic
+      // settle, so a still-running reportlab call cannot look "stable".
+      await expect(
+        page.locator('main').getByText(`created ${filename}`, { exact: false }).first()
+      ).toBeVisible({ timeout: LLM_TIMEOUT });
+      await waitForResponseComplete(page, LLM_TIMEOUT);
+
+      // ── ④-a canonical: session dir holds the artifact AND its tracked store.
+      //    (develop: artifact yes, tracked_files.json is one level deeper → red)
+      let sessionDir: string | null = null;
+      const deadline = Date.now() + 60_000;
+      while (!sessionDir && Date.now() < deadline) {
+        sessionDir = findSessionDirWithFile(miqiSessionsDir, filename);
+        if (!sessionDir) await page.waitForTimeout(500);
+      }
+      expect(
+        sessionDir,
+        `artifact ${filename} never appeared under ${miqiSessionsDir}/*/files/`
+      ).not.toBeNull();
+      console.log(`[test] session dir = ${sessionDir}`);
+
+      const trackedPath = join(sessionDir!, 'tracked_files.json');
+      expect(existsSync(trackedPath), `canonical tracked store missing: ${trackedPath}`).toBe(true);
+      const tracked = JSON.parse(readFileSync(trackedPath, 'utf-8'));
+      const trackedKeys = Object.keys(tracked.files ?? {});
+      expect(
+        trackedKeys.some((k) => k === filename || k.endsWith(`/${filename}`)),
+        `canonical store keys = ${JSON.stringify(trackedKeys)}`
+      ).toBe(true);
+      console.log('[test] ✅ ④-a canonical tracked store contains the artifact');
+
+      // ── ④-b no orphan store under the session's files/ (develop writes
+      //    <files>/sessions/<key>/tracked_files.json → red).
+      const orphans = findTrackedFilesJson(join(sessionDir!, 'files'));
+      expect(orphans, `orphan tracked store(s): ${orphans.join(', ')}`).toEqual([]);
+      console.log('[test] ✅ ④-b no orphan tracked store under <sessionDir>/files');
+
+      // ── ④-c panel read path (real IPC → bridge → SessionManager.load_tracked_files
+      //    with ownership check): the same store the panel reads.
+      const tf: any = await page.evaluate(
+        (k) => (window as any).miqi.sessions.getTrackedFiles(k),
+        sessionKey
+      );
+      const tfList: any[] = tf?.tracked_files ?? [];
+      expect(
+        tfList.some(
+          (f) =>
+            f?.name === filename ||
+            f?.path === filename ||
+            String(f?.path ?? '').endsWith(`/${filename}`)
+        ),
+        `getTrackedFiles returned ${JSON.stringify(tfList)}`
+      ).toBe(true);
+      console.log('[test] ✅ ④-c sessions.getTrackedFiles sees the artifact');
+
+      // ── ① smoke only (green on unfixed develop too — NOT #983 evidence).
+      const card = page
+        .getByTestId('task-assets-panel')
+        .locator('.rounded-lg.p-2\\.5', { hasText: filename })
+        .last();
+      await expect(card).toBeVisible({ timeout: 60_000 });
+      console.log('[test] ✅ ① smoke: asset panel card rendered');
+
+      // Per e2e-test-workflow skill: every run ends with a visual proof.
+      await page.screenshot({
+        path: `test-results/issue-983-doc-tool-assets-${test.info().title.replace(/\s+/g, '-')}.png`,
+        fullPage: true,
+      });
+    }
+  );
+});

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -546,6 +546,10 @@ def _session_files_dir_key(session_key: str) -> str:
     ``desktop_1786...``) and keeps the whole key for two-segment channel
     keys (``desktop:1786...`` → ``desktop_1786...``) — matching the disk
     convention used by ``files.read`` and attachment saving.
+
+    Idempotent: feeding an already-derived key back in returns it
+    unchanged, so callers may pass either the raw key or a derived key
+    (``_tracked_store_root`` relies on this for its dir-name check).
     """
     from miqi.utils.helpers import safe_filename
 

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -188,6 +188,45 @@ def _effective_shared_roots(
     return merged
 
 
+def _tracked_store_root(workspace: Path | None, session_key: str | None) -> Path | None:
+    """把「默认工作区下的会话 files 目录」剥回默认工作区根（tracked 存储根）。
+
+    ``create_pdf/docx/pptx/xlsx`` 等文档工具注册时的 workspace 是
+    ``<ws>/sessions/<key>/files``。tracked 条目的存储根必须是 ``<ws>``
+    （``SessionManager(<ws>)`` → ``<ws>/sessions/<key>/tracked_files.json``），
+    否则条目会落到 ``<files>/sessions/<key>/tracked_files.json`` 这条孤儿路径，
+    资产面板永远读不到。
+
+    只有形状（``.../sessions/<key>/files``）与默认根都匹配时才剥离：
+    - 拿不到默认根（异常）→ 不剥（fail-closed）；
+    - 自定义工作区（``base != get_miqi_home()/workspace``）→ 不剥；
+    - 目录名不是本会话的派生名 → 不剥（一致性校验）；
+    - ``session_key`` 为空 → 不剥。
+    """
+    if workspace is None:
+        return None
+    ws = Path(workspace).expanduser()          # 归一（防 str 入参）
+    try:
+        ws = ws.resolve()
+    except Exception:
+        return ws                              # 解析失败 → 不剥
+    if not session_key:
+        return ws
+    if ws.name != "files" or ws.parent.parent.name != "sessions":
+        return ws                              # 形状不符 → 不剥
+    base = ws.parent.parent.parent
+    try:
+        from miqi.paths import get_miqi_home
+        default_base = (get_miqi_home() / "workspace").resolve()
+    except Exception:
+        return ws                              # fail-closed：拿不到默认根绝不剥
+    if base != default_base:
+        return ws                              # 自定义工作区 → 不剥
+    if ws.parent.name != _session_files_dir_key(session_key):
+        return ws                              # 目录名非本会话派生名 → 不剥
+    return base
+
+
 def _persist_tracked_file(
     workspace: Path | None,
     file_path: str | Path,
@@ -205,15 +244,9 @@ def _persist_tracked_file(
         return
     try:
         from miqi.session.manager import SessionManager
-        sm = SessionManager(workspace)
-        # Strip the client_id prefix.  The orchestrator passes
-        # ctx.session_id which has the form "<client_id>:<session_key>"
-        # (e.g. "miqi-desktop:desktop:1784099553254"), but the frontend
-        # and SessionManager use just "<session_key>" as the lookup key.
-        if ":" in session_key:
-            parts = session_key.split(":", 1)
-            if len(parts) == 2 and parts[0] != "desktop":
-                session_key = parts[1]
+        # 修复 B：store key 与目录名派生同源（替换原 :213-216 的 client_id 剥离规则）
+        session_key = _session_files_dir_key(session_key)
+        sm = SessionManager(_tracked_store_root(workspace, session_key) or workspace)
         # Use workspace-relative paths for consistent reads across sessions
         rel_path = str(file_path)
         ws_str = str(workspace.resolve()).replace("\\", "/")

--- a/miqi/agent/tools/mcp_download_sink.py
+++ b/miqi/agent/tools/mcp_download_sink.py
@@ -48,6 +48,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
+from loguru import logger
+
 # ── 限额（v6.2 §5.1）────────────────────────────────────────────────────────
 
 # 最终文件累计字节上限。
@@ -428,12 +430,15 @@ def sanitize_name(name: str) -> str:
     return cleaned
 
 
-def resolve_downloads_dir(base_workspace: Path, session_key: str) -> Path:
-    """会话落盘根（v6.2 §R1）：复用 filesystem 的会话目录权威逻辑。
+_DOWNLOADS_RELDIR = Path(".miqi") / "downloads"
 
-    默认 workspace → ``<ws>/sessions/<safe_key>/files/.miqi/downloads``
-    （文件工具合法根内，模型可直接读/搬，不跨会话互见）；自选项目目录 /
-    空 session_key → ``<ws>/.miqi/downloads``。**不在此文件自创目录算法**。
+
+def _downloads_root_base(base_workspace: Path, session_key: str) -> Path:
+    """会话落盘与 tracked 登记的共同根：会话 files 目录 / 工作区根。
+
+    默认 workspace → ``<ws>/sessions/<safe_key>/files``（文件工具合法根，
+    模型可直接读/搬，不跨会话互见）；自选项目目录 / 空 session_key →
+    ``<base_workspace>``。**不在此文件自创目录算法**。
     """
     from miqi.agent.tools.filesystem import _session_files_dir_for_key
 
@@ -441,7 +446,17 @@ def resolve_downloads_dir(base_workspace: Path, session_key: str) -> Path:
     base = session_files_dir if session_files_dir is not None else base_workspace
     if base is None:
         raise DownloadPathError("下载失败：会话工作区不可用（workspace 为空）。")
-    return base / ".miqi" / "downloads"
+    return base
+
+
+def resolve_downloads_dir(base_workspace: Path, session_key: str) -> Path:
+    """会话落盘根（v6.2 §R1）：复用 filesystem 的会话目录权威逻辑。
+
+    默认 workspace → ``<ws>/sessions/<safe_key>/files/.miqi/downloads``
+    （文件工具合法根内，模型可直接读/搬，不跨会话互见）；自选项目目录 /
+    空 session_key → ``<ws>/.miqi/downloads``。**不在此文件自创目录算法**。
+    """
+    return _downloads_root_base(base_workspace, session_key) / _DOWNLOADS_RELDIR
 
 
 def _ensure_contained(root: Path, target: Path) -> Path:
@@ -882,7 +897,11 @@ class DownloadSink:
         解析在事件循环内（纯 CPU 且受 16MiB 门保护）；decode/写盘在
         ``asyncio.to_thread``——大文件不阻塞主循环。
         """
-        downloads_dir = resolve_downloads_dir(self._base_workspace, session_key)
+        # 落盘根与 tracked 登记根同源（#983 缺口 2）：tracking_base 是会话
+        # files 目录（默认工作区）或工作区根，条目键即 ``.miqi/downloads/<name>``，
+        # 面板 ``files.read`` 能按同一根解析到产物。
+        tracking_base = _downloads_root_base(self._base_workspace, session_key)
+        downloads_dir = tracking_base / _DOWNLOADS_RELDIR
         self._sweep_stale_once(downloads_dir)
 
         parsed = parse_mcp_result(result)
@@ -931,17 +950,45 @@ class DownloadSink:
             # 命名分配临界区在工作线程内的 plan→rename 段（_NAMING_LOCK），
             # 锁外不持有任何全局互斥 → 并发下载的 decode/写盘不互相串行。
             if parsed.multi_chunk:
-                return await asyncio.to_thread(
+                artifact = await asyncio.to_thread(
                     self._accept_chunks_sync,
                     parsed=parsed, identity=identity,
                     downloads_dir=downloads_dir,
                     turn_id=turn_id, tool_call_id=tool_call_id,
                 )
-            return await asyncio.to_thread(
-                self._materialize_single_sync,
-                parsed=parsed, identity=identity,
-                downloads_dir=downloads_dir,
-                turn_id=turn_id, tool_call_id=tool_call_id,
+            else:
+                artifact = await asyncio.to_thread(
+                    self._materialize_single_sync,
+                    parsed=parsed, identity=identity,
+                    downloads_dir=downloads_dir,
+                    turn_id=turn_id, tool_call_id=tool_call_id,
+                )
+
+        # #983 缺口 2：产物已提交 → 登记进会话 tracked（任务附件面板可见，
+        # 用户可经 #877「下载/另存为」导出）。在身份锁外执行，且登记失败
+        # 只降级为「面板看不到」，绝不把已交付的文件报成下载失败。
+        await asyncio.to_thread(self._track_delivered, artifact, tracking_base)
+        return artifact
+
+    def _track_delivered(self, artifact: DownloadArtifact, tracking_base: Path) -> None:
+        """交付成功后写 tracked_files.json（与 create_pdf 同机制）。
+
+        ``_persist_tracked_file`` 内部按 ``_tracked_store_root`` 把默认工作区下
+        的会话 files 目录剥回存储根，故条目落
+        ``<ws>/sessions/<derived_key>/tracked_files.json``（面板读端同一份）。
+        """
+        try:
+            from miqi.agent.tools.filesystem import _persist_tracked_file
+
+            _persist_tracked_file(
+                tracking_base,
+                artifact.path,
+                op="write",
+                session_key=artifact.identity.session_key,
+            )
+        except Exception as exc:  # 登记是旁路，绝不改交付结果
+            logger.warning(
+                "download artifact tracking failed: path={} err={}", artifact.path, exc
             )
 
     # ── 单包路径（C1 语义不变，拆出入参以便与分片共享身份/目录决策）──────

--- a/miqi/agent/tools/mcp_download_sink.py
+++ b/miqi/agent/tools/mcp_download_sink.py
@@ -898,8 +898,9 @@ class DownloadSink:
         ``asyncio.to_thread``——大文件不阻塞主循环。
         """
         # 落盘根与 tracked 登记根同源（#983 缺口 2）：tracking_base 是会话
-        # files 目录（默认工作区）或工作区根，条目键即 ``.miqi/downloads/<name>``，
-        # 面板 ``files.read`` 能按同一根解析到产物。
+        # files 目录（默认工作区）或工作区根，条目键即 ``.miqi/downloads/<name>``。
+        # 默认工作区布局下面板 ``files.read`` 按同一根解析到产物；自选工作区
+        # 布局下读端仍锚 ``<ws>/sessions/<key>/files``（既有语义，见 PR 后续计划）。
         tracking_base = _downloads_root_base(self._base_workspace, session_key)
         downloads_dir = tracking_base / _DOWNLOADS_RELDIR
         self._sweep_stale_once(downloads_dir)

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -2979,13 +2979,12 @@ class ExecTool(Tool):
         except Exception:
             return
         try:
+            from miqi.agent.tools.filesystem import _session_files_dir_key
             from miqi.session.manager import SessionManager
             sm = SessionManager(workspace)
-            # Strip the client_id prefix (same rule as _persist_tracked_file).
-            if ":" in session_key:
-                parts = session_key.split(":", 1)
-                if len(parts) == 2 and parts[0] != "desktop":
-                    session_key = parts[1]
+            # Store key 与目录名派生同源（与 _persist_tracked_file 一致）：
+            # ``cli:direct`` → ``cli_direct``，exec 产物与文档产物落同一会话目录。
+            session_key = _session_files_dir_key(session_key)
             sm.save_tracked_files_batch(
                 session_key, [(p, "write") for p in changed],
             )

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -59,7 +59,8 @@ def _tracked_files_store_key(session_key: str) -> str:
     ``key.replace(":", "_")``（``get_session_dir`` 的目录名规则）逐字相同，
     故本次归一不改变既有行为；只有三段 key 才会分叉。
 
-    归一发生在 ownership 校验之前，校验仍由 ``load_tracked_files(key,
+    归一发生在 ownership 校验之前：读路径由 ``load_tracked_files(key,
+    client_id=...)`` 内部、清理路径由 ``clear_tracked_files(key,
     client_id=...)`` 内部的 ``_verify_ownership_for_mutation`` 完成，且落在
     「条目所在的那条会话记录」上（``get_session_dir(key)`` 同一条派生链），
     因此不削弱归属校验。

--- a/miqi/runtime/session_handlers.py
+++ b/miqi/runtime/session_handlers.py
@@ -46,6 +46,29 @@ def _client_session_id(client_id: str, session_key: str) -> str:
     return f"{client_id}:{session_key}"
 
 
+def _tracked_files_store_key(session_key: str) -> str:
+    """Derive the on-disk key for ``tracked_files.json`` (write/read 同源).
+
+    #1003 finding ①：写端 ``_persist_tracked_file`` 用
+    ``_session_files_dir_key`` 派生目录名（``sessions/<derived>/tracked_files.json``），
+    读端必须用同一派生，否则三段 namespaced key（``miqi-desktop:desktop:983``）
+    会读到 ``sessions/miqi-desktop_desktop_983/``，而条目实际落在
+    ``sessions/desktop_983/``。
+
+    两段 key（现网唯一形态，如 ``desktop:1786...``）派生结果与
+    ``key.replace(":", "_")``（``get_session_dir`` 的目录名规则）逐字相同，
+    故本次归一不改变既有行为；只有三段 key 才会分叉。
+
+    归一发生在 ownership 校验之前，校验仍由 ``load_tracked_files(key,
+    client_id=...)`` 内部的 ``_verify_ownership_for_mutation`` 完成，且落在
+    「条目所在的那条会话记录」上（``get_session_dir(key)`` 同一条派生链），
+    因此不削弱归属校验。
+    """
+    from miqi.agent.tools.filesystem import _session_files_dir_key
+
+    return _session_files_dir_key(session_key)
+
+
 # ── sessions.list ──────────────────────────────────────────────────────────
 
 
@@ -481,7 +504,7 @@ async def sessions_get_tracked_files_handler(
 ) -> dict[str, Any]:
     """Return tracked files for a session from tracked_files.json (client-scoped)."""
     typed = validate_session_params("sessions.get_tracked_files", params)
-    session_key = typed.session_key
+    session_key = _tracked_files_store_key(typed.session_key)
 
     sm = _get_session_manager()
     try:
@@ -508,7 +531,7 @@ async def sessions_clear_tracked_files_handler(
 ) -> dict[str, Any]:
     """Remove all tracked file entries for a session (client-scoped)."""
     typed = validate_session_params("sessions.clear_tracked_files", params)
-    session_key = typed.session_key
+    session_key = _tracked_files_store_key(typed.session_key)
 
     sm = _get_session_manager()
     try:

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -164,11 +164,16 @@ class SessionManager:
         return self.get_session_dir(key) / "conversation.jsonl"
 
     def _get_session_lock(self, key: str) -> threading.RLock:
+        # 锁标识 = 磁盘上真实的会话目录（``get_session_dir``），而不是调用方传入
+        # 的 key 字符串：``desktop:983``（file_handlers 传客户端原始 key）与
+        # ``desktop_983``（_persist_tracked_file 传派生名）派生同一目录，按原始
+        # 字符串取锁会让两者写同一个 tracked_files.json 却各持一把锁。
+        lock_key = str(self.get_session_dir(key))
         with _session_locks_guard:
-            lock = _session_locks.get(key)
+            lock = _session_locks.get(lock_key)
             if lock is None:
                 lock = threading.RLock()
-                _session_locks[key] = lock
+                _session_locks[lock_key] = lock
             return lock
 
     def _migrate_flat_to_dir(self, key: str) -> None:
@@ -548,11 +553,16 @@ class SessionManager:
         """Remove the entire tracked_files.json for a session.
 
         When client_id is provided, ownership is verified first.
+
+        #1003 finding ③（复核）：clear 是整文件删除，必须在同一把 key 锁内，
+        否则会与在途的读-改-写交错（删除被随后的 ``tmp.replace`` 悄悄撤销，
+        或删掉刚写入的批次）。
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
-        path = self._get_tracked_files_path(key)
-        path.unlink(missing_ok=True)
+        with self._get_session_lock(key):
+            path = self._get_tracked_files_path(key)
+            path.unlink(missing_ok=True)
 
     # ── Archive ───────────────────────────────────────────────────────
 

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -722,22 +722,30 @@ class SessionManager:
         When client_id is provided, ownership is verified first.
         Unowned sessions raise REQUIRES_CLAIM.
         Sessions owned by other clients raise UNAUTHORIZED.
+
+        #1003 finding ④（CodeRabbit 复审）：落盘删除与 tracked 读-改-写共用同一把
+        key 锁。否则 ``save_tracked_file`` 在 ``rmtree`` 之后才跑到
+        ``path.parent.mkdir(...)`` + ``tmp.replace``，会把刚删掉的会话目录连同
+        ``tracked_files.json`` 一起重建（已删会话复活）；反向交错则让写端抛
+        ``FileNotFoundError``。锁是 ``threading.RLock``（可重入），本路径内不再
+        获取其它锁，无锁序问题。
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
         self._cache.pop(key, None)
-        self._migrate_flat_to_dir(key)
-        session_dir = self.get_session_dir(key)
-        if session_dir.exists():
-            shutil.rmtree(session_dir)
-            return True
-        # Fallback: old flat file that was never migrated
-        safe_key = safe_filename(key.replace(":", "_"))
-        old_flat = self.sessions_dir / f"{safe_key}.jsonl"
-        if old_flat.exists():
-            old_flat.unlink()
-            return True
-        return False
+        with self._get_session_lock(key):
+            self._migrate_flat_to_dir(key)
+            session_dir = self.get_session_dir(key)
+            if session_dir.exists():
+                shutil.rmtree(session_dir)
+                return True
+            # Fallback: old flat file that was never migrated
+            safe_key = safe_filename(key.replace(":", "_"))
+            old_flat = self.sessions_dir / f"{safe_key}.jsonl"
+            if old_flat.exists():
+                old_flat.unlink()
+                return True
+            return False
 
     def rename(self, key: str, title: str, *, client_id: str | None = None) -> str:
         """Set a custom display title for a session, persisted in metadata.title.

--- a/miqi/session/manager.py
+++ b/miqi/session/manager.py
@@ -15,6 +15,17 @@ from loguru import logger
 from miqi.paths import get_legacy_data_dir
 from miqi.utils.helpers import ensure_dir, safe_filename
 
+# Per-session-key locks shared by ALL SessionManager instances in the process.
+#
+# #1003: tracked_files.json 的写入是「整读整写」，而调用方（
+# ``_persist_tracked_file``、AppServer handler）每次各自新建 SessionManager —
+# 实例级锁锁不住同一 key 的并发写：两个实例读到同一份旧快照，后写者覆盖
+# 先写者 → 丢条目。锁提升为模块级后，同进程内不同实例对同一 key 串行化。
+#
+# 跨进程（多个 bridge 进程 / 外部编辑）协调仍缺失，见 PR #1003 说明。
+_session_locks: dict[str, threading.RLock] = {}
+_session_locks_guard = threading.Lock()
+
 
 def _normalize_datetime(value: datetime) -> datetime:
     if value.tzinfo is None:
@@ -143,8 +154,6 @@ class SessionManager:
         self.compact_threshold_bytes = max(1, compact_threshold_bytes)
         self.compact_keep_messages = max(1, compact_keep_messages)
         self._cache: dict[str, Session] = {}
-        self._session_locks: dict[str, threading.RLock] = {}
-        self._session_locks_guard = threading.Lock()
 
     def get_session_dir(self, key: str) -> Path:
         safe_key = safe_filename(key.replace(":", "_"))
@@ -155,11 +164,11 @@ class SessionManager:
         return self.get_session_dir(key) / "conversation.jsonl"
 
     def _get_session_lock(self, key: str) -> threading.RLock:
-        with self._session_locks_guard:
-            lock = self._session_locks.get(key)
+        with _session_locks_guard:
+            lock = _session_locks.get(key)
             if lock is None:
                 lock = threading.RLock()
-                self._session_locks[key] = lock
+                _session_locks[key] = lock
             return lock
 
     def _migrate_flat_to_dir(self, key: str) -> None:
@@ -407,31 +416,35 @@ class SessionManager:
         ``op`` is one of: read, write, edit, delete.
 
         When client_id is provided, ownership is verified first.
+
+        #1003 finding ③：读-改-写全程持 key 锁（模块级，跨实例共享），否则两个
+        SessionManager 实例各自读到旧快照，后写者覆盖先写者 → 丢条目。
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
-        files = self.load_tracked_files(key)
-        norm = file_path.replace("\\", "/")
-        existing = files.get(norm, {})
-        # Upgrade: read < edit < write < delete
-        rank = {"read": 0, "edit": 1, "write": 2, "delete": 3}
-        cur_rank = rank.get(existing.get("op", "read"), 0)
-        new_rank = rank.get(op, 0)
-        if new_rank >= cur_rank:
-            from pathlib import PurePosixPath
-            files[norm] = {
-                "op": op,
-                "name": name or PurePosixPath(norm).name,
-                "lastSeen": int(datetime.now().timestamp() * 1000),
-            }
-        path = self._get_tracked_files_path(key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            json.dumps({"version": 1, "files": files}, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        tmp.replace(path)
+        with self._get_session_lock(key):
+            files = self.load_tracked_files(key)
+            norm = file_path.replace("\\", "/")
+            existing = files.get(norm, {})
+            # Upgrade: read < edit < write < delete
+            rank = {"read": 0, "edit": 1, "write": 2, "delete": 3}
+            cur_rank = rank.get(existing.get("op", "read"), 0)
+            new_rank = rank.get(op, 0)
+            if new_rank >= cur_rank:
+                from pathlib import PurePosixPath
+                files[norm] = {
+                    "op": op,
+                    "name": name or PurePosixPath(norm).name,
+                    "lastSeen": int(datetime.now().timestamp() * 1000),
+                }
+            path = self._get_tracked_files_path(key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "files": files}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
 
     def save_tracked_files_batch(
         self, key: str, entries: list[tuple[str, str]],
@@ -444,33 +457,37 @@ class SessionManager:
         exec artifact tracker (Phase 59 / #607): N files created by one
         command no longer cost N full read+rewrite cycles on the caller's
         thread (CodeRabbit #682 review).
+
+        #1003 finding ③：与 ``save_tracked_file`` 共用同一把模块级 key 锁，
+        跨实例的「批量写 vs 单条写」不再互相覆盖。
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
         if not entries:
             return
-        files = self.load_tracked_files(key)
-        rank = {"read": 0, "edit": 1, "write": 2, "delete": 3}
-        now = int(datetime.now().timestamp() * 1000)
-        from pathlib import PurePosixPath
+        with self._get_session_lock(key):
+            files = self.load_tracked_files(key)
+            rank = {"read": 0, "edit": 1, "write": 2, "delete": 3}
+            now = int(datetime.now().timestamp() * 1000)
+            from pathlib import PurePosixPath
 
-        for file_path, op in entries:
-            norm = file_path.replace("\\", "/")
-            existing = files.get(norm, {})
-            if rank.get(op, 0) >= rank.get(existing.get("op", "read"), 0):
-                files[norm] = {
-                    "op": op,
-                    "name": PurePosixPath(norm).name,
-                    "lastSeen": now,
-                }
-        path = self._get_tracked_files_path(key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            json.dumps({"version": 1, "files": files}, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        tmp.replace(path)
+            for file_path, op in entries:
+                norm = file_path.replace("\\", "/")
+                existing = files.get(norm, {})
+                if rank.get(op, 0) >= rank.get(existing.get("op", "read"), 0):
+                    files[norm] = {
+                        "op": op,
+                        "name": PurePosixPath(norm).name,
+                        "lastSeen": now,
+                    }
+            path = self._get_tracked_files_path(key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "files": files}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
 
     def reset_tracked_file_op(
         self, key: str, file_path: str, op: str = "read",
@@ -485,20 +502,21 @@ class SessionManager:
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
-        files = self.load_tracked_files(key)
-        norm = file_path.replace("\\", "/")
-        if norm not in files:
-            return
-        files[norm]["op"] = op
-        files[norm]["lastSeen"] = int(datetime.now().timestamp() * 1000)
-        path = self._get_tracked_files_path(key)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            json.dumps({"version": 1, "files": files}, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        tmp.replace(path)
+        with self._get_session_lock(key):
+            files = self.load_tracked_files(key)
+            norm = file_path.replace("\\", "/")
+            if norm not in files:
+                return
+            files[norm]["op"] = op
+            files[norm]["lastSeen"] = int(datetime.now().timestamp() * 1000)
+            path = self._get_tracked_files_path(key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "files": files}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
 
     def remove_tracked_file(
         self, key: str, file_path: str, *, client_id: str | None = None,
@@ -509,19 +527,20 @@ class SessionManager:
         """
         if client_id is not None:
             self._verify_ownership_for_mutation(key, client_id)
-        files = self.load_tracked_files(key)
-        norm = file_path.replace("\\", "/")
-        files.pop(norm, None)
-        path = self._get_tracked_files_path(key)
-        if not files:
-            path.unlink(missing_ok=True)
-            return
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            json.dumps({"version": 1, "files": files}, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        tmp.replace(path)
+        with self._get_session_lock(key):
+            files = self.load_tracked_files(key)
+            norm = file_path.replace("\\", "/")
+            files.pop(norm, None)
+            path = self._get_tracked_files_path(key)
+            if not files:
+                path.unlink(missing_ok=True)
+                return
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(
+                json.dumps({"version": 1, "files": files}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
 
     def clear_tracked_files(
         self, key: str, *, client_id: str | None = None,

--- a/tests/agent/tools/test_mcp_download_sink_tracked.py
+++ b/tests/agent/tools/test_mcp_download_sink_tracked.py
@@ -1,0 +1,283 @@
+"""#983 缺口 2：MCP 下载产物落盘后必须进会话 tracked（任务附件面板可见）。
+
+背景：#975 ``DownloadSink`` 把 binary artifact 交付到
+``<ws>/sessions/<key>/files/.miqi/downloads/``，但**不写 tracked_files.json**
+→ 产物只存在于磁盘，资产面板（``sessions.get_tracked_files``）看不到，用户
+拿不到 #877 的「下载/另存为」入口。
+
+修复：``materialize`` 在产物提交后调用 ``_persist_tracked_file``（与
+create_pdf/docx 同机制）。落盘根与登记根同源（``_downloads_root_base``），
+故条目键为 ``.miqi/downloads/<name>``——面板 ``files.read`` 按同一根解析得到
+产物本身（见 ``test_tracked_key_resolves_through_panel_read_path``）。
+
+判别性：去掉 ``materialize`` 里的 ``_track_delivered`` 调用后，本文件前 4 例
+全红（见 PR 证据「变异验证」）。
+"""
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import _session_files_dir_key
+from miqi.agent.tools.mcp_download_sink import (
+    DownloadPendingError,
+    DownloadSha256MismatchError,
+    DownloadSink,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+SESSION_KEY = "miqi-desktop:desktop:983downloads"
+
+
+def _default_ws() -> Path:
+    """``MIQI_HOME/workspace`` —— 默认工作区（会话 files 隔离生效的判别根）。"""
+    from miqi.paths import get_miqi_home
+
+    ws = Path(get_miqi_home()) / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _session_files_dir(ws: Path, key: str = SESSION_KEY) -> Path:
+    return ws / "sessions" / _session_files_dir_key(key) / "files"
+
+
+def _store_path(store_root: Path, key: str = SESSION_KEY) -> Path:
+    return store_root / "sessions" / _session_files_dir_key(key) / "tracked_files.json"
+
+
+def _read_tracked(path: Path) -> dict:
+    assert path.exists(), f"tracked_files.json 不存在：{path}"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data.get("version") == 1
+    return data.get("files", {})
+
+
+def _panel_tracked(store_root: Path, key: str = SESSION_KEY) -> dict:
+    """面板读取回路（逐字对齐 ``sessions.get_tracked_files``）：
+    handler 先用 ``_session_files_dir_key`` 归一 key（#1003 finding ①），再
+    ``SessionManager(<工作区>).load_tracked_files(<归一后 key>)``。"""
+    from miqi.session.manager import SessionManager
+
+    return SessionManager(store_root).load_tracked_files(_session_files_dir_key(key))
+
+
+def _artifact_payload(data: bytes, name: str = "result.cube") -> str:
+    return json.dumps(
+        {
+            "name": name,
+            "size_bytes": len(data),
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "content_base64": base64.b64encode(data).decode(),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _result_from_text(text: str):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        isError=False, structuredContent=None,
+        content=[SimpleNamespace(text=text)],
+    )
+
+
+def _single_chunk_payload(
+    piece: bytes,
+    *,
+    chunk_index: int,
+    total_chunks: int,
+    name: str = "chunked.cube",
+    sha256: str | None = None,
+    size_bytes: int | None = None,
+) -> str:
+    payload: dict = {
+        "name": name,
+        "chunk_index": chunk_index,
+        "total_chunks": total_chunks,
+        "content_base64": base64.b64encode(piece).decode(),
+    }
+    if sha256 is not None:
+        payload["sha256"] = sha256
+    if size_bytes is not None:
+        payload["size_bytes"] = size_bytes
+    return json.dumps(payload)
+
+
+async def _materialize(sink: DownloadSink, result, *, key: str = SESSION_KEY, **kw):
+    defaults = dict(
+        session_key=key,
+        server_name="miqroforge",
+        tool_name="download_file",
+        request_kwargs={"name": "result.cube"},
+        turn_id="turn-1",
+        tool_call_id="call-1",
+    )
+    defaults.update(kw)
+    return await sink.materialize(result=result, **defaults)
+
+
+# ── 正例：单包产物落会话 tracked 根 ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_shot_artifact_lands_in_session_tracked_store():
+    """单包下载：产物落会话 downloads 目录，条目落会话存储根（非孤儿路径）。"""
+    ws = _default_ws()
+    files_dir = _session_files_dir(ws)
+    sink = DownloadSink(base_workspace=ws)
+    data = b"cube-bytes-983"
+
+    artifact = await _materialize(sink, _result_from_text(_artifact_payload(data)))
+
+    assert artifact.path == files_dir / ".miqi" / "downloads" / "result.cube"
+    assert artifact.path.read_bytes() == data
+
+    tracked = _read_tracked(_store_path(ws))
+    assert ".miqi/downloads/result.cube" in tracked, f"条目未落会话存储根：{sorted(tracked)}"
+    assert tracked[".miqi/downloads/result.cube"]["op"] == "write"
+    assert tracked[".miqi/downloads/result.cube"]["name"] == "result.cube"
+
+    # 孤儿路径（会话 files 目录被当仓库根）不得出现
+    assert not _store_path(files_dir).exists()
+
+    # 面板读端（sessions.get_tracked_files 同源读端）必须读到
+    assert ".miqi/downloads/result.cube" in _panel_tracked(ws)
+
+
+@pytest.mark.asyncio
+async def test_tracked_key_resolves_through_panel_read_path():
+    """面板 ``files.read(path, session_key)`` 的解析语义：相对路径按会话
+    files 目录拼 → 命中的正是产物本身（条目键必须与落盘根同源）。"""
+    ws = _default_ws()
+    files_dir = _session_files_dir(ws)
+    sink = DownloadSink(base_workspace=ws)
+
+    artifact = await _materialize(sink, _result_from_text(_artifact_payload(b"x")))
+
+    key = next(iter(_read_tracked(_store_path(ws))))
+    assert (files_dir / key).resolve() == artifact.path.resolve()
+
+
+# ── 正例：分片续传「完成才登记」 ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chunked_transfer_tracked_only_after_completion():
+    """形态乙：中间态（未交付）不登记；末片交付后才出现 tracked 条目。"""
+    ws = _default_ws()
+    sink = DownloadSink(base_workspace=ws)
+    pieces = [b"part-0-", b"part-1"]
+    full = b"".join(pieces)
+    sha, size = hashlib.sha256(full).hexdigest(), len(full)
+
+    first = _result_from_text(_single_chunk_payload(
+        pieces[0], chunk_index=0, total_chunks=2, sha256=sha, size_bytes=size,
+    ))
+    with pytest.raises(DownloadPendingError):
+        await _materialize(
+            sink, first, request_kwargs={"name": "chunked.cube", "chunk_index": 0},
+        )
+    # 未交付 → 不得登记（面板里出现半截文件是数据完整性事故）
+    assert not _store_path(ws).exists(), "未完成的传输被登记进 tracked"
+
+    second = _result_from_text(_single_chunk_payload(
+        pieces[1], chunk_index=1, total_chunks=2, sha256=sha, size_bytes=size,
+    ))
+    artifact = await _materialize(
+        sink, second, request_kwargs={"name": "chunked.cube", "chunk_index": 1},
+    )
+    assert artifact.path.read_bytes() == full
+
+    tracked = _read_tracked(_store_path(ws))
+    assert ".miqi/downloads/chunked.cube" in tracked
+    assert ".miqi/downloads/chunked.cube" in _panel_tracked(ws)
+
+
+# ── 正例：复用既有文件（reuse_existing）仍登记 ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reuse_existing_artifact_is_tracked_again():
+    """同身份同内容重试走 reuse_existing（不重写文件）——条目仍须在。"""
+    ws = _default_ws()
+    sink = DownloadSink(base_workspace=ws)
+    payload = _artifact_payload(b"same-bytes")
+
+    await _materialize(sink, _result_from_text(payload))
+    store = _store_path(ws)
+    store.unlink()  # 清空条目，验证第二次（reuse 分支）重新登记
+
+    artifact = await _materialize(sink, _result_from_text(payload))
+
+    assert artifact.path.read_bytes() == b"same-bytes"
+    assert ".miqi/downloads/result.cube" in _read_tracked(store)
+
+
+# ── 正例：自定义工作区（非默认根）────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_custom_workspace_tracks_at_workspace_store_root(tmp_path):
+    """自选项目目录：产物落 ``<custom>/.miqi/downloads``，条目落
+    ``<custom>/sessions/<key>/tracked_files.json``（面板读端同根同 key）。"""
+    custom = tmp_path / "project"
+    custom.mkdir()
+    sink = DownloadSink(base_workspace=custom)
+
+    artifact = await _materialize(sink, _result_from_text(_artifact_payload(b"c")))
+
+    assert artifact.path == custom / ".miqi" / "downloads" / "result.cube"
+    tracked = _read_tracked(_store_path(custom))
+    assert ".miqi/downloads/result.cube" in tracked
+    assert ".miqi/downloads/result.cube" in _panel_tracked(custom)
+    # 不得把会话目录当成仓库根再嵌套一层（#1003 的孤儿形态）
+    nested = custom / ".miqi" / "downloads" / "sessions"
+    assert not nested.exists(), f"条目仍落嵌套孤儿路径：{nested}"
+
+
+# ── 反例：未交付 / 登记失败 ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_failed_download_is_not_tracked():
+    """校验失败（sha 不符）→ 文件未交付 → 不得留下 tracked 条目。"""
+    ws = _default_ws()
+    sink = DownloadSink(base_workspace=ws)
+    payload = json.dumps({
+        "name": "bad.cube",
+        "size_bytes": 3,
+        "sha256": "0" * 64,
+        "content_base64": base64.b64encode(b"abc").decode(),
+    })
+
+    with pytest.raises(DownloadSha256MismatchError):
+        await _materialize(sink, _result_from_text(payload))
+
+    assert not _store_path(ws).exists()
+    assert not (ws / "sessions" / _session_files_dir_key(SESSION_KEY)
+                / "files" / ".miqi" / "downloads" / "bad.cube").exists()
+
+
+@pytest.mark.asyncio
+async def test_tracking_failure_does_not_fail_delivery(monkeypatch):
+    """登记是旁路：``_persist_tracked_file`` 抛异常也不得让已交付的下载失败。"""
+    ws = _default_ws()
+    sink = DownloadSink(base_workspace=ws)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("tracked store unavailable")
+
+    monkeypatch.setattr(
+        "miqi.agent.tools.filesystem._persist_tracked_file", _boom,
+    )
+
+    artifact = await _materialize(sink, _result_from_text(_artifact_payload(b"delivered")))
+
+    assert artifact.path.read_bytes() == b"delivered"
+    assert artifact.size_bytes == 9

--- a/tests/agent/tools/test_mcp_download_sink_tracked.py
+++ b/tests/agent/tools/test_mcp_download_sink_tracked.py
@@ -7,8 +7,19 @@
 
 修复：``materialize`` 在产物提交后调用 ``_persist_tracked_file``（与
 create_pdf/docx 同机制）。落盘根与登记根同源（``_downloads_root_base``），
-故条目键为 ``.miqi/downloads/<name>``——面板 ``files.read`` 按同一根解析得到
-产物本身（见 ``test_tracked_key_resolves_through_panel_read_path``）。
+故条目键为 ``.miqi/downloads/<name>``。
+
+面板读端两条链路（默认工作区布局，现网形态）：
+- 存储读端 ``sessions.get_tracked_files`` → ``SessionManager(<ws>)
+  .load_tracked_files(_session_files_dir_key(key))``；
+- 文件读端 ``files.read(path, session_key)`` → 相对路径锚在
+  ``<ws>/sessions/<key>/files``（``file_handlers._resolve_session_files_path``）。
+
+**边界（既有读端行为，非本改动引入）**：自选工作区布局下产物落
+``<custom>/.miqi/downloads``，而文件读端仍锚 ``<custom>/sessions/<key>/files``
+→ 条目可见但按相对路径取不到字节（create_pdf 等文档工具同此）。本文件只断言
+存储读端；文件读端的端到端回路见
+``tests/runtime/test_file_handlers.py::test_get_tracked_files_reads_sink_delivered_artifact``。
 
 判别性：去掉 ``materialize`` 里的 ``_track_delivered`` 调用后，本文件前 4 例
 全红（见 PR 证据「变异验证」）。
@@ -30,7 +41,10 @@ from miqi.agent.tools.mcp_download_sink import (
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-SESSION_KEY = "miqi-desktop:desktop:983downloads"
+# 现网形态（两段 key，ChatConsole `desktop:${Date.now()}`）：文件读端的目录
+# 派生（safe_filename(key.replace(":", "_"))）与写端 `_session_files_dir_key`
+# 逐字相同，故本文件的相对路径断言与真实 handler 同源。
+SESSION_KEY = "desktop:983downloads"
 
 
 def _default_ws() -> Path:
@@ -152,8 +166,9 @@ async def test_single_shot_artifact_lands_in_session_tracked_store():
 
 @pytest.mark.asyncio
 async def test_tracked_key_resolves_through_panel_read_path():
-    """面板 ``files.read(path, session_key)`` 的解析语义：相对路径按会话
-    files 目录拼 → 命中的正是产物本身（条目键必须与落盘根同源）。"""
+    """面板 ``files.read(path, session_key)`` 的解析语义（两段 key = 现网形态）：
+    相对路径按 ``<ws>/sessions/<key>/files`` 拼 → 命中的正是产物本身
+    （条目键必须与落盘根同源）。"""
     ws = _default_ws()
     files_dir = _session_files_dir(ws)
     sink = DownloadSink(base_workspace=ws)
@@ -225,7 +240,13 @@ async def test_reuse_existing_artifact_is_tracked_again():
 @pytest.mark.asyncio
 async def test_custom_workspace_tracks_at_workspace_store_root(tmp_path):
     """自选项目目录：产物落 ``<custom>/.miqi/downloads``，条目落
-    ``<custom>/sessions/<key>/tracked_files.json``（面板读端同根同 key）。"""
+    ``<custom>/sessions/<key>/tracked_files.json``——与存储读端
+    （``SessionManager(config.workspace_path)``）同根同 key。
+
+    **只断言存储读端**：该布局下文件读端仍锚 ``<custom>/sessions/<key>/files``
+    （既有 ``_resolve_session_files_path`` 语义），按相对键取字节会落空；这是
+    文档工具同样存在的既有边界，不在本次改动范围（见 PR「后续计划」）。
+    """
     custom = tmp_path / "project"
     custom.mkdir()
     sink = DownloadSink(base_workspace=custom)

--- a/tests/agent/tools/test_tracked_files_store_root.py
+++ b/tests/agent/tools/test_tracked_files_store_root.py
@@ -258,7 +258,8 @@ async def test_non_desktop_channel_key_lands_in_matching_dir():
 
 @pytest.mark.asyncio
 async def test_namespaced_desktop_key_matches_two_segment_dir():
-    """desktop 两形态派生同一目录名（``_session_files_dir_key`` 幂等）。"""
+    """三段 namespaced key（``miqi-desktop:desktop:983namespaced``）剥掉
+    client_id 后，与两段 key 派生同一目录名 ``desktop_983namespaced``。"""
     ws = _default_ws()
     key = "miqi-desktop:desktop:983namespaced"
     files_dir = _session_files_dir(ws, key)
@@ -272,6 +273,30 @@ async def test_namespaced_desktop_key_matches_two_segment_dir():
     tracked = _read_tracked(ws / "sessions" / "desktop_983namespaced" / "tracked_files.json")
     assert "ns.docx" in tracked
     assert not _store_path(files_dir, key).exists()
+
+
+@pytest.mark.parametrize(
+    "key, derived",
+    [
+        pytest.param("desktop:1786807046853", "desktop_1786807046853", id="desktop"),
+        pytest.param("cli:direct", "cli_direct", id="cli_direct"),
+        pytest.param("cli:other", "cli_other", id="cli_other"),
+        pytest.param("gateway:default", "gateway_default", id="gateway_default"),
+        pytest.param("miqi-desktop:desktop:1786807046853", "desktop_1786807046853",
+                     id="namespaced"),
+        pytest.param("thread_nomap", "thread_nomap", id="no_colon"),
+    ],
+)
+def test_session_files_dir_key_is_idempotent(key, derived):
+    """不变量：``_session_files_dir_key`` 幂等 —— 把已派生的 key 再喂进来
+    返回它本身，因此调用方传原始 key 或已派生 key 都可以
+    （``_tracked_store_root`` 的目录名一致性校验依赖这一点）。
+
+    期望表照抄 #1005：两种形态不会派生出第二个会话目录。
+    """
+    once = _session_files_dir_key(key)
+    assert once == derived
+    assert _session_files_dir_key(once) == once
 
 
 # ── exec 批量追踪（shell.py：统一的第 3 个文件）────────────────────────────

--- a/tests/agent/tools/test_tracked_files_store_root.py
+++ b/tests/agent/tools/test_tracked_files_store_root.py
@@ -1,0 +1,376 @@
+"""#983: 文档工具 tracked 条目写入孤儿路径 —— 存储根解耦（修复 A）与
+store key 派生统一（修复 B）。
+
+根因：``create_pdf/docx/pptx/xlsx`` 注册时 ``workspace=<ws>/sessions/<key>/files``，
+``_persist_tracked_file`` 把该目录当仓库根构造 ``SessionManager`` →
+条目落 ``<files>/sessions/<key>/tracked_files.json``（孤儿），
+面板读 ``<ws>/sessions/<key>/tracked_files.json`` 永远看不到。
+
+前置（方案 §3 L1）：会话 files 目录必须建在 ``MIQI_HOME/workspace`` 之下，
+否则修复 A 的 fail-closed 守卫（``base != 默认根`` → 不剥）不触发，
+精确路径断言会恒红而不是给出有效信号。故统一走 ``_default_ws()``。
+
+修复 A 只剥「默认工作区下的会话 files 目录」；自定义工作区、key 不匹配、
+``session_key=None`` 一律不剥（反例逐字不变）。修复 B 让 store key 与
+目录名派生同源（``_session_files_dir_key``），非 desktop 渠道键
+（``cli:other``）不再落错会话目录；同一条派生规则也用在 shell.py 的 exec
+批量追踪（``_persist_changed_batch``）上，故 ``cli:direct`` 的 exec 产物与
+文档产物落同一会话目录。
+"""
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import _session_files_dir_key
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _default_ws() -> Path:
+    """``MIQI_HOME/workspace`` — 修复 A 的判别根（必须显式 mkdir）。"""
+    from miqi.paths import get_miqi_home
+
+    ws = Path(get_miqi_home()) / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def _session_files_dir(ws: Path, session_key: str) -> Path:
+    """``<ws>/sessions/<derived key>/files`` — 文档工具的注册工作区。"""
+    d = ws / "sessions" / _session_files_dir_key(session_key) / "files"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _store_path(store_root: Path, session_key: str) -> Path:
+    """``<store_root>/sessions/<derived key>/tracked_files.json``。"""
+    return store_root / "sessions" / _session_files_dir_key(session_key) / "tracked_files.json"
+
+
+def _read_tracked(path: Path) -> dict:
+    assert path.exists(), f"tracked_files.json 不存在：{path}"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data.get("version") == 1
+    return data.get("files", {})
+
+
+def _panel_tracked(store_root: Path, session_key: str) -> dict:
+    """面板读取回路：与 ``sessions.get_tracked_files`` 同一条读端
+    （``SessionManager(workspace).load_tracked_files(session_key)``）。"""
+    from miqi.session.manager import SessionManager
+
+    return SessionManager(store_root).load_tracked_files(session_key)
+
+
+def _tool(dotted: str, **kwargs):
+    module_name, cls_name = dotted.split(":")
+    return getattr(importlib.import_module(module_name), cls_name)(**kwargs)
+
+
+# ── 正例：4 个 Create* 工具 ────────────────────────────────────────────────
+
+_CREATE_CASES = [
+    pytest.param(
+        "miqi.documents.pdf_create_tool:CreatePdfTool",
+        {"filename": "report.pdf", "title": "Title", "content": "body"},
+        "report.pdf",
+        id="create_pdf",
+    ),
+    pytest.param(
+        "miqi.documents.docx_tool:CreateDocxTool",
+        {"filename": "report.docx", "title": "Title", "paragraphs": ["body"]},
+        "report.docx",
+        id="create_docx",
+    ),
+    pytest.param(
+        "miqi.documents.pptx_tool:CreatePptxTool",
+        {"filename": "deck.pptx", "slides": [{"title": "Cover"}]},
+        "deck.pptx",
+        id="create_pptx",
+    ),
+    pytest.param(
+        "miqi.documents.xlsx_tool:CreateXlsxTool",
+        {"filename": "book.xlsx", "rows": [["A", "B"], [1, 2]]},
+        "book.xlsx",
+        id="create_xlsx",
+    ),
+]
+
+
+@pytest.mark.parametrize("tool_dotted, kwargs, filename", _CREATE_CASES)
+@pytest.mark.asyncio
+async def test_create_tools_track_into_session_store_root(tool_dotted, kwargs, filename):
+    """Create* 工具的条目必须落会话存储根，而不是会话 files 目录下的孤儿路径。"""
+    ws = _default_ws()
+    key = "desktop:983create"
+    files_dir = _session_files_dir(ws, key)
+    tool = _tool(tool_dotted, workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(_session_key=key, **kwargs)
+    assert "Created:" in result, result
+
+    tracked = _read_tracked(_store_path(ws, key))
+    assert filename in tracked, f"条目未落会话存储根：{sorted(tracked)}"
+    assert tracked[filename]["op"] == "write"
+    assert tracked[filename]["name"] == filename
+
+    # 孤儿路径（会话 files 目录被当作仓库根）不得再出现
+    orphan = _store_path(files_dir, key)
+    assert not orphan.exists(), f"条目仍落孤儿路径：{orphan}"
+
+    # 面板读取回路：走与 sessions.get_tracked_files 相同的读端
+    # （SessionManager(<默认工作区>).load_tracked_files(key)）必须读到该条目。
+    assert filename in _panel_tracked(ws, key)
+
+
+@pytest.mark.asyncio
+async def test_append_xlsx_tracks_edit_into_session_store_root():
+    """AppendXlsxTool：先用 openpyxl 直接造 xlsx（不经 CreateXlsxTool，
+    避免 op 升级干扰）→ append → op=='edit'（miqi/documents/xlsx_tool.py:463）。"""
+    from openpyxl import Workbook
+
+    ws = _default_ws()
+    key = "desktop:983append"
+    files_dir = _session_files_dir(ws, key)
+    target = files_dir / "data.xlsx"
+    wb = Workbook()
+    wb.active.title = "Data"
+    wb.active.append(["A", "B"])
+    wb.save(str(target))
+
+    tool = _tool("miqi.documents.xlsx_tool:AppendXlsxTool",
+                 workspace=files_dir, allowed_dir=files_dir)
+    result = await tool.execute(
+        filename="data.xlsx", sheet_name="Data", rows=[[1, 2]], _session_key=key,
+    )
+    assert "Appended:" in result, result
+
+    tracked = _read_tracked(_store_path(ws, key))
+    assert tracked["data.xlsx"]["op"] == "edit"
+    assert not _store_path(files_dir, key).exists()
+
+
+@pytest.mark.asyncio
+async def test_create_then_append_keeps_write_op():
+    """op 升级口径：跨调用 create→append 不降级（manager.py:417-420
+    read<edit<write<delete），仍为 write。"""
+    ws = _default_ws()
+    key = "desktop:983upgrade"
+    files_dir = _session_files_dir(ws, key)
+
+    create = _tool("miqi.documents.xlsx_tool:CreateXlsxTool",
+                   workspace=files_dir, allowed_dir=files_dir)
+    assert "Created:" in await create.execute(
+        filename="up.xlsx", rows=[["A"]], _session_key=key,
+    )
+    append = _tool("miqi.documents.xlsx_tool:AppendXlsxTool",
+                   workspace=files_dir, allowed_dir=files_dir)
+    assert "Appended:" in await append.execute(
+        filename="up.xlsx", rows=[[1]], _session_key=key,
+    )
+
+    tracked = _read_tracked(_store_path(ws, key))
+    assert tracked["up.xlsx"]["op"] == "write"
+
+
+# ── 反例：自定义工作区（行为逐字不变）────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_custom_workspace_is_not_stripped(tmp_path):
+    """自定义工作区（非 ``MIQI_HOME/workspace``）：不剥，仍写
+    ``<files>/sessions/<key>/tracked_files.json`` —— 行为与修复前逐字相同。
+
+    key 必须用 desktop 形态：修复 B 对 ``cli:other`` 会改键，混进来会掩盖反例。
+    """
+    key = "desktop:983custom"
+    files_dir = tmp_path / "proj" / "sessions" / _session_files_dir_key(key) / "files"
+    files_dir.mkdir(parents=True)
+    tool = _tool("miqi.documents.docx_tool:CreateDocxTool",
+                 workspace=files_dir, allowed_dir=files_dir)
+
+    result = await tool.execute(filename="custom.docx", title="T", _session_key=key)
+    assert "Created:" in result, result
+
+    tracked = _read_tracked(_store_path(files_dir, key))
+    assert "custom.docx" in tracked
+
+    from miqi.paths import get_miqi_home
+
+    default_root = Path(get_miqi_home()) / "workspace"
+    assert not _store_path(default_root, key).exists()
+
+
+def test_tracked_store_root_guard_matrix(tmp_path):
+    """``_tracked_store_root`` 的守卫语义：只剥默认根下的会话 files 目录。"""
+    from miqi.agent.tools.filesystem import _tracked_store_root
+
+    ws = _default_ws()
+    key = "desktop:983guard"
+    files_dir = _session_files_dir(ws, key)
+
+    # 默认根 + 形状匹配 + 目录名匹配 → 剥回默认根
+    assert _tracked_store_root(files_dir, key) == ws.resolve()
+    # str 入参（docstring 承诺「归一（防 str 入参）」）→ 同样剥离
+    assert _tracked_store_root(str(files_dir), key) == ws.resolve()
+    # 目录名非本会话派生名 → 不剥
+    other = ws / "sessions" / "desktop_other" / "files"
+    other.mkdir(parents=True, exist_ok=True)
+    assert _tracked_store_root(other, key) == other.resolve()
+    # 自定义工作区（base != 默认根）→ 不剥
+    custom = tmp_path / "proj" / "sessions" / _session_files_dir_key(key) / "files"
+    custom.mkdir(parents=True)
+    assert _tracked_store_root(custom, key) == custom.resolve()
+    # 形状不符（不是 sessions/<key>/files）→ 不剥
+    assert _tracked_store_root(ws, key) == ws.resolve()
+    # session_key=None → 不剥
+    assert _tracked_store_root(files_dir, None) == files_dir.resolve()
+    # session_key='' → 不剥（与 None 同口径）
+    assert _tracked_store_root(files_dir, "") == files_dir.resolve()
+    # workspace=None → None
+    assert _tracked_store_root(None, key) is None
+
+
+# ── key 形态（修复 B 证据）───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_desktop_channel_key_lands_in_matching_dir():
+    """修复 B：store key 与目录名派生同源。``cli:other`` 的旧剥离规则
+    （``parts[0] != "desktop"`` → ``other``）会写进 ``sessions/other/``。"""
+    ws = _default_ws()
+    key = "cli:other"
+    files_dir = _session_files_dir(ws, key)  # …/sessions/cli_other/files
+    tool = _tool("miqi.documents.docx_tool:CreateDocxTool",
+                 workspace=files_dir, allowed_dir=files_dir)
+
+    assert "Created:" in await tool.execute(
+        filename="cli.docx", title="T", _session_key=key,
+    )
+
+    tracked = _read_tracked(ws / "sessions" / "cli_other" / "tracked_files.json")
+    assert "cli.docx" in tracked
+    assert not (ws / "sessions" / "other" / "tracked_files.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_namespaced_desktop_key_matches_two_segment_dir():
+    """desktop 两形态派生同一目录名（``_session_files_dir_key`` 幂等）。"""
+    ws = _default_ws()
+    key = "miqi-desktop:desktop:983namespaced"
+    files_dir = _session_files_dir(ws, key)
+    tool = _tool("miqi.documents.docx_tool:CreateDocxTool",
+                 workspace=files_dir, allowed_dir=files_dir)
+
+    assert "Created:" in await tool.execute(
+        filename="ns.docx", title="T", _session_key=key,
+    )
+
+    tracked = _read_tracked(ws / "sessions" / "desktop_983namespaced" / "tracked_files.json")
+    assert "ns.docx" in tracked
+    assert not _store_path(files_dir, key).exists()
+
+
+# ── exec 批量追踪（shell.py：统一的第 3 个文件）────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exec_batch_persist_shares_session_dir_with_doc_tools(monkeypatch):
+    """shell.py ``_persist_changed_batch`` 与文档工具同源派生 store key：
+    ``cli:direct`` → ``cli_direct``（旧规则给 ``direct``）→ exec 产物与文档产物
+    落同一会话目录，面板读端可读到。"""
+    from miqi.agent.tools.shell import ExecTool
+
+    ws = _default_ws()
+    key = "cli:direct"
+    files_dir = _session_files_dir(ws, key)  # …/sessions/cli_direct/files
+    monkeypatch.setattr(
+        "miqi.runtime.file_handlers._get_workspace_path", lambda: str(ws),
+    )
+
+    # 文档产物（同会话）
+    doc = _tool("miqi.documents.docx_tool:CreateDocxTool",
+                workspace=files_dir, allowed_dir=files_dir)
+    assert "Created:" in await doc.execute(
+        filename="cli.docx", title="T", _session_key=key,
+    )
+
+    # exec 产物
+    exec_tool = ExecTool()
+    exec_tool.working_dir = None
+    artifact = files_dir / "out.md"
+    exec_tool._persist_changed_batch([str(artifact)], key)
+
+    # 字面目录名钉住派生：两者同落 sessions/cli_direct/
+    tracked = _read_tracked(ws / "sessions" / "cli_direct" / "tracked_files.json")
+    assert "cli.docx" in tracked
+    assert str(artifact).replace("\\", "/") in tracked
+    # 旧剥离规则目录（sessions/direct）不得再出现
+    assert not (ws / "sessions" / "direct" / "tracked_files.json").exists()
+    # 面板读取回路能读到 exec 产物
+    assert str(artifact).replace("\\", "/") in _panel_tracked(ws, key)
+
+
+@pytest.mark.asyncio
+async def test_no_session_key_writes_nothing(tmp_path):
+    """``session_key=None`` → 不剥、也不写（早退）。"""
+    ws = _default_ws()
+    files_dir = _session_files_dir(ws, "desktop:983none")
+    tool = _tool("miqi.documents.docx_tool:CreateDocxTool",
+                 workspace=files_dir, allowed_dir=files_dir)
+
+    assert "Created:" in await tool.execute(filename="none.docx", title="T")
+
+    assert not _store_path(ws, "desktop:983none").exists()
+    assert not _store_path(files_dir, "desktop:983none").exists()
+
+
+# ── 调用方矩阵（相对路径基准不变）────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "file_rel, expected_key",
+    [
+        pytest.param("papers/x.pdf", "papers/x.pdf", id="papers"),
+        pytest.param("x.md", "x.md", id="shell"),
+    ],
+)
+def test_persist_with_base_workspace_keeps_relative_key(file_rel, expected_key):
+    """papers / shell 传 ``workspace=<base>``（非会话 files 目录）→ 不剥，
+    键仍为 base 相对路径。"""
+    from miqi.agent.tools.filesystem import _persist_tracked_file
+
+    ws = _default_ws()
+    key = "desktop:983matrix"
+    target = ws / file_rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x", encoding="utf-8")
+
+    _persist_tracked_file(ws, target, op="write", session_key=key)
+
+    assert expected_key in _read_tracked(_store_path(ws, key))
+
+
+@pytest.mark.asyncio
+async def test_write_file_tracks_session_relative_segment():
+    """write_file 传 ``_tracking_workspace=<base>`` 与
+    ``<base>/sessions/<k>/files/x.md`` → 键保持含 ``sessions/<k>/files/`` 段。"""
+    from miqi.agent.tools.filesystem import WriteFileTool
+
+    ws = _default_ws()
+    key = "desktop:983write"
+    files_dir = _session_files_dir(ws, key)
+    tool = WriteFileTool(workspace=ws, base_workspace=ws, session_files_dir=files_dir)
+
+    result = await tool.execute(
+        path=str(files_dir / "note.md"), content="hi", _session_key=key,
+    )
+    assert "Successfully wrote" in result, result
+
+    tracked = _read_tracked(_store_path(ws, key))
+    expected = f"sessions/{_session_files_dir_key(key)}/files/note.md"
+    assert expected in tracked
+    assert not _store_path(files_dir, key).exists()

--- a/tests/agent/tools/test_tracked_files_store_root.py
+++ b/tests/agent/tools/test_tracked_files_store_root.py
@@ -215,6 +215,12 @@ async def test_custom_workspace_is_not_stripped(fake_config, tmp_path):
     tracked = _read_tracked(_store_path(store_root, key))
     assert "custom.docx" in tracked
     assert "custom.docx" in SessionManager(store_root).load_tracked_files(key)
+    # 面板读端根独立取一次：sessions.get_tracked_files → SessionManager(
+    # config.workspace_path)（session_handlers.py:32-41）——若 registry 的
+    # workspace 与 config 派生的读端根分叉，这里会红。
+    panel_root = fake_config.workspace_path
+    assert panel_root == custom
+    assert "custom.docx" in SessionManager(panel_root).load_tracked_files(key)
 
     # fail-closed 反例语义保留：默认工作区下不得出现该会话条目
     from miqi.paths import get_miqi_home

--- a/tests/agent/tools/test_tracked_files_store_root.py
+++ b/tests/agent/tools/test_tracked_files_store_root.py
@@ -176,32 +176,56 @@ async def test_create_then_append_keeps_write_op():
     assert tracked["up.xlsx"]["op"] == "write"
 
 
-# ── 反例：自定义工作区（行为逐字不变）────────────────────────────────────
+# ── 反例：自定义工作区（真实生产形态）────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_custom_workspace_is_not_stripped(tmp_path):
-    """自定义工作区（非 ``MIQI_HOME/workspace``）：不剥，仍写
-    ``<files>/sessions/<key>/tracked_files.json`` —— 行为与修复前逐字相同。
+async def test_custom_workspace_is_not_stripped(fake_config, tmp_path):
+    """真实 custom workspace（sijie-Z 发现 1）：走 ``create_runtime_tool_registry()``
+    的生产调用链，而不是手工拼 ``sessions/<key>/files`` 形状。
 
-    key 必须用 desktop 形态：修复 B 对 ``cli:other`` 会改键，混进来会掩盖反例。
+    非默认工作区不启用 per-session files 隔离（``tool_registry_factory.py:310-316``）：
+    ``_write_workspace = workspace``，文档工具的 workspace 就是用户选定的 custom
+    根。此时 ``_tracked_store_root`` 不剥（fail-closed 反例语义保留），条目落
+    ``<custom>/sessions/<key>/tracked_files.json``；面板读端同根同 key。
     """
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+    from miqi.session.manager import SessionManager
+
+    custom = tmp_path / "project"
+    custom.mkdir()
     key = "desktop:983custom"
-    files_dir = tmp_path / "proj" / "sessions" / _session_files_dir_key(key) / "files"
-    files_dir.mkdir(parents=True)
-    tool = _tool("miqi.documents.docx_tool:CreateDocxTool",
-                 workspace=files_dir, allowed_dir=files_dir)
+    # 生产：工作区选择器把选中目录写进 config.agents.defaults.workspace
+    # （apps/desktop/src/main/ipc/index.ts CONFIG_WRITE_INITIAL）→ 面板读端根 = custom
+    fake_config.agents.defaults.workspace = str(custom)
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=custom, session_id=key,
+    )
+    tool = registry.get("create_docx")
+    assert tool is not None
+    # 生产形态：custom 下不嵌套 sessions/<key>/files
+    assert tool._workspace == custom
 
     result = await tool.execute(filename="custom.docx", title="T", _session_key=key)
     assert "Created:" in result, result
 
-    tracked = _read_tracked(_store_path(files_dir, key))
+    # tracked 存储根 == 工具 workspace == 面板读端根（同一个根，未被剥回默认根）
+    store_root = tool._workspace
+    tracked = _read_tracked(_store_path(store_root, key))
     assert "custom.docx" in tracked
+    assert "custom.docx" in SessionManager(store_root).load_tracked_files(key)
 
+    # fail-closed 反例语义保留：默认工作区下不得出现该会话条目
     from miqi.paths import get_miqi_home
 
     default_root = Path(get_miqi_home()) / "workspace"
     assert not _store_path(default_root, key).exists()
+    # 也不得出现「会话 files 目录被当仓库根」的嵌套孤儿路径
+    nested = _store_path(
+        store_root / "sessions" / _session_files_dir_key(key) / "files", key,
+    )
+    assert not nested.exists(), f"条目仍落嵌套孤儿路径：{nested}"
 
 
 def test_tracked_store_root_guard_matrix(tmp_path):

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -438,9 +438,14 @@ async def test_get_tracked_files_reads_sink_delivered_artifact(tmp_path):
     """``DownloadSink`` 交付的 MCP 下载产物必须出现在面板读端（真实 handler）。
 
     写端：sink 落盘 → ``_persist_tracked_file``（与 create_pdf 同机制）。
-    读端：``sessions.get_tracked_files``（#1003 finding ① 归一后）必须读到，
-    且条目键是会话根相对路径 ``.miqi/downloads/<name>``——面板
-    ``files.read(path, session_key)`` 按会话 files 目录拼得到产物本身。
+    读端两条真实链路：
+    - ``sessions.get_tracked_files``（#1003 finding ① 归一后）读到条目；
+    - ``files.read(path, session_key, as_binary)`` 按条目键取回字节
+      （面板「下载/另存为」走的就是这条，#877）。
+
+    产物名用 ``.pdf``：``files.read`` 只服务文本安全/可预览/可二进制读的
+    后缀集，非白名单后缀（如 ``.cube``）会在读取层被拒（既有读端门，见 PR
+    「后续计划」）——用白名单内的后缀才能证明端到端回路成立。
     """
     import base64
     import hashlib
@@ -449,13 +454,14 @@ async def test_get_tracked_files_reads_sink_delivered_artifact(tmp_path):
 
     from miqi.agent.tools.mcp_download_sink import DownloadSink
     from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.file_handlers import files_read_handler
     from miqi.runtime.session_handlers import sessions_get_tracked_files_handler
 
     key = "desktop:983downloads"
     sm, ws = _setup_session(key, "client-A")
-    data = b"artifact-bytes-983"
+    data = b"%PDF-1.4 artifact-bytes-983"
     payload = json.dumps({
-        "name": "report.cube",
+        "name": "report.pdf",
         "size_bytes": len(data),
         "sha256": hashlib.sha256(data).hexdigest(),
         "content_base64": base64.b64encode(data).decode(),
@@ -471,7 +477,7 @@ async def test_get_tracked_files_reads_sink_delivered_artifact(tmp_path):
         session_key=key,
         server_name="miqroforge",
         tool_name="download_file",
-        request_kwargs={"name": "report.cube"},
+        request_kwargs={"name": "report.pdf"},
         turn_id="turn-1",
         tool_call_id="call-1",
     )
@@ -482,12 +488,16 @@ async def test_get_tracked_files_reads_sink_delivered_artifact(tmp_path):
         "req-1", {"session_key": key}, "client-A", None, registry,
     )
     paths = {item["path"] for item in out["result"]["tracked_files"]}
-    assert ".miqi/downloads/report.cube" in paths, paths
-    # 面板 files.read 的相对路径基准 = 会话 files 目录 → 命中的就是产物
-    from miqi.agent.tools.filesystem import _session_files_dir_key
+    assert ".miqi/downloads/report.pdf" in paths, paths
 
-    files_dir = ws / "sessions" / _session_files_dir_key(key) / "files"
-    assert (files_dir / ".miqi/downloads/report.cube").resolve() == artifact.path.resolve()
+    # 面板「下载/另存为」链路：条目键 → files.read 取回原字节
+    read = await files_read_handler(
+        "req-2",
+        {"path": ".miqi/downloads/report.pdf", "session_key": key, "as_binary": True},
+        "client-A", None, registry,
+    )
+    assert base64.b64decode(read["result"]["data_base64"]) == data
+    assert read["result"]["size"] == len(data)
 
 
 # ── SandboxManager client-scoped namespace ───────────────────────────────────

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -372,12 +372,15 @@ async def test_get_tracked_files_namespaced_key_reads_write_path_store(tmp_path)
     paths = {item["path"] for item in result["result"]["tracked_files"]}
     assert "ns.md" in paths, paths
 
-    # 归一不削弱 ownership：同一 namespaced key 换 client 仍被拒
+    # 归一不削弱 ownership：同一 namespaced key 换 client 仍被拒。
+    # 精确到 UNAUTHORIZED：会话归属元数据已由 _setup_session(client-A) 落在归一
+    # 后的同一个会话目录里，读到 REQUIRES_CLAIM 只会意味着「目录解析错到了没有
+    # ownership 元数据的地方」，是回归而不是可接受分支（CodeRabbit #1003）。
     with pytest.raises(AppServerError) as exc_info:
         await sessions_get_tracked_files_handler(
             "req-2", {"session_key": key}, "client-B", None, registry,
         )
-    assert exc_info.value.code in ("UNAUTHORIZED", "REQUIRES_CLAIM")
+    assert exc_info.value.code == "UNAUTHORIZED"
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -337,6 +337,99 @@ async def test_files_accept_cross_client_rejected(fake_config, fake_provider, tm
     assert exc_info.value.code == "UNAUTHORIZED"
 
 
+# ── sessions.get_tracked_files / clear_tracked_files（#1003 finding ①）───────
+
+
+@pytest.mark.asyncio
+async def test_get_tracked_files_namespaced_key_reads_write_path_store(fake_config, fake_provider, tmp_path):
+    """三段 namespaced key：读端必须与写端解析到同一目录。
+
+    写端 ``_persist_tracked_file`` 按 ``_session_files_dir_key`` 落
+    ``sessions/desktop_983namespaced/tracked_files.json``；读端（handler）若不
+    归一就会读 ``sessions/miqi-desktop_desktop_983namespaced/`` → 空。
+    """
+    from miqi.agent.tools.filesystem import _persist_tracked_file, _session_files_dir_key
+    from miqi.runtime.app_server import AppServerError, ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_tracked_files_handler
+
+    key = "miqi-desktop:desktop:983namespaced"
+    derived = _session_files_dir_key(key)
+    assert derived == "desktop_983namespaced"
+    assert derived != key.replace(":", "_")  # 三段 key 才会分叉
+
+    # 归属记录落在派生目录（sessions/desktop_983namespaced/conversation.jsonl）
+    sm, ws = _setup_session("desktop:983namespaced", "client-A")
+    files_dir = ws / "sessions" / derived / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    target = files_dir / "ns.md"
+    target.write_text("x", encoding="utf-8")
+    _persist_tracked_file(files_dir, target, op="write", session_key=key)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_tracked_files_handler(
+        "req-1", {"session_key": key}, "client-A", None, registry,
+    )
+    paths = {item["path"] for item in result["result"]["tracked_files"]}
+    assert "ns.md" in paths, paths
+
+    # 归一不削弱 ownership：同一 namespaced key 换 client 仍被拒
+    with pytest.raises(AppServerError) as exc_info:
+        await sessions_get_tracked_files_handler(
+            "req-2", {"session_key": key}, "client-B", None, registry,
+        )
+    assert exc_info.value.code in ("UNAUTHORIZED", "REQUIRES_CLAIM")
+
+
+@pytest.mark.asyncio
+async def test_get_tracked_files_two_segment_key_behavior_unchanged(fake_config, fake_provider, tmp_path):
+    """两段 key（现网唯一形态）：归一为恒等，读端行为逐字不变。"""
+    from miqi.agent.tools.filesystem import _persist_tracked_file, _session_files_dir_key
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_tracked_files_handler
+
+    key = "desktop:983twoseg"
+    assert _session_files_dir_key(key) == key.replace(":", "_")  # 归一恒等
+
+    sm, ws = _setup_session(key, "client-A")
+    files_dir = ws / "sessions" / _session_files_dir_key(key) / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    target = files_dir / "two.md"
+    target.write_text("x", encoding="utf-8")
+    _persist_tracked_file(files_dir, target, op="write", session_key=key)
+
+    registry = ClientSessionRegistry()
+    result = await sessions_get_tracked_files_handler(
+        "req-1", {"session_key": key}, "client-A", None, registry,
+    )
+    paths = {item["path"] for item in result["result"]["tracked_files"]}
+    assert "two.md" in paths, paths
+
+
+@pytest.mark.asyncio
+async def test_clear_tracked_files_namespaced_key_clears_write_path_store(fake_config, fake_provider, tmp_path):
+    """三段 namespaced key 的 clear 必须删到写端落盘的那份 tracked_files.json。"""
+    from miqi.agent.tools.filesystem import _persist_tracked_file, _session_files_dir_key
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_clear_tracked_files_handler
+
+    key = "miqi-desktop:desktop:983clear"
+    sm, ws = _setup_session("desktop:983clear", "client-A")
+    files_dir = ws / "sessions" / _session_files_dir_key(key) / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    target = files_dir / "clr.md"
+    target.write_text("x", encoding="utf-8")
+    _persist_tracked_file(files_dir, target, op="write", session_key=key)
+    store = ws / "sessions" / _session_files_dir_key(key) / "tracked_files.json"
+    assert store.exists()
+
+    registry = ClientSessionRegistry()
+    result = await sessions_clear_tracked_files_handler(
+        "req-1", {"session_key": key}, "client-A", None, registry,
+    )
+    assert result["result"]["cleared"] is True
+    assert not store.exists(), f"clear 未删到写端落盘的文件：{store}"
+
+
 # ── SandboxManager client-scoped namespace ───────────────────────────────────
 
 

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -430,6 +430,66 @@ async def test_clear_tracked_files_namespaced_key_clears_write_path_store(tmp_pa
     assert not store.exists(), f"clear 未删到写端落盘的文件：{store}"
 
 
+# ── #983 缺口 2：DownloadSink 产物进 tracked（面板读端回路）────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_tracked_files_reads_sink_delivered_artifact(tmp_path):
+    """``DownloadSink`` 交付的 MCP 下载产物必须出现在面板读端（真实 handler）。
+
+    写端：sink 落盘 → ``_persist_tracked_file``（与 create_pdf 同机制）。
+    读端：``sessions.get_tracked_files``（#1003 finding ① 归一后）必须读到，
+    且条目键是会话根相对路径 ``.miqi/downloads/<name>``——面板
+    ``files.read(path, session_key)`` 按会话 files 目录拼得到产物本身。
+    """
+    import base64
+    import hashlib
+    import json
+    from types import SimpleNamespace
+
+    from miqi.agent.tools.mcp_download_sink import DownloadSink
+    from miqi.runtime.app_server import ClientSessionRegistry
+    from miqi.runtime.session_handlers import sessions_get_tracked_files_handler
+
+    key = "desktop:983downloads"
+    sm, ws = _setup_session(key, "client-A")
+    data = b"artifact-bytes-983"
+    payload = json.dumps({
+        "name": "report.cube",
+        "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "content_base64": base64.b64encode(data).decode(),
+    })
+    result = SimpleNamespace(
+        isError=False, structuredContent=None,
+        content=[SimpleNamespace(text=payload)],
+    )
+
+    sink = DownloadSink(base_workspace=ws)
+    artifact = await sink.materialize(
+        result=result,
+        session_key=key,
+        server_name="miqroforge",
+        tool_name="download_file",
+        request_kwargs={"name": "report.cube"},
+        turn_id="turn-1",
+        tool_call_id="call-1",
+    )
+    assert artifact.path.read_bytes() == data
+
+    registry = ClientSessionRegistry()
+    out = await sessions_get_tracked_files_handler(
+        "req-1", {"session_key": key}, "client-A", None, registry,
+    )
+    paths = {item["path"] for item in out["result"]["tracked_files"]}
+    assert ".miqi/downloads/report.cube" in paths, paths
+    # 面板 files.read 的相对路径基准 = 会话 files 目录 → 命中的就是产物
+    from miqi.agent.tools.filesystem import _session_files_dir_key
+
+    files_dir = ws / "sessions" / _session_files_dir_key(key) / "files"
+    assert (files_dir / ".miqi/downloads/report.cube").resolve() == artifact.path.resolve()
+
+
 # ── SandboxManager client-scoped namespace ───────────────────────────────────
 
 

--- a/tests/runtime/test_file_handlers.py
+++ b/tests/runtime/test_file_handlers.py
@@ -341,7 +341,7 @@ async def test_files_accept_cross_client_rejected(fake_config, fake_provider, tm
 
 
 @pytest.mark.asyncio
-async def test_get_tracked_files_namespaced_key_reads_write_path_store(fake_config, fake_provider, tmp_path):
+async def test_get_tracked_files_namespaced_key_reads_write_path_store(tmp_path):
     """三段 namespaced key：读端必须与写端解析到同一目录。
 
     写端 ``_persist_tracked_file`` 按 ``_session_files_dir_key`` 落
@@ -381,7 +381,7 @@ async def test_get_tracked_files_namespaced_key_reads_write_path_store(fake_conf
 
 
 @pytest.mark.asyncio
-async def test_get_tracked_files_two_segment_key_behavior_unchanged(fake_config, fake_provider, tmp_path):
+async def test_get_tracked_files_two_segment_key_behavior_unchanged(tmp_path):
     """两段 key（现网唯一形态）：归一为恒等，读端行为逐字不变。"""
     from miqi.agent.tools.filesystem import _persist_tracked_file, _session_files_dir_key
     from miqi.runtime.app_server import ClientSessionRegistry
@@ -406,7 +406,7 @@ async def test_get_tracked_files_two_segment_key_behavior_unchanged(fake_config,
 
 
 @pytest.mark.asyncio
-async def test_clear_tracked_files_namespaced_key_clears_write_path_store(fake_config, fake_provider, tmp_path):
+async def test_clear_tracked_files_namespaced_key_clears_write_path_store(tmp_path):
     """三段 namespaced key 的 clear 必须删到写端落盘的那份 tracked_files.json。"""
     from miqi.agent.tools.filesystem import _persist_tracked_file, _session_files_dir_key
     from miqi.runtime.app_server import ClientSessionRegistry

--- a/tests/session/test_tracked_files_concurrency.py
+++ b/tests/session/test_tracked_files_concurrency.py
@@ -69,6 +69,19 @@ def test_session_lock_is_shared_across_instances(tmp_path):
     assert sm_a._get_session_lock("desktop:983") is not sm_a._get_session_lock("desktop:984")
 
 
+def test_session_lock_is_shared_by_alias_keys(tmp_path):
+    """``desktop:983`` 与 ``desktop_983`` 派生同一目录 → 必须同一把锁。
+
+    两条写链的 key 形态不同：``_persist_tracked_file`` 传派生名
+    （``desktop_983``），``file_handlers``（files.accept/revert/write）传客户端
+    原始 key（``desktop:983``）。按原始字符串取锁 = 同一文件两把锁。
+    """
+    sm = SessionManager(tmp_path)
+
+    assert sm.get_session_dir("desktop:983") == sm.get_session_dir("desktop_983")
+    assert sm._get_session_lock("desktop:983") is sm._get_session_lock("desktop_983")
+
+
 def test_two_instances_concurrent_single_writes_keep_both(tmp_path, monkeypatch):
     """两个不同实例并发写不同条目 → 两条都必须保留。"""
     _slow_read(monkeypatch)
@@ -103,3 +116,48 @@ def test_two_instances_concurrent_batch_and_single_keep_both(tmp_path, monkeypat
     assert errors == [], errors
     files = SessionManager(tmp_path).load_tracked_files(key)
     assert set(files) == {"batch1.md", "batch2.md", "single.md"}, files
+
+
+def test_concurrent_raw_and_derived_key_writes_keep_both(tmp_path, monkeypatch):
+    """别名 key 并发写同一文件：两条都要保留。
+
+    复刻生产的两条写链：工具写端 ``_persist_tracked_file`` 传派生 key
+    （``desktop_983alias``），面板写端 ``file_handlers`` 传客户端原始 key
+    （``desktop:983alias``）——两者落同一个 tracked_files.json。
+    """
+    _slow_read(monkeypatch)
+    sm_tool = SessionManager(tmp_path)
+    sm_panel = SessionManager(tmp_path)
+
+    errors = _run_two_threads(
+        lambda: sm_tool.save_tracked_file("desktop_983alias", "tool.md", op="write"),
+        lambda: sm_panel.save_tracked_file("desktop:983alias", "panel.md", op="write"),
+    )
+
+    assert errors == [], errors
+    files = SessionManager(tmp_path).load_tracked_files("desktop:983alias")
+    assert set(files) == {"tool.md", "panel.md"}, files
+
+
+def test_clear_tracked_files_waits_for_key_lock(tmp_path):
+    """clear 必须在 key 锁内：否则整文件删除会与在途的读-改-写交错。"""
+    key = "desktop:983clear"
+    sm = SessionManager(tmp_path)
+    sm.save_tracked_file(key, "a.md", op="write")
+    store = sm.get_session_dir(key) / "tracked_files.json"
+    assert store.exists()
+
+    done = threading.Event()
+    thread = threading.Thread(
+        target=lambda: (sm.clear_tracked_files(key), done.set()),
+        name="tracked-clearer",
+    )
+    with sm._get_session_lock(key):
+        thread.start()
+        time.sleep(0.1)
+        assert not done.is_set(), "clear 未等待 key 锁"
+        assert store.exists(), "clear 在持锁期间删除了文件"
+    thread.join(timeout=10)
+
+    assert done.is_set(), "clear 未退出"
+    assert not store.exists()

--- a/tests/session/test_tracked_files_concurrency.py
+++ b/tests/session/test_tracked_files_concurrency.py
@@ -8,6 +8,9 @@ handler 各自新建 ``SessionManager``，所以「实例级锁」锁不住同�
 并在 4 个 tracked 读-改-写方法（save_tracked_file / save_tracked_files_batch /
 reset_tracked_file_op / remove_tracked_file）内全程持锁。
 
+CodeRabbit 复审补充：``SessionManager.delete`` 也纳入同一把 key 锁 —— 否则
+落盘删除会与在途写回交错，把已删会话目录连同 ``tracked_files.json`` 重建（复活）。
+
 边界：本 PR 只做到**同进程跨实例**；跨进程（多个 bridge 进程、外部进程直接改
 文件）协调仍缺失，见 PR #1003 说明。
 """
@@ -137,6 +140,98 @@ def test_concurrent_raw_and_derived_key_writes_keep_both(tmp_path, monkeypatch):
     assert errors == [], errors
     files = SessionManager(tmp_path).load_tracked_files("desktop:983alias")
     assert set(files) == {"tool.md", "panel.md"}, files
+
+
+def _gate_tracked_read(monkeypatch, gate: dict) -> None:
+    """把写端卡在「已读旧快照、尚未 mkdir/写回」的窗口内，直到 ``release`` 置位。
+
+    与 ``_slow_read`` 的固定 sleep 不同，这里用事件闸门定序：写端进入窗口后主线程
+    才启动删除线程，「删除线程是否被 key 锁挡住」完全由锁决定，不靠调度运气。
+    """
+    orig = SessionManager.load_tracked_files
+
+    def gated(self, key, **kwargs):
+        files = orig(self, key, **kwargs)
+        gate["entered"].set()
+        gate["release"].wait(timeout=30)
+        return files
+
+    monkeypatch.setattr(SessionManager, "load_tracked_files", gated)
+
+
+def _delete_race_round(tmp_path, key, gate: dict, round_no: int) -> None:
+    """一轮「在途 save_tracked_file vs delete」竞态，断言删除后目录未被重建。"""
+    sm_writer = SessionManager(tmp_path)
+    sm_deleter = SessionManager(tmp_path)
+    session_dir = sm_writer.get_session_dir(key)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "conversation.jsonl").write_text("", encoding="utf-8")
+
+    gate["entered"].clear()
+    gate["release"].clear()
+    errors: list[BaseException] = []
+    delete_results: list[bool] = []
+    delete_done = threading.Event()
+
+    def writer():
+        try:
+            sm_writer.save_tracked_file(key, f"ghost-{round_no}.md", op="write")
+        except BaseException as exc:  # noqa: BLE001 — 线程异常要带回主线程
+            errors.append(exc)
+
+    def deleter():
+        try:
+            delete_results.append(sm_deleter.delete(key))
+        except BaseException as exc:  # noqa: BLE001 — 线程异常要带回主线程
+            errors.append(exc)
+        finally:
+            delete_done.set()
+
+    t_writer = threading.Thread(target=writer, name=f"tracked-writer-{round_no}")
+    t_deleter = threading.Thread(target=deleter, name=f"session-deleter-{round_no}")
+    t_writer.start()
+    assert gate["entered"].wait(timeout=30), f"[round {round_no}] 写线程未进入读-改-写窗口"
+    t_deleter.start()
+
+    # 写线程仍持 key 锁：删除线程必须被挡住，不得在写回之前完成删除
+    deleted_while_writing = delete_done.wait(timeout=0.5)
+    gate["release"].set()
+    t_writer.join(timeout=30)
+    t_deleter.join(timeout=30)
+
+    assert not t_writer.is_alive(), f"[round {round_no}] 写线程未退出（疑似死锁）"
+    assert not t_deleter.is_alive(), f"[round {round_no}] 删除线程未退出（疑似死锁）"
+    assert errors == [], errors
+    assert not deleted_while_writing, (
+        f"[round {round_no}] delete 未等待 key 锁：写端仍持锁时就完成了删除"
+    )
+    assert delete_results == [True], delete_results
+    assert not session_dir.exists(), (
+        f"[round {round_no}] 已删除的会话目录被在途写端重建（会话复活）"
+    )
+    assert not (session_dir / "tracked_files.json").exists(), (
+        f"[round {round_no}] tracked_files.json 在删除后被重建"
+    )
+
+
+def test_delete_does_not_resurrect_session_during_in_flight_tracked_write(tmp_path, monkeypatch):
+    """delete 必须与 tracked 读-改-写共用同一把 key 锁（#1003 CodeRabbit 复审）。
+
+    写端在 ``save_tracked_file`` 的「已读旧快照 → mkdir/写回」窗口内被闸门卡住，
+    删除端此刻并发 ``delete``：
+
+    - 无锁实现：删除立刻 ``rmtree``，写端随后 ``path.parent.mkdir(...)`` 把会话
+      目录连同 ``tracked_files.json`` 重建 —— 已删会话复活；
+    - 持锁实现：删除端被 key 锁挡住，等写端写完后才删，目录保持消失。
+
+    连跑 3 轮，避免单轮调度偶然性。
+    """
+    key = "desktop:983delete"
+    gate: dict = {"entered": threading.Event(), "release": threading.Event()}
+    _gate_tracked_read(monkeypatch, gate)
+
+    for round_no in range(3):
+        _delete_race_round(tmp_path, key, gate, round_no)
 
 
 def test_clear_tracked_files_waits_for_key_lock(tmp_path):

--- a/tests/session/test_tracked_files_concurrency.py
+++ b/tests/session/test_tracked_files_concurrency.py
@@ -1,0 +1,105 @@
+"""#1003 finding ③：tracked_files.json 的读-改-写必须跨 SessionManager 实例串行。
+
+``_persist_tracked_file``（``miqi/agent/tools/filesystem.py``）与 AppServer
+handler 各自新建 ``SessionManager``，所以「实例级锁」锁不住同一 key 的并发写：
+两个实例读到同一份旧快照，后写者覆盖先写者 → 丢条目。
+
+修复把 ``_session_locks`` / ``_session_locks_guard`` 提升为模块级（按 key 共享），
+并在 4 个 tracked 读-改-写方法（save_tracked_file / save_tracked_files_batch /
+reset_tracked_file_op / remove_tracked_file）内全程持锁。
+
+边界：本 PR 只做到**同进程跨实例**；跨进程（多个 bridge 进程、外部进程直接改
+文件）协调仍缺失，见 PR #1003 说明。
+"""
+
+import threading
+import time
+
+from miqi.session.manager import SessionManager
+
+
+def _slow_read(monkeypatch, delay: float = 0.02) -> None:
+    """把「读旧快照 → 写回」的窗口撑开，使竞态稳定复现（不靠调度运气）。
+
+    读完之后固定等待 *delay*：无锁实现下两个线程都会拿到同一份旧快照，
+    后写者必然覆盖先写者；持锁实现下第二次读发生在第一次写之后，两条都在。
+    """
+    orig = SessionManager.load_tracked_files
+
+    def slow(self, key, **kwargs):
+        files = orig(self, key, **kwargs)
+        time.sleep(delay)
+        return files
+
+    monkeypatch.setattr(SessionManager, "load_tracked_files", slow)
+
+
+def _run_two_threads(fn_a, fn_b) -> list[BaseException]:
+    """并发跑两个闭包，返回线程内未处理的异常（主线程断言用）。"""
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(2)
+
+    def wrap(fn):
+        try:
+            barrier.wait(timeout=10)
+            fn()
+        except BaseException as exc:  # noqa: BLE001 — 线程异常要带回主线程
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=wrap, args=(fn_a,), name="tracked-writer-a"),
+        threading.Thread(target=wrap, args=(fn_b,), name="tracked-writer-b"),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not any(t.is_alive() for t in threads), "线程未退出（疑似死锁）"
+    return errors
+
+
+def test_session_lock_is_shared_across_instances(tmp_path):
+    """锁本身：同一 key 在不同实例上拿到同一把锁。"""
+    sm_a = SessionManager(tmp_path)
+    sm_b = SessionManager(tmp_path)
+
+    assert sm_a._get_session_lock("desktop:983") is sm_b._get_session_lock("desktop:983")
+    # 不同 key 仍是不同的锁
+    assert sm_a._get_session_lock("desktop:983") is not sm_a._get_session_lock("desktop:984")
+
+
+def test_two_instances_concurrent_single_writes_keep_both(tmp_path, monkeypatch):
+    """两个不同实例并发写不同条目 → 两条都必须保留。"""
+    _slow_read(monkeypatch)
+    key = "desktop:983concurrent"
+    sm_a = SessionManager(tmp_path)
+    sm_b = SessionManager(tmp_path)
+
+    errors = _run_two_threads(
+        lambda: sm_a.save_tracked_file(key, "a.md", op="write"),
+        lambda: sm_b.save_tracked_file(key, "b.md", op="write"),
+    )
+
+    assert errors == [], errors
+    files = SessionManager(tmp_path).load_tracked_files(key)
+    assert set(files) == {"a.md", "b.md"}, files
+
+
+def test_two_instances_concurrent_batch_and_single_keep_both(tmp_path, monkeypatch):
+    """批量写与单条写共用同一把 key 锁 → 三条都必须保留。"""
+    _slow_read(monkeypatch)
+    key = "desktop:983batch"
+    sm_a = SessionManager(tmp_path)
+    sm_b = SessionManager(tmp_path)
+
+    errors = _run_two_threads(
+        lambda: sm_a.save_tracked_files_batch(
+            key, [("batch1.md", "write"), ("batch2.md", "write")],
+        ),
+        lambda: sm_b.save_tracked_file(key, "single.md", op="write"),
+    )
+
+    assert errors == [], errors
+    files = SessionManager(tmp_path).load_tracked_files(key)
+    assert set(files) == {"batch1.md", "batch2.md", "single.md"}, files


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复文档工具（create_pdf/docx/pptx/xlsx）的 tracked 条目写入孤儿路径、任务附件面板看不到；把 store key 派生统一到 `_session_files_dir_key`（含 exec 批量追踪，第 3 个文件）；并交付 **#983 缺口 2 —— #975 MCP 下载产物进 tracked**。

第四轮（本轮）在 `origin/develop` 已合入 #988（`e85bae6d`，MCP 下载客户端消费端）之后，把 `DownloadSink` 的落盘点补上 `_persist_tracked_file`（与 create_pdf 同机制）→ 下载产物自动进「任务附件」面板，用户可经 #877「下载/另存为」导出。

第三轮按外部评审三条 finding 全部处置：**① 读端 session key 归一**、**② custom workspace 测试改为真实生产调用链**、**③ tracked 读-改-写跨实例串行**；并在自审对抗复核中加固 ③（锁标识改为磁盘目录、`clear_tracked_files` 纳入同一把锁）。

第五轮（CodeRabbit 复审）处置 2 条：**`SessionManager.delete` 纳入 tracked 的同一把 key 锁**（消除「已删会话被在途写回复活」竞态，含 3 轮闸门竞态回归用例 + 去锁变异复现）、**跨 client 断言精确到 `UNAUTHORIZED`**。

## 背景/问题

**现象**：默认工作区下用文档工具生成的 PDF/DOCX/PPTX/XLSX 不进「任务附件」面板，用户拿不到 #877 的「下载/另存为」入口。实测孤儿文件：`~/.miqi/workspace/sessions/desktop_1788855465181/files/sessions/desktop_1788855465181/tracked_files.json`（含 4 个 PEST PDF），而同会话正规 tracked 19 条无 PDF。

**根因**：文档工具注册时 `workspace=<ws>/sessions/<key>/files`；`_persist_tracked_file`（`miqi/agent/tools/filesystem.py:191`）把该目录当仓库根构造 `SessionManager` → 条目落 `<files>/sessions/<key>/tracked_files.json`；面板读 `<ws>/sessions/<key>/tracked_files.json`，永远读不到。

**次因（store key 派生分叉）**：`_persist_tracked_file` 与 `shell.py::_persist_changed_batch` 各自实现「剥 client_id」规则，非 desktop 两段键被改错（`cli:other` → `other`、`cli:direct` → `direct`），与目录名派生端（`_session_files_dir_key`，`tool_registry_factory.py:300`）及读端（`file_handlers.py:100` / `session_handlers.py` 的 `safe_filename(key.replace(':', '_'))`）不一致 → 条目落错会话目录。

**缺口 2（本轮）**：#975 `DownloadSink` 把 MCP binary artifact 交付到 `<ws>/sessions/<key>/files/.miqi/downloads/`，但 sink **不写 tracked_files.json** → 产物只在磁盘上，资产面板看不到，用户拿不到 #877 的导出入口（#983 需求 1 的下载路径）。

**第三轮三条 finding（外部评审，HEAD = `adab0325`）**：

1. CodeRabbit（`miqi/agent/tools/filesystem.py:248`，Major）：`sessions.get_tracked_files` 未用 `_session_files_dir_key` 归一 key 就调 `load_tracked_files`，namespaced key 会解析到与 `_persist_tracked_file` 不同的目录。
2. sijie-Z 发现 1（tests）：`test_custom_workspace_is_not_stripped` 的测试前提与生产路径不一致——生产 custom workspace 不会进 `sessions/<key>/files`。
3. sijie-Z 发现 2（并发）：`save_tracked_file` / `save_tracked_files_batch` 是「整读整写 + 实例级锁」，`_persist_tracked_file` 每次新建 `SessionManager` → 并发写会丢条目。

## 关联 issue

Closes #983

#983（总目标）—— 本 PR 交付其**方案 A（产物 tracked 化）的全部落点**：

| #983 需求 | 落点 | 状态 |
|---|---|---|
| 文档工具产物 tracked | `filesystem.py` 存储根解耦 + key 派生统一 | 已交付（第一~三轮） |
| exec 产物 tracked | `shell.py::_persist_changed_batch` 同源派生 | 已交付（第二轮） |
| 面板级验证（L2 e2e） | `issue-983-doc-tool-assets.spec.ts`（原 #1002 挂账） | 已交付（第三轮） |
| **#975 下载产物 tracked（缺口 2）** | `mcp_download_sink.py` 交付后登记 | **已交付（本轮）** |

**关闭口径**：#983 需求 1 的两个落盘点（exec/文档工具 + #975 下载）均已交付并有回归锁；需求 2「agent 主动/目录级批量物化」在 issue 中标注「（可选，后续）」且需新授权通道（#875/#934/#935），不在本 PR 范围。读侧 `files.read` 工作区外路径受 **#955 冻结**（issue 评论已判定「建议冻结」，方案 A 经「另存为」绕开该缺口）。

- #1008（子 issue）→ 已按「内容并入 #983」撤销关闭
- #1002（L2 挂账）→ 已由本 PR 交付并撤销关闭

### 缺口 2 交付说明（本轮）

**改动点**（`miqi/agent/tools/mcp_download_sink.py`）：

- `materialize()` 在产物**已提交**（单包 `os.replace` / 分片 finalize 完成）后，于身份锁**外**、线程池内调用 `_track_delivered` → `_persist_tracked_file(..., op="write", session_key=...)`（与 create_pdf/docx 同机制）。
- 新增 `_downloads_root_base()`：**落盘根与 tracked 登记根同源**——默认工作区 = `<ws>/sessions/<key>/files`（`_tracked_store_root` 剥回 `<ws>` → 条目落 `<ws>/sessions/<derived>/tracked_files.json`，面板读端同一份）；自选项目目录 / 空 key = 工作区根。`resolve_downloads_dir()` 改为其薄封装，行为逐字不变。
- 条目键 = `.miqi/downloads/<name>`（会话 files 根相对路径）。

**fail-closed 边界**（逐条有回归）：

| 场景 | 行为 | 用例 |
|---|---|---|
| 分片中间态（`DownloadPendingError`） | 不登记 | `test_chunked_transfer_tracked_only_after_completion` |
| size/sha 校验失败、协议违例 | 不登记 | `test_failed_download_is_not_tracked` |
| 同内容复用（`reuse_existing`，不重写文件） | 仍登记（条目可能被外部清空） | `test_reuse_existing_artifact_is_tracked_again` |
| 登记本身失败（store 不可写等） | 只降级为「面板看不到」，**绝不**把已交付报成下载失败 | `test_tracking_failure_does_not_fail_delivery` |
| 空 session_key | `_persist_tracked_file` 早退，不写、不崩 | 既有 + `_downloads_root_base` 语义 |

**面板读端回路**（`tests/runtime/test_file_handlers.py::test_get_tracked_files_reads_sink_delivered_artifact`）：sink 交付 → 真实 handler `sessions.get_tracked_files` 读到 `.miqi/downloads/report.pdf` → 真实 handler `files.read(as_binary)` 取回原始字节（面板「下载/另存为」走的就是这条，`#877`）。

## 变更内容

| 文件 | 改动 | 理由 |
|---|---|---|
| `miqi/agent/tools/filesystem.py` | 新增 `_tracked_store_root`（+39 行）；`_persist_tracked_file` 改为「先用 `_session_files_dir_key` 归一 key，再以 `_tracked_store_root(...)` 作为 `SessionManager` 根」；`_session_files_dir_key` docstring 补幂等不变量 | **修复 A + 修复 B**。剥离 fail-closed：拿不到默认根 / 自定义工作区 / 目录名不匹配 / key 为空一律不剥 |
| `miqi/agent/tools/shell.py` | `_persist_changed_batch` 的旧 client_id 剥离规则替换为 `_session_files_dir_key(session_key)`（+4/-5） | **「统一」所需的第 3 个文件**：否则 `cli:direct` 会话里 exec 产物落 `sessions/direct/`、文档产物落 `sessions/cli_direct/`，面板只读后者 |
| `miqi/runtime/session_handlers.py` | 新增 `_tracked_files_store_key()`（+24 行）；`sessions_get_tracked_files_handler` / `sessions_clear_tracked_files_handler` 调用前归一 key（+2 行） | **第三轮 finding ①** |
| `miqi/session/manager.py` | `_session_locks` / `_session_locks_guard` 实例级 → 模块级；锁标识改为磁盘会话目录；4 个 tracked 读-改-写方法 + `clear_tracked_files` 全程持 key 锁（真实改动 +34/-5，其余为 `with` 缩进重排） | **第三轮 finding ③** + 复核加固 |
| `miqi/agent/tools/mcp_download_sink.py` | 新增 `_downloads_root_base()` / `_track_delivered()`；`materialize()` 交付后登记（锁外、线程池）；`resolve_downloads_dir` 改为薄封装（+61/-13） | **缺口 2（本轮）** |
| `tests/agent/tools/test_tracked_files_store_root.py` | 新增 21 例（+431 行；本轮重写 custom workspace 反例） | 修复 A/B 回归锁 + 第三轮 finding ② |
| `tests/agent/tools/test_mcp_download_sink_tracked.py` | 新增 7 例（+304 行，新文件） | **缺口 2 回归锁（本轮）** |
| `tests/runtime/test_file_handlers.py` | 新增 3 例 + 缺口 2 的读端回路 1 例（+163 行） | 第三轮 finding ① 读端回归 + **缺口 2 面板读端（本轮）** |
| `tests/session/test_tracked_files_concurrency.py` | 新增 6 例（+163 行，新文件） | 第三轮 finding ③ 的并发回归（含复核加固 3 例） |
| `apps/desktop/tests/e2e/issue-983-doc-tool-assets.spec.ts` | 新增（285 行） | **L2 面板级 e2e**（原 #1002）：agent 真调 `create_pdf` → ④-a canonical / ④-b 孤儿 / ④-c 面板读端同源 |
| `apps/desktop/tests/e2e/fixtures/create_pdf_mock.py` | 新增（180 行） | L2 的确定性 mock（自包含，不改 `scripts/mock_openai.py`） |

**本轮提交（4 个，各自单独可跑绿）**：

- `3becbc3f` —— `git merge origin/develop`（带入 #988 的 `mcp_download_sink.py`；7 文件 +2939/-67）
- `0d9b06c5` —— 缺口 2 实现 + 8 例回归（3 文件 +403/-13）
- `4e486958` —— 对抗复核加固（用例对齐现网两段 key + 补 `files.read` 取字节回路；2 文件 +48/-17）
- `300b3413` —— 注释校正（`files.read` 同根解析仅默认工作区布局成立；1 文件 +3/-2）

**diff 规模**：全 PR `origin/develop...2ea074c5` 11 文件 **+1891/-118**（含 merge 带入 develop 的既有提交）；第五轮净增 +118/-12（`miqi/session/manager.py` 忽略空白后为 +42/-5，其余是 `with` 块缩进重排）。

### 第四轮对抗复核 → 处置（缺口 2，逐条）

| # | 级别 | finding | 处置 |
|---|---|---|---|
| 1 | major | 自选工作区布局下文件读端仍锚 `<ws>/sessions/<key>/files` → 条目可见但按相对键取不到字节（文档工具同此，既有行为） | **不改代码**（读侧边界属 #955 冻结面）；用例/模块 docstring 明确边界，只断言存储读端，并写入「后续计划」 |
| 2 | major（潜在） | 三段 namespaced key 的文件读端派生不剥 client_id（`file_handlers.py:100`）→ 与写端 `_session_files_dir_key` 分叉 | **用例加固** `4e486958`：改用现网两段 key（两种派生逐字相同）；三段分叉记入「后续计划」 |
| 3 | major（范围受限） | `files.read` 只服务白名单后缀，`.cube` 类产物可见但取不到字节 | **用例加固**：读端回路改用白名单内后缀 `.pdf` 并真取字节；非白名单后缀限制记入「后续计划」 |
| 4 | minor | 每会话 custom workspace override 只到 `RuntimeServices.workspace`，sink base_workspace 仍是 `config.workspace_path` | 既有接线，记入「后续计划」 |
| 5 | minor | 登记在工具调用窗口内同步等待 → 病态 store 可能把已交付拖成超时 | **接受**：登记是单次 JSON upsert（毫秒级）；超时后重试走 `reuse_existing` 分支会重新登记（有用例）。fail-closed 语义不变 |

### 第三轮评审发现 → 处置（逐条）

| # | 来源 / 位置 | finding | 处置 | 证据 |
|---|---|---|---|---|
| ① | CodeRabbit `filesystem.py:248`（Major） | 读端未归一 key → namespaced key 读错目录 | **已修** `47d53f26`：新增 `_tracked_files_store_key()`，两个 handler 调用前归一 | 3 例新测试（走 `sessions.get_tracked_files` / `clear_tracked_files` handler）；改前 2 红 / 改后全绿（见日志 1–2）；ownership 论证见下 |
| ② | sijie-Z 发现 1（tests） | custom workspace 测试前提与生产不一致 | **已修** `03c42813`：改走 `create_runtime_tool_registry()` 真实调用链 | 变异对照（把 `_persist_tracked_file` 改成「一律写默认根」→ 该用例红，见日志 4）；fail-closed 断言保留 |
| ③ | sijie-Z 发现 2（并发） | 整读整写 + 实例级锁 → 并发写丢条目 | **已修** `094a40d2` + 加固 `17aba8a7`：锁提升模块级、锁标识改为磁盘目录、6 个 RMW/删除方法全程持锁 | 6 例新测试：改前 3 红（丢 `b.md` / 批量+单条全丢）、加固前再 3 红（别名 key 丢 `tool.md` / clear 未等待）（见日志 5–8） |

#### ① ownership 校验未被削弱（代码核实）

- 归一发生在 `load_tracked_files(key, client_id=...)` **之前**；归属校验仍由 `SessionManager._verify_ownership_for_mutation` 完成（`miqi/session/manager.py:976-1008`），它用 `_get_session_path(key)` → `get_session_dir(key)` = `sessions/<safe_filename(key.replace(":", "_"))>/conversation.jsonl`（`manager.py:158-160`）定位会话记录。
- **2 段 key（现网唯一形态）**：desktop 侧会话键构造为 `` `desktop:${Date.now()}` ``（`ChatConsole.tsx:4034`），传给 handler 的 `session_key` 即 2 段。对 2 段 key，`_session_files_dir_key(key) == safe_filename(key.replace(":", "_"))` **逐字相同** → 校验对象与结果都不变（`test_get_tracked_files_two_segment_key_behavior_unchanged` 断言恒等 + 读端回环）。
- **3 段 namespaced key**：只有这种形态才分叉。写端本来就把条目落 `sessions/desktop_983/`，归一后读端校验的正是「条目所属的那条会话记录」；跨 client 仍被拒（新测试 `test_get_tracked_files_namespaced_key_reads_write_path_store` 内断言 client-B → `UNAUTHORIZED`/`REQUIRES_CLAIM`）。
- 3 段 key 只出现在 AppServer registry 的 `session_id`（`<client_id>:<session_key>`）里，当前无调用方把它直接传给这两个 handler；本次归一同时为将来传 3 段 key 铺平。

#### ② 测试重写要点

- 生产形态（`tool_registry_factory.py:286,310-323`）：只有 `is_default_ws and session_workspace_enabled` 才把 `_work_dir` 设为 `workspace/sessions/<safe_key>/files`；**custom workspace 下 `_write_workspace = workspace`**，文档工具直接落在用户选定的目录。
- 旧用例手工拼 `<tmp>/proj/sessions/<key>/files` 当工具 workspace —— 这个形状生产上不会作为 custom workspace 传入，只能证明 helper 对非生产形状保持旧行为。
- 新用例：`tmp_path` 下非默认工作区 + `create_runtime_tool_registry(config=fake_config, workspace=custom, session_id=key)` 取 `create_docx` 实例 → 断言 `tool._workspace == custom`（无嵌套）→ 执行 → 断言 tracked 存储根（`tool._workspace`）与面板读端**同根可读**；面板读端根另从 `fake_config.workspace_path` 独立取一次（`sessions.get_tracked_files → SessionManager(config.workspace_path)`），若 registry workspace 与 config 派生读端根分叉会红。
- 原守卫矩阵用例 `test_tracked_store_root_guard_matrix` 继续覆盖 `base != 默认根` 分支（该分支是 helper 级语义，保留）。

#### ③ 并发边界与复核加固

- 锁按 **磁盘会话目录** 在进程内共享：同进程内不同 `SessionManager` 实例对同一目录串行化。不同 workspace 的同名 key 现在落到不同锁（更精确）。
- **复核加固（`17aba8a7`）**：自审对抗评审发现原实现仍有两处缺口，同属一类——
  1. 锁按调用方传入的 **key 字符串** 取：工具写端传派生名（`desktop_983`），`file_handlers`（files.accept/revert/write）传客户端原始 key（`desktop:983`）→ 同一 `tracked_files.json` 两把锁，仍会互相覆盖（实测丢 `tool.md`）。改为 **锁标识 = `get_session_dir(key)` 的磁盘路径**。
  2. `clear_tracked_files` 未持锁：整文件删除会与在途读-改-写交错（删除被随后的 `tmp.replace` 悄悄撤销）。已纳入同一把 key 锁。
- **本 PR 只做到同进程跨实例；跨进程协调（多个 bridge 进程、外部进程直接改 `tracked_files.json`）仍缺失，已记入后续计划。**
- 无跨 key 嵌套加锁：`save` / `set_title` / `compact` 与 tracked 方法各自只持本 key 锁 → 无死锁面。

### 前两轮评审 finding 逐条处置（保留）

| # | 级别 | 处置 |
|---|---|---|
| 1 | high（L2 electron e2e 缺失） | **已交付**（第三轮 `6fac8502`）：`issue-983-doc-tool-assets.spec.ts` 走真实 `create_pdf` 调用链，④-a/④-b/④-c 判别性断言，见日志 14–15、17 |
| 2 | medium（shell.py 旧规则 + 失真注释） | **已做**：改用 `_session_files_dir_key`；新增 `test_exec_batch_persist_shares_session_dir_with_doc_tools` |
| 3 | low（中间提交单独不绿） | **已做**：`aed51d29` squash；后续各轮提交各自单独可跑绿 |
| 4 | low（str 入参 / 空串 / 面板读取回路未断言） | **已做** |
| 5 | low（ruff format 不符合） | **不适用**：仓库未启用 Python 格式化门禁 |
| 6 | info（守卫与落点逐项核查未发现缺陷） | 引用为无缺陷证据 |

### 前两轮复核（P1/P2 处置，HEAD = `adab0325`）

- **P1「新测试没隔离，在写真实 MIQI_HOME」→ 撤销（误报）**：`tests/conftest.py:145` 是 `@pytest.fixture(autouse=True)`，`:171` `monkeypatch.setenv("MIQI_HOME", ...)`；`miqi/paths.py:18-22` 的 `get_miqi_home()` 每次调用都读 `os.environ`。
- **P2「`_tracked_store_root` 双重归一」→ 非 correctness bug**：`_session_files_dir_key` 实测幂等，本轮已把该契约变成可执行（docstring 不变量 + 幂等断言 6 例）。
- **边界**：本 PR 解决「后端存储根与读端契约对齐」+「面板级验证」+「下载产物 tracked」；读侧工作区外路径受 #955 冻结。

### 第五轮 CodeRabbit 复审 → 处置（逐条，2 条）

| # | 级别 / 位置 | finding | 处置 | 证据 |
|---|---|---|---|---|
| 1 | Major `miqi/session/manager.py:430` | `delete` 不持 key 锁：同进程内与在途 `save_tracked_file` 交错 → 删除后写端 `path.parent.mkdir` + `tmp.replace` 把会话目录与 `tracked_files.json` 重建（已删会话复活）；反向交错写端抛 `FileNotFoundError` | **已修** `7e33ca1`：`_migrate_flat_to_dir` → `rmtree` → 旧扁平兜底整段纳入 `with self._get_session_lock(key)`；`_cache.pop` 与 `_verify_ownership_for_mutation` 保持锁外。该锁是模块级 `threading.RLock`（可重入），delete 路径内不再获取其它锁 → 无锁序问题 | 新用例 `test_delete_does_not_resurrect_session_during_in_flight_tracked_write`（3 轮闸门竞态）：去锁必红、加锁全绿（日志 29–31） |
| 2 | Minor `tests/runtime/test_file_handlers.py:380` | 断言放宽到 `in ("UNAUTHORIZED", "REQUIRES_CLAIM")` → 会放过「ownership 元数据缺失 / 目录解析错」的回归 | **已修** `2ea074c5`：精确到 `UNAUTHORIZED`。实跑仍绿 —— 生产侧确实返回 `UNAUTHORIZED`，未改实现迁就断言 | `tests/runtime` 1364 passed / 5 skipped（日志 32） |

## 日志/验证证据

```
# 1) ① 改前红（git checkout -- miqi/runtime/session_handlers.py，仅回退本轮 handler 改动）
$ .venv/Scripts/python.exe -m pytest tests/runtime/test_file_handlers.py -q -k "namespaced_key or two_segment"
FAILED tests/runtime/test_file_handlers.py::test_get_tracked_files_namespaced_key_reads_write_path_store
FAILED tests/runtime/test_file_handlers.py::test_clear_tracked_files_namespaced_key_clears_write_path_store
E       AssertionError: clear 未删到写端落盘的文件：.../workspace/sessions/desktop_983clear/tracked_files.json
2 failed, 1 passed, 22 deselected in 0.36s
# （2 段 key 用例改前改后都绿 = 归一恒等，行为不变）

# 2) ① 改后绿
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py tests/runtime/test_file_handlers.py -q
..............................................                           [100%]
46 passed in 1.71s

# 3) ② 重写后的用例（真实 registry 调用链）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py -q
.....................                                                    [100%]
21 passed in 1.07s

# 4) ② 非恒真（变异对照：把 _persist_tracked_file 改成一律写默认工作区根）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py -q -k custom
>       assert path.exists(), f"tracked_files.json 不存在：{path}"
E       AssertionError: tracked_files.json 不存在：.../project/sessions/desktop_983custom/tracked_files.json
FAILED tests/agent/tools/test_tracked_files_store_root.py::test_custom_workspace_is_not_stripped
1 failed, 20 deselected in 0.51s
# （变异已回退，未进提交）

# 5) ③ 改前红（git checkout HEAD -- miqi/session/manager.py，回退到 adab0325 的实例级锁）
$ .venv/Scripts/python.exe -m pytest tests/session/test_tracked_files_concurrency.py -q
E       AssertionError: assert <RLock owner=0 ...> is <RLock owner=0 ...>     # 实例锁不共享
E       AssertionError: {'a.md': {...}}                                       # 丢掉 'b.md'
E         Extra items in the right set: 'b.md'
E       AssertionError: {}                                                    # 批量 + 单条全丢
E         Extra items in the right set: 'batch1.md' 'single.md' 'batch2.md'
FAILED ...::test_session_lock_is_shared_across_instances
FAILED ...::test_two_instances_concurrent_single_writes_keep_both
FAILED ...::test_two_instances_concurrent_batch_and_single_keep_both
3 failed in 0.28s

# 6) ③ 首次修复后绿
$ .venv/Scripts/python.exe -m pytest tests/session/test_tracked_files_concurrency.py -q
...                                                                      [100%]
3 passed in 0.19s

# 7) ③ 复核加固：新增 3 例在加固前红（HEAD = 094a40d2 的实现）
$ .venv/Scripts/python.exe -m pytest tests/session/test_tracked_files_concurrency.py -q
E       AssertionError: assert <RLock ...> is <RLock ...>                     # 别名 key 两把锁
E        +  where _get_session_lock = ...._get_session_lock('desktop:983')
E        +  and   _get_session_lock = ...._get_session_lock('desktop_983')
E       AssertionError: {'panel.md': {...}}                                   # 丢掉 'tool.md'
E         Extra items in the right set: 'tool.md'
E           AssertionError: clear 未等待 key 锁
FAILED ...::test_session_lock_is_shared_by_alias_keys
FAILED ...::test_concurrent_raw_and_derived_key_writes_keep_both
FAILED ...::test_clear_tracked_files_waits_for_key_lock
3 failed, 3 passed in 0.50s

# 8) ③ 加固后绿（全部 6 例）
$ .venv/Scripts/python.exe -m pytest tests/session/test_tracked_files_concurrency.py -q
......                                                                   [100%]
6 passed in 0.40s

# 9) 必跑回归 1
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py tests/runtime/test_file_handlers.py -q
46 passed in 1.71s

# 10) 必跑回归 2
$ .venv/Scripts/python.exe -m pytest tests/agent/tools tests/documents tests/runtime -q
1663 passed, 5 skipped in 87.79s (0:01:27)

# 11) 共享锁影响面：session / bridge
$ .venv/Scripts/python.exe -m pytest tests/session -q
64 passed in 0.85s
$ .venv/Scripts/python.exe -m pytest tests/session tests/bridge -q
311 passed in 23.40s

# 12) 全量本地套件（HEAD = 259afb93，第三轮）
$ .venv/Scripts/python.exe -m pytest tests -q
3 failed, 3624 passed, 21 skipped in 425.58s (0:07:05)
# 3 failed 全在 tests/sandbox（WSL 环境相关，与本改动无关）：
#   test_bwrap_auto_install.py::test_wsl_sandbox_auto_install
#   test_wsl_detect_readiness.py::test_ensure_wsl_deps_installs_python_toolchain
#   test_wsl_detect_readiness.py::test_detect_falls_back_to_another_distro_when_preferred_missing_pip
# 失败原因：`apt-get install` 在本机 WSL distro 内失败（E: Failed to install bwrap in WSL distro 'Ubuntu-22.04'）
# 本 PR 未触及 miqi/sandbox/**。

# 13) ruff（本轮改动文件）
$ uv tool run ruff check miqi/runtime/session_handlers.py miqi/session/manager.py tests/runtime/test_file_handlers.py tests/session/test_tracked_files_concurrency.py tests/agent/tools/test_tracked_files_store_root.py
All checks passed!

# 14) L2 面板级 electron e2e（commit 6fac8502；本机 Windows 11）
$ cd apps/desktop && PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test --config=playwright.config.ts --project=electron --workers=1 issue-983-doc-tool-assets.spec.ts --reporter=list
[test] session key = desktop:default
[test] session dir = ...\workspace\sessions\desktop_default
[test] ✅ ④-a canonical tracked store contains the artifact
[test] ✅ ④-b no orphan tracked store under <sessionDir>/files
[test] ✅ ④-c sessions.getTrackedFiles sees the artifact
[test] ✅ ① smoke: asset panel card rendered
  1 passed (53.0s)

# 15) L2 判别性对照（把 miqi/agent/tools/filesystem.py + shell.py 临时回退到 origin/develop，同一 spec）
Error: canonical tracked store missing: <MIQI_HOME>\workspace\sessions\desktop_default\tracked_files.json
  1 failed
# （回退已还原，未进提交；证明 spec 非恒绿）

# 16) tracked 相关三文件回归（HEAD = 6fac8502）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py tests/runtime/test_file_handlers.py tests/session/test_tracked_files_concurrency.py -q
52 passed in 5.36s

# 17) CI（GitHub Actions，HEAD = f602c7f0，第三轮）
#   Desktop CI / electron-e2e：132 passed, 2 flaky, 48 skipped, 0 failed (17.4m)
#   本 spec 在 CI 中真实执行并全绿（关键行）：
[test] session key = desktop:default
[test] ✅ ④-a canonical tracked store contains the artifact
[test] ✅ ④-b no orphan tracked store under <sessionDir>/files
[test] ✅ ④-c sessions.getTrackedFiles sees the artifact
[test] ✅ ① smoke: asset panel card rendered
#   其余 job：quick / macos-build / macos-e2e / lint / typecheck / bwrap / wsl-sandbox / wsl-e2e /
#   test(ubuntu|windows) / check-format / check-title / validate 全 pass

# 17b) CI（HEAD = 300b3413，第四轮）—— `gh pr checks 1003` 全部 pass
#   Analyze(actions|js|python) / CodeQL / bwrap / check-format / check-title / electron-e2e /
#   lint / macos-build / macos-e2e / quick / test(ubuntu|windows) / typecheck / validate = 14 pass
#   electron-e2e：135 passed, 47 skipped, 0 failed (15.5m)；L2 spec 在 CI 真实执行并全绿：
[test] ✅ ④-a canonical tracked store contains the artifact
[test] ✅ ④-b no orphan tracked store under <sessionDir>/files
[test] ✅ ④-c sessions.getTrackedFiles sees the artifact
#   macos-e2e 首跑 fail（25m57s）→ 复跑 pass（25m14s）：失败原因是
#   `Error: worker-1 process did not exit within 300000ms after stop, force-killed it`
#   + 1 flaky（tests/e2e/task-assets.spec.ts:143「Preview on tracked file」首跑 60s 超时、
#   重试通过；该用例走 write_file，不经下载 sink）→ 判定为仓库既有 flaky（
#   develop 上一跑 e85bae6d 同 job 亦为 success），非本改动引入；已如实记录、未绕过检查。

# 18) CodeQL
#   修复前：CodeQL 检查 fail —— py/polynomial-redos（high）apps/desktop/tests/e2e/fixtures/create_pdf_mock.py:55
#   修复后（f602c7f0）：CodeQL pass；open code-scanning alerts（本 PR）= 0

# ── 第四轮（缺口 2）────────────────────────────────────────────────────────

# 19) 同步 develop：把 #988 的 mcp_download_sink.py 带进分支
$ git merge origin/develop
Merge made by the 'ort' strategy.
 miqi/agent/tools/mcp_download_sink.py              | 1471 ++++++++++++++++++++
 tests/agent/tools/test_mcp_download_sink.py        |  886 +++++++++++++++++++++
 ... 7 files changed, 2939 insertions(+), 67 deletions(-)

# 20) 缺口 2 新用例（改前 = 无 _track_delivered 调用，故先给出改后绿）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_mcp_download_sink_tracked.py -q
7 passed in 0.34s

# 21) 变异验证 A：删掉 materialize 里的 _track_delivered 调用（登记点整段消失）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_mcp_download_sink_tracked.py tests/runtime/test_file_handlers.py -q
FAILED ...::test_single_shot_artifact_lands_in_session_tracked_store
FAILED ...::test_tracked_key_resolves_through_panel_read_path
FAILED ...::test_chunked_transfer_tracked_only_after_completion
FAILED ...::test_reuse_existing_artifact_is_tracked_again
FAILED ...::test_custom_workspace_tracks_at_workspace_store_root
FAILED tests/runtime/test_file_handlers.py::test_get_tracked_files_reads_sink_delivered_artifact
6 failed, 27 passed in 0.95s
# （两条反例用例仍绿 = 它们断言「不登记 / 不影响交付」，语义正确）

# 22) 变异验证 B：登记根改成 base_workspace（条目键会多一层 sessions/<k>/files/ 前缀）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_mcp_download_sink_tracked.py tests/runtime/test_file_handlers.py -q
E       assert '.miqi/downloads/result.cube' in {'sessions/desktop_983downloads/files/.miqi/downloads/result.cube': {...}}
E       assert '.miqi/downloads/report.pdf' in {'sessions/desktop_983downloads/files/.miqi/downloads/report.pdf'}
FAILED ...::test_single_shot_artifact_lands_in_session_tracked_store
FAILED ...::test_tracked_key_resolves_through_panel_read_path
FAILED ...::test_chunked_transfer_tracked_only_after_completion
FAILED ...::test_reuse_existing_artifact_is_tracked_again
FAILED tests/runtime/test_file_handlers.py::test_get_tracked_files_reads_sink_delivered_artifact
5 failed, 28 passed in 0.93s
# （两次变异均已回退，未进提交）

# 23) 复核加固后恢复绿（HEAD = 4e486958）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_mcp_download_sink_tracked.py tests/runtime/test_file_handlers.py -q
33 passed in 0.83s

# 24) 必跑回归 1（tracked 三文件）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools/test_tracked_files_store_root.py tests/runtime/test_file_handlers.py tests/session/test_tracked_files_concurrency.py -q
53 passed in 1.92s

# 25) 必跑回归 2（agent/tools + documents + runtime，HEAD = 4e486958）
$ .venv/Scripts/python.exe -m pytest tests/agent/tools tests/documents tests/runtime -q
1723 passed, 5 skipped in 84.46s (0:01:24)

# 26) tests/agent/tools 单目录
$ .venv/Scripts/python.exe -m pytest tests/agent/tools -q
296 passed in 4.93s

# 27) 全量本地套件（HEAD = 4e486958）
$ .venv/Scripts/python.exe -m pytest tests -q
4 failed, 3694 passed, 21 skipped, 4 warnings in 608.29s (0:10:08)
# 3 failed = tests/sandbox 的 WSL 环境问题（同日志 12，本 PR 未触及 miqi/sandbox/**）
# 1 failed = tests/execution/test_exec_timeout_810.py::test_outer_cancellation_kills_process_tree
#   连跑 3 次：1 failed / 1 failed / 1 passed —— 该用例在 asyncio.wait_for(..., timeout=2)
#   内等子进程写 pid 文件，属计时竞态/环境相关（失败点在 pid 文件未生成，非断言逻辑），
#   本 PR 未触及 miqi/execution/**：
$ for i in 1 2 3; do .venv/Scripts/python.exe -m pytest tests/execution/test_exec_timeout_810.py::test_outer_cancellation_kills_process_tree -q | tail -1; done
1 failed in 2.25s
1 failed in 2.23s
1 passed in 2.72s

# 28) ruff（本轮改动文件）
$ uv tool run ruff check miqi/agent/tools/mcp_download_sink.py tests/agent/tools/test_mcp_download_sink_tracked.py tests/runtime/test_file_handlers.py
All checks passed!
# ── 第五轮（CodeRabbit 复审 2 条）────────────────────────────────────────────
# 29) 意见 1 变异验证：去掉 delete 的 key 锁（已回退，未进提交）
#    探针 = 同一用例但把「目录是否被重建」放到锁等待断言之前，用于同时看到两个后果
$ uv run --extra dev pytest <probe>/probe_delete_resurrect_test.py::test_delete_does_not_resurrect_session_during_in_flight_tracked_write -p no:cacheprovider -q -s
[probe round 0] deleted_while_writing=True delete_results=[True] errors=[] session_dir.exists=True tracked_json.exists=True
1 failed in 0.20s
E  AssertionError: [round 0] 已删除的会话目录被在途写端重建（会话复活）

# 30) 同一变异下的真实用例（无锁）
$ uv run --extra dev pytest tests/session/test_tracked_files_concurrency.py -p no:cacheprovider -q
1 failed, 6 passed in 0.61s
E  AssertionError: [round 0] delete 未等待 key 锁：写端仍持锁时就完成了删除
# 红的正是新增用例，其余 6 例不受影响

# 31) 加锁后（HEAD = 2ea074c5）
$ uv run --extra dev pytest <probe>/... -p no:cacheprovider -q -s
[probe round 0] deleted_while_writing=False delete_results=[True] errors=[] session_dir.exists=False tracked_json.exists=False
[probe round 1] deleted_while_writing=False delete_results=[True] errors=[] session_dir.exists=False tracked_json.exists=False
[probe round 2] deleted_while_writing=False delete_results=[True] errors=[] session_dir.exists=False tracked_json.exists=False
1 passed in 1.61s
$ uv run --extra dev pytest tests/session -p no:cacheprovider -q
65 passed in 2.36s
$ uv run --extra dev pytest tests/session/test_tracked_files_concurrency.py -p no:cacheprovider -q
7 passed in 1.95s
$ uv run --extra dev pytest tests/runtime -p no:cacheprovider -q
1364 passed, 5 skipped in 81.89s
$ uv run --extra dev pytest tests/agent/tools -p no:cacheprovider -q
296 passed in 5.61s
$ uv run --extra dev ruff check .
All checks passed!

# 32) 意见 2：断言精确到 UNAUTHORIZED 后实跑（HEAD = 2ea074c5）
$ uv run --extra dev pytest tests/runtime/test_file_handlers.py -p no:cacheprovider -q
26 passed in 0.59s
$ uv run --extra dev pytest tests/runtime/test_file_handlers.py::test_get_tracked_files_namespaced_key_reads_write_path_store -p no:cacheprovider -q
1 passed in 0.11s
# 生产侧确实返回 UNAUTHORIZED（未改实现迁就断言）；若返回 REQUIRES_CLAIM 说明目录解析分叉，属回归

# 33) CI（HEAD = 2ea074c5，第五轮）—— `gh pr checks 1003` 19 项全 pass
#   Analyze(actions|javascript-typescript|python) / CodeQL / GitGuardian / bwrap /
#   check-format / check-title / lint / macos-build / quick / typecheck / validate /
#   test(ubuntu-latest) / test(windows-latest) / wsl-sandbox / electron-e2e /
#   macos-e2e / wsl-e2e = pass
#   electron-e2e：134 passed, 1 flaky, 0 failed (17.5m)，job pass
#     1 flaky = tests/e2e/guard-issue-811-real-llm.spec.ts:187「B: 越界删除（/etc）」
#     （real LLM 用例，重试后通过；不经 tracked / session-delete 路径），非本改动引入
#   macos-e2e：pass (22m55s)；wsl-e2e：pass (19m10s)
```

## 测试情况

- 缺口 2 新增用例：`tests/agent/tools/test_mcp_download_sink_tracked.py` **7 passed**；`tests/runtime/test_file_handlers.py` 缺口 2 读端回路 **+1 例**
- 变异验证：去掉登记调用 **6 failed**；登记根改错 **5 failed**（见日志 21–22）
- tracked 三文件回归：**53 passed in 1.92s**
- 必跑回归 `tests/agent/tools tests/documents tests/runtime`：**1723 passed, 5 skipped in 84.46s**（合并 develop 后基线含 #988 的 sink 用例 52 例；本 PR 净增 8 例）
- `tests/agent/tools`：**296 passed**；`tests/session tests/bridge`：**311 passed**
- 全量本地套件：**3694 passed, 21 skipped, 4 failed**（3 = `tests/sandbox` WSL 环境；1 = `test_exec_timeout_810` 计时竞态，连跑 3 次 2 红 1 绿 —— 均与本改动无关，见日志 27）
- **CI**（HEAD = `2ea074c5`，第五轮）：`gh pr checks 1003` **19 项全 pass**（含 CodeQL / electron-e2e / macos-e2e / wsl-e2e / test(ubuntu|windows) / lint / typecheck / check-format / check-title / validate）；`electron-e2e` **134 passed / 1 flaky / 0 failed**（17.5m，flaky 为 real-LLM 用例重试通过，非本改动引入）
- 第五轮（CodeRabbit 复审）：`SessionManager.delete` 锁修复 + 断言精确化 —— `tests/session` **65 passed** / `tests/session/test_tracked_files_concurrency.py` **7 passed** / `tests/runtime` **1364 passed, 5 skipped** / `tests/agent/tools` **296 passed** / `ruff check .` **All checks passed!**；变异去锁 **1 failed**（见日志 29–32）
- `uv tool run ruff check` 本轮改动文件：**All checks passed!**
- 面板级 electron e2e（方案 §3 L2，原 #1002）：**1 passed (53.0s)**；判别性对照 **1 failed**（回退 develop 源码后 canonical tracked 缺失 → 非恒绿）
- **CI**（HEAD = `300b3413`）：`gh pr checks 1003` **14 项全 pass**（含 CodeQL / electron-e2e / macos-e2e / wsl-e2e / test(ubuntu|windows) / lint / typecheck / check-format / check-title / validate）；`electron-e2e` **135 passed / 47 skipped / 0 failed**（15.5m），L2 spec 全绿。`macos-e2e` 首跑 fail（worker 退出超时 + 1 例既有 flaky 用例重试通过）→ 复跑 **pass**（见日志 17b，未绕过检查）
- **未做**：下载路径的 L2 electron e2e（需为 MCP 下载配 mock server + 白名单 server 名 `miqroforge`，与 #988 的 mock 基建一并设计）；跨进程锁协调 → 见后续计划

## 截图

无 UI 变更，无需人工截图。L2 e2e 每次运行由 Playwright 自动落 `apps/desktop/test-results/issue-983-doc-tool-assets-*.png`（未入库）。

## 后续计划

- **跨进程 tracked 写入协调**（第三轮 ③ 只做到同进程跨实例）：多 bridge 进程 / 外部进程直接改 `tracked_files.json` 仍可能丢条目，需文件锁（如 `msvcrt.locking` / `fcntl.flock`）或单写者收口
- **读端锚点与写端落点的分叉**（第四轮对抗复核发现，**均非本 PR 引入**）：
  1. 自选工作区布局下 `files.read` 恒锚 `<ws>/sessions/<key>/files`（`file_handlers.py:187-196`）→ tracked 条目可见、按相对键取不到字节（文档工具与下载产物同此）；是否让读端对「不存在的会话相对路径」回退到工作区根，属读侧边界变更，需单独评估
  2. 三段 namespaced key 下文件读端目录派生不剥 client_id（`file_handlers.py:100`），与写端 `_session_files_dir_key` 分叉（#1003 finding ① 的同类问题，位置在文件路径侧）；现网 key 为两段，潜在
  3. `files.read` 只服务白名单后缀（文本安全 / 可预览 / `as_binary` 可读）；非白名单后缀（`.cube`/`.traj`/`.out` 等）产物在面板可见但取不到字节（`File type not supported`）→ #877 另存为对这类科学产物不可用
  4. 每会话 custom workspace override 只到 `RuntimeServices.workspace`（`bridge/loop.py:904`），MCP sink 的 `base_workspace` 仍是 `config.workspace_path`（`runtime/session.py:190-195`）→ 该形态下下载落默认根
- **ownership 校验的空目录盲区**（自审复核发现，**非本 PR 引入**，未在本 PR 修）：`_verify_ownership_for_mutation` 在 `conversation.jsonl` 不存在时放行（`manager.py:993-996`）；若会话目录只有 `tracked_files.json`（工具先落盘、会话尚未 save），另一 client 猜中 key 可读到该条目。属既有边界，需单独 issue 区分「目录不存在」与「有 tracked 数据但无 owner 记录」
- **#983 需求 2「agent 主动/目录级批量物化」**（issue 内标注「可选，后续」）：需新授权通道（复用 #875 授权卡 / #934 Grant Token / #935 审计），不在本 PR 范围
- 方案 §4 其余挂账（**不在本 PR 范围**）：
  ① exec **沙箱内** `open()` 产物不入面板（`bwrap.py:1884 _sync_workspace` 无调用者）
  ② 工作区外（桌面）产物**可见但打不开**（`file_handlers.py:177-184`；受 **#955 冻结**）
  ③ `EditDocxTool`（`docx_tool.py:551`）不 track
  ④ 前端 `normalizeTrackedPath` 的 `lastIndexOf('/workspace/')` 截断（`ChatConsole.tsx:842-844`）

