### PR TITLE
fix(documents): 文档工具路径边界——会话 key 派生分叉 + docx/pptx 图片块无界读（#1005）

### DIFF
--- a/docs/backend/path-semantics.yaml
+++ b/docs/backend/path-semantics.yaml
@@ -8,6 +8,9 @@
 #   解析器会自动剥离该前缀，不会产生目录嵌套（修复 issue #806 的嵌套落盘问题）
 # - 指向其他会话目录的路径会被拒绝（会话隔离）
 # - 成功创建后返回实际落盘路径
+# - 输入图片路径（docx 的 content 图片块 path / pptx 的 slides[].image_path）
+#   不是可信输入：解析后必须落在工作区 / 会话文件区 / 用户授权目录内，
+#   越界即不读该文件、跳过该图片并在返回串中报告（issue #1005 节 2）
 #
 # 详细实现见 miqi/documents/path_utils.py 模块文档。
 path_semantics:
@@ -15,3 +18,4 @@ path_semantics:
   prefix_stripping: "以会话目录前缀开头的路径自动剥离前缀，避免嵌套"
   cross_session: "指向其他会话目录的路径会被拒绝（会话隔离）"
   return_value: "成功创建后返回实际落盘路径"
+  input_images: "docx/pptx 的图片块走 resolve_read_path，与输出同一边界；越界/缺失/非图片跳过该图片（不读文件）并在返回串中报告"

--- a/miqi/documents/docx_tool.py
+++ b/miqi/documents/docx_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,10 @@ from miqi.documents.path_utils import (
     ensure_suffix,
     raw_output_path,
     resolve_output_path,
+    resolve_read_path,
 )
+
+logger = logging.getLogger(__name__)
 
 _MARKDOWN_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
 
@@ -66,8 +70,24 @@ _CHINESE_SIZE_TO_PT = {
 }
 
 
-def _add_docx_content(doc: Any, content: Any) -> int:
-    """Add supported structured content to a python-docx document."""
+def _add_docx_content(
+    doc: Any,
+    content: Any,
+    *,
+    workspace: Path | None = None,
+    allowed_dir: Path | None = None,
+    user_roots: Any = None,
+    allow_user_roots: bool = False,
+    skipped: list[str] | None = None,
+) -> int:
+    """Add supported structured content to a python-docx document.
+
+    Image blocks carry a model-controlled path, so each one is resolved
+    through :func:`resolve_read_path` (workspace / session files / authorized
+    user roots only) and a failure skips *that block* — never the whole
+    document.  Reasons are appended to *skipped* for the caller's return
+    string.
+    """
     blocks = content if isinstance(content, list) else [{"type": "paragraph", "text": str(content)}]
     count = 0
     for block in blocks:
@@ -92,8 +112,24 @@ def _add_docx_content(doc: Any, content: Any) -> int:
         elif block_type == "image":
             image_path = block.get("path")
             if image_path:
-                doc.add_picture(str(image_path))
-                count += 1
+                try:
+                    resolved = resolve_read_path(
+                        str(image_path),
+                        workspace,
+                        allowed_dir,
+                        user_roots,
+                        allow_user_roots,
+                    )
+                    doc.add_picture(str(resolved))
+                    count += 1
+                except Exception as e:
+                    # Out-of-bounds, missing, or not-an-image: skip this block
+                    # and keep building the document (issue #1005 节 2).
+                    logger.warning(
+                        "create_docx: 跳过图片块 %s：%s", image_path, e,
+                    )
+                    if skipped is not None:
+                        skipped.append(f"{image_path}（{e}）")
         else:
             doc.add_paragraph(str(block.get("text", "")))
             count += 1
@@ -391,16 +427,21 @@ class CreateDocxTool(Tool):
         "Create a Word (.docx) document in the workspace files directory. "
         "Supports title, paragraphs, headings, tables, images, and common "
         "Word formatting such as Chinese fonts, font sizes, alignment, bold, "
-        "and line spacing."
+        "and line spacing. "
+        "Image blocks' path must resolve inside the session files directory "
+        "(or a user-authorized directory); an image outside those roots is "
+        "skipped, not embedded, and reported in the result."
     )
 
     def __init__(
         self,
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
+        allow_user_roots: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
+        self._allow_user_roots = allow_user_roots
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -491,6 +532,7 @@ class CreateDocxTool(Tool):
         from docx import Document
 
         _sess_key = kwargs.pop("_session_key", None)
+        user_roots = kwargs.pop("_user_roots", None)
         raw_path = raw_output_path(kwargs)
         content = kwargs.get("content", "")
         if not raw_path.strip():
@@ -518,8 +560,17 @@ class CreateDocxTool(Tool):
             doc = Document()
             if kwargs.get("title"):
                 doc.add_heading(str(kwargs["title"]), level=0)
+            skipped_images: list[str] = []
             if isinstance(content, list):
-                _add_docx_content(doc, content)
+                _add_docx_content(
+                    doc,
+                    content,
+                    workspace=self._workspace,
+                    allowed_dir=self._allowed_dir,
+                    user_roots=user_roots,
+                    allow_user_roots=self._allow_user_roots,
+                    skipped=skipped_images,
+                )
             elif content:
                 _add_markdown_like_text(doc, content)
             for paragraph in kwargs.get("paragraphs", []) or []:
@@ -533,7 +584,13 @@ class CreateDocxTool(Tool):
             file_path.parent.mkdir(parents=True, exist_ok=True)
             doc.save(str(file_path))
             _persist_tracked_file(self._workspace, file_path, op="write", session_key=_sess_key)
-            return f"Created: {file_path}"
+            result = f"Created: {file_path}"
+            if skipped_images:
+                result += (
+                    f"（跳过 {len(skipped_images)} 个图片："
+                    f"{'；'.join(skipped_images)}）"
+                )
+            return result
         except Exception as e:
             return f"Error writing {raw_path}: {e}"
 
@@ -544,6 +601,9 @@ class DocxWriteTool(CreateDocxTool):
     name = "docx_write"
     description = (
         "Create a new Word (.docx) document with the given content. "
+        "Image blocks' path must resolve inside the session files directory "
+        "(or a user-authorized directory); out-of-bounds images are skipped "
+        "and reported. "
         "Prefer create_docx for new calls."
     )
 

--- a/miqi/documents/path_utils.py
+++ b/miqi/documents/path_utils.py
@@ -151,3 +151,63 @@ def resolve_output_path(
                 f"'{effective_dir}'（相对路径基准：会话 files 根目录，即 '{workspace}'）"
             )
     return resolved
+
+
+def resolve_read_path(
+    read_path: str,
+    workspace: Path | None,
+    allowed_dir: Path | None,
+    user_roots: Any = None,
+    allow_user_roots: bool = False,
+) -> Path:
+    """Resolve an **input** path (a file to read/embed) under the same boundary.
+
+    Output paths go through :func:`resolve_output_path`; input paths need the
+    same containment check *after* resolution, otherwise a model-controlled
+    argument such as ``content=[{"type": "image", "path": "/etc/passwd"}]``
+    lets a document tool read and embed files outside the workspace (issue
+    #1005 节 2, same class of hole as #994 H1 for ``create_pdf``).
+
+    Resolution order, fail-closed:
+
+    1. :func:`resolve_output_path` — workspace / session files root, with the
+       workspace-base prefix normalization and cross-session rejection.
+    2. User-authorized directories (``_user_roots``, the #821 injection),
+       **only** when *allow_user_roots* is true and roots were actually
+       injected.  Absolute paths only — a relative path that failed step 1 is
+       never joined onto a user root.
+
+    Anything else raises :class:`PermissionError`; callers must skip the file
+    rather than embed it.
+
+    Semantics are intentionally identical to
+    ``pdf_create_tool._resolve_source_path`` (the source of truth on the #994
+    branch, ``pdf_create_tool.py:1020-1050``).  This module must not import
+    that tool (import cycle); once #994 lands, a follow-up should make pdf
+    delegate here instead of duplicating the rule.
+
+    Raises:
+        PermissionError: if the path is outside every allowed root.
+    """
+    try:
+        return resolve_output_path(read_path, workspace, allowed_dir)
+    except (PermissionError, ValueError, OSError):
+        pass
+    if not allow_user_roots or not user_roots:
+        raise PermissionError(
+            f"路径 '{read_path}' 不在可读范围（工作区/会话文件区/用户授权目录）"
+        )
+    cand = Path(read_path)
+    if not cand.is_absolute():
+        raise PermissionError(f"路径 '{read_path}' 非绝对路径且不在工作区内")
+    try:
+        cand = cand.resolve()
+    except OSError as e:
+        raise PermissionError(f"路径 '{read_path}' 不在可读范围（无法解析：{e}）")
+    for root in user_roots:
+        try:
+            cand.relative_to(Path(str(root)).resolve())
+            return cand
+        except (TypeError, ValueError, OSError):
+            continue
+    raise PermissionError(f"路径 '{read_path}' 不在用户授权目录内")

--- a/miqi/documents/pptx_tool.py
+++ b/miqi/documents/pptx_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +13,10 @@ from miqi.documents.path_utils import (
     ensure_suffix,
     raw_output_path,
     resolve_output_path,
+    resolve_read_path,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PptxReadTool(Tool):
@@ -95,16 +99,21 @@ class CreatePptxTool(Tool):
     name = "create_pptx"
     description = (
         "Create a PowerPoint (.pptx) presentation in the workspace files directory. "
-        "Supports multiple slides with titles, bullets, body text, and images."
+        "Supports multiple slides with titles, bullets, body text, and images. "
+        "Each slide's image_path must resolve inside the session files directory "
+        "(or a user-authorized directory); an image outside those roots is "
+        "skipped, not embedded, and reported in the result."
     )
 
     def __init__(
         self,
         workspace: Path | None = None,
         allowed_dir: Path | None = None,
+        allow_user_roots: bool = False,
     ):
         self._workspace = workspace
         self._allowed_dir = allowed_dir
+        self._allow_user_roots = allow_user_roots
 
     @property
     def parameters(self) -> dict[str, Any]:
@@ -152,6 +161,7 @@ class CreatePptxTool(Tool):
         from pptx.util import Inches
 
         _sess_key = kwargs.pop("_session_key", None)
+        user_roots = kwargs.pop("_user_roots", None)
         raw_path = raw_output_path(kwargs)
         slides = kwargs.get("slides") or []
         if not raw_path.strip():
@@ -170,6 +180,7 @@ class CreatePptxTool(Tool):
         if not slides:
             return "Error: 必须提供 slides"
 
+        skipped_images: list[str] = []
         try:
             prs = Presentation()
             for slide_data in slides:
@@ -204,17 +215,39 @@ class CreatePptxTool(Tool):
                         paragraph.level = 0
                 image_path = slide_data.get("image_path")
                 if image_path:
-                    slide.shapes.add_picture(
-                        str(image_path),
-                        Inches(float(slide_data.get("image_left", 5.5))),
-                        Inches(float(slide_data.get("image_top", 1.5))),
-                        width=Inches(float(slide_data.get("image_width", 3.0))),
-                    )
+                    try:
+                        resolved = resolve_read_path(
+                            str(image_path),
+                            self._workspace,
+                            self._allowed_dir,
+                            user_roots,
+                            self._allow_user_roots,
+                        )
+                        slide.shapes.add_picture(
+                            str(resolved),
+                            Inches(float(slide_data.get("image_left", 5.5))),
+                            Inches(float(slide_data.get("image_top", 1.5))),
+                            width=Inches(float(slide_data.get("image_width", 3.0))),
+                        )
+                    except Exception as e:
+                        # Out-of-bounds, missing, or not-an-image: skip this
+                        # slide's picture and keep building the deck
+                        # (issue #1005 节 2).
+                        logger.warning(
+                            "create_pptx: 跳过图片 %s：%s", image_path, e,
+                        )
+                        skipped_images.append(f"{image_path}（{e}）")
 
             file_path.parent.mkdir(parents=True, exist_ok=True)
             prs.save(str(file_path))
             _persist_tracked_file(self._workspace, file_path, op="write", session_key=_sess_key)
-            return f"Created: {file_path} ({len(slides)} slides)"
+            result = f"Created: {file_path} ({len(slides)} slides)"
+            if skipped_images:
+                result += (
+                    f"（跳过 {len(skipped_images)} 个图片："
+                    f"{'；'.join(skipped_images)}）"
+                )
+            return result
         except Exception as e:
             return f"Error writing {raw_path}: {e}"
 
@@ -223,4 +256,9 @@ class PptxWriteTool(CreatePptxTool):
     """Backward-compatible alias for create_pptx."""
 
     name = "pptx_write"
-    description = "Create a new PowerPoint (.pptx) file. Prefer create_pptx for new calls."
+    description = (
+        "Create a new PowerPoint (.pptx) file. Each slide's image_path must "
+        "resolve inside the session files directory (or a user-authorized "
+        "directory); out-of-bounds images are skipped and reported. "
+        "Prefer create_pptx for new calls."
+    )

--- a/miqi/runtime/file_handlers.py
+++ b/miqi/runtime/file_handlers.py
@@ -456,12 +456,18 @@ def _find_in_sandbox_workspaces(
             logger.info("[files:read] sandbox fallback: sandbox manager disabled/absent")
             return None
 
-        # Build session-scoped suffix (same logic as _get_session_workspace)
+        # Build the session-scoped suffix with the canonical key derivation
+        # (``_session_files_dir_key``, #1003) — the same one
+        # ``_get_session_workspace`` uses.  Deriving it locally produced a
+        # divergent directory for two-segment channel keys
+        # (``desktop:<ts>`` → ``sessions/<ts>/files`` instead of
+        # ``sessions/desktop_<ts>/files``), so this fallback searched a
+        # directory no writer ever creates (issue #1005).
         session_suffix = ""
         if session_key:
-            from miqi.utils.helpers import safe_filename
-            key = session_key.split(":", 1)[-1] if ":" in session_key else session_key
-            safe_key = safe_filename(key.replace(":", "_"))
+            from miqi.agent.tools.filesystem import _session_files_dir_key
+
+            safe_key = _session_files_dir_key(session_key)
             session_suffix = f"sessions/{safe_key}/files"
 
         sandboxes = sm.list_sandboxes()

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -599,12 +599,24 @@ def create_runtime_tool_registry(
     # Office write tools always write inside the workspace, independently
     # of the `restrict_to_workspace` config (which only controls
     # WriteFileTool / EditFileTool).
-    registry.register(CreateDocxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
-    registry.register(DocxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(CreateDocxTool(
+        workspace=_write_workspace, allowed_dir=_write_workspace,
+        allow_user_roots=_auto_user_dirs,
+    ))
+    registry.register(DocxWriteTool(
+        workspace=_write_workspace, allowed_dir=_write_workspace,
+        allow_user_roots=_auto_user_dirs,
+    ))
     registry.register(EditDocxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(PptxReadTool(workspace=_write_workspace, allowed_dir=_write_workspace))
-    registry.register(CreatePptxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
-    registry.register(PptxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))
+    registry.register(CreatePptxTool(
+        workspace=_write_workspace, allowed_dir=_write_workspace,
+        allow_user_roots=_auto_user_dirs,
+    ))
+    registry.register(PptxWriteTool(
+        workspace=_write_workspace, allowed_dir=_write_workspace,
+        allow_user_roots=_auto_user_dirs,
+    ))
     registry.register(XlsxReadTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(CreateXlsxTool(workspace=_write_workspace, allowed_dir=_write_workspace))
     registry.register(XlsxWriteTool(workspace=_write_workspace, allowed_dir=_write_workspace))

--- a/tests/documents/test_office_image_path_boundary.py
+++ b/tests/documents/test_office_image_path_boundary.py
@@ -1,0 +1,351 @@
+"""#1005 节 2：docx/pptx 输入图片路径必须过边界校验（越界不读文件）。
+
+模型可控参数（``create_docx`` 的 ``content[].path`` / ``create_pptx`` 的
+``slides[].image_path``）在修复前直接喂给 ``add_picture``，可把工作区外的任意
+文件读进产物（``word/media/`` / ``ppt/media/``）并随产物外发——与 #994 的 H1
+同类破口。
+
+测试口径（见 plan_1005_v3 §3 / v4 patch §1、§4）：
+
+- 越界断言**三元组**：spy 调用列表为空 + 产物 media 为空 + 返回串含「跳过」。
+  只用 media 为空会假绿——未修复代码对相对跨会话路径抛 FileNotFoundError，
+  被 ``execute`` 的 except 吞掉后同样产不出 media。
+- spy 必须 **call-through**（真调用原 ``Image.from_file``），否则界内分支也
+  产不出 media，界外断言跟着假绿；因此每组越界用例都配**正对照**。
+- 用户授权目录（``_user_roots``，#821 机制）正/反各一：``allow_user_roots=True``
+  + 注入 ``_user_roots`` 才可读，缺一即跳过（fail-closed）。
+"""
+
+from __future__ import annotations
+
+import importlib
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_DOCX_IMAGE = "docx.image.image.Image"
+_PPTX_IMAGE = "pptx.parts.image.Image"
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _write_png(path: Path) -> Path:
+    """Write a real (readable by python-docx/pptx) PNG and return it."""
+    from PIL import Image
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), (200, 30, 30)).save(str(path))
+    return path
+
+
+def _session_files_dir(tmp_path: Path, key: str = "desktop_A") -> Path:
+    """``<base>/sessions/<key>/files`` — the session files root office tools get."""
+    files_dir = tmp_path / "workspace" / "sessions" / key / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    return files_dir
+
+
+def _media_entries(artifact: Path, prefix: str) -> list[str]:
+    """Names of embedded media parts inside a .docx/.pptx zip container."""
+    with zipfile.ZipFile(str(artifact)) as zf:
+        return [n for n in zf.namelist() if n.startswith(prefix)]
+
+
+def _spy_image_from_file(monkeypatch, dotted: str) -> list:
+    """Patch ``<Image>.from_file`` with a call-through spy; return its call list.
+
+    Call-through is mandatory: a bare MagicMock would make *in-bounds* images
+    produce no media either, so the out-of-bounds ``media == []`` assertion
+    would pass vacuously.
+    """
+    mod_name, cls_name = dotted.rsplit(".", 1)
+    cls = getattr(importlib.import_module(mod_name), cls_name)
+    real = cls.from_file
+    calls: list = []
+
+    def spy(image_descriptor):
+        calls.append(image_descriptor)
+        return real(image_descriptor)
+
+    monkeypatch.setattr(cls, "from_file", spy)
+    return calls
+
+
+async def _run_docx(files_dir: Path, image_path, **kwargs) -> str:
+    from miqi.documents.docx_tool import CreateDocxTool
+
+    tool = CreateDocxTool(
+        workspace=files_dir,
+        allowed_dir=files_dir,
+        allow_user_roots=kwargs.pop("allow_user_roots", False),
+    )
+    return await tool.execute(
+        filename="out.docx",
+        content=[{"type": "image", "path": str(image_path)}],
+        **kwargs,
+    )
+
+
+async def _run_pptx(files_dir: Path, image_path, **kwargs) -> str:
+    from miqi.documents.pptx_tool import CreatePptxTool
+
+    tool = CreatePptxTool(
+        workspace=files_dir,
+        allowed_dir=files_dir,
+        allow_user_roots=kwargs.pop("allow_user_roots", False),
+    )
+    return await tool.execute(
+        filename="out.pptx",
+        slides=[{"title": "t", "image_path": str(image_path)}],
+        **kwargs,
+    )
+
+
+# ── docx ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_docx_out_of_bounds_image_is_not_read(tmp_path, monkeypatch):
+    """工作区外的绝对路径图片：不读文件、产物无 media、返回串含「跳过」。"""
+    files_dir = _session_files_dir(tmp_path)
+    secret = _write_png(tmp_path / "outside" / "secret.png")
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(files_dir, secret)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.docx", "word/media/") == []
+    assert "跳过" in result
+
+
+@pytest.mark.asyncio
+async def test_docx_in_bounds_image_is_embedded(tmp_path, monkeypatch):
+    """正对照：界内图片真嵌入（spy 恰好 1 次、media 非空）。"""
+    files_dir = _session_files_dir(tmp_path)
+    image = _write_png(files_dir / "assets" / "chart.png")
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(files_dir, image)
+
+    assert len(calls) == 1
+    assert _media_entries(files_dir / "out.docx", "word/media/") != []
+    assert "Created:" in result
+    assert "跳过" not in result
+
+
+@pytest.mark.asyncio
+async def test_docx_cross_session_image_is_not_read(tmp_path, monkeypatch):
+    """跨会话图片（绝对路径指向另一会话 files 根）：三元组断言。"""
+    files_dir = _session_files_dir(tmp_path, key="desktop_A")
+    other = _write_png(
+        _session_files_dir(tmp_path, key="desktop_B") / "secret.png"
+    )
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(files_dir, other)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.docx", "word/media/") == []
+    assert "跳过" in result
+
+
+@pytest.mark.asyncio
+async def test_docx_missing_and_non_image_blocks_do_not_fail_document(
+    tmp_path, monkeypatch,
+):
+    """界内但不存在 / 非图片：跳过该图片，文档照常产出（不整档失败）。"""
+    from docx import Document
+
+    files_dir = _session_files_dir(tmp_path)
+    not_an_image = files_dir / "fake.png"
+    not_an_image.write_text("this is not a png", encoding="utf-8")
+    _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(files_dir, files_dir / "missing.png")
+    assert "跳过" in result
+    result2 = await _run_docx(files_dir, not_an_image)
+    assert "跳过" in result2
+
+    # 这两种失败发生在 Image.from_file 内部（spy 会被调到），所以只断言
+    # 「没产出 media + 文档照常建成」，不断言 spy 为空。
+    assert _media_entries(files_dir / "out.docx", "word/media/") == []
+    # 文档本身仍然可读（不是 Error 串）
+    assert "Created:" in result2
+    assert Document(str(files_dir / "out.docx")) is not None
+
+
+@pytest.mark.asyncio
+async def test_docx_user_roots_positive(tmp_path, monkeypatch):
+    """allow_user_roots=True + 注入 _user_roots：授权目录内图片真嵌入。"""
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = _write_png(authorized / "photo.png")
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(
+        files_dir,
+        image,
+        allow_user_roots=True,
+        _user_roots=[str(authorized)],
+    )
+
+    assert len(calls) == 1
+    assert _media_entries(files_dir / "out.docx", "word/media/") != []
+    assert "Created:" in result
+
+
+@pytest.mark.asyncio
+async def test_docx_user_roots_not_injected_is_skipped(tmp_path, monkeypatch):
+    """反例：allow_user_roots=True 但没注入 _user_roots → 跳过。"""
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = _write_png(authorized / "photo.png")
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(files_dir, image, allow_user_roots=True)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.docx", "word/media/") == []
+    assert "跳过" in result
+
+
+@pytest.mark.asyncio
+async def test_docx_user_roots_disabled_flag_is_skipped(tmp_path, monkeypatch):
+    """反例：注入了 _user_roots 但 allow_user_roots=False → 仍跳过（fail-closed）。"""
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = _write_png(authorized / "photo.png")
+    calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
+
+    result = await _run_docx(
+        files_dir,
+        image,
+        allow_user_roots=False,
+        _user_roots=[str(authorized)],
+    )
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.docx", "word/media/") == []
+    assert "跳过" in result
+
+
+# ── pptx ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pptx_out_of_bounds_image_is_not_read(tmp_path, monkeypatch):
+    files_dir = _session_files_dir(tmp_path)
+    secret = _write_png(tmp_path / "outside" / "secret.png")
+    calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
+
+    result = await _run_pptx(files_dir, secret)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.pptx", "ppt/media/") == []
+    assert "跳过" in result
+
+
+@pytest.mark.asyncio
+async def test_pptx_in_bounds_image_is_embedded(tmp_path, monkeypatch):
+    files_dir = _session_files_dir(tmp_path)
+    image = _write_png(files_dir / "assets" / "chart.png")
+    calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
+
+    result = await _run_pptx(files_dir, image)
+
+    assert len(calls) == 1
+    assert _media_entries(files_dir / "out.pptx", "ppt/media/") != []
+    assert "Created:" in result
+    assert "跳过" not in result
+
+
+@pytest.mark.asyncio
+async def test_pptx_cross_session_image_is_not_read(tmp_path, monkeypatch):
+    files_dir = _session_files_dir(tmp_path, key="desktop_A")
+    other = _write_png(
+        _session_files_dir(tmp_path, key="desktop_B") / "secret.png"
+    )
+    calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
+
+    result = await _run_pptx(files_dir, other)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.pptx", "ppt/media/") == []
+    assert "跳过" in result
+
+
+@pytest.mark.asyncio
+async def test_pptx_user_roots_positive(tmp_path, monkeypatch):
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = _write_png(authorized / "photo.png")
+    calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
+
+    result = await _run_pptx(
+        files_dir,
+        image,
+        allow_user_roots=True,
+        _user_roots=[str(authorized)],
+    )
+
+    assert len(calls) == 1
+    assert _media_entries(files_dir / "out.pptx", "ppt/media/") != []
+    assert "Created:" in result
+
+
+@pytest.mark.asyncio
+async def test_pptx_user_roots_not_injected_is_skipped(tmp_path, monkeypatch):
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = _write_png(authorized / "photo.png")
+    calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
+
+    result = await _run_pptx(files_dir, image, allow_user_roots=True)
+
+    assert calls == []
+    assert _media_entries(files_dir / "out.pptx", "ppt/media/") == []
+    assert "跳过" in result
+
+
+# ── 接线级：工厂必须把 tools.auto_user_dirs 传进 4 个工具 ─────────────
+
+
+def _registry(fake_config, session_id: str = "desktop:1005"):
+    from pathlib import Path as _Path
+
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    return create_runtime_tool_registry(
+        config=fake_config,
+        workspace=_Path(fake_config.agents.defaults.workspace),
+        session_id=session_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["create_docx", "docx_write", "create_pptx", "pptx_write"],
+)
+def test_registry_wires_auto_user_dirs_true(fake_config, tool_name):
+    """正向接线：默认 auto_user_dirs=True → 4 个别名工具都得 True。
+
+    只断言 create_docx 会漏掉 docx_write / create_pptx / pptx_write 的静默
+    丢图（别名工具继承 __init__，漏传即静默 allow_user_roots=False）。
+    """
+    registry = _registry(fake_config)
+
+    assert registry.get(tool_name)._allow_user_roots is True
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["create_docx", "docx_write", "create_pptx", "pptx_write"],
+)
+def test_registry_wires_auto_user_dirs_false(fake_config, tool_name):
+    """负向接线：auto_user_dirs=False → False（挡「工厂里硬编码 True」）。"""
+    fake_config.tools.auto_user_dirs = False
+    registry = _registry(fake_config)
+
+    assert registry.get(tool_name)._allow_user_roots is False

--- a/tests/documents/test_office_image_path_boundary.py
+++ b/tests/documents/test_office_image_path_boundary.py
@@ -110,10 +110,10 @@ async def _run_pptx(files_dir: Path, image_path, **kwargs) -> str:
 async def test_docx_out_of_bounds_image_is_not_read(tmp_path, monkeypatch):
     """工作区外的绝对路径图片：不读文件、产物无 media、返回串含「跳过」。"""
     files_dir = _session_files_dir(tmp_path)
-    secret = _write_png(tmp_path / "outside" / "secret.png")
+    outside_image = _write_png(tmp_path / "outside" / "outside.png")
     calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
 
-    result = await _run_docx(files_dir, secret)
+    result = await _run_docx(files_dir, outside_image)
 
     assert calls == []
     assert _media_entries(files_dir / "out.docx", "word/media/") == []
@@ -140,7 +140,7 @@ async def test_docx_cross_session_image_is_not_read(tmp_path, monkeypatch):
     """跨会话图片（绝对路径指向另一会话 files 根）：三元组断言。"""
     files_dir = _session_files_dir(tmp_path, key="desktop_A")
     other = _write_png(
-        _session_files_dir(tmp_path, key="desktop_B") / "secret.png"
+        _session_files_dir(tmp_path, key="desktop_B") / "outside.png"
     )
     calls = _spy_image_from_file(monkeypatch, _DOCX_IMAGE)
 
@@ -237,10 +237,10 @@ async def test_docx_user_roots_disabled_flag_is_skipped(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_pptx_out_of_bounds_image_is_not_read(tmp_path, monkeypatch):
     files_dir = _session_files_dir(tmp_path)
-    secret = _write_png(tmp_path / "outside" / "secret.png")
+    outside_image = _write_png(tmp_path / "outside" / "outside.png")
     calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
 
-    result = await _run_pptx(files_dir, secret)
+    result = await _run_pptx(files_dir, outside_image)
 
     assert calls == []
     assert _media_entries(files_dir / "out.pptx", "ppt/media/") == []
@@ -265,7 +265,7 @@ async def test_pptx_in_bounds_image_is_embedded(tmp_path, monkeypatch):
 async def test_pptx_cross_session_image_is_not_read(tmp_path, monkeypatch):
     files_dir = _session_files_dir(tmp_path, key="desktop_A")
     other = _write_png(
-        _session_files_dir(tmp_path, key="desktop_B") / "secret.png"
+        _session_files_dir(tmp_path, key="desktop_B") / "outside.png"
     )
     calls = _spy_image_from_file(monkeypatch, _PPTX_IMAGE)
 

--- a/tests/documents/test_path_utils.py
+++ b/tests/documents/test_path_utils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from miqi.documents.path_utils import resolve_output_path
+from miqi.documents.path_utils import resolve_output_path, resolve_read_path
 
 
 def _session_files_dir(tmp_path, key: str = "desktop_test123"):
@@ -246,3 +246,89 @@ async def test_create_xlsx_normalizes_workspace_base_prefix(tmp_path):
     assert "Created:" in result
     assert expected.exists()
     assert not (files_dir / "sessions").exists()
+
+
+# ── resolve_read_path: 输入路径与输出路径同边界（issue #1005 节 2）─────
+
+
+def test_read_path_in_bounds_matches_output_path(tmp_path):
+    """界内相对路径：与 resolve_output_path 解析出同一结果。"""
+    files_dir = _session_files_dir(tmp_path)
+
+    read = resolve_read_path("assets/chart.png", files_dir, files_dir)
+    out = resolve_output_path("assets/chart.png", files_dir, files_dir)
+
+    assert read == out == (files_dir / "assets" / "chart.png").resolve()
+
+
+def test_read_path_out_of_bounds_rejected_without_user_roots(tmp_path):
+    files_dir = _session_files_dir(tmp_path)
+    secret = tmp_path / "outside" / "secret.png"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_bytes(b"x")
+
+    with pytest.raises(PermissionError, match="不在"):
+        resolve_read_path(str(secret), files_dir, files_dir)
+
+
+def test_read_path_requires_injected_user_roots(tmp_path):
+    """allow_user_roots=True 但没有注入 _user_roots → 仍然拒绝（fail-closed）。"""
+    files_dir = _session_files_dir(tmp_path)
+    secret = tmp_path / "outside" / "secret.png"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_bytes(b"x")
+
+    with pytest.raises(PermissionError, match="不在"):
+        resolve_read_path(
+            str(secret), files_dir, files_dir, None, True,
+        )
+
+
+def test_read_path_allows_authorized_user_root(tmp_path):
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    image = authorized / "photo.png"
+    authorized.mkdir(parents=True, exist_ok=True)
+    image.write_bytes(b"x")
+
+    resolved = resolve_read_path(
+        str(image), files_dir, files_dir, [str(authorized)], True,
+    )
+
+    assert resolved == image.resolve()
+
+
+def test_read_path_rejects_path_outside_authorized_roots(tmp_path):
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    authorized.mkdir(parents=True, exist_ok=True)
+    secret = tmp_path / "outside" / "secret.png"
+    secret.parent.mkdir(parents=True, exist_ok=True)
+    secret.write_bytes(b"x")
+
+    with pytest.raises(PermissionError, match="不在用户授权目录内"):
+        resolve_read_path(
+            str(secret), files_dir, files_dir, [str(authorized)], True,
+        )
+
+
+def test_read_path_never_joins_relative_path_onto_user_root(tmp_path):
+    """越界的相对路径不落到用户授权目录（否则 ../../.. 可逃逸）。"""
+    files_dir = _session_files_dir(tmp_path)
+    authorized = tmp_path / "user_pics"
+    authorized.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(PermissionError, match="非绝对路径"):
+        resolve_read_path(
+            "../../outside/secret.png", files_dir, files_dir,
+            [str(authorized)], True,
+        )
+
+
+def test_read_path_rejects_cross_session(tmp_path):
+    files_dir = _session_files_dir(tmp_path, key="desktop_A")
+    other = _session_files_dir(tmp_path, key="desktop_B") / "secret.png"
+    other.write_bytes(b"x")
+
+    with pytest.raises(PermissionError, match="不在"):
+        resolve_read_path(str(other), files_dir, files_dir)

--- a/tests/runtime/test_file_handlers_session_key_derivation.py
+++ b/tests/runtime/test_file_handlers_session_key_derivation.py
@@ -1,0 +1,69 @@
+"""#1005 节 1：``files.read`` 沙箱兜底的会话目录派生必须与 canonical 派生一致。
+
+``_find_in_sandbox_workspaces`` 自己拼 ``sessions/<safe_key>/files`` 兜底搜索路径。
+它原先用 ``split(":", 1)[-1]`` 派生目录名，对两段渠道键（``desktop:<ts>`` /
+``cli:*`` / ``gateway:*``）少剥一层，搜到一个没有任何写入方的目录 → 文件明明
+在沙箱工作区里也报「文件不存在」。
+
+用例对 issue #1005 期望表的 6 个 key 形态各写死一个字面期望目录名；修复前
+4 个形态（两段键）会红。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# issue #1005 期望表：raw key → 磁盘目录名（与
+# tests/agent/tools/test_session_workspace_isolation.py::test_session_files_dir_key_derivation
+# 锁定的是同一组期望值）。
+SESSION_KEY_EXPECTATIONS = [
+    ("miqi-desktop:desktop:1786807046853", "desktop_1786807046853"),
+    ("desktop:1786807046853", "desktop_1786807046853"),
+    ("cli:direct", "cli_direct"),
+    ("cli:other", "cli_other"),
+    ("gateway:default", "gateway_default"),
+    ("thread_nomap", "thread_nomap"),
+]
+
+
+class _FakeSandboxManager:
+    """Minimal stand-in for the sandbox manager used by the read fallback."""
+
+    def __init__(self, workspace):
+        self._workspace = str(workspace)
+
+    def list_sandboxes(self):
+        return [{"workspace": self._workspace, "distro": ""}]
+
+
+class _FakeBridgeState:
+    def __init__(self, workspace):
+        self._sandbox_manager = _FakeSandboxManager(workspace)
+
+
+@pytest.mark.parametrize("session_key,expected_dir", SESSION_KEY_EXPECTATIONS)
+def test_sandbox_fallback_searches_canonical_session_dir(
+    tmp_path, monkeypatch, session_key, expected_dir,
+):
+    """文件只存在于 ``sessions/<canonical_key>/files`` 时，兜底必须命中它。"""
+    import miqi.bridge.server as bridge_module
+
+    from miqi.runtime.file_handlers import _find_in_sandbox_workspaces
+
+    sandbox_ws = tmp_path / "sandbox_ws"
+    target = sandbox_ws / "sessions" / expected_dir / "files" / "report.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("payload", encoding="utf-8")
+
+    monkeypatch.setattr(bridge_module, "_state", _FakeBridgeState(sandbox_ws))
+
+    found = _find_in_sandbox_workspaces(
+        "report.md", tmp_path / "host" / "report.md", session_key,
+    )
+
+    assert found is not None, (
+        f"session_key={session_key!r}: 兜底没找到 "
+        f"sessions/{expected_dir}/files/report.md"
+    )
+    assert found[0] == target.resolve()
+    assert found[1] == ""

--- a/tests/runtime/test_file_handlers_session_key_derivation.py
+++ b/tests/runtime/test_file_handlers_session_key_derivation.py
@@ -47,7 +47,6 @@ def test_sandbox_fallback_searches_canonical_session_dir(
 ):
     """文件只存在于 ``sessions/<canonical_key>/files`` 时，兜底必须命中它。"""
     import miqi.bridge.server as bridge_module
-
     from miqi.runtime.file_handlers import _find_in_sandbox_workspaces
 
     sandbox_ws = tmp_path / "sandbox_ws"


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复两类既有「文档工具路径边界」缺口：`files.read` 沙箱兜底的会话目录派生分叉（节 1）、docx/pptx 图片块路径无界读（节 2）。

## 背景/问题

**节 1 —— 会话 key 派生分叉**：`miqi/runtime/file_handlers.py:463`（`_find_in_sandbox_workspaces`）用 `split(":", 1)[-1]` 自派生 `sessions/<safe_key>/files`，对两段渠道键（`desktop:<ts>` / `cli:*` / `gateway:*`）少剥一层，搜到的是 `sessions/<ts>/files`——没有任何写入方会创建这个目录，于是文件明明在沙箱工作区里也报「文件不存在」。上一行注释自称 *same logic as `_get_session_workspace`*，但后者走 `_session_files_dir_key`（#1003 canonical：段数 ≥3 才剥首段），注释与实现不符。

**节 2 —— docx/pptx 图片块无界读**：`create_docx` 的 `content[].path` 与 `create_pptx` 的 `slides[].image_path` 直接取自模型可控参数，未经任何边界校验就喂给 `add_picture`。模型给一个工作区外的绝对路径（或 `../../..` 穿越路径）即可把该文件读进产物（`word/media/` / `ppt/media/`）并随产物外发——与 #994 H1（pdf）同类破口；H1 当时只覆盖 `create_pdf`，这两个工具不在其改动范围。两个工具的 `enforce_boundary` 只作用于**输出**文件。

## 关联 issue

- Closes #1005 文档工具路径边界既有缺口：会话 key 派生分叉 + docx/pptx image 块无界读

## 变更内容

### 提交列表

| commit | 内容 |
|---|---|
| `ef96798f` | 节 1：`file_handlers.py` 沙箱兜底派生统一 + 6 例 |
| `2a275685` | 节 2：`resolve_read_path` + docx/pptx 接线 + 注册处 4 处 + 27 例 |
| `2474a87e` | 节 1 用例 `I001` import 排序（CI lint 红，纯排序，不改断言） |
| `e54c9bec` | 节 2 用例 fixture 改名，消除 CodeQL 误报（见下） |

两个**逻辑** commit（节 1 / 节 2）保持独立、各自可单独 revert；后两个是 CI 门禁产生的修正提交，不改变语义。

### 节 1（commit `ef96798f`）

- `miqi/runtime/file_handlers.py`：`:463` 改走 `_session_files_dir_key(session_key)`（#1003 canonical 派生），并修正 `:459` 那句与实现不符的注释。
- **不动 `:751-756`**（raw 约定是对的）：按 issue 节 1 建议修法 2，「key 归一发生在哪一层」需先定，不在本 PR 范围。
- 新增 `tests/runtime/test_file_handlers_session_key_derivation.py`：issue 期望表 6 个 key 形态各写死一个字面期望目录名。

### 节 2（commit `2a275685`）

- 新增 `miqi/documents/path_utils.py::resolve_read_path`：输入路径与输出路径走**同一**边界（工作区 / 会话文件区 / 用户授权目录），fail-closed；`except` 带 `OSError`（Windows `Path.resolve()` 可抛）。语义对齐 #994 的 `_resolve_source_path`，docstring 指向它为 source of truth，**不 import pdf**（避免环，也避开未合并的 #994）。
- `CreateDocxTool` / `CreatePptxTool`：`__init__` 加 `allow_user_roots: bool = False` 并存 `self._allow_user_roots`（与 pdf 先例 `pdf_create_tool.py:1074/1078` 一致）；`execute` pop `_user_roots`。
- `add_picture` 一并包进 skip 处理：越界 / 缺失 / 非图片只跳过该图片 + `warning`，并在返回串报告「跳过 N 个图片」，不再让整档失败（原先 `execute` 的 `except` 会把整档吞掉）。
- `miqi/runtime/tool_registry_factory.py:602/603/606/607` **4 处全接** `allow_user_roots=_auto_user_dirs`——`DocxWriteTool` / `PptxWriteTool` 没有自己的 `__init__`（继承），漏接会让别名工具静默 `allow_user_roots=False`（同一请求走 `create_docx` 成功、走 `docx_write` 静默丢图）。
- 行为变更声明：4 个工具的 `description`（`docx_tool.py:390-395`/`:545-548`、`pptx_tool.py:96-99`/`:226`）+ `docs/backend/path-semantics.yaml`。
- 范围说明：**节 2 的 exec/KUN 侧（`miqi/kun_runtime/`）不在本 issue 范围**——KUN 未接主执行路径（`docs/dev-notes/legacy-main-path-only.md`），legacy 主路径（`miqi/execution/orchestrator.py:903-911`）对 `_FILE_MUTATION_TOOLS` 注入 `_user_roots`，4 个工具都在该集合内。

## 日志/验证证据

```
$ .venv/Scripts/python.exe -m pytest tests/runtime/test_file_handlers_session_key_derivation.py -q
6 passed in 0.12s

# 节 1 反证：还原 :463 修复后重跑（4 个两段键形态红、2 个三段键/无线程形态绿）
FAILED tests/runtime/test_file_handlers_session_key_derivation.py::test_sandbox_fallback_searches_canonical_session_dir[desktop:1786807046853-desktop_1786807046853]
FAILED tests/runtime/test_file_handlers_session_key_derivation.py::test_sandbox_fallback_searches_canonical_session_dir[cli:direct-cli_direct]
FAILED tests/runtime/test_file_handlers_session_key_derivation.py::test_sandbox_fallback_searches_canonical_session_dir[cli:other-cli_other]
FAILED tests/runtime/test_file_handlers_session_key_derivation.py::test_sandbox_fallback_searches_canonical_session_dir[gateway:default-gateway_default]
4 failed, 2 passed in 0.28s

$ .venv/Scripts/python.exe -m pytest tests/documents/test_office_image_path_boundary.py tests/documents/test_path_utils.py -q
42 passed in 1.58s

# 节 2 反证：git stash 掉 miqi/ + docs/ 改动、保留测试后重跑
20 failed in 0.80s

$ .venv/Scripts/python.exe -m pytest tests/documents/ tests/execution/test_phase32_office_path_enforcement.py -q
107 passed in 6.92s

$ .venv/Scripts/python.exe -m pytest tests/runtime/ tests/execution/ tests/agent/tools/ -q
2052 passed, 5 skipped in 276.38s

$ .venv/Scripts/python.exe -m pytest tests/ --ignore=tests/runtime --ignore=tests/execution --ignore=tests/agent/tools --ignore=tests/documents -q
3 failed, 1485 passed, 16 skipped in 146.74s
# 3 个失败全在 tests/sandbox（真机 WSL apt-get 装 bwrap），断言：
#   AssertionError: Failed to install bwrap in WSL distro 'Ubuntu-22.04'. Check internet connectivity and apt-get.
#   AssertionError: _ensure_wsl_deps failed on real distro 'Ubuntu-22.04'
#   tests/sandbox/test_bwrap_auto_install.py::test_wsl_sandbox_auto_install
#   tests/sandbox/test_wsl_detect_readiness.py::test_ensure_wsl_deps_installs_python_toolchain
#   tests/sandbox/test_wsl_detect_readiness.py::test_detect_falls_back_to_another_distro_when_preferred_missing_pip
# 已用 git stash 还原本 PR 全部改动后复跑同样 3 红（3 failed, 2 passed, 1 skipped）
# → 仓库既有环境依赖失败（WSL/网络），与本 PR 无关。

$ uvx ruff check .
All checks passed!
```

**CI 门禁的两处修正**（首轮 CI 结果 → 修正）：

- `lint` 红：`tests/runtime/test_file_handlers_session_key_derivation.py:49` `I001`（函数内两条 import 之间的空行）→ `2474a87e` 删除空行，`uvx ruff check .` 全仓通过。
- `CodeQL` 红：2 个 `py/clear-text-logging-sensitive-data`（high）。SARIF 的 taint 流显示源是**测试**里的局部变量 `secret`（`tests/documents/test_office_image_path_boundary.py:113/240`），经工具调用流进 `logger.warning` 被判「明文记录敏感数据」。该 fixture 只是「工作区外的一张图片」，不含任何凭据 → `e54c9bec` 把变量/文件名改为 `outside_image` / `outside.png`；**生产侧日志行为不变**（仍记录被拒路径 + 原因）。修正后 `CodeQL` pass。

## 测试情况

- **节 1**：新增 6 例（issue 期望表 6 形态字面期望值）。修复前 4 红 / 修复后 6 绿。
- **节 2**：新增 `tests/documents/test_office_image_path_boundary.py` 20 例 + `test_path_utils.py` 的 `resolve_read_path` 契约 7 例。
  - 越界断言**三元组**：call-through spy（`docx.image.image.Image.from_file` / `pptx.parts.image.Image.from_file`）调用列表为空 + 产物 media 为空 + 返回串含「跳过」；每组越界用例都配界内**正对照**（`len(calls)==1`、media 非空）——裸 MagicMock 会让界内分支也产不出 media，界外断言跟着假绿。
  - 用户授权目录**正/反**：`allow_user_roots=True` + 注入 `_user_roots` 才真嵌入（media 非空）；缺注入或缺 flag 均跳过（fail-closed）。
  - 跨会话用例用会话结构 workspace（`sessions/desktop_A/files`）+ 真实 PNG 绝对路径，避免 `_normalize_session_prefixed` 退化导致假绿。
  - 接线级**正/反**：工厂 4 个工具 `_allow_user_roots is True`；`tools.auto_user_dirs=False` → `is False`（挡「工厂里硬编码 True」）。
  - 「不存在 / 非图片 → 跳过」：文档照常产出（`Created:` + 文档可读），只跳过该图片。
- **回归**：`tests/documents/` + phase32 = 107 绿；`tests/runtime/` + `tests/execution/` + `tests/agent/tools/` = 2052 绿（5 skip）；其余 1485 绿（3 个 WSL 环境依赖失败为既有）。
- **每个 commit 单独可跑绿**：commit 1 状态只含节 1 改动 + 节 1 用例（6 绿，`tests/documents/` 未受影响）；commit 2 = HEAD 全绿；两个修正提交各自只改测试文件（跑 `tests/runtime/test_file_handlers_session_key_derivation.py` 与 `tests/documents/test_office_image_path_boundary.py` 均绿）。
- **CI**：**20/20 checks SUCCESS**（`Analyze (actions)`、`Analyze (javascript-typescript)`、`Analyze (python)`、`CodeQL`、`CodeRabbit`、`GitGuardian Security Checks`、`bwrap`、`check-format`、`check-title`、`electron-e2e`、`lint`、`macos-build`、`macos-e2e`、`quick`、`test (ubuntu-latest)`、`test (windows-latest)`、`typecheck`、`validate`、`wsl-e2e`、`wsl-sandbox`）。

## 截图

无需截图（无 UI 变更）

## 后续计划

- #994 合并后开 follow-up：让 `pdf_create_tool._resolve_source_path` 委托 `path_utils.resolve_read_path`，消除两处复制漂移（本 PR **未改 `pdf_create_tool.py`**，避开未合并的 #994）。
