### PR TITLE
fix(sandbox): 沙箱写边界（层 1+2+3）—— /mnt 只读 + 授权路径 per-call rw bind + python 写系护栏（#984）

### DIFF
--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -36,6 +36,7 @@
 
 - [confirm-card-two-runtime-map](confirm-card-two-runtime-map.md) — 确认卡双路径地图；KUN runtime 实际未启用
 - [legacy-main-path-only](legacy-main-path-only.md) — 新功能只做 legacy 主路径（KUN runtime 未接入主执行路径）
+- [sandbox-write-boundary-984](sandbox-write-boundary-984.md) — #984 写边界：/mnt 只读 + per-call rw bind，边界与残余缺口清单
 - [confirm-card-issue-714-fix](confirm-card-issue-714-fix.md) — #714 确认卡排队串行方案要点与踩坑
 - [mcp-desktop-wiring](mcp-desktop-wiring.md) — MCP 桌面主路径接线 + anyio cancel-scope 坑
 - [pr-613-skill-discovery](pr-613-skill-discovery.md) — 技能发现：一条全局规则胜过触发词机制

--- a/docs/dev-notes/sandbox-write-boundary-984.md
+++ b/docs/dev-notes/sandbox-write-boundary-984.md
@@ -1,15 +1,27 @@
 ---
 name: sandbox-write-boundary-984
-description: #984 沙箱写边界 PR1 —— /mnt 改只读后，哪些写入口受内核约束、哪些仍有缺口
+description: #984 沙箱写边界（层 1+2+3）—— /mnt 只读 + per-call rw bind + 静态词表，边界与残余缺口清单
 type: project
 ---
 
-2026-09-09，#984 PR1（`fix/984-sandbox-write-boundary`）落地三层写边界。
+2026-09-09，#984（`fix/984-sandbox-write-boundary`，PR #1007）落地三层写边界。
 本文记录**边界在哪、缺口在哪**，避免后续把「护栏」当成「完备」。
 
-## 强制层是什么
+## 三层各是什么
 
-`bwrap` 挂载是唯一的内核强制点。PR1 把它收紧：
+| 层 | 位置 | 性质 | 作用 |
+|---|---|---|---|
+| 层 2 | `miqi/sandbox/bwrap.py` `--ro-bind-try /mnt /mnt` | **内核强制** | 整个 Windows 用户数据区不可写；任意拼写（`open(...,'w')`、`write_text`、`shutil.copy`）都被 EROFS 挡住 |
+| 层 1 | per-call `extra_rw_binds`（硬 `--bind`） | **内核授权** | 把用户点名的输出目录 / 工作区 / 静态根重新打开为可写 |
+| 层 3 | `miqi/agent/command_guard.py` 词表 | **体验层（可绕过）** | 更早、更可读的报错 + 安全替代提示；**不是**强制层 |
+
+一句话取舍：**强制靠挂载（层 1/2），层 3 只负责把「注定失败」的命令提前讲清楚。**
+静态分析不可能完备——词表没命中的写法一律 fail-open（放行，由层 2 兜底），
+绝不为了「更严」而误拦合法写入。
+
+## 层 1/2：内核强制与内核授权
+
+`bwrap` 挂载是唯一的内核强制点。本 PR 把它收紧：
 
 - **层 2**：`--bind-try /mnt /mnt` → `--ro-bind-try /mnt /mnt`
   （`miqi/sandbox/bwrap.py` `_build_bwrap_args`）。整个 Windows 用户数据区
@@ -33,23 +45,58 @@ exec 侧  = 工作区根 ∪ 静态 _shared_roots ∪ (auto_user_dirs ? _user_ro
   ExecTool 没有它的引用。仅卡片授权的目录 → 文件工具可写、exec 在 ro `/mnt`
   下 EROFS。
 
-## 已知缺口（PR1 不覆盖）
+## 层 3：静态词表（体验层，可绕过）
 
-1. **层 3 未做**：`command_guard.py` 的 python 写系词表（`write_text` /
-   `open(...,'w')` / `shutil.copy*` …）留给 PR2。它是**体验层**（更早、更可读的
-   报错），不是强制层——强制层是上面的挂载。
-2. **宿主回退不受约束**：沙箱未就绪 / `get_or_create` 返 None /
-   `tools.sandbox.enabled=false` / 非 WSL，全部退回宿主执行，只剩静态护栏。
-3. **非沙箱写入方不受约束**：documents 工具（`pdf_create_tool.py` 宿主写）、
-   MCP、graph_render 的宿主分支、安装路由（root 跑在 WSL、不经 bwrap）。
-4. **读 + 外传不受限**：`share_net=True`，`/mnt` 只读不影响读。
-5. **KUN 链**：`kun_runtime/tool_host.py` 的 `_USER_ROOTS_TOOLS` 不含 `exec`，
-   且只对白名单工具注入 `_user_roots` → 层 2 之后 KUN 链的 exec 写用户提及目录
-   会失效（KUN 未接入主执行路径，政策见 [legacy-main-path-only](legacy-main-path-only.md)）。
-6. **提及但未创建**的目录：exec 的硬 `--bind` 直接失败（ExecTool 产出引导文案：
+`command_guard.py` 的内联脚本词表（`_DESTRUCTIVE_CALL_RE` + `_open_call_writes`）
+补齐 python 写系拼写：
+
+- **写**：`open(..., 'w'/'a'/'x'/'wb'/'ab'/'r+'/'wt')`（含 `X.open('w')` 方法形式与
+  `mode='w'` 关键字）、`write_text` / `write_bytes`、`os.mkdir` / `os.makedirs` /
+  `Path.mkdir`、`shutil.copy*`、`shutil.move`、`os.rename` / `os.replace`。
+- **读不误报**：`open(f)` / `open(f,'r')` / `open(f,'rb')` 一律不触发。模式串只从
+  该次调用的**参数表**里取（括号感知），所以 `open(os.path.join(d,'a'),'r')` 仍算读。
+- **`shutil.copy*` 源侧按读处理**：与 shell `cp /etc/x out` 对齐——源可读、目标必须在
+  范围内。`shutil.move` / `os.rename` 会删源，两侧都算变更。
+- **heredoc 正文保真**：正文从**原始文本**读（`_raw_heredoc_body`），不再用 tokenizer
+  拼接——拼接会吃掉引号，路径字面量全丢 → 一律 `script_uncertain`，授权目录的
+  `python3 - <<EOF` 交付会被误拦。
+- **授权目录不误拦**：`RuntimePaths.extra_write_roots` 承接 per-call `_user_roots`
+  （`tools.auto_user_dirs` 开时才生效，**与层 1 的 bind 同一开关**），授权子树内的
+  写/改名/移动/删一律放行；系统路径仍优先拒绝（纵深防御）。
+
+**显式授权动作（#821）**：用户消息里点名目录（`C:\Users\<u>\Desktop\<dir>`、
+`/mnt/c/...`、POSIX 绝对路径）→ `extract_user_mentioned_roots` 抽取 → harness 每轮
+**无条件**注入 `_user_roots`（模型自带副本一律剥除）→ 层 1 硬 `--bind` 开写、层 3 同步
+放行。没点名 = 没授权 = 层 2 EROFS + 层 3 拒绝。
+
+**静态根（`tools.extra_roots`）不一样**：它进层 1 的 bind 集合、也进文件工具的合法根，
+但**不进层 3 的 `extra_write_roots`**——exec 的内联写（shell 与 python 同口径）仍按会话
+范围判定，写这类目录会拿到「请用文件工具 / 让用户点名」的拒绝。原因是静态根里含工作区
+根，整包纳入会破坏 Level 1 与跨 session 保护（工作区根不能变成可写区）。`python3 script.py`
+这类**无内联 payload** 的写法不受影响（层 3 看不见，由层 1 的 bind 决定）。
+
+## 已知缺口（不覆盖）
+
+1. **层 3 只是体验层，词表必然不完备**：没进词表的写法（`numpy.save`、`os.open`、
+  `pandas.to_csv`、`subprocess.run(['cp', ...])`、拼字符串动态调用 …）一律 fail-open
+  放行，交给层 2。**已知绕过面**：
+   - **宿主回退**：沙箱未就绪 / `get_or_create` 返 None / `tools.sandbox.enabled=false`
+     / 非 WSL → 退回宿主执行，此时**只剩层 3**（静态词表 + legacy deny patterns）。
+   - **非 bwrap 路由**：安装路由（root 跑在 WSL、不经 bwrap）、documents 工具
+     （`pdf_create_tool.py` 宿主写）、MCP 写文件、graph_render 宿主分支。
+   - **KUN exec**：`kun_runtime/tool_host.py` 的 `_USER_ROOTS_TOOLS` 不含 `exec`，
+     且只对白名单工具注入 `_user_roots` → 层 2 之后 KUN 链的 exec 写用户提及目录
+     会失效（KUN 未接入主执行路径，政策见 [legacy-main-path-only](legacy-main-path-only.md)）。
+   - **沙箱内路径写**：`/home/miqi/**`、`/tmp` 是沙箱 overlay，写不落宿主；但自定义
+     工作区模式把宿主工作区 bind 到 `/home/miqi/workspace`，那一部分**就是**宿主路径
+     （本身即会话自己的可写区）。
+2. **读 + 外传不受限**：`share_net=True`，`/mnt` 只读不影响读。
+3. **仅卡片授权（#864）的目录**：文件工具可写、exec 在 ro `/mnt` 下 EROFS（授权存在
+   文件工具实例 `self._granted`，ExecTool 无引用）。
+4. **提及但未创建**的目录：exec 的硬 `--bind` 直接失败（ExecTool 产出引导文案：
    先用文件工具写一次）；文件工具会**宿主侧 mkdir bootstrap**，所以顺序敏感——
    先文件工具、后 exec。
-7. **子 agent 重启丢根**：`AgentJob.user_roots` 只在内存（`AgentGraphStore`
+5. **子 agent 重启丢根**：`AgentJob.user_roots` 只在内存（`AgentGraphStore`
    schema 固定，不持久化）。AppServer `agent.spawn` 由 Desktop 传
    `params["user_roots"]`，不发则子 agent 无根。
 
@@ -64,5 +111,7 @@ exec 侧  = 工作区根 ∪ 静态 _shared_roots ∪ (auto_user_dirs ? _user_ro
   `users`/`home`/`mnt` **必须**留在表外——`C:\Users\<u>\Desktop\<dir>` 正是主场景。
 
 **How to apply:** 改动沙箱写路径时先问「这条命令最终走 bwrap 还是宿主」。走 bwrap
-才有层 1+2；走宿主就只有静态护栏。给写入口加新路径时，记得同时接上
-`extra_rw_binds`（bind 集合）与 `bootstrap_sandbox_roots`（目录必须存在）。
+才有层 1+2；走宿主就只有静态护栏（层 3）。给写入口加新路径时，记得同时接上
+`extra_rw_binds`（bind 集合）与 `bootstrap_sandbox_roots`（目录必须存在）；给
+`command_guard.py` 加词表条目时，先想清楚「授权目录里的同一条命令会不会被它误拦」
+——授权通道（`_user_roots` → `extra_write_roots`）必须与词表同进同退。

--- a/docs/dev-notes/sandbox-write-boundary-984.md
+++ b/docs/dev-notes/sandbox-write-boundary-984.md
@@ -1,0 +1,68 @@
+---
+name: sandbox-write-boundary-984
+description: #984 沙箱写边界 PR1 —— /mnt 改只读后，哪些写入口受内核约束、哪些仍有缺口
+type: project
+---
+
+2026-09-09，#984 PR1（`fix/984-sandbox-write-boundary`）落地三层写边界。
+本文记录**边界在哪、缺口在哪**，避免后续把「护栏」当成「完备」。
+
+## 强制层是什么
+
+`bwrap` 挂载是唯一的内核强制点。PR1 把它收紧：
+
+- **层 2**：`--bind-try /mnt /mnt` → `--ro-bind-try /mnt /mnt`
+  （`miqi/sandbox/bwrap.py` `_build_bwrap_args`）。整个 Windows 用户数据区
+  不再可写，`python -c "open(...,'w')"` 之类任意拼写都被 EROFS 挡住。
+- **层 1**：per-call `extra_rw_binds` 用**硬 `--bind`** 把授权子树重新打开，
+  排在 `/mnt` ro 之后（bwrap 后挂载覆盖前者）。**禁 `--bind-try`**：源不存在
+  必须大声失败，不能静默丢掉刚授予的写权限，更不能回退宿主执行。
+
+bind 集合：
+
+```
+exec 侧  = 工作区根 ∪ 静态 _shared_roots ∪ (auto_user_dirs ? _user_roots : ∅)
+文件工具 = 工作区根 ∪ 静态 _shared_roots ∪ (allow_user_roots ? _user_roots : ∅) ∪ #864 已授权(shared)
+```
+
+- exec 的四个 `_execute_*` 签名都接受 `extra_rw_binds`，8 处 `**splat` 全打通；
+  宿主执行分支收下即忽略（宿主没有 mount namespace，忽略**不是**降级）。
+- 文件工具四个写入方（`write_file` / `edit_file` / `apply_patch` /
+  `graph_render`）各自把 `shared` 传给 `_sandbox_write_file`。
+- **#864 卡片授权不进 exec 集合**：授权存在文件工具实例的 `self._granted`，
+  ExecTool 没有它的引用。仅卡片授权的目录 → 文件工具可写、exec 在 ro `/mnt`
+  下 EROFS。
+
+## 已知缺口（PR1 不覆盖）
+
+1. **层 3 未做**：`command_guard.py` 的 python 写系词表（`write_text` /
+   `open(...,'w')` / `shutil.copy*` …）留给 PR2。它是**体验层**（更早、更可读的
+   报错），不是强制层——强制层是上面的挂载。
+2. **宿主回退不受约束**：沙箱未就绪 / `get_or_create` 返 None /
+   `tools.sandbox.enabled=false` / 非 WSL，全部退回宿主执行，只剩静态护栏。
+3. **非沙箱写入方不受约束**：documents 工具（`pdf_create_tool.py` 宿主写）、
+   MCP、graph_render 的宿主分支、安装路由（root 跑在 WSL、不经 bwrap）。
+4. **读 + 外传不受限**：`share_net=True`，`/mnt` 只读不影响读。
+5. **KUN 链**：`kun_runtime/tool_host.py` 的 `_USER_ROOTS_TOOLS` 不含 `exec`，
+   且只对白名单工具注入 `_user_roots` → 层 2 之后 KUN 链的 exec 写用户提及目录
+   会失效（KUN 未接入主执行路径，政策见 [legacy-main-path-only](legacy-main-path-only.md)）。
+6. **提及但未创建**的目录：exec 的硬 `--bind` 直接失败（ExecTool 产出引导文案：
+   先用文件工具写一次）；文件工具会**宿主侧 mkdir bootstrap**，所以顺序敏感——
+   先文件工具、后 exec。
+7. **子 agent 重启丢根**：`AgentJob.user_roots` 只在内存（`AgentGraphStore`
+   schema 固定，不持久化）。AppServer `agent.spawn` 由 Desktop 传
+   `params["user_roots"]`，不发则子 agent 无根。
+
+## 顺手修掉的 bug
+
+- `_sandbox_write_file` 旧写法 `mkdir -p '$(dirname "…")'`：**单引号内不做命令
+  替换**，bash 建出字面目录 `$(dirname "…")`，重定向 rc=1——凡是写新子目录必挂。
+  修法是**在 Python 里算 dirname**；**不要**把外层引号改双引号，否则 Windows
+  目录名里的 `$`/反引号会变成命令替换。
+- `extract_user_mentioned_roots` 的前缀表：`_TOP_LEVEL_SYSTEM_DIRS` 只挡 depth-1，
+  `C:\Windows\Temp\x` / `/etc/cron.d/x` 之前会变成可写根。注意
+  `users`/`home`/`mnt` **必须**留在表外——`C:\Users\<u>\Desktop\<dir>` 正是主场景。
+
+**How to apply:** 改动沙箱写路径时先问「这条命令最终走 bwrap 还是宿主」。走 bwrap
+才有层 1+2；走宿主就只有静态护栏。给写入口加新路径时，记得同时接上
+`extra_rw_binds`（bind 集合）与 `bootstrap_sandbox_roots`（目录必须存在）。

--- a/docs/dev-notes/sandbox-write-boundary-984.md
+++ b/docs/dev-notes/sandbox-write-boundary-984.md
@@ -96,9 +96,27 @@ exec 侧  = 工作区根 ∪ 静态 _shared_roots ∪ (auto_user_dirs ? _user_ro
 4. **提及但未创建**的目录：exec 的硬 `--bind` 直接失败（ExecTool 产出引导文案：
    先用文件工具写一次）；文件工具会**宿主侧 mkdir bootstrap**，所以顺序敏感——
    先文件工具、后 exec。
-5. **子 agent 重启丢根**：`AgentJob.user_roots` 只在内存（`AgentGraphStore`
-   schema 固定，不持久化）。AppServer `agent.spawn` 由 Desktop 传
-   `params["user_roots"]`，不发则子 agent 无根。
+5. **子 agent 重启丢根，且 `agent.spawn` 不再从请求里取根**：
+
+   - **只为内存**：`AgentJob.user_roots`（`agent_jobs.py:39`）不落库——
+     `AgentGraphStore` schema 固定、`save_job` 只收显式关键字。子 agent
+     重启/重载后丢根，这一点**仍然成立**。
+   - **请求参数不是授权**：AppServer `agent.spawn`（`bridge/loop.py:1508`）
+     自 `a17d2812` 起固定传 `user_roots=None`（fail-closed），原先那句
+     "re-filtered here" 的 sanitize 已随该提交删除。理由是 roots 同时喂给
+     bwrap 的 rw bind 与命令护栏的写范围，而 `params` 由调用方自带——
+     把请求里的列表「过滤一遍」也只是让调用方继续挑范围，所以宁可**不给根**：
+     该通道**没有服务端 root store**（父回合的授权根没按 session/turn 记录），
+     等服务端状态接入后再注入。
+   - **该 IPC 路径当前不可达**：Desktop `AgentSpawnInput`
+     （`apps/desktop/src/shared/ipc.ts:299`）不含 `user_roots`，
+     `apps/desktop/src/main/ipc/index.ts:2164` 在 Zod parse 之后只转发
+     `agent_type`/`task`/`label`/`session_key`。
+     **当前可达的路径**是模型侧 `SpawnTool._user_roots`
+     （`miqi/agent/tools/spawn.py:88`）→ `AgentControl.spawn` →
+     `AgentJobRuntime.start` → `AgentJob.user_roots`：roots 走的是
+     **harness-only 的 `_user_roots`/extra 通道**（`ToolRegistry` 会把模型自带
+     参数里的 `_user_roots` 剥掉）。
 
 ## 顺手修掉的 bug
 

--- a/miqi/agent/command_guard.py
+++ b/miqi/agent/command_guard.py
@@ -305,12 +305,40 @@ _REMOVAL_CALL_RE = re.compile(
 _COPY_CALL_RE = re.compile(r"\bshutil\.copy\w*\s*\(")
 
 
+#: ``src=`` keyword of the copy family, anchored at the start of a depth-0
+#: argument.  Every call this regex (:data:`_COPY_CALL_RE`) matches names its
+#: first parameter ``src`` — ``copy``, ``copy2``, ``copyfile`` and
+#: ``copytree`` alike (``shutil.move`` is deliberately not matched there).
+_COPY_SRC_KEYWORD_RE = re.compile(r"\s*src\s*=\s*")
+
+
 def _copy_source_spans(payload: str) -> list[tuple[int, int]]:
-    """Spans of the SOURCE argument of every ``shutil.copy*`` call."""
+    """Spans of the SOURCE argument of every ``shutil.copy*`` call.
+
+    Positional form: the first argument is the source
+    (``shutil.copy('/etc/x', out)``).  Keyword form: the argument values
+    are looked at by NAME, because the first argument is then NOT
+    necessarily the source — ``shutil.copy(dst=out, src=p)`` writes the
+    argument that ``args[0]`` would have labelled a read, letting an
+    out-of-scope target through as "just a cp source".
+
+    Only when no ``src=`` argument is present does the first argument
+    count as the source, so every positional payload keeps its previous
+    classification verbatim.  A malformed ``src=`` (no value) yields an
+    empty span, which matches no literal — i.e. it degrades to "this
+    literal is a mutation", never to a read.
+    """
     spans: list[tuple[int, int]] = []
     for m in _COPY_CALL_RE.finditer(payload):
         args = _top_level_call_arg_spans(payload, m.end())
-        if args:
+        if not args:
+            continue
+        for a, b in args:
+            keyword = _COPY_SRC_KEYWORD_RE.match(payload[a:b])
+            if keyword:
+                spans.append((a + keyword.end(), b))
+                break
+        else:
             spans.append(args[0])
     return spans
 

--- a/miqi/agent/command_guard.py
+++ b/miqi/agent/command_guard.py
@@ -15,7 +15,11 @@ pattern-stacking with a path-aware capability check:
     forms (``python -c``/``perl -e``/``node -e``/``php -r``/``bash -c``
     payloads containing ``shutil.rmtree``, ``os.remove``, ``fs.rmSync``,
     nested ``rm -rf``, ...) — so re-spelling the operation does not
-    bypass the check (capability parity).
+    bypass the check (capability parity).  Python WRITE spellings
+    (``open(..., 'w')``, ``write_text``/``write_bytes``, ``os.mkdir``/
+    ``makedirs``, ``shutil.copy*``, ``os.rename`` — #984 layer 3) are
+    treated the same way: the vocabulary is a best-effort EXPERIENCE
+    layer (earlier, clearer refusals), not the enforcement layer.
   * Every affected path is resolved (canonical ``.``/``..`` handling,
     symlink resolution on the host) and classified against the session
     scope.  Permission levels:
@@ -28,6 +32,13 @@ pattern-stacking with a path-aware capability check:
       other sessions / outside workspace / statically
       unresolvable targets ($VAR, globs, command
       substitution) — UNCERTAIN → DENY (fail closed)
+
+    Per-call AUTHORIZED ROOTS (``RuntimePaths.extra_write_roots``: the
+    ``_user_roots`` dirs the user named, issue #821) are a mutation scope
+    too — layer 1 binds them rw inside the sandbox (#984), so refusing a
+    write there would contradict a grant the user just made (and break
+    every delivery to the directory they asked for).  System paths still
+    win over an authorized root (defense in depth).
 
     Sandbox semantics: when the exec runs inside the bwrap sandbox,
     ``/home/miqi/**`` and ``/tmp`` are sandbox-internal overlays
@@ -66,33 +77,45 @@ _REASON_TEXTS: dict[str, str] = {
         "（全局工作区只读）。"
     ),
     "workspace_root": "目标是工作区或 session 根目录本身。",
+    "authorized_root": "目标是用户授权目录本身。",
     "uncertain_path": "目标含变量/通配符/命令替换等无法静态解析的成分。",
     "script_uncertain": "内联脚本中的破坏性操作无法静态确定目标路径。",
     "find_exec": "find 的 -exec/-execdir 会执行任意程序，无法静态验证删除范围。",
 }
 
 _POLICY_TEXTS: dict[str, str] = {
-    "delete": "只允许删除当前 session 工作区内的文件。",
-    "write": "只允许写入当前 session 工作区内的文件。",
-    "move": "只允许在当前 session 工作区内移动/重命名文件。",
+    "delete": "只允许删除当前 session 工作区或用户授权目录内的文件。",
+    "write": "只允许写入当前 session 工作区或用户授权目录内的文件。",
+    "move": "只允许在当前 session 工作区或用户授权目录内移动/重命名文件。",
     "uncertain": "无法确认作用范围的破坏性操作一律拒绝（宁可误拒）。",
     "workspace_root": "禁止删除工作区或 session 根目录。",
+    "authorized_root": (
+        "授权目录内的文件可写可删，但目录本身不可删除。"
+    ),
     "find_exec": "无法确认删除范围的 find 操作一律拒绝。",
     "privilege": "沙箱为无特权环境，系统目录只读，提权命令不可用。",
 }
 
 _SAFE_TEXTS: dict[str, str] = {
     "delete": (
-        "请将目标限定在当前 session 目录内，例如：rm -rf ./run-output"
+        "请将目标限定在当前 session 目录内，例如：rm -rf ./run-output；"
+        "会话外目录请让用户在消息中点名该目录（本轮即授权）。"
     ),
-    "write": "请将写入目标限定在当前 session 目录内。",
-    "move": "请将源与目标都限定在当前 session 目录内。",
+    "write": (
+        "请将写入目标限定在当前 session 目录内；写入会话外目录请用文件工具"
+        "（write_file），或让用户在消息中点名该目录（本轮即授权 exec 写入）。"
+    ),
+    "move": "请将源与目标都限定在当前 session 目录或用户授权目录内。",
     "uncertain": (
         "请使用明确的目录名（如 rm -rf ./run-output），"
         "不要使用 $变量、通配符或命令替换。"
     ),
     "workspace_root": (
         "请指定根目录下的具体子目录，例如：rm -rf ./run-output"
+    ),
+    "authorized_root": (
+        "请删除授权目录内的具体文件（例如 rm -rf <授权目录>/sub），"
+        "目录本身请让用户处理。"
     ),
     "find_exec": (
         "请用 rm 加明确路径逐个删除，或对 session 目录内的明确子目录"
@@ -133,13 +156,21 @@ _INSTALL_EXCLUDE_PREV = frozenset({
     "scoop", "flatpak", "snap", "emerge",
 })
 
-#: Destructive call names inside inline-script payloads (issue #811:
-#: ``shutil.rmtree`` must be caught the same way ``rm -rf`` is).
+#: Destructive / write call names inside inline-script payloads.
+#: Issue #811: ``shutil.rmtree`` must be caught the same way ``rm -rf`` is.
+#: Issue #984 layer 3: python WRITE spellings must be caught the same way
+#: ``tee``/``mkdir`` are — ``write_text``/``open(..., 'w')`` used to sail
+#: through while the shell equivalent was refused.  Deliberately fail-open:
+#: an unrecognised spelling is simply not flagged.  The kernel layer (``/mnt``
+#: ro-bind + per-call rw binds) is the enforcement layer; this is the
+#: experience layer (earlier, clearer refusal).
 _DESTRUCTIVE_CALL_RE = re.compile(
     r"\bshutil\.rmtree\b"
     r"|\bshutil\.move\b"
+    r"|\bshutil\.copy\w*\b"
     r"|\bos\.(remove|unlink|rmdir|removedirs)\b"
     r"|\bos\.system\b"
+    r"|\bos\.(rename|replace)\b"
     r"|\bpathlib\.[^;)]*\.unlink\("
     r"|\.unlink\(\s*\)"
     r"|\bfs\.(rmSync|rmdirSync|unlinkSync|rm|rmdir|unlink)\s*\("
@@ -147,8 +178,164 @@ _DESTRUCTIVE_CALL_RE = re.compile(
     r"|\bFileUtils\.(rm|rm_r|rm_rf|rmdir|remove_dir)\b"
     r"|\bunlink\b"
     r"|\brmtree\b"
+    r"|\bwrite_text\b"
+    r"|\bwrite_bytes\b"
+    r"|\bmkdir\s*\("
+    r"|\bmakedirs\s*\("
     r"|\brm\s+-[a-zA-Z]*r"
 )
+
+#: ``open(...)`` with a WRITE mode (#984 layer 3) cannot be one pattern: the
+#: mode lives in the call's own argument list, and a READ ``open(f)`` /
+#: ``open(f, 'r')`` / ``open(f, 'rb')`` must stay unflagged (fail-open).  The
+#: call is scanned linearly with a bounded window — no backtracking regex
+#: (CodeQL ReDoS; see the note on _extract_string_literals below).
+_OPEN_CALL_RE = re.compile(r"\bopen\s*\(")
+_MODE_LITERAL_RE = re.compile(r"['\"]([rwxabt+]{1,8})['\"]")
+_WRITE_MODE_CHARS = frozenset("wax+")
+_OPEN_ARGS_LIMIT = 400
+
+
+def _top_level_call_arg_spans(text: str, start: int) -> list[tuple[int, int]]:
+    """``(start, end)`` spans of the depth-0 arguments of a call's arg list.
+
+    *start* is the index just after the opening paren.  Quote- and
+    paren-aware: ``open(os.path.join(d, 'a'), 'r')`` yields the spans of
+    ``os.path.join(d, 'a')`` and ``'r'``, so the nested ``'a'`` is never
+    mistaken for a mode.  Linear scan with a bounded window; unbalanced
+    input simply ends the scan (never raises).
+    """
+    spans: list[tuple[int, int]] = []
+    arg_start = start
+    depth = 1
+    i = start
+    stop = min(len(text), start + _OPEN_ARGS_LIMIT)
+    while i < stop:
+        ch = text[i]
+        if ch in ("'", '"'):
+            i += 1
+            while i < stop:
+                c = text[i]
+                if c == "\\" and i + 1 < stop:
+                    i += 2
+                    continue
+                i += 1
+                if c == ch:
+                    break
+            continue
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+            if depth == 0:
+                spans.append((arg_start, i))
+                return spans
+        elif ch == "," and depth == 1:
+            spans.append((arg_start, i))
+            arg_start = i + 1
+        i += 1
+    spans.append((arg_start, stop))
+    return spans
+
+
+def _top_level_call_args(text: str, start: int) -> list[str]:
+    """Arguments at depth 0 of the call whose ``(`` ends at *start*."""
+    return [text[a:b] for a, b in _top_level_call_arg_spans(text, start)]
+
+
+def _open_call_writes(payload: str) -> bool:
+    """True when *payload* calls ``open`` with a WRITE mode (#984 layer 3).
+
+    Reads stay unflagged: ``open(f)``, ``open(f, 'r')``, ``open(f, 'rb')``.
+    Writes are flagged: ``open(f, 'w'|'a'|'x'|'wb'|'ab'|'r+')``, the
+    ``X.open('w')`` method form, and ``open(f, mode='w')``.  Only the mode
+    POSITION is examined (2nd positional of a bare ``open``, 1st of a
+    method call, or a ``mode=`` keyword), so
+    ``open(os.path.join(d, 'a'), 'r')`` stays a read.
+    """
+    for m in _OPEN_CALL_RE.finditer(payload):
+        is_method = m.start() > 0 and payload[m.start() - 1] == "."
+        for idx, raw in enumerate(_top_level_call_args(payload, m.end())):
+            arg = raw.strip()
+            if arg.startswith("mode="):
+                arg = arg[len("mode="):].strip()
+            elif idx != (0 if is_method else 1):
+                continue
+            lit = _MODE_LITERAL_RE.fullmatch(arg)
+            if lit and set(lit.group(1).lower()) & _WRITE_MODE_CHARS:
+                return True
+    return False
+
+
+def _payload_is_destructive(payload: str) -> bool:
+    """True when an inline payload contains a destructive/write call.
+
+    The regex vocabulary is the fast path; ``open(..., <write mode>)``
+    needs the call's own argument list and goes through
+    :func:`_open_call_writes`.  Fail-open: unrecognised spellings fall
+    through and are left to the kernel layer.
+    """
+    return bool(_DESTRUCTIVE_CALL_RE.search(payload)) or _open_call_writes(payload)
+
+
+#: Delete-family subset of the vocabulary — used ONLY to pick the refusal
+#: wording (delete vs write guidance) for an inline payload.
+_DELETE_CALL_RE = re.compile(
+    r"\bshutil\.rmtree\b"
+    r"|\bos\.(remove|unlink|rmdir|removedirs)\b"
+    r"|\bunlink\b"
+    r"|\brmtree\b"
+    r"|\brm\s+-[a-zA-Z]*r"
+)
+
+#: Delete / move family — the paths these touch can be REMOVED, so an
+#: authorized root itself must not be their operand (see
+#: :func:`_is_authorized_root_itself`).
+_REMOVAL_CALL_RE = re.compile(
+    r"\bshutil\.(rmtree|move)\b"
+    r"|\bos\.(remove|unlink|rmdir|removedirs|rename|replace)\b"
+    r"|\bunlink\b"
+    r"|\brmtree\b"
+    r"|\brm\s+-[a-zA-Z]*r"
+)
+
+#: Copy-family calls whose FIRST argument is only READ (shell ``cp`` parity).
+#: ``shutil.move`` / ``os.rename`` are deliberately absent: they REMOVE the
+#: source, so both sides are mutations.
+_COPY_CALL_RE = re.compile(r"\bshutil\.copy\w*\s*\(")
+
+
+def _copy_source_spans(payload: str) -> list[tuple[int, int]]:
+    """Spans of the SOURCE argument of every ``shutil.copy*`` call."""
+    spans: list[tuple[int, int]] = []
+    for m in _COPY_CALL_RE.finditer(payload):
+        args = _top_level_call_arg_spans(payload, m.end())
+        if args:
+            spans.append(args[0])
+    return spans
+
+
+def _only_as_copy_source(
+    payload: str, literal: str, spans: list[tuple[int, int]],
+) -> bool:
+    """True when EVERY occurrence of *literal* is a copy SOURCE argument.
+
+    Inline payloads classify every literal as a mutation by default, which
+    would refuse ``shutil.copy('/etc/x', out)`` although the shell
+    ``cp /etc/x out`` is allowed.  A literal that also appears anywhere
+    else (``shutil.copy(p, q); os.remove(p)``) keeps its mutation role.
+    """
+    if not literal or not spans:
+        return False
+    pos = payload.find(literal)
+    if pos == -1:
+        return False
+    while pos != -1:
+        if not any(a <= pos and pos + len(literal) <= b for a, b in spans):
+            return False
+        pos = payload.find(literal, pos + 1)
+    return True
+
 
 #: String literals inside a script payload are extracted with a LINEAR
 #: scanner (_extract_string_literals) — a backreference regex here would
@@ -494,6 +681,37 @@ def _under(path: str, parent: str) -> bool:
     return p.startswith(q + "/") or p == q
 
 
+def _authorized_write(pstr: str, rt: "RuntimePaths") -> bool:
+    """True when *pstr* sits in a per-call AUTHORIZED root (#821/#984).
+
+    ``extra_write_roots`` carries the dirs the USER named for this call.
+    Layer 1 re-opens them writable inside the sandbox, so a refusal here
+    would contradict a grant the user just made (and break every delivery
+    to the directory they asked for).  Equality counts: the file tools
+    accept the root itself (``Path.relative_to``), and so does the bind.
+    """
+    for root in rt.extra_write_roots:
+        if _under(pstr, root):
+            return True
+    return False
+
+
+def _is_authorized_root_itself(pstr: str, rt: "RuntimePaths") -> bool:
+    """True when *pstr* IS an authorized root (not merely inside one).
+
+    Equality is a mutation scope for WRITE-kind targets (``cp a <root>``,
+    ``mv x <root>``, ``mkdir <root>`` — the operand is the directory being
+    written into), but a delete/move-SOURCE must not remove the granted
+    directory itself: the grant is "deliver here", not "delete my folder".
+    Mirrors the existing workspace/session-root protection.
+    """
+    p = _norm_str(pstr).rstrip("/")
+    for root in rt.extra_write_roots:
+        if p and p == _norm_str(root).rstrip("/"):
+            return True
+    return False
+
+
 def _is_system_path(pstr: str, rt: "RuntimePaths") -> bool:
     """True when *pstr* (normalized host path) is a protected system path."""
     n = _norm_str(pstr).rstrip("/")
@@ -544,6 +762,12 @@ class RuntimePaths:
     sandbox_cwd: str = "/home/miqi/workspace"
     miqi_home: str | None = None
     host_home: str | None = None
+    #: Host roots the user authorized for THIS call (issue #821
+    #: ``_user_roots`` — the output dirs they named).  Layer 1 binds them
+    #: rw inside the sandbox (#984), so the guard must not refuse a
+    #: mutation inside them.  Populated only when ``tools.auto_user_dirs``
+    #: is on, i.e. exactly when the bind happens.
+    extra_write_roots: tuple[str, ...] = ()
 
     @property
     def current_session_key(self) -> str | None:
@@ -597,7 +821,31 @@ def _is_flag(tok: _Token, windows_flags: bool = False) -> bool:
     return False
 
 
-def _extract_heredoc_payload(tokens: list[_Token]) -> str:
+def _raw_heredoc_body(command: str, delim: str) -> str | None:
+    """Body of the heredoc opened with *delim*, read from the RAW text.
+
+    ``_tokenize`` strips quotes, so a payload rebuilt from tokens loses
+    every string literal — ``Path('/x').write_text('y')`` becomes
+    ``Path(/x).write_text(y)`` — and the capability engine can only answer
+    "uncertain", refusing writes the user explicitly authorized (#984
+    layer 3).  The raw body keeps quotes, so literal extraction works.
+    Returns None when the opener/body cannot be located.
+    """
+    m = re.search(r"<<-?\s*['\"]?" + re.escape(delim) + r"['\"]?", command)
+    if m is None:
+        return None
+    nl = command.find("\n", m.end())
+    if nl == -1:
+        return None
+    end = command.find("\n" + delim, nl)
+    if end == -1:
+        end = command.find(delim, nl)
+    return command[nl + 1:end if end != -1 else len(command)]
+
+
+def _extract_heredoc_payload(
+    tokens: list[_Token], raw: str | None = None,
+) -> str:
     """Extract a heredoc body after a stdin launcher flag.
 
     ``python3 - <<PY\\nimport shutil; shutil.rmtree('/etc/x')\\nPY`` →
@@ -605,6 +853,10 @@ def _extract_heredoc_payload(tokens: list[_Token]) -> str:
     payload string for the inline-script scanner (#875 B7 实测：stdin
     heredoc 是唯一穿透 launcher 扫描的入口).  Handles both ``<< PY``
     and ``<<PY`` token forms.  Returns "" when no heredoc is present.
+
+    When *raw* (the subcommand's original text) is given, the body is read
+    from it instead — the token join loses quotes, which would degrade
+    every authorized write to "uncertain" (#984 layer 3).
     """
     for idx, tok in enumerate(tokens):
         if tok.text == "<<" or tok.text.startswith("<<"):
@@ -616,6 +868,10 @@ def _extract_heredoc_payload(tokens: list[_Token]) -> str:
             delim = prefix.strip("'\"")
             if not delim:
                 return ""
+            if raw is not None:
+                body_raw = _raw_heredoc_body(raw, delim)
+                if body_raw is not None:
+                    return body_raw
             body_start = idx + 1 if not tok.text[2:] else idx + 1
             body: list[str] = []
             for body_tok in tokens[body_start:]:
@@ -626,7 +882,9 @@ def _extract_heredoc_payload(tokens: list[_Token]) -> str:
     return ""
 
 
-def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
+def _detect_ops(
+    tokens: list[_Token], raw: str | None = None,
+) -> list[_FileOp]:
     """Find destructive file operations in one subcommand's token list.
 
     Operator classification is position-aware (issue #811 review,
@@ -635,6 +893,9 @@ def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
     does (``echo "rm -rf x"`` is not a delete) while an UNQUOTED word
     still does — so ``xargs rm -rf /x`` keeps its rm detection.
     Quoted tokens also act as operands (paths with spaces).
+
+    *raw* is the subcommand's original text, used only to read heredoc
+    bodies with their quotes intact (see :func:`_raw_heredoc_body`).
     """
     ops: list[_FileOp] = []
     n = len(tokens)
@@ -701,7 +962,9 @@ def _detect_ops(tokens: list[_Token]) -> list[_FileOp]:
                     # stdin 启动器（- / -s）：payload 是 <<EOF heredoc 正文
                     # （#875 B7 实测：python3 - <<EOF 可携带 shutil.rmtree 穿透）
                     if ftok.text in _STDIN_LAUNCHER_FLAGS:
-                        payload = _extract_heredoc_payload(tokens[j + 1:])
+                        payload = _extract_heredoc_payload(
+                            tokens[j + 1:], raw=raw,
+                        )
                         if payload:
                             ops.append(_FileOp(
                                 kind="inline_script", display=text,
@@ -869,9 +1132,17 @@ def _classify_sandbox_abs(
     if _norm_str(norm) == "/" or any(
         _norm_str(norm) == r or _norm_str(norm).startswith(r + "/")
         for r in _SYSTEM_POSIX_ROOTS
-    ):
+    ) or _is_system_path(norm, rt):
+        # ``_is_system_path`` adds the host home/.ssh and the MiQroForge
+        # config home — a POSIX-native path reaches those directly in the
+        # sandbox (no /mnt/<drive> mapping), and a per-call grant must
+        # never open them (defense in depth).
         if for_write:
             return False, "system_path", norm
+        return True, "", norm
+    # POSIX-native authorized roots keep their host path in the sandbox
+    # (``--bind src src``) — same grant as the /mnt/<drive> form above.
+    if for_write and _authorized_write(norm, rt):
         return True, "", norm
     if for_write:
         return False, "outside_workspace", norm
@@ -925,6 +1196,12 @@ def _classify_host(
     # 6. System paths → deny.
     if _is_system_path(pstr, rt):
         return False, "system_path", pstr
+
+    # 6b. Per-call authorized roots (#821 ``_user_roots``) — a mutation
+    #     scope, because layer 1 binds them rw inside the sandbox.  System
+    #     paths above still win (defense in depth).
+    if _authorized_write(pstr, rt):
+        return True, "", pstr
 
     # 7. Global workspace but outside the session tree → Level 1 read-only.
     if ws and _under(pstr, ws):
@@ -1037,12 +1314,15 @@ def _check_ops_operands(
             )
             if not ok:
                 return False, code, display, _refusal(desc, code, display, policy)
-        # mv removes the source: source must be in-scope too.
+        # mv removes the source: source must be in-scope too, and never the
+        # granted directory itself.
         if op.kind == "move":
             for src in sources:
                 ok, code, display = _classify_operand(
                     src.text, rt, for_write=True,
                 )
+                if ok and _is_authorized_root_itself(display, rt):
+                    ok, code = False, "authorized_root"
                 if not ok:
                     return False, code, display, _refusal(desc, code, display, policy)
         ok, code, display = _classify_operand(target.text, rt, for_write=True)
@@ -1052,8 +1332,58 @@ def _check_ops_operands(
     # delete / write (rm, tee, mkdir, touch, ln targets)
     for t in operands:
         ok, code, display = _classify_operand(t.text, rt, for_write=True)
+        if ok and op.kind == "delete" and _is_authorized_root_itself(display, rt):
+            # The grant is "deliver into this dir", not "delete the dir".
+            return False, "authorized_root", display, _refusal(
+                desc, "authorized_root", display, "authorized_root",
+            )
         if not ok:
             return False, code, display, _refusal(desc, code, display, policy)
+    return True, "", "", ""
+
+
+def _check_script_payload(
+    payload: str, rt: RuntimePaths, *, desc: str,
+) -> tuple[bool, str, str, str]:
+    """Check a python/perl/node/php payload for out-of-scope writes.
+
+    Returns ``(ok, reason_code, display, refusal_message)``.  Used for the
+    top-level inline script AND for a nested one (``bash -c "python3 -c
+    ..."`` — the launcher scan already recursed once; this closes the
+    write-spelling hole at that depth).  Fail-closed when a destructive
+    call's path literals cannot be extracted at all.
+    """
+    if not _payload_is_destructive(payload):
+        return True, "", "", ""
+    literals = _extract_string_literals(payload)
+    path_literals = [
+        lit for lit in literals
+        if "/" in lit or "\\" in lit
+        or lit.startswith(".") or lit.startswith("~")
+    ]
+    if not path_literals:
+        return False, "script_uncertain", payload[:200], _refusal(
+            desc, "script_uncertain", payload[:200], "uncertain",
+        )
+    src_spans = _copy_source_spans(payload)
+    policy = "delete" if _DELETE_CALL_RE.search(payload) else "write"
+    removal = bool(_REMOVAL_CALL_RE.search(payload))
+    for lit in path_literals:
+        # A literal used ONLY as a ``shutil.copy*`` source is a READ (cp
+        # parity); everything else is a mutation.
+        for_write = not _only_as_copy_source(payload, lit, src_spans)
+        ok, code, display = _classify_operand(lit, rt, for_write=for_write)
+        if (
+            ok and for_write and removal
+            and _is_authorized_root_itself(display, rt)
+        ):
+            ok, code = False, "authorized_root"
+        if not ok:
+            return False, code, display, _refusal(
+                desc, code, display,
+                "authorized_root" if code == "authorized_root"
+                else (policy if for_write else "uncertain"),
+            )
     return True, "", "", ""
 
 
@@ -1084,7 +1414,7 @@ def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
             return verdict
 
         # 2. Destructive file operations — path-aware capability check.
-        ops = _detect_ops(tokens)
+        ops = _detect_ops(tokens, raw=sub)
 
         # 3. Redirect targets — every subcommand's write targets must be
         #    in scope.  Process substitution is UNCERTAIN only next to a
@@ -1135,10 +1465,18 @@ def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
                         )
                         return verdict
                     for inner in inner_ops:
-                        if inner.kind == "inline_script":
-                            continue  # deeper nesting — not parsed
                         inner.display = f"{op.display} -c"
-                        if inner.kind == "find_delete":
+                        if inner.kind == "inline_script":
+                            # Nested launcher (bash -c "python3 -c ..."):
+                            # check its payload too — a write spelling must
+                            # not evade the vocabulary one level down.
+                            ok, code, display, msg = _check_script_payload(
+                                inner.extra, rt,
+                                desc=desc_map["inline_script"].format(
+                                    verb=inner.display,
+                                ),
+                            )
+                        elif inner.kind == "find_delete":
                             ok, code, display, msg = _check_find_op(
                                 inner, rt, payload[:200],
                             )
@@ -1152,30 +1490,14 @@ def evaluate_command(command: str, rt: RuntimePaths) -> GuardVerdict:
                             verdict.message = msg
                             return verdict
                     continue
-                if not _DESTRUCTIVE_CALL_RE.search(payload):
-                    continue  # plain python -c "print(1)" etc.
-                literals = _extract_string_literals(payload)
-                path_literals = [
-                    lit for lit in literals
-                    if "/" in lit or "\\" in lit
-                    or lit.startswith(".") or lit.startswith("~")
-                ]
-                if not path_literals:
+                ok, code, display, msg = _check_script_payload(
+                    payload, rt, desc=op_desc,
+                )
+                if not ok:
                     verdict.allowed = False
-                    verdict.reason_code = "script_uncertain"
-                    verdict.message = _refusal(
-                        op_desc, "script_uncertain", payload[:200], "uncertain",
-                    )
+                    verdict.reason_code = code
+                    verdict.message = msg
                     return verdict
-                for lit in path_literals:
-                    ok, code, display = _classify_operand(
-                        lit, rt, for_write=True,
-                    )
-                    if not ok:
-                        verdict.allowed = False
-                        verdict.reason_code = code
-                        verdict.message = _refusal(op_desc, code, display, "delete")
-                        return verdict
                 continue
 
             # delete / copy / move / write

--- a/miqi/agent/tools/apply_patch.py
+++ b/miqi/agent/tools/apply_patch.py
@@ -30,6 +30,7 @@ from miqi.agent.tools.filesystem import (
     _sandbox_read_file,
     _sandbox_to_host_path,
     _sandbox_write_file,
+    bootstrap_sandbox_roots,
 )
 
 
@@ -448,6 +449,9 @@ class ApplyPatchTool(Tool):
         if authorized is not None:
             shared = authorized
 
+        # #984: create authorized roots before the sandbox binds them.
+        bootstrap_sandbox_roots(shared)
+
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # session_files_dir enforces per-session isolation (#689): the
             # shared roots now include the workspace root, so without it a
@@ -476,7 +480,9 @@ class ApplyPatchTool(Tool):
             new_content = apply_file_patch(original, file_patch)
 
             try:
-                await _sandbox_write_file(sandbox, sandbox_path, new_content)
+                await _sandbox_write_file(
+                    sandbox, sandbox_path, new_content, extra_rw_binds=shared,
+                )
             except Exception as e:
                 raise IOError(f"Cannot write file in sandbox: {e}") from e
 

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1137,11 +1137,13 @@ def bootstrap_sandbox_roots(roots: Iterable[Path] | None) -> list[str]:
                 continue
             p.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            _log.warning("bootstrap_sandbox_roots: cannot create {}: {}", p, exc)
+            # stdlib logger: ``%s``, not ``{}`` (str.format placeholders make
+            # logging raise TypeError internally and DROP the message).
+            _log.warning("bootstrap_sandbox_roots: cannot create %s: %s", p, exc)
             continue
         created.append(str(p))
     if created:
-        _log.info("bootstrap_sandbox_roots: created {}", created)
+        _log.info("bootstrap_sandbox_roots: created %s", created)
     return created
 
 

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1106,7 +1106,8 @@ def bootstrap_sandbox_roots(roots: Iterable[Path] | None) -> list[str]:
       * only roots the caller already whitelisted (the bind set) — nothing
         outside it is ever created;
       * only absolute host paths that map into the sandbox: UNC/WSL-native
-        (``\\\\wsl$\\…``) and relative paths are skipped;
+        (``\\\\wsl$\\…``), relative and drive-relative (``C:``, ``C:relative``)
+        paths are skipped;
       * on Windows a POSIX path is a WSL-native path, not a host path, and is
         skipped — ``windows_path_to_mnt`` could not map it either;
       * the ``_user_roots`` component is already gated by
@@ -1125,8 +1126,15 @@ def bootstrap_sandbox_roots(roots: Iterable[Path] | None) -> list[str]:
         s = str(p).replace("\\", "/")
         if s.startswith("//"):
             continue  # UNC / WSL-native — no sandbox mapping
-        if len(s) >= 2 and s[1] == ":":
-            pass  # Windows drive path
+        # Drive-ABSOLUTE only (``C:/…``) — the same judge as
+        # ``miqi.sandbox.bwrap._host_path_to_sandbox`` (bwrap.py:79).  The
+        # drive-RELATIVE spellings Windows accepts (``C:``, ``C:relative``)
+        # mean "relative to that drive's current directory" and name no fixed
+        # root: the old ``len(s) >= 2 and s[1] == ":"`` test let them through,
+        # so bootstrap mkdir-ed a path nobody named and handed it to the
+        # sandbox as an rw bind source (review #1007).
+        if len(s) >= 3 and s[1] == ":" and s[2] in "/\\":
+            pass  # Windows drive-absolute path
         elif s.startswith("/"):
             if _os.name == "nt":
                 continue  # WSL-native path, invisible to the Windows host

--- a/miqi/agent/tools/filesystem.py
+++ b/miqi/agent/tools/filesystem.py
@@ -1092,15 +1092,88 @@ async def _sandbox_read_file(sandbox, sandbox_path: str) -> str:
     return stdout
 
 
-async def _sandbox_write_file(sandbox, sandbox_path: str, content: str) -> None:
-    """Write content to a file inside the sandbox via run_command."""
+def bootstrap_sandbox_roots(roots: Iterable[Path] | None) -> list[str]:
+    """Create authorized roots on the host so the sandbox can bind them (#984).
+
+    A per-call rw bind is a hard ``--bind``, so a missing source fails the
+    command.  The user may name an output directory that does not exist yet
+    ("输出到 新目录"), so the FILE tools — the write channel, whose roots are
+    already whitelisted — create it first.  ``exec`` deliberately does not
+    (plan v5 §5.1): it only accepts existing roots and points the model at a
+    file tool instead.
+
+    Boundaries (plan v5 §5.1):
+      * only roots the caller already whitelisted (the bind set) — nothing
+        outside it is ever created;
+      * only absolute host paths that map into the sandbox: UNC/WSL-native
+        (``\\\\wsl$\\…``) and relative paths are skipped;
+      * on Windows a POSIX path is a WSL-native path, not a host path, and is
+        skipped — ``windows_path_to_mnt`` could not map it either;
+      * the ``_user_roots`` component is already gated by
+        ``tools.auto_user_dirs`` in the caller (``_effective_shared_roots``).
+
+    Returns the paths actually created (for logging and tests).
+    """
+    import os as _os
+
+    created: list[str] = []
+    for raw in roots or []:
+        try:
+            p = Path(raw)
+        except (TypeError, ValueError):
+            continue
+        s = str(p).replace("\\", "/")
+        if s.startswith("//"):
+            continue  # UNC / WSL-native — no sandbox mapping
+        if len(s) >= 2 and s[1] == ":":
+            pass  # Windows drive path
+        elif s.startswith("/"):
+            if _os.name == "nt":
+                continue  # WSL-native path, invisible to the Windows host
+        else:
+            continue  # relative — never a bind source
+        try:
+            if p.exists():
+                continue
+            p.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            _log.warning("bootstrap_sandbox_roots: cannot create {}: {}", p, exc)
+            continue
+        created.append(str(p))
+    if created:
+        _log.info("bootstrap_sandbox_roots: created {}", created)
+    return created
+
+
+async def _sandbox_write_file(
+    sandbox,
+    sandbox_path: str,
+    content: str,
+    *,
+    extra_rw_binds: Iterable[Path] | None = None,
+) -> None:
+    """Write content to a file inside the sandbox via run_command.
+
+    ``extra_rw_binds`` (#984) are the caller's authorized roots, re-opened
+    writable for this one command — without them a write under the
+    read-only ``/mnt`` fails with EROFS.
+    """
     escaped_path = sandbox_path.replace("'", "'\\''")
+    # #984: compute the parent directory in Python.  The previous form
+    # ``mkdir -p '$(dirname "…")'`` kept the substitution inside SINGLE
+    # quotes, so bash created a literal directory named ``$(dirname "…")``
+    # and the redirect below failed with rc=1 for every new subdirectory.
+    # Do NOT move the outer quotes to double quotes: a Windows directory
+    # name containing $ or ` would then become command substitution.
+    parent = sandbox_path.rsplit("/", 1)[0] if "/" in sandbox_path else "."
+    escaped_parent = parent.replace("'", "'\\''") or "."
     # Use base64 encoding to safely transfer content through shell
     import base64
     encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
     rc, _, stderr = await sandbox.run_command(
-        f"mkdir -p '$(dirname \"{escaped_path}\")' && "
-        f"echo '{encoded}' | base64 -d > '{escaped_path}'"
+        f"mkdir -p '{escaped_parent}' && "
+        f"echo '{encoded}' | base64 -d > '{escaped_path}'",
+        extra_rw_binds=[str(r) for r in (extra_rw_binds or [])] or None,
     )
     if rc != 0:
         raise IOError(f"Cannot write {sandbox_path}: {stderr}")
@@ -1478,6 +1551,9 @@ class WriteFileTool(Tool):
         )
         if authorized is not None:
             shared = authorized
+        # #984: the sandbox binds these roots with a hard --bind, so a
+        # not-yet-created output dir must exist on the host first.
+        bootstrap_sandbox_roots(shared)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
@@ -1488,7 +1564,9 @@ class WriteFileTool(Tool):
             )
             _log.info("write_file [sandbox]: %s → %s", path, sandbox_path)
             try:
-                await _sandbox_write_file(sandbox, sandbox_path, content)
+                await _sandbox_write_file(
+                    sandbox, sandbox_path, content, extra_rw_binds=shared,
+                )
             except IOError as e:
                 return f"Error: 沙箱中写入文件失败（path={sandbox_path}）：{e}"
             except Exception as e:
@@ -1711,6 +1789,8 @@ class EditFileTool(Tool):
         )
         if authorized is not None:
             shared = authorized
+        # #984: create authorized roots before the sandbox binds them.
+        bootstrap_sandbox_roots(shared)
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             # WSL sandbox — route file operations through the sandbox.
             # session_files_dir enforces cross-session isolation: a path
@@ -1742,7 +1822,9 @@ class EditFileTool(Tool):
 
             new_content = content.replace(old_text, new_text, 1)
             try:
-                await _sandbox_write_file(sandbox, sandbox_path, new_content)
+                await _sandbox_write_file(
+                    sandbox, sandbox_path, new_content, extra_rw_binds=shared,
+                )
             except Exception as e:
                 return f"Error: 沙箱中写入编辑后文件失败（path={sandbox_path}）：{type(e).__name__}：{e}"
 

--- a/miqi/agent/tools/graph_render.py
+++ b/miqi/agent/tools/graph_render.py
@@ -36,6 +36,7 @@ from miqi.agent.tools.filesystem import (
     _resolve_session_dir,
     _sandbox_read_file,
     _sandbox_write_file,
+    bootstrap_sandbox_roots,
 )
 
 # ── 图文件自动发现名称 ──────────────────────────────────────────────────
@@ -698,12 +699,21 @@ class GraphRenderTool(Tool):
         if sandbox is not None and getattr(sandbox, "_use_wsl", False):
             from miqi.agent.tools.filesystem import _sandbox_to_host_path
 
+            # #984: create authorized roots before the sandbox binds them.
+            bootstrap_sandbox_roots(
+                shared if shared is not None else self._shared_roots
+            )
             sandbox_path = _resolve_sandbox_path(
                 str(resolved), self._workspace, sandbox,
                 extra_roots=list(shared) if shared is not None else self._shared_roots,
                 session_files_dir=session_dir,
             )
-            await _sandbox_write_file(sandbox, sandbox_path, content)
+            await _sandbox_write_file(
+                sandbox, sandbox_path, content,
+                extra_rw_binds=(
+                    list(shared) if shared is not None else self._shared_roots
+                ),
+            )
             # 镜像到宿主 workspace，供 files.read 读取（与 WriteFileTool 一致）
             host_path = _sandbox_to_host_path(sandbox_path, self._workspace, sandbox)
             if not sandbox_path.startswith("/mnt/"):

--- a/miqi/agent/tools/registry.py
+++ b/miqi/agent/tools/registry.py
@@ -164,6 +164,15 @@ class ToolRegistry:
         """
         hint = "\n\n[Analyze the error above and try a different approach.]"
 
+        # #984 layer 3 (R4): ``_user_roots`` is a harness-owned channel
+        # (ToolOrchestrator strips the model's copy before injecting its
+        # own).  ``params`` on this path IS model-authored — on any caller
+        # that skips the orchestrator (e.g. the legacy SubagentManager) a
+        # model-supplied ``_user_roots`` would become both a sandbox bind
+        # source and the guard's write scope.  Only ``**extra`` may carry
+        # it.
+        params = {k: v for k, v in params.items() if k != "_user_roots"}
+
         tool = self._tools.get(name)
         if not tool:
             return f"Error: 未找到工具 '{name}'。可用工具：{', '.join(self.tool_names)}"

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -535,6 +535,17 @@ class ExecTool(Tool):
                 return
             if not isinstance(raw_str, str) or not raw_str:
                 return
+            # #984 review: a UNC / WSL-share source (``\\wsl$\…``) has no
+            # sandbox mapping — ``_host_path_to_sandbox`` raises on it, so a
+            # hard ``--bind`` would fail EVERY command with a generic sandbox
+            # error.  It is not a bind source at all (same rule as
+            # ``filesystem.bootstrap_sandbox_roots``); the root extractors
+            # cannot produce one.
+            if raw_str.replace("\\", "/").startswith("//"):
+                logger.debug(
+                    "exec: skipping UNC rw bind (no sandbox mapping) {}", raw_str,
+                )
+                return
             key = os.path.normcase(os.path.abspath(raw_str))
             if key in seen:
                 return
@@ -567,15 +578,20 @@ class ExecTool(Tool):
         bwrap fail the whole command.  Check the sources this process can
         actually see (Windows drive paths on Windows, POSIX paths elsewhere)
         and report them with guidance instead of surfacing a raw bwrap error.
-        WSL-native paths are not visible from the Windows host and are left
-        to bwrap — they are never produced by the root extractors.
+
+        UNC / WSL-share paths are not tested here: they are not bind sources
+        at all.  ``_host_path_to_sandbox`` cannot map them and raises, which
+        the sandbox path would surface as a generic 「沙箱执行失败」, so
+        :meth:`_exec_rw_binds` drops them before they reach this check — and
+        the root extractors never produce one.  WSL-native POSIX paths are
+        invisible from the Windows host and ARE left to bwrap: they bind
+        unchanged, and one that is genuinely missing fails loudly there.
         """
         missing: list[str] = []
         for raw in binds or []:
             s = str(raw).replace("\\", "/")
             if s.startswith("//"):
-                missing.append(str(raw))
-                continue
+                continue  # not a bind source — see above
             if len(s) >= 2 and s[1] == ":":
                 if os.name == "nt" and not os.path.exists(str(raw)):
                     missing.append(str(raw))
@@ -811,7 +827,12 @@ class ExecTool(Tool):
             # ExecTool MUST follow it — no independent sandbox decision.
             if _sandbox is not None:
                 result = await self._execute_with_sandbox_selection(
-                    _sandbox, command, cwd, **exec_kwargs,
+                    _sandbox, command, cwd,
+                    # #984 review: only the BWRAP fallback consumes it (the
+                    # other branches take no grant), so it is passed here
+                    # rather than through ``exec_kwargs``.
+                    user_roots=_user_roots,
+                    **exec_kwargs,
                 )
             # Legacy path (no orchestrator): session_key preferred, fall back to active sandbox
             elif self._sandbox_manager is not None:
@@ -1277,6 +1298,12 @@ class ExecTool(Tool):
         # #984: per-call writable host paths (bwrap paths only; ignored by
         # the host-execution branches, which cannot mount anything).
         extra_rw_binds: list[str] | None = None,
+        # #984 review: the per-call ``_user_roots`` grant itself, needed by
+        # the BWRAP→host fallback below so its guard re-check sees the same
+        # authorization the pre-flight guard did.  It is NOT splatted into
+        # ``exec_kwargs``: the host executors take no grant of their own and
+        # would reject the keyword.
+        user_roots: Any = None,
     ) -> _ExecResult:
         """Execute a command according to the ToolOrchestrator's SandboxSelection.
 
@@ -1334,7 +1361,14 @@ class ExecTool(Tool):
             # allowed sandbox-internal paths (/home/miqi/**, /tmp) that
             # mean something else on the host.  Re-check with HOST
             # semantics before falling back (issue #811 review).
-            fallback_guard = self._guard_host_fallback(command, cwd)
+            # #984 review: the per-call grant travels with it — without it
+            # ``_guard_write_roots`` sees None and refuses the very write the
+            # user just authorized (the legacy fallback below already passed
+            # them).  ``extra_rw_binds`` is NOT the right argument here: the
+            # guard contract only ever widens for the per-call roots.
+            fallback_guard = self._guard_host_fallback(
+                command, cwd, user_roots=user_roots,
+            )
             if fallback_guard is not None:
                 return fallback_guard
             # Fall back to direct execution (e.g. during first-time

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -377,6 +377,8 @@ class ExecTool(Tool):
         approval_callback=None,
         sandbox_manager=None,
         system_install_approver=None,
+        shared_roots: list[Any] | None = None,
+        allow_user_dirs: bool = True,
     ):
         self.timeout = timeout
         self.max_timeout = max_timeout
@@ -420,6 +422,13 @@ class ExecTool(Tool):
         # "deny_no_channel"。fail-closed: 无通道/异常/超时一律 deny（外部
         # 审阅 #854；#875 review F3 增加 deny_no_channel 区分"卡从未出现"）。
         self.system_install_approver = system_install_approver
+        # #984: host roots this tool may re-open writable inside the bwrap
+        # sandbox (workspace root + tools.extra_roots + memory/skills dirs,
+        # resolved once by tool_registry_factory).  ``allow_user_dirs``
+        # mirrors tools.auto_user_dirs and gates the per-call ``_user_roots``
+        # component — same switch the file tools honour (issue #821).
+        self._shared_roots: list[Any] = list(shared_roots or [])
+        self._allow_user_dirs = allow_user_dirs
 
     @property
     def name(self) -> str:
@@ -484,6 +493,84 @@ class ExecTool(Tool):
             )
         return requested * 1000, None
 
+    # ── #984: per-call writable binds for the bwrap sandbox ─────────────
+
+    def _exec_rw_binds(self, user_roots: Any) -> list[str]:
+        """Host paths to re-open writable for ONE exec call (#984).
+
+        Set (plan v5 §2): workspace root ∪ static ``shared_roots`` ∪
+        per-call user-mentioned roots when ``tools.auto_user_dirs`` is on.
+        The #864 approval-card grants are deliberately NOT part of the exec
+        set — they live on the file-tool instances (``self._granted``) and
+        ExecTool holds no reference to them; exec still reaches user-mentioned
+        dirs through ``_user_roots`` (see the PR body for the residual gap).
+
+        Missing STATIC roots are skipped with a debug log: they come from
+        config, and before #984 they were never bound, so a stale entry must
+        not start failing every command.  Per-call user roots are kept
+        unconditionally — silently dropping one would revoke a grant the user
+        just made; a missing source is reported with guidance instead (see
+        :meth:`_missing_bind_sources`).
+        """
+        out: list[str] = []
+        seen: set[str] = set()
+
+        def _add(raw: Any, *, strict: bool) -> None:
+            try:
+                raw_str = os.fspath(raw)
+            except TypeError:
+                return
+            if not isinstance(raw_str, str) or not raw_str:
+                return
+            key = os.path.normcase(os.path.abspath(raw_str))
+            if key in seen:
+                return
+            if not strict:
+                try:
+                    if not os.path.exists(raw_str):
+                        logger.debug(
+                            "exec: skipping missing static rw bind {}", raw_str,
+                        )
+                        return
+                except OSError:
+                    return
+            seen.add(key)
+            out.append(raw_str)
+
+        if self.working_dir:
+            _add(self.working_dir, strict=False)
+        for root in self._shared_roots:
+            _add(root, strict=False)
+        if self._allow_user_dirs:
+            for root in user_roots or []:
+                _add(root, strict=True)
+        return out
+
+    @staticmethod
+    def _missing_bind_sources(binds: list[str] | None) -> list[str]:
+        """Bind sources that do not exist on the host, for a pre-flight error.
+
+        The per-call binds use a hard ``--bind``, so a missing source makes
+        bwrap fail the whole command.  Check the sources this process can
+        actually see (Windows drive paths on Windows, POSIX paths elsewhere)
+        and report them with guidance instead of surfacing a raw bwrap error.
+        WSL-native paths are not visible from the Windows host and are left
+        to bwrap — they are never produced by the root extractors.
+        """
+        missing: list[str] = []
+        for raw in binds or []:
+            s = str(raw).replace("\\", "/")
+            if s.startswith("//"):
+                missing.append(str(raw))
+                continue
+            if len(s) >= 2 and s[1] == ":":
+                if os.name == "nt" and not os.path.exists(str(raw)):
+                    missing.append(str(raw))
+            elif s.startswith("/") and os.name != "nt":
+                if not os.path.exists(str(raw)):
+                    missing.append(str(raw))
+        return missing
+
     @property
     def description(self) -> str:
         from miqi.sandbox.manager import describe_exec_environment
@@ -544,6 +631,13 @@ class ExecTool(Tool):
         # Phase 31: consume SandboxSelection injected by ToolOrchestrator.
         _sandbox = kwargs.pop("_sandbox", None)
         _session_key = kwargs.pop("_session_key", None)
+
+        # #984: per-call user-mentioned output dirs — the same channel the
+        # file tools consume.  They are re-opened writable in the bwrap
+        # sandbox for THIS command only, so a runtime write (`open(...)`,
+        # `write_text`, any spelling) succeeds where the user asked without
+        # making the whole of /mnt writable again.
+        _user_roots = kwargs.pop("_user_roots", None)
 
         # Resolve sandbox_type for the begin event from the actual selection
         if _sandbox is not None:
@@ -691,6 +785,9 @@ class ExecTool(Tool):
                 thread_id=thread_id,
                 # Session key for per-session sandbox isolation
                 session_key=_session_key,
+                # #984: per-call writable binds for the bwrap sandbox.
+                # Host execution paths accept and ignore them.
+                extra_rw_binds=self._exec_rw_binds(_user_roots),
             )
 
             # Phase 31: if ToolOrchestrator injected a SandboxSelection,
@@ -787,6 +884,8 @@ class ExecTool(Tool):
         ledger_runtime=None,
         thread_id: str = "",
         session_key: str | None = None,
+        # #984: per-call writable host paths (workspace + authorized dirs)
+        extra_rw_binds: list[str] | None = None,
     ) -> _ExecResult:
         """Execute a command inside the bwrap sandbox with streaming I/O.
 
@@ -812,6 +911,23 @@ class ExecTool(Tool):
                 exit_code=-1, cancelled=True,
             )
 
+        # #984: the per-call rw binds use a hard --bind, so a missing source
+        # fails the command.  Report it with guidance instead of a raw bwrap
+        # error, and NEVER fall back to host execution — the command was
+        # authorized for a sandboxed write it cannot get.
+        _missing_binds = self._missing_bind_sources(extra_rw_binds)
+        if _missing_binds:
+            return _ExecResult(
+                output=(
+                    "Error: 授权写入目录不存在，命令未执行："
+                    + "、".join(_missing_binds)
+                    + "\nHint: 请先在 Windows 侧创建该目录，"
+                    "或先用文件工具写入一次（文件工具会自动创建授权目录），"
+                    "再重试本条命令。"
+                ),
+                exit_code=1,
+            )
+
         start = time.monotonic()
 
         # Build sandbox env and cwd
@@ -827,6 +943,7 @@ class ExecTool(Tool):
         try:
             handle = await sandbox.run_command_streaming(
                 command, env=sandbox_env, cwd=sandbox_cwd,
+                extra_rw_binds=extra_rw_binds,
             )
         except Exception as e:
             duration_ms = int((time.monotonic() - start) * 1000)
@@ -1139,6 +1256,9 @@ class ExecTool(Tool):
         ledger_runtime=None,
         thread_id: str = "",
         session_key: str | None = None,
+        # #984: per-call writable host paths (bwrap paths only; ignored by
+        # the host-execution branches, which cannot mount anything).
+        extra_rw_binds: list[str] | None = None,
     ) -> _ExecResult:
         """Execute a command according to the ToolOrchestrator's SandboxSelection.
 
@@ -1169,6 +1289,9 @@ class ExecTool(Tool):
             # Phase 31.8: pass ledger runtime and thread_id to sub-executors
             ledger_runtime=ledger_runtime,
             thread_id=thread_id,
+            # #984: per-call rw binds — consumed by _execute_in_sandbox,
+            # accepted-and-ignored by the host paths.
+            extra_rw_binds=extra_rw_binds,
         )
 
         # ── NONE: orchestrator explicitly allowed direct execution ──────
@@ -1243,6 +1366,11 @@ class ExecTool(Tool):
         # Phase 31.8: ledger runtime for replay-persistent event recording
         ledger_runtime=None,
         thread_id: str = "",
+        # #984: accepted for call-site uniformity (``**common`` splat) and
+        # deliberately ignored — RESTRICTED executes on the host, where no
+        # bind exists to apply.  Its explicit _execute_direct call below
+        # must keep working without passing it (plan v6 §3).
+        extra_rw_binds: list[str] | None = None,
     ) -> _ExecResult:
         """Execute with RESTRICTED sandbox policy enforcement.
 
@@ -1645,6 +1773,11 @@ class ExecTool(Tool):
         ledger_runtime=None,
         thread_id: str = "",
         session_key: str | None = None,
+        # #984: accepted for call-site uniformity (``**exec_kwargs`` /
+        # ``**common`` splats) and deliberately ignored — host execution has
+        # no mount namespace to bind into.  Ignoring is NOT a silent
+        # downgrade: the bind only ever widened sandbox writes.
+        extra_rw_binds: list[str] | None = None,
     ) -> _ExecResult:
         """Execute a command directly on the host (no sandbox).
 

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -379,6 +379,8 @@ class ExecTool(Tool):
         system_install_approver=None,
         shared_roots: list[Any] | None = None,
         allow_user_dirs: bool = True,
+        workspace_root: str | None = None,
+        session_files_dir: str | None = None,
     ):
         self.timeout = timeout
         self.max_timeout = max_timeout
@@ -429,6 +431,16 @@ class ExecTool(Tool):
         # component — same switch the file tools honour (issue #821).
         self._shared_roots: list[Any] = list(shared_roots or [])
         self._allow_user_dirs = allow_user_dirs
+        # #1007 review: the workspace root is in the rw bind set (it is part
+        # of ``shared_roots``), and ``<workspace>/sessions/**`` lives under
+        # it — so every exec call re-opened OTHER sessions' files writable.
+        # These two host paths let the sandbox re-protect that subtree while
+        # keeping THIS session's own files dir writable (see
+        # ``bwrap._cross_session_guard_args``).  Both are fixed at
+        # construction, like every other bind source here; ``None`` (unknown
+        # workspace / no per-session layout) keeps the previous args exactly.
+        self._workspace_root = workspace_root
+        self._session_files_dir = session_files_dir
 
     @property
     def name(self) -> str:
@@ -524,6 +536,13 @@ class ExecTool(Tool):
         the per-call ``_user_roots`` channel this issue exists to gate.
         Locked by
         ``tests/execution/test_exec_write_boundary_984.py::TestWorkingDirNotABindSource``.
+
+        Because the workspace root is in this set, ``<ws>/sessions/**`` —
+        every OTHER session's files — is re-opened writable by that same
+        bind.  :meth:`_execute_in_sandbox` therefore also hands the sandbox
+        ``self._workspace_root`` / ``self._session_files_dir``, and bwrap
+        re-mounts ``<ws>/sessions`` READ-ONLY after the bind with only this
+        session's own files dir re-opened after that (#1007 review).
         """
         out: list[str] = []
         seen: set[str] = set()
@@ -983,6 +1002,12 @@ class ExecTool(Tool):
             handle = await sandbox.run_command_streaming(
                 command, env=sandbox_env, cwd=sandbox_cwd,
                 extra_rw_binds=extra_rw_binds,
+                # #1007 review: the workspace root above is re-opened
+                # writable, so <workspace>/sessions must be re-protected —
+                # read-only, with this session's own files dir re-opened
+                # after it.  Both are construction-time instance attributes.
+                workspace_root=self._workspace_root,
+                session_files_dir=self._session_files_dir,
             )
         except Exception as e:
             duration_ms = int((time.monotonic() - start) * 1000)

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -760,6 +760,9 @@ class ExecTool(Tool):
                             ) is not None
                         )
                     ),
+                    # #984 layer 3: the same per-call grant layer 1 binds
+                    # rw — the guard must not refuse it.
+                    user_roots=_user_roots,
                 )
                 if guard_error:
                     return _ExecResult(output=guard_error, exit_code=1)
@@ -825,7 +828,9 @@ class ExecTool(Tool):
                 else:
                     # Legacy fallback (no sandbox): same host-semantics
                     # re-check as the BWRAP fallback (issue #811 review).
-                    fallback_guard = self._guard_host_fallback(command, cwd)
+                    fallback_guard = self._guard_host_fallback(
+                        command, cwd, user_roots=_user_roots,
+                    )
                     if fallback_guard is not None:
                         return fallback_guard
                     # Fall back to direct execution (no sandbox)
@@ -2751,6 +2756,7 @@ class ExecTool(Tool):
 
     def _guard_command(
         self, command: str, cwd: str, *, sandbox_active: bool = False,
+        user_roots: Any = None,
     ) -> str | None:
         """Path-aware capability guard for exec commands (issue #811).
 
@@ -2769,6 +2775,11 @@ class ExecTool(Tool):
         ``restrict_to_workspace`` string checks still apply to them.
         ``allow_patterns`` (when configured) still applies to the whole
         command.
+
+        ``user_roots`` is the per-call #821 grant (the output dirs the
+        user named).  It widens the engine's mutation scope exactly when
+        layer 1 binds them rw, so the guard never refuses a write the
+        kernel just granted (#984 layer 3).
         """
         from miqi.agent.command_guard import (
             FILE_OP_PATTERN_EXCLUSIONS,
@@ -2776,7 +2787,8 @@ class ExecTool(Tool):
         )
 
         verdict = evaluate_command(
-            command, self._guard_runtime_paths(cwd, sandbox_active),
+            command,
+            self._guard_runtime_paths(cwd, sandbox_active, user_roots),
         )
         if not verdict.allowed:
             return verdict.message
@@ -2815,7 +2827,7 @@ class ExecTool(Tool):
         return None
 
     def _guard_host_fallback(
-        self, command: str, cwd: str,
+        self, command: str, cwd: str, user_roots: Any = None,
     ) -> _ExecResult | None:
         """Re-check the guard with HOST path semantics before a
         host-fallback execution (issue #811 review).
@@ -2830,7 +2842,9 @@ class ExecTool(Tool):
         """
         if self.approval_callback is not None:
             return None
-        guard_error = self._guard_command(command, cwd, sandbox_active=False)
+        guard_error = self._guard_command(
+            command, cwd, sandbox_active=False, user_roots=user_roots,
+        )
         if guard_error:
             return _ExecResult(output=guard_error, exit_code=1)
         return None
@@ -2858,12 +2872,51 @@ class ExecTool(Tool):
 
         return None
 
-    def _guard_runtime_paths(self, cwd: str, sandbox_active: bool):
+    def _guard_write_roots(self, user_roots: Any) -> tuple[str, ...]:
+        """Per-call authorized roots the static guard may treat as writable.
+
+        Only the ``_user_roots`` grant (#821) qualifies, and only when
+        ``allow_user_dirs`` (``tools.auto_user_dirs``) is on — i.e. exactly
+        when :meth:`_exec_rw_binds` re-opens them inside the sandbox.
+        Without this the guard would refuse the very writes layer 1 just
+        granted (#984 layer 3: the tightening ships WITH the authorization
+        channel, never before it).
+
+        The static ``shared_roots`` and the workspace root are deliberately
+        NOT included: their guard semantics (Level 1 read-only outside the
+        session tree) are unchanged — an inline write into a configured
+        ``tools.extra_roots`` dir is still refused here and the refusal
+        points at the file tool.  Non-absolute entries are dropped, and
+        each root is RESOLVED: the classifier resolves every operand, so an
+        8.3 / symlink / case-variant spelling of the root would otherwise
+        silently fail the grant.
+        """
+        if not self._allow_user_dirs:
+            return ()
+        out: list[str] = []
+        for raw in user_roots or []:
+            try:
+                s = os.fspath(raw)
+            except TypeError:
+                continue
+            if not (isinstance(s, str) and s and os.path.isabs(s)):
+                continue
+            try:
+                out.append(str(Path(s).resolve()))
+            except (OSError, ValueError):
+                continue
+        return tuple(out)
+
+    def _guard_runtime_paths(
+        self, cwd: str, sandbox_active: bool, user_roots: Any = None,
+    ):
         """Build the RuntimePaths context for the capability engine.
 
         Resolves the host workspace root and the session files dir
         (``<workspace>/sessions/<key>/files``) so the engine can apply
-        the Level 0/1/2 path hierarchy from issue #811.
+        the Level 0/1/2 path hierarchy from issue #811.  ``user_roots``
+        (per-call #821 grant) becomes ``extra_write_roots`` — the engine's
+        extra mutation scope, matching layer 1's rw binds (#984).
         """
         from miqi.agent.command_guard import RuntimePaths
 
@@ -2908,6 +2961,7 @@ class ExecTool(Tool):
             sandbox_cwd=self._resolve_sandbox_cwd(cwd) if sandbox_active else "",
             miqi_home=miqi_home,
             host_home=str(Path.home()) if hasattr(Path, "home") else None,
+            extra_write_roots=self._guard_write_roots(user_roots),
         )
 
     async def _mirror_downloaded_files(

--- a/miqi/agent/tools/shell.py
+++ b/miqi/agent/tools/shell.py
@@ -511,6 +511,19 @@ class ExecTool(Tool):
         unconditionally — silently dropping one would revoke a grant the user
         just made; a missing source is reported with guidance instead (see
         :meth:`_missing_bind_sources`).
+
+        CONTRACT — every bind SOURCE here is fixed at CONSTRUCTION time.
+        Apart from ``user_roots`` (harness-injected; see
+        ``ToolOrchestrator._execute_in_sandbox``), the sources are instance
+        attributes set when the tool was built: ``self.working_dir`` and
+        ``self._shared_roots``.  The per-call ``working_dir`` argument of
+        :meth:`execute` selects the process cwd and the workspace-diff root
+        ONLY; it MUST NOT be folded into this set.  Were it honoured here, a
+        model-authored ``working_dir`` would re-open an arbitrary host
+        directory writable inside the sandbox with no grant at all, bypassing
+        the per-call ``_user_roots`` channel this issue exists to gate.
+        Locked by
+        ``tests/execution/test_exec_write_boundary_984.py::TestWorkingDirNotABindSource``.
         """
         out: list[str] = []
         seen: set[str] = set()

--- a/miqi/agent/tools/spawn.py
+++ b/miqi/agent/tools/spawn.py
@@ -80,10 +80,20 @@ class SpawnTool(Tool):
                 "Legacy SubagentManager fallback is disabled."
             )
 
+        # #984: the parent turn's authorized roots travel with the job so the
+        # sub-agent's exec/file tools can write where the user asked.  The
+        # task text is NOT scanned for paths — it is model-authored, and
+        # re-extracting from it would re-open the injection channel #821
+        # deliberately closed (see TurnContext.is_subagent).
+        user_roots = [
+            str(r) for r in (kwargs.pop("_user_roots", None) or [])
+        ]
+
         agent = await self._agent_control.spawn(
             agent_type="code-agent",
             task=task,
             label=display_label,
+            user_roots=user_roots,
         )
         logger.info(
             "Subagent spawned via AgentControl: {} ({})",

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -29,7 +29,7 @@ import os as _os
 import re as _re
 import sys as _sys
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 from miqi.paths import get_config_path
 
@@ -221,6 +221,138 @@ def _candidate_root(host: str) -> Path | None:
         return None
 
 
+def _root_for(cand: Path) -> Path:
+    """The writable root a candidate path implies.
+
+    An existing file's parent is the writable root; a directory (or a
+    not-yet-existing path, i.e. a future output dir) roots itself.
+    """
+    try:
+        if cand.is_dir():
+            return cand
+        if cand.is_file():
+            return cand.parent
+    except OSError:
+        pass
+    return cand
+
+
+def _accept_root(root: Path, workspace: Path | None) -> bool:
+    """True when *root* may become an authorized write root.
+
+    Shared by :func:`extract_user_mentioned_roots` (#821, user message
+    mentions) and :func:`sanitize_user_roots` (#984 review, untrusted
+    ``agent.spawn`` params): both channels end up in
+    ``ToolExecutionContext.user_mentioned_roots`` — the exec rw binds and
+    the command guard's write scope — so a root dropped on one of them must
+    not slip in through the other.
+    """
+    # Drive root (e.g. C:\) — Path.parent of a drive root is itself.
+    if root.parent == root:
+        return False
+    # The user profile root itself is too broad.
+    if root == Path.home().resolve():
+        return False
+    # Top-level system directories of a drive.
+    if _is_top_level_system_dir(root):
+        return False
+    # #984: protected system subtrees below the drive root
+    # (C:\Windows\Temp\x, /etc/…, ~/.miqi/…) — the depth-1 check above
+    # does not catch these.
+    if _is_protected_prefix(root):
+        return False
+    if workspace is not None:
+        # Protected paths: config file / per-session files.
+        if _is_protected_extra_root(root, workspace):
+            return False
+        # Already covered by the workspace root — no need to add.
+        try:
+            root.relative_to(workspace.resolve())
+            return False
+        except ValueError:
+            pass
+    return True
+
+
+def _grant_to_host_path(raw: Any) -> str | None:
+    """Absolute host path from one untrusted root entry, or None.
+
+    Only spellings that name ONE fixed location qualify: POSIX-absolute
+    (``/…``) or drive-ABSOLUTE (``C:/…``).  Rejected, as they cannot name a
+    fixed root: relative paths, bare drives / drive-relative forms (``C:``,
+    ``C:relative`` — relative to that drive's current directory, see
+    ``bwrap._host_path_to_sandbox``) and UNC shares (no sandbox mapping).
+    Drive paths on a POSIX host are dropped by :func:`_to_host_path`, the
+    same way a drive-letter mention is.
+    """
+    try:
+        s = _os.fspath(raw)
+    except TypeError:
+        return None
+    if not isinstance(s, str) or not s:
+        return None
+    s = s.replace("\\", "/")
+    if s.startswith("//"):
+        return None  # UNC / WSL share — not bindable
+    if not (
+        s.startswith("/")
+        or (len(s) >= 3 and s[0].isalpha() and s[1] == ":" and s[2] == "/")
+    ):
+        return None
+    return _to_host_path(s)
+
+
+def sanitize_user_roots(
+    paths: Iterable[Any],
+    *,
+    workspace: Path | None = None,
+    max_roots: int = DEFAULT_MAX_USER_ROOTS,
+) -> list[str]:
+    """Filter untrusted root entries; returns canonical host path strings.
+
+    For roots that arrive from OUTSIDE the runtime — the ``agent.spawn``
+    IPC parameter (#984 review) — and would otherwise reach
+    ``TurnContext.user_mentioned_roots`` without ever passing through
+    :func:`extract_user_mentioned_roots`.  They feed the same two
+    authorization channels there (the bwrap rw binds and the command guard's
+    write scope), so they get the same guard rails as a mention.
+
+    Entries that are not usable absolute paths (``None``, numbers, ``bytes``,
+    relative / drive-relative / UNC strings) are dropped instead of raising:
+    the input is untrusted IPC data.
+    """
+    # A str/bytes/dict "list" is a malformed payload, not a root list:
+    # iterating it would hand over characters or keys — and a non-iterable
+    # would raise inside the handler.
+    if paths is None or isinstance(paths, (str, bytes, dict)):
+        return []
+    try:
+        entries = list(paths)
+    except TypeError:
+        return []
+
+    roots: list[str] = []
+    seen: set[str] = set()
+    for raw in entries:
+        host = _grant_to_host_path(raw)
+        if host is None:
+            continue
+        cand = _candidate_root(host)
+        if cand is None:
+            continue
+        root = _root_for(cand)
+        if not _accept_root(root, workspace):
+            continue
+        key = _os.path.normcase(str(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(str(root))
+        if len(roots) >= max_roots:
+            break
+    return roots
+
+
 def extract_user_mentioned_roots(
     texts: Iterable[str],
     *,
@@ -259,42 +391,9 @@ def extract_user_mentioned_roots(
         if cand is None:
             continue
 
-        # An existing file's parent is the writable root; a directory (or a
-        # not-yet-existing path, i.e. a future output dir) roots itself.
-        try:
-            if cand.is_dir():
-                root = cand
-            elif cand.is_file():
-                root = cand.parent
-            else:
-                root = cand
-        except OSError:
-            root = cand
-
-        # Drive root (e.g. C:\) — Path.parent of a drive root is itself.
-        if root.parent == root:
+        root = _root_for(cand)
+        if not _accept_root(root, workspace):
             continue
-        # The user profile root itself is too broad.
-        if root == Path.home().resolve():
-            continue
-        # Top-level system directories of a drive.
-        if _is_top_level_system_dir(root):
-            continue
-        # #984: protected system subtrees below the drive root
-        # (C:\Windows\Temp\x, /etc/…, ~/.miqi/…) — the depth-1 check above
-        # does not catch these.
-        if _is_protected_prefix(root):
-            continue
-        # Protected paths: config file / per-session files.
-        if workspace is not None and _is_protected_extra_root(root, workspace):
-            continue
-        # Already covered by the workspace root — no need to add.
-        if workspace is not None:
-            try:
-                root.relative_to(workspace.resolve())
-                continue
-            except ValueError:
-                pass
 
         key = _os.path.normcase(str(root))
         if key in seen:

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -241,8 +241,8 @@ def _accept_root(root: Path, workspace: Path | None) -> bool:
     """True when *root* may become an authorized write root.
 
     Shared by :func:`extract_user_mentioned_roots` (#821, user message
-    mentions) and :func:`sanitize_user_roots` (#984 review, untrusted
-    ``agent.spawn`` params): both channels end up in
+    mentions) and :func:`sanitize_user_roots` (#984 review, root lists
+    arriving from outside the runtime): both channels end up in
     ``ToolExecutionContext.user_mentioned_roots`` — the exec rw binds and
     the command guard's write scope — so a root dropped on one of them must
     not slip in through the other.
@@ -310,16 +310,22 @@ def sanitize_user_roots(
 ) -> list[str]:
     """Filter untrusted root entries; returns canonical host path strings.
 
-    For roots that arrive from OUTSIDE the runtime — the ``agent.spawn``
-    IPC parameter (#984 review) — and would otherwise reach
-    ``TurnContext.user_mentioned_roots`` without ever passing through
+    For root lists that arrive from OUTSIDE the runtime and would otherwise
+    reach ``TurnContext.user_mentioned_roots`` without ever passing through
     :func:`extract_user_mentioned_roots`.  They feed the same two
     authorization channels there (the bwrap rw binds and the command guard's
     write scope), so they get the same guard rails as a mention.
 
+    NOTE (#1007 review): filtering a caller-supplied list does not make it
+    trustworthy — the caller still chooses the scope.  ``agent.spawn`` no
+    longer uses this function: it takes no roots from the request at all
+    (fail-closed) and must instead be handed roots from server-side state.
+    Keep this helper for a future server-held store; do NOT wire it back to
+    a request field.
+
     Entries that are not usable absolute paths (``None``, numbers, ``bytes``,
     relative / drive-relative / UNC strings) are dropped instead of raising:
-    the input is untrusted IPC data.
+    the input is untrusted data.
     """
     # A str/bytes/dict "list" is a malformed payload, not a root list:
     # iterating it would hand over characters or keys — and a non-iterable

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -79,8 +79,54 @@ _TOP_LEVEL_SYSTEM_DIRS = frozenset({
     "system", "library", "applications",
 })
 
+# #984: system subtrees that must never become writable roots even though
+# they sit deeper than the depth-1 filter above.  Without this, a mention of
+# ``C:\Windows\Temp\x`` or ``/etc/cron.d/x`` became a writable root, because
+# ``_is_top_level_system_dir`` only rejects the drive/dir root itself.
+# Matched against the first component below the anchor.
+# 'users'/'home'/'mnt'/'media' are deliberately ABSENT — the primary feature
+# (issue #821) is exactly "write to C:\Users\<u>\Desktop\<dir>".
+_PROTECTED_TOP_COMPONENTS = frozenset({
+    # Windows — drive-level system trees
+    "windows", "programdata", "program files", "program files (x86)",
+    "perflogs", "$recycle.bin", "system volume information", "recovery",
+    "temp",
+    # POSIX — system trees
+    "bin", "boot", "dev", "etc", "lib", "lib32", "lib64", "libx32",
+    "opt", "proc", "root", "run", "sbin", "srv", "sys", "usr", "var",
+    "tmp",
+})
+
+# Components that are protected anywhere in the path (Windows user-profile
+# internals: AppData\Local\Temp, AppData\Roaming, ...).
+_PROTECTED_ANY_COMPONENT = frozenset({"appdata"})
+
 # Default cap on auto-sensed roots per turn.
 DEFAULT_MAX_USER_ROOTS = 8
+
+
+def _is_protected_prefix(root: Path) -> bool:
+    """True when *root* sits inside a protected system subtree (#984).
+
+    Only message *mentions* are filtered here; explicit configuration
+    (``tools.extra_roots``) is unaffected — a user who lists a directory
+    there has made a deliberate choice.
+    """
+    parts = root.parts
+    # parts[0] is the anchor ("C:\\", "\\\\server\\share\\", "/" or "").
+    if len(parts) > 1 and parts[1].lower() in _PROTECTED_TOP_COMPONENTS:
+        return True
+    if _PROTECTED_ANY_COMPONENT & {p.lower() for p in parts[1:]}:
+        return True
+    # The host config directory (~/.miqi) and everything under it.  Roots
+    # that merely *contain* it are left to the existing guards: the home
+    # directory and drive roots are dropped above, and ``_is_protected_extra_root``
+    # rejects any root covering the config file once a workspace is known.
+    try:
+        config_home = get_config_path().resolve().parent
+    except (OSError, ValueError):
+        return False
+    return root == config_home or root.is_relative_to(config_home)
 
 
 def _is_protected_extra_root(root: Path, workspace: Path) -> bool:
@@ -233,6 +279,11 @@ def extract_user_mentioned_roots(
             continue
         # Top-level system directories of a drive.
         if _is_top_level_system_dir(root):
+            continue
+        # #984: protected system subtrees below the drive root
+        # (C:\Windows\Temp\x, /etc/…, ~/.miqi/…) — the depth-1 check above
+        # does not catch these.
+        if _is_protected_prefix(root):
             continue
         # Protected paths: config file / per-session files.
         if workspace is not None and _is_protected_extra_root(root, workspace):

--- a/miqi/agent/tools/user_roots.py
+++ b/miqi/agent/tools/user_roots.py
@@ -320,8 +320,11 @@ def sanitize_user_roots(
     trustworthy — the caller still chooses the scope.  ``agent.spawn`` no
     longer uses this function: it takes no roots from the request at all
     (fail-closed) and must instead be handed roots from server-side state.
-    Keep this helper for a future server-held store; do NOT wire it back to
-    a request field.
+
+    NOTE (#984 R6): this is consequently no longer the IPC path's filter point
+    and has NO production call site at all — it is kept as a public helper for
+    the tests and for wiring that server-held root store later on.  Do NOT
+    wire it back to a request field.
 
     Entries that are not usable absolute paths (``None``, numbers, ``bytes``,
     relative / drive-relative / UNC strings) are dropped instead of raising:

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1522,28 +1522,26 @@ class BridgeRuntimeLoop:
                 "Agent control not initialized", code="INTERNAL",
             )
 
-        # #984 review: roots arriving over IPC bypass
-        # ``extract_user_mentioned_roots`` and would reach
-        # ``TurnContext.user_mentioned_roots`` — i.e. both the bwrap rw binds
-        # and the command guard's write scope — unfiltered.  They are
-        # re-filtered here, at the trust boundary, before they are stored on
-        # the job.  (Defence in depth: the Desktop IPC has no ``user_roots``
-        # field yet, so this path is not reachable from the shipped client.)
-        from miqi.agent.tools.user_roots import sanitize_user_roots
-
-        user_roots = sanitize_user_roots(
-            params.get("user_roots") or [],
-            workspace=getattr(ac, "workspace", None),
-        )
-
+        # #984 review: the roots a sub-agent runs with feed two authorization
+        # channels — the sandbox rw binds and the command guard's write scope
+        # — so they must come from state the SERVER holds, never from the
+        # request.  ``params`` is caller-supplied and therefore forgeable: a
+        # request field is a request, not a grant.  Filtering it (rather than
+        # dropping it) would still leave the caller choosing the scope.
+        #
+        # This channel currently has no server-side root store (the parent
+        # turn's authorized roots are not recorded per session/turn), so the
+        # sub-agent gets none: fail closed.  Wiring the parent turn's roots in
+        # is a new capability — it needs that store first — and is tracked
+        # separately from this fix.  The model-side ``spawn`` tool is not
+        # affected: it carries ``_user_roots`` through the harness-only
+        # ``extra`` channel, which ToolRegistry strips from model-authored
+        # params.
         agent = await ac.spawn(
             agent_type=params.get("agent_type", "code-agent"),
             task=params.get("task", ""),
             label=params.get("label"),
-            # #984: the Desktop may forward the parent turn's authorized
-            # output roots; without them the sub-agent gets none (the server
-            # has no other root source for this channel).
-            user_roots=user_roots,
+            user_roots=None,
         )
         return {"result": {"agent_id": agent.agent_id, "thread_id": agent.thread_id}}
 

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1522,6 +1522,20 @@ class BridgeRuntimeLoop:
                 "Agent control not initialized", code="INTERNAL",
             )
 
+        # #984 review: roots arriving over IPC bypass
+        # ``extract_user_mentioned_roots`` and would reach
+        # ``TurnContext.user_mentioned_roots`` — i.e. both the bwrap rw binds
+        # and the command guard's write scope — unfiltered.  They are
+        # re-filtered here, at the trust boundary, before they are stored on
+        # the job.  (Defence in depth: the Desktop IPC has no ``user_roots``
+        # field yet, so this path is not reachable from the shipped client.)
+        from miqi.agent.tools.user_roots import sanitize_user_roots
+
+        user_roots = sanitize_user_roots(
+            params.get("user_roots") or [],
+            workspace=getattr(ac, "workspace", None),
+        )
+
         agent = await ac.spawn(
             agent_type=params.get("agent_type", "code-agent"),
             task=params.get("task", ""),
@@ -1529,7 +1543,7 @@ class BridgeRuntimeLoop:
             # #984: the Desktop may forward the parent turn's authorized
             # output roots; without them the sub-agent gets none (the server
             # has no other root source for this channel).
-            user_roots=params.get("user_roots") or [],
+            user_roots=user_roots,
         )
         return {"result": {"agent_id": agent.agent_id, "thread_id": agent.thread_id}}
 

--- a/miqi/bridge/loop.py
+++ b/miqi/bridge/loop.py
@@ -1526,6 +1526,10 @@ class BridgeRuntimeLoop:
             agent_type=params.get("agent_type", "code-agent"),
             task=params.get("task", ""),
             label=params.get("label"),
+            # #984: the Desktop may forward the parent turn's authorized
+            # output roots; without them the sub-agent gets none (the server
+            # has no other root source for this channel).
+            user_roots=params.get("user_roots") or [],
         )
         return {"result": {"agent_id": agent.agent_id, "thread_id": agent.thread_id}}
 

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -63,6 +63,9 @@ _FILE_MUTATION_TOOLS = frozenset({
     # graph_render 写 svg/html 产物 + 读源 JSON——需 _session_key
     # 注入否则资产栏追踪永不生效（CodeRabbit #761）
     "graph_render",
+    # #984: spawn 是子 agent 的授权根继承入口——父 turn 的 _user_roots 经此
+    # 传到 AgentControl.spawn，否则子 agent 的 exec/文件工具拿不到任何根。
+    "spawn",
 })
 
 # Phase 31.4: max lengths for sanitized approval metadata fields

--- a/miqi/execution/orchestrator.py
+++ b/miqi/execution/orchestrator.py
@@ -903,6 +903,14 @@ class ToolOrchestrator:
         # normally RESTRICTED.  Injecting even NONE is future-proofing
         # for tool-body sandbox enforcement and auditing.
         kwargs = {**ctx.arguments}
+        # #984 (R2): ``_user_roots`` is a harness-owned channel — it appears in
+        # no tool schema, and object validation only walks declared keys
+        # (base.py:112-114), so a model-supplied value would ride through
+        # ``ctx.arguments`` and re-open the write boundary this turn's sensed
+        # roots are meant to gate.  Drop it first, then inject the harness
+        # value below — empty list included, so "no roots this turn" is an
+        # explicit harness answer instead of a fall-through to the model's list.
+        kwargs.pop("_user_roots", None)
         if ctx.tool_name == "exec" or ctx.tool_name in _FILE_MUTATION_TOOLS:
             kwargs["_sandbox"] = sandbox
             # _session_key already includes client_id prefix (e.g. "miqi-desktop:desktop:xxx")
@@ -910,8 +918,7 @@ class ToolOrchestrator:
             # #821: auto-sensed user-mentioned output dirs — mirrors the KUN
             # tool host injection so file tools accept the user's explicitly
             # requested output location (e.g. Desktop/test_result).
-            if ctx.user_mentioned_roots:
-                kwargs["_user_roots"] = list(ctx.user_mentioned_roots)
+            kwargs["_user_roots"] = list(ctx.user_mentioned_roots or [])
         elif ctx.tool_name.startswith("mcp_"):
             # MCP 工具（issue #927）：注入会话上下文供 slurm 计费握手使用
             #（MCPToolWrapper 会 pop 掉，不传给 MCP 服务端）。

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -211,6 +211,13 @@ class MiQiToolHost:
                 args = json.loads(args)
             except (json.JSONDecodeError, ValueError):
                 args = {}
+        # #984 (R2): ``_user_roots`` is a harness-owned channel — it appears in
+        # no tool schema, and unknown keys pass validation (base.py:112-114),
+        # so a model-supplied copy would otherwise reach the tool verbatim (and
+        # collide with the injected kwarg in ``execute(**args, **extra)``).
+        # Drop it here; the harness value is injected below, empty list included.
+        if isinstance(args, dict):
+            args = {k: v for k, v in args.items() if k != "_user_roots"}
 
         if context.await_approval is not None and _requires_approval(tool_name, context.approval_policy):
             decision = await context.await_approval({
@@ -356,9 +363,11 @@ class MiQiToolHost:
             # User-mentioned output dirs (issue #821): pass the turn's
             # auto-sensed roots to file tools so the user's explicitly
             # requested output location (e.g. Desktop/test_result) works
-            # without static tools.extra_roots config.
-            if tool_name in _USER_ROOTS_TOOLS and context.user_mentioned_roots:
-                extra["_user_roots"] = list(context.user_mentioned_roots)
+            # without static tools.extra_roots config.  #984 (R2): injected
+            # unconditionally (empty list included) and after the model's copy
+            # has been stripped — same contract as the legacy orchestrator.
+            if tool_name in _USER_ROOTS_TOOLS:
+                extra["_user_roots"] = list(context.user_mentioned_roots or [])
             # Reasoning mode (issue #680): hand the fast-mode search strategy
             # to web_search so it can fan out (parallel queries + fetches).
             if tool_name == "web_search" and context.search_strategy is not None:

--- a/miqi/kun_runtime/tool_host.py
+++ b/miqi/kun_runtime/tool_host.py
@@ -112,6 +112,8 @@ _SESSION_KEY_TOOLS = frozenset({
 _USER_ROOTS_TOOLS = frozenset({
     "write_file", "edit_file", "read_file", "list_dir",
     "apply_patch", "graph_render",
+    # #984: spawn forwards the parent turn's roots to the sub-agent job.
+    "spawn",
 })
 
 

--- a/miqi/runtime/agent_control.py
+++ b/miqi/runtime/agent_control.py
@@ -139,6 +139,7 @@ class AgentControl:
         label: str | None = None,
         fork_history: bool = False,
         model_override: str | None = None,
+        user_roots: list[str] | None = None,
     ) -> LiveAgent:
         """Spawn a new agent to handle a task.
 
@@ -149,6 +150,9 @@ class AgentControl:
             label: Human-readable task label
             fork_history: Whether to copy parent's conversation history
             model_override: Override the default model for this agent
+            user_roots: #984 — the parent turn's authorized output roots,
+                inherited by the sub-agent (job path only; the legacy
+                ``_run_agent`` path has no root source).
 
         Returns:
             LiveAgent handle for the spawned agent
@@ -181,6 +185,7 @@ class AgentControl:
                 agent_type=agent_type,
                 task=task,
                 parent_thread_id=parent_agent_id or self.session_id,
+                user_roots=user_roots,
             )
             agent_id = job.job_id
             thread_id = job.thread_id
@@ -608,19 +613,14 @@ class AgentControl:
                             client_id=turn_ctx.client_id,
                             session_id=turn_ctx.session_id,
                         )
-                        # #821: sub-agents inherit the parent task's
-                        # user-mentioned output dirs (the spawn prompt usually
-                        # echoes them).
-                        try:
-                            from miqi.agent.tools.user_roots import extract_user_mentioned_roots
-
-                            ctx.user_mentioned_roots = [
-                                str(r) for r in extract_user_mentioned_roots(
-                                    [task], workspace=self.workspace,
-                                )
-                            ]
-                        except Exception:
-                            ctx.user_mentioned_roots = []
+                        # #984: the legacy path no longer re-extracts roots
+                        # from the spawn task text.  The task is model-authored
+                        # (the model can echo any path it likes into it), so
+                        # extraction here re-opened the injection channel #821
+                        # closed.  Roots now travel explicitly through
+                        # AgentJob.user_roots on the job path; a legacy
+                        # sub-agent gets no roots (documented behaviour
+                        # change, plan v5 §3).
                         ctx = await self._orchestrator.execute(ctx)
                         result = ctx.result or ""
                         success = ctx.status == OrchestrationResult.SUCCESS

--- a/miqi/runtime/agent_jobs.py
+++ b/miqi/runtime/agent_jobs.py
@@ -32,6 +32,11 @@ class AgentJob:
     error: str | None = None
     created_at: float = field(default_factory=time.time)
     completed_at: float | None = None
+    # #984: authorized output roots inherited from the parent turn, so the
+    # sub-agent's exec/file tools can write where the user asked.  In-memory
+    # only — AgentGraphStore.save_job takes explicit keyword args and the
+    # SQLite schema is fixed, so a restart loses them (documented in the PR).
+    user_roots: list[str] = field(default_factory=list)
 
 
 class AgentJobRuntime:
@@ -79,8 +84,14 @@ class AgentJobRuntime:
         agent_type: str,
         task: str,
         parent_thread_id: str,
+        user_roots: list[str] | None = None,
     ) -> AgentJob:
-        """Start a new agent job and return its handle."""
+        """Start a new agent job and return its handle.
+
+        ``user_roots`` (#984) are the parent turn's authorized output dirs;
+        they are inherited by the sub-agent turn.  They are intentionally
+        NOT persisted — see :class:`AgentJob`.
+        """
         job_id = str(uuid.uuid4())[:12]
         thread_id = f"{self.services.session_id}:{job_id}"
 
@@ -90,6 +101,7 @@ class AgentJobRuntime:
             task=task,
             thread_id=thread_id,
             parent_thread_id=parent_thread_id,
+            user_roots=list(user_roots or []),
         )
         self._jobs[job_id] = job
 

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -501,6 +501,11 @@ def create_runtime_tool_registry(
             env_passthrough=list(getattr(exec_cfg, "env_passthrough", [])) if exec_cfg is not None else [],
             approval_callback=approval_callback,
             sandbox_manager=_sbm,
+            # #984: workspace + static extra roots the sandbox must keep
+            # writable after /mnt went read-only; ``allow_user_dirs`` gates
+            # the per-call _user_roots component (tools.auto_user_dirs).
+            shared_roots=_shared_roots,
+            allow_user_dirs=_auto_user_dirs,
             # #854: 系统包安装授权确认卡——关闭状态下拦截点弹卡（once/always/deny）。
             # "允许并记住"走统一入口：runtime 属性 + config 持久化（外部审阅 #854）。
             system_install_approver=_make_system_install_approver(

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -506,6 +506,12 @@ def create_runtime_tool_registry(
             # the per-call _user_roots component (tools.auto_user_dirs).
             shared_roots=_shared_roots,
             allow_user_dirs=_auto_user_dirs,
+            # #1007 review: the workspace root is in that bind set, which
+            # would re-open <ws>/sessions/** (other sessions' files) too.
+            # These two host paths let bwrap re-mount <ws>/sessions read-only
+            # and keep only this session's files dir writable.
+            workspace_root=str(workspace.resolve()),
+            session_files_dir=str(_work_dir) if _work_dir is not None else None,
             # #854: 系统包安装授权确认卡——关闭状态下拦截点弹卡（once/always/deny）。
             # "允许并记住"走统一入口：runtime 属性 + config 持久化（外部审阅 #854）。
             system_install_approver=_make_system_install_approver(

--- a/miqi/runtime/turn_context.py
+++ b/miqi/runtime/turn_context.py
@@ -55,3 +55,9 @@ class TurnContext:
     # (auto-sensed by the turn runner; injected into file tools as
     # ``_user_roots`` via ToolRuntime/orchestrator).  Host Paths.
     user_mentioned_roots: list[Path] = field(default_factory=list)
+    # #984: True for sub-agent turns.  Their roots are inherited from the
+    # parent job (``AgentJob.user_roots``), so the turn runner must NOT
+    # re-extract them from the sub-agent's own text — that text is
+    # model-authored, and extraction would re-open the injection channel
+    # #821 deliberately closed.
+    is_subagent: bool = False

--- a/miqi/runtime/turn_runner.py
+++ b/miqi/runtime/turn_runner.py
@@ -295,10 +295,14 @@ class TurnRunner:
         # (e.g. "输出到 C:\Users\x\Desktop\test_result") so file tools can
         # read/write them.  Extracted once per turn from user-role text only;
         # mid-turn steering messages refresh the roots below.
+        # #984: sub-agent turns keep the roots inherited from their parent
+        # job — the text here is model-authored, so extracting from it would
+        # re-open the injection channel this feature closed.
         _user_texts = [user_content]
-        turn.user_mentioned_roots = extract_user_mentioned_roots(
-            _user_texts, workspace=getattr(turn, "workspace", None),
-        )
+        if not getattr(turn, "is_subagent", False):
+            turn.user_mentioned_roots = extract_user_mentioned_roots(
+                _user_texts, workspace=getattr(turn, "workspace", None),
+            )
 
         messages = self._context.build_initial_messages(
             turn=turn,
@@ -614,11 +618,13 @@ class TurnRunner:
                         messages_delta.append(delta)
                     # #821: refresh auto-sensed roots with the steering text
                     # (the user may name a new output dir mid-turn).
+                    # #984: never for sub-agent turns — see above.
                     for steer in steers:
                         _user_texts.append(steer["content"])
-                    turn.user_mentioned_roots = extract_user_mentioned_roots(
-                        _user_texts, workspace=getattr(turn, "workspace", None),
-                    )
+                    if not getattr(turn, "is_subagent", False):
+                        turn.user_mentioned_roots = extract_user_mentioned_roots(
+                            _user_texts, workspace=getattr(turn, "workspace", None),
+                        )
                     continue
 
                 content = response.content or ""
@@ -934,6 +940,11 @@ class TurnRunner:
             execution_policy="edit",  # sub-agents default to normal approval flow
             temperature=0.1,
             max_tokens=8192,
+            # #984: sub-agents inherit the parent turn's authorized roots
+            # instead of re-extracting them from their own (model-authored)
+            # task text — see TurnContext.is_subagent.
+            is_subagent=True,
+            user_mentioned_roots=[Path(r) for r in (job.user_roots or [])],
         )
 
         # Resolve capabilities if available (Phase 13)

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -66,11 +66,17 @@ def _host_path_to_sandbox(path: str) -> str:
     raises — a per-call writable bind must never be silently dropped, or the
     command would run without the write access it was granted.
 
+    A drive path must be drive-ABSOLUTE (``C:/…``).  The drive-relative
+    spellings Windows accepts (``C:``, ``C:relative``) mean "relative to
+    that drive's current directory" and have no fixed sandbox target; the
+    old ``p[1] == ":"`` test mapped them to ``/mnt/c`` / ``/mnt/crelative``
+    — a bind of a path nobody named (review #1007).
+
     Deliberately local: importing ``miqi.sandbox.manager.windows_path_to_mnt``
     at module scope is circular (``manager`` imports this module at line 45).
     """
     p = str(path).replace("\\", "/")
-    if len(p) >= 2 and p[1] == ":":
+    if len(p) >= 3 and p[1] == ":" and p[2] in "/\\":
         return "/mnt/" + p[0].lower() + p[2:]
     if p.startswith("//"):
         raise BwrapSandboxError(

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -89,6 +89,82 @@ def _host_path_to_sandbox(path: str) -> str:
     return p
 
 
+def _bind_key(path: str) -> str:
+    """Comparison key for a bind path (``/``-joined, case-folded on Windows).
+
+    ``os.path.normcase`` is identity on POSIX (paths stay case-sensitive) and
+    lower-cases + flips separators on Windows — the same normalisation
+    ``ExecTool._exec_rw_binds`` uses to de-duplicate its bind set, so a
+    comparison here matches what actually reached the mount list.
+    """
+    return os.path.normcase(str(path)).replace("\\", "/").rstrip("/")
+
+
+def _is_same_or_ancestor(parent: str, child: str) -> bool:
+    """True when *child* is *parent* itself or lives under it.
+
+    Path-boundary aware: ``…/workspace`` is NOT an ancestor of
+    ``…/workspace-other`` (a plain ``startswith`` would say it is).
+    """
+    p = _bind_key(parent)
+    c = _bind_key(child)
+    return c == p or c.startswith(p.rstrip("/") + "/")
+
+
+def _cross_session_guard_args(
+    workspace_root: str | None,
+    session_files_dir: str | None,
+    rw_sources: list[str],
+) -> list[str]:
+    """Mount args that keep OTHER sessions' directories read-only (#1007).
+
+    Layer 1 re-opens the workspace root writable with a hard ``--bind``, and
+    ``<workspace>/sessions/**`` lives underneath it — so session A's exec
+    could write session B's files, undoing both the per-session containment
+    checks and layer 2's read-only ``/mnt``.  bwrap applies mounts in order,
+    so a later ``--ro-bind`` of ``<workspace>/sessions`` wins over the earlier
+    rw bind; the current session's own files dir is then re-opened with a
+    later ``--bind`` so normal work keeps working.
+
+    Deliberately conditional:
+
+    * only when the workspace root (or one of its ancestors) is actually in
+      the rw bind set — otherwise there is nothing to protect and the old arg
+      list is emitted unchanged;
+    * only when ``session_files_dir`` is given AND sits under
+      ``<workspace>/sessions``.  That is the per-session files layout, which
+      ``filesystem._session_files_dir_for_key`` establishes for the DEFAULT
+      workspace only; a custom workspace has no per-session files area, and
+      its ``<project>/sessions`` may be the project's own directory — turning
+      that read-only inside exec would break legitimate work.
+
+    The guard mount is ``--ro-bind-try``: it only ever NARROWS, and a missing
+    ``sessions`` dir means there are no session dirs to protect, so a hard
+    bind would fail every command for nothing.  The re-open is a hard
+    ``--bind`` and only for a path already in the rw set (an existing,
+    authorized source).
+    """
+    if not workspace_root or not session_files_dir:
+        return []
+    try:
+        ws = _host_path_to_sandbox(workspace_root)
+        own = _host_path_to_sandbox(session_files_dir)
+    except BwrapSandboxError:
+        # UNC / drive-relative / relative — not bindable, same rule the bind
+        # sources themselves follow.
+        return []
+    if not any(_is_same_or_ancestor(src, ws) for src in rw_sources):
+        return []
+    sessions = ws.rstrip("/") + "/sessions"
+    if not _is_same_or_ancestor(sessions, own):
+        return []
+    args = ["--ro-bind-try", sessions, sessions]
+    if any(_bind_key(src) == _bind_key(own) for src in rw_sources):
+        # After the ro-bind → the current session's area stays writable.
+        args.extend(["--bind", own, own])
+    return args
+
+
 _auto_install_cache: dict[str, bool] = {}
 """Cache auto-install results per distro to avoid repeated apt-get calls."""
 
@@ -1423,6 +1499,8 @@ class BwrapSandbox:
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         extra_rw_binds: list[str] | None = None,
+        workspace_root: str | None = None,
+        session_files_dir: str | None = None,
     ) -> tuple[int, str, str]:
         """Run a command inside the bwrap sandbox.
 
@@ -1430,6 +1508,11 @@ class BwrapSandbox:
             extra_rw_binds: PER-CALL host paths to bind writable for this
                 command only (#984) — the session's authorized output dirs.
                 They do not modify the sandbox; see :meth:`_build_bwrap_args`.
+            workspace_root: Host path of the workspace root, when the caller
+                knows it — enables the cross-session read-only guard (#1007).
+            session_files_dir: Host path of THIS session's files dir; it is
+                re-opened writable after that guard.  Neither kwarg alone
+                disables anything else: ``None`` reproduces the old args.
 
         Returns:
             (exit_code, stdout, stderr)
@@ -1461,6 +1544,7 @@ class BwrapSandbox:
 
         bwrap_args = self._build_bwrap_args(
             command, env=env, cwd=cwd, extra_rw_binds=extra_rw_binds,
+            workspace_root=workspace_root, session_files_dir=session_files_dir,
         )
 
         exit_code = -1
@@ -1559,6 +1643,8 @@ class BwrapSandbox:
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         extra_rw_binds: list[str] | None = None,
+        workspace_root: str | None = None,
+        session_files_dir: str | None = None,
     ) -> BwrapCommandHandle:
         """Run a command inside the bwrap sandbox with streaming I/O.
 
@@ -1575,7 +1661,9 @@ class BwrapSandbox:
         :meth:`BwrapCommandHandle.kill` to stop a running command.
 
         ``extra_rw_binds`` are per-call writable host paths (#984), same
-        semantics as :meth:`run_command`.
+        semantics as :meth:`run_command`; ``workspace_root`` /
+        ``session_files_dir`` feed the cross-session read-only guard
+        (#1007 review), same semantics as :meth:`run_command` too.
 
         Returns:
             BwrapCommandHandle with .stdout, .stderr, .wait(), .kill(),
@@ -1589,6 +1677,7 @@ class BwrapSandbox:
 
         bwrap_args = self._build_bwrap_args(
             command, env=env, cwd=cwd, extra_rw_binds=extra_rw_binds,
+            workspace_root=workspace_root, session_files_dir=session_files_dir,
         )
 
         if not hasattr(self, '_streaming_handles'):
@@ -1780,6 +1869,8 @@ class BwrapSandbox:
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         extra_rw_binds: list[str] | None = None,
+        workspace_root: str | None = None,
+        session_files_dir: str | None = None,
     ) -> list[str]:
         """Build the full bwrap argument list.
 
@@ -1794,6 +1885,13 @@ class BwrapSandbox:
         sandbox paths and hard ``--bind``-ed after the read-only ``/mnt``
         mount, so a missing or unmappable source fails loudly instead of
         silently running without the granted write access.
+
+        ``workspace_root`` / ``session_files_dir`` (host paths, #1007 review)
+        feed the cross-session guard: when the workspace root is in the rw
+        set, ``<workspace>/sessions`` is re-mounted READ-ONLY after it (other
+        sessions live there) and this session's own files dir is re-opened
+        writable after THAT — see :func:`_cross_session_guard_args`.  Both
+        default to ``None``, which keeps the previous argument list exactly.
 
         The sandbox layout:
         /usr, /bin, /lib, etc — read-only bind mounts from host
@@ -1879,9 +1977,19 @@ class BwrapSandbox:
         # never ``--bind-try``: a missing/unmappable source must fail the
         # command loudly instead of silently running without the write
         # access the caller granted (and without falling back to the host).
+        rw_sources: list[str] = list(self.extra_rw_binds)
         for raw in extra_rw_binds or []:
             src = _host_path_to_sandbox(raw)
+            rw_sources.append(src)
             args.extend(["--bind", src, src])
+
+        # ── Cross-session guard (#1007 review) ──────────────────────
+        # ``<workspace>/sessions`` was re-opened writable by the bind above;
+        # close it again (later mount wins) and keep only THIS session's own
+        # files dir writable.
+        args.extend(_cross_session_guard_args(
+            workspace_root, session_files_dir, rw_sources,
+        ))
 
         # ── Die with parent ─────────────────────────────────────────
         args.append("--die-with-parent")

--- a/miqi/sandbox/bwrap.py
+++ b/miqi/sandbox/bwrap.py
@@ -58,6 +58,31 @@ class BwrapSandboxError(Exception):
     """Error raised when bwrap operations fail."""
 
 
+def _host_path_to_sandbox(path: str) -> str:
+    """Map a host path to the path bwrap must bind it at (#984).
+
+    ``C:\\x`` → ``/mnt/c/x``; a WSL-native path is already usable and is
+    returned unchanged.  Anything else (UNC, relative) cannot be mapped and
+    raises — a per-call writable bind must never be silently dropped, or the
+    command would run without the write access it was granted.
+
+    Deliberately local: importing ``miqi.sandbox.manager.windows_path_to_mnt``
+    at module scope is circular (``manager`` imports this module at line 45).
+    """
+    p = str(path).replace("\\", "/")
+    if len(p) >= 2 and p[1] == ":":
+        return "/mnt/" + p[0].lower() + p[2:]
+    if p.startswith("//"):
+        raise BwrapSandboxError(
+            f"Cannot bind UNC path into the sandbox: {path}"
+        )
+    if not p.startswith("/"):
+        raise BwrapSandboxError(
+            f"Cannot bind relative path into the sandbox: {path}"
+        )
+    return p
+
+
 _auto_install_cache: dict[str, bool] = {}
 """Cache auto-install results per distro to avoid repeated apt-get calls."""
 
@@ -1391,8 +1416,14 @@ class BwrapSandbox:
         timeout: float = 60.0,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        extra_rw_binds: list[str] | None = None,
     ) -> tuple[int, str, str]:
         """Run a command inside the bwrap sandbox.
+
+        Args:
+            extra_rw_binds: PER-CALL host paths to bind writable for this
+                command only (#984) — the session's authorized output dirs.
+                They do not modify the sandbox; see :meth:`_build_bwrap_args`.
 
         Returns:
             (exit_code, stdout, stderr)
@@ -1422,7 +1453,9 @@ class BwrapSandbox:
                 )
             logger.info("Sandbox directories recreated for {}", self.session_key)
 
-        bwrap_args = self._build_bwrap_args(command, env=env, cwd=cwd)
+        bwrap_args = self._build_bwrap_args(
+            command, env=env, cwd=cwd, extra_rw_binds=extra_rw_binds,
+        )
 
         exit_code = -1
         stdout = ""
@@ -1519,6 +1552,7 @@ class BwrapSandbox:
         command: str,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        extra_rw_binds: list[str] | None = None,
     ) -> BwrapCommandHandle:
         """Run a command inside the bwrap sandbox with streaming I/O.
 
@@ -1534,6 +1568,9 @@ class BwrapSandbox:
         The caller also owns timeout and cancellation — use
         :meth:`BwrapCommandHandle.kill` to stop a running command.
 
+        ``extra_rw_binds`` are per-call writable host paths (#984), same
+        semantics as :meth:`run_command`.
+
         Returns:
             BwrapCommandHandle with .stdout, .stderr, .wait(), .kill(),
             and .cleanup().
@@ -1544,7 +1581,9 @@ class BwrapSandbox:
         if not self._running or not self._bwrap_path:
             raise BwrapSandboxError("Sandbox not started")
 
-        bwrap_args = self._build_bwrap_args(command, env=env, cwd=cwd)
+        bwrap_args = self._build_bwrap_args(
+            command, env=env, cwd=cwd, extra_rw_binds=extra_rw_binds,
+        )
 
         if not hasattr(self, '_streaming_handles'):
             self._streaming_handles: list[BwrapCommandHandle] = []
@@ -1734,6 +1773,7 @@ class BwrapSandbox:
         command: str,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        extra_rw_binds: list[str] | None = None,
     ) -> list[str]:
         """Build the full bwrap argument list.
 
@@ -1741,6 +1781,13 @@ class BwrapSandbox:
         shell quoting needed because each argument is passed separately.
 
         On WSL, this list is directly appended after ``wsl.exe -d distro --``.
+
+        ``extra_rw_binds`` are PER-CALL host paths (issue #984) that must be
+        writable for this one command — the workspace, static extra roots and
+        the turn's authorized output dirs.  They are converted to their
+        sandbox paths and hard ``--bind``-ed after the read-only ``/mnt``
+        mount, so a missing or unmappable source fails loudly instead of
+        silently running without the granted write access.
 
         The sandbox layout:
         /usr, /bin, /lib, etc — read-only bind mounts from host
@@ -1785,8 +1832,13 @@ class BwrapSandbox:
         # Windows files are accessible via /mnt/c, /mnt/d, etc. in WSL.
         # We need to bind-mount /mnt so the sandbox can access the
         # workspace files that live on the Windows filesystem.
+        # READ-ONLY since #984: the whole Windows user data area used to be
+        # writable through this one mount, so a python `open(..., "w")`
+        # bypassed the shell write guard.  Writable paths are re-opened
+        # below with an explicit hard --bind (workspace, extra roots,
+        # per-call authorized dirs).
         if self._use_wsl:
-            args.extend(["--bind-try", "/mnt", "/mnt"])
+            args.extend(["--ro-bind-try", "/mnt", "/mnt"])
 
         # ── Writable overlays ───────────────────────────────────────
         args.extend(["--tmpfs", "/tmp"])
@@ -1813,6 +1865,16 @@ class BwrapSandbox:
         for src in self.extra_ro_binds:
             args.extend(["--ro-bind", src, src])
         for src in self.extra_rw_binds:
+            args.extend(["--bind", src, src])
+
+        # ── Per-call writable binds (#984) ──────────────────────────
+        # These land AFTER the read-only ``/mnt`` mount above, so a later
+        # bind re-opens exactly the authorized subtrees.  Hard ``--bind``,
+        # never ``--bind-try``: a missing/unmappable source must fail the
+        # command loudly instead of silently running without the write
+        # access the caller granted (and without falling back to the host).
+        for raw in extra_rw_binds or []:
+            src = _host_path_to_sandbox(raw)
             args.extend(["--bind", src, src])
 
         # ── Die with parent ─────────────────────────────────────────

--- a/tests/agent/test_command_guard_python_writes_984.py
+++ b/tests/agent/test_command_guard_python_writes_984.py
@@ -1,0 +1,513 @@
+"""#984 layer 3 — python write-family spellings in the command guard.
+
+The inline-script vocabulary now covers the write spellings an agent
+actually reaches for (``open(..., 'w')``, ``write_text``/``write_bytes``,
+``os.mkdir``/``makedirs``, ``shutil.copy*``, ``os.rename``) so re-spelling
+a write as python no longer bypasses the check (issue #984 期望 1/3).
+
+Boundaries locked here:
+
+* **fail-open**: a READ spelling (``open(f)`` / ``open(f, 'r')``) is never
+  flagged, and an unrecognised spelling is not flagged either — the kernel
+  layer (``/mnt`` ro-bind + per-call rw binds) is the enforcement layer;
+* **no false positives**: session scope AND the per-call authorized roots
+  (#821 ``_user_roots``, which layer 1 binds rw in the sandbox) keep
+  working — the tightening ships with the authorization channel;
+* **heredoc fidelity**: heredoc bodies are read from the RAW text
+  (``_raw_heredoc_body``) so quotes survive; otherwise every authorized
+  heredoc delivery would degrade to ``script_uncertain``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.command_guard import RuntimePaths, evaluate_command
+from miqi.agent.tools.shell import ExecTool
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+#: Sandbox-mode paths are synthetic POSIX paths: they classify identically
+#: on every host (``/srv`` is neither a system root nor a sandbox overlay),
+#: so the same payloads exercise Windows and Linux CI.
+AUTH = "/srv/data/out"          # authorized root (#821 grant)
+SIBLING = "/srv/data/other"     # same tree, NOT authorized
+
+
+def _posix(p: Path) -> str:
+    return str(p).replace("\\", "/")
+
+
+def host_rt(tmp_path: Path, roots: tuple[str, ...] = ()) -> RuntimePaths:
+    """Host-semantics context (sandbox off)."""
+    ws = tmp_path / "workspace"
+    sess = ws / "sessions" / "desktop_abc" / "files"
+    sess.mkdir(parents=True, exist_ok=True)
+    return RuntimePaths(
+        host_cwd=str(sess),
+        host_workspace=str(ws),
+        session_files_dir=str(sess),
+        sandbox_active=False,
+        sandbox_cwd="/home/miqi/workspace",
+        miqi_home=str(tmp_path / "miqi-home"),
+        host_home=str(tmp_path / "home"),
+        extra_write_roots=roots,
+    )
+
+
+def sandbox_rt(tmp_path: Path, roots: tuple[str, ...] = ()) -> RuntimePaths:
+    """bwrap-semantics context (sandbox on)."""
+    ws = tmp_path / "workspace"
+    sess = ws / "sessions" / "desktop_abc" / "files"
+    sess.mkdir(parents=True, exist_ok=True)
+    return RuntimePaths(
+        host_cwd=str(sess),
+        host_workspace=str(ws),
+        session_files_dir=str(sess),
+        sandbox_active=True,
+        sandbox_cwd="/home/miqi/workspace",
+        miqi_home=str(tmp_path / "miqi-home"),
+        host_home=str(tmp_path / "home"),
+        extra_write_roots=roots,
+    )
+
+
+def v(cmd: str, rt: RuntimePaths):
+    return evaluate_command(cmd, rt)
+
+
+# ── 期望 3：python 写会话外被拦截（换写法不再绕过） ─────────────────────
+
+
+class TestWriteSpellingsDenied:
+    """Every write spelling in the #984 list is refused out of scope."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            # open(..., <write mode>) — the issue's bypass point
+            f"open('{SIBLING}/a.txt','w').write('x')",
+            f"open('{SIBLING}/a.txt','a').write('x')",
+            f"open('{SIBLING}/a.txt','x').write('x')",
+            f"open('{SIBLING}/a.txt','wb').write(b'x')",
+            f"open('{SIBLING}/a.txt','ab').write(b'x')",
+            f"open('{SIBLING}/a.txt','r+').write('x')",
+            f"open('{SIBLING}/a.txt', mode='w').write('x')",
+            # pathlib
+            f"from pathlib import Path; Path('{SIBLING}/a.txt').write_text('x')",
+            f"from pathlib import Path; Path('{SIBLING}/a.txt').write_bytes(b'x')",
+            f"from pathlib import Path; Path('{SIBLING}/a.txt').open('w')",
+            # mkdir family
+            f"import os; os.makedirs('{SIBLING}/assets')",
+            f"import os; os.mkdir('{SIBLING}/assets')",
+            # copy / move / rename
+            f"import shutil; shutil.copy('/etc/hosts','{SIBLING}/a.txt')",
+            f"import shutil; shutil.copy2('/etc/hosts','{SIBLING}/a.txt')",
+            f"import shutil; shutil.copyfile('/etc/hosts','{SIBLING}/a.txt')",
+            f"import shutil; shutil.move('{SIBLING}/a','{SIBLING}/b')",
+            f"import os; os.rename('{SIBLING}/a','{SIBLING}/b')",
+            f"import os; os.replace('{SIBLING}/a','{SIBLING}/b')",
+            f"import shutil; shutil.copytree('/etc/x','{SIBLING}/y')",
+        ],
+    )
+    def test_spelling_out_of_scope_denied(self, tmp_path, payload):
+        verdict = v(f'python3 -c "{payload}"', sandbox_rt(tmp_path))
+        assert not verdict.allowed, payload
+        assert verdict.reason_code == "outside_workspace", payload
+        assert "安全替代" in verdict.message
+
+    def test_shell_and_python_now_agree(self, tmp_path):
+        """The issue's exact comparison: bash write refused, python write
+        refused too (was: python allowed)."""
+        rt = sandbox_rt(tmp_path)
+        shell = v(f"mkdir -p {SIBLING}/xxx", rt)
+        py = v(
+            f'python3 -c "from pathlib import Path; '
+            f"Path('{SIBLING}/xxx/a.txt').write_text('x')\"",
+            rt,
+        )
+        assert not shell.allowed
+        assert not py.allowed
+        assert shell.reason_code == py.reason_code == "outside_workspace"
+
+    def test_heredoc_write_denied(self, tmp_path):
+        """The real delivery shape from the issue log (heredoc)."""
+        rt = sandbox_rt(tmp_path)
+        verdict = v(
+            "python3 - <<'PYEOF'\n"
+            "from pathlib import Path\n"
+            f"Path('{SIBLING}/_probe.txt').write_text('ok')\n"
+            "PYEOF",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+
+    def test_copy_source_is_read_but_target_is_checked(self, tmp_path):
+        """cp parity: the SOURCE may live outside the scope (read), the
+        TARGET may not (write)."""
+        rt = sandbox_rt(tmp_path)
+        assert v(
+            "python3 -c \"import shutil; shutil.copy('/etc/hosts','./out.txt')\"",
+            rt,
+        ).allowed
+        verdict = v(
+            f"python3 -c \"import shutil; shutil.copy('./x','{SIBLING}/a.txt')\"",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+
+    def test_copy_source_that_is_also_written_stays_a_mutation(self, tmp_path):
+        """A literal used as a copy source AND elsewhere is not a read."""
+        rt = sandbox_rt(tmp_path)
+        verdict = v(
+            "python3 -c \"import shutil, os; "
+            f"shutil.copy('{SIBLING}/a','./b'); os.remove('{SIBLING}/a')\"",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+        # same literal on both sides of one copy: the target wins
+        verdict = v(
+            f"python3 -c \"import shutil; shutil.copy('{SIBLING}/a','{SIBLING}/a')\"",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+
+    def test_copy_keyword_source_is_read(self, tmp_path):
+        rt = sandbox_rt(tmp_path)
+        assert v(
+            "python3 -c \"import shutil; "
+            "shutil.copy(src='/etc/x', dst='./y')\"",
+            rt,
+        ).allowed
+
+
+# ── fail-open：读写法与无法识别的写法不得误报 ───────────────────────────
+
+
+class TestNoFalsePositives:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "print(open('data.txt').read())",
+            "print(open('data.txt','r').read())",
+            "print(open('/etc/hosts','rb').read())",
+            "print(open('/etc/hosts','rb',encoding=None).read())",
+            "import os; print(open(os.path.join('/etc','hosts'),'r').read())",
+            "import json; json.load(open('x.json'))",
+            "print(1)",
+            "from pathlib import Path; print(Path('a.txt').read_text())",
+            "import shutil; print(shutil.which('python3'))",
+        ],
+    )
+    def test_read_and_benign_payloads_allowed(self, tmp_path, payload):
+        verdict = v(f'python3 -c "{payload}"', sandbox_rt(tmp_path))
+        assert verdict.allowed, payload
+
+    def test_read_heredoc_allowed(self, tmp_path):
+        verdict = v(
+            "python3 - <<'EOF'\nprint(open('data.txt').read())\nEOF",
+            sandbox_rt(tmp_path),
+        )
+        assert verdict.allowed
+
+    def test_unrecognised_spelling_fails_open(self, tmp_path):
+        """Static analysis is incomplete by design — a spelling outside the
+        vocabulary is left to the kernel layer, never blanket-denied."""
+        rt = sandbox_rt(tmp_path)
+        assert v(
+            "python3 -c \"import numpy; numpy.save('/srv/data/other/a.npy', 1)\"",
+            rt,
+        ).allowed
+        assert v(
+            "python3 -c \"import os; fd=os.open('/srv/data/other/a', os.O_WRONLY)\"",
+            rt,
+        ).allowed
+
+
+# ── 显式授权目录（#821 user_roots）不得被误拦 ───────────────────────────
+
+
+class TestAuthorizedRootsAllowed:
+    def test_write_spellings_into_authorized_root_allowed(self, tmp_path):
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        payloads = [
+            f"from pathlib import Path; Path('{AUTH}/a.txt').write_text('x')",
+            f"from pathlib import Path; Path('{AUTH}/a.txt').write_bytes(b'x')",
+            f"open('{AUTH}/a.txt','w').write('x')",
+            f"open('{AUTH}/sub/a.txt','wb').write(b'x')",
+            f"import os; os.makedirs('{AUTH}/assets')",
+            f"import os; os.mkdir('{AUTH}/d')",
+            f"import shutil; shutil.copy('/etc/hosts','{AUTH}/a.txt')",
+            f"import shutil; shutil.copy2('/etc/hosts','{AUTH}/a.txt')",
+            f"import shutil; shutil.move('{AUTH}/a','{AUTH}/b')",
+            f"import os; os.rename('{AUTH}/a','{AUTH}/b')",
+        ]
+        for payload in payloads:
+            verdict = v(f'python3 -c "{payload}"', rt)
+            assert verdict.allowed, payload
+
+    def test_authorized_root_itself_allowed(self, tmp_path):
+        """Equality counts for WRITE-kind targets: the file tools accept the
+        root itself (``Path.relative_to``) and so does the bind."""
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        assert v(f"python3 -c \"import os; os.mkdir('{AUTH}')\"", rt).allowed
+
+    def test_authorized_root_itself_not_removable(self, tmp_path):
+        """The grant is "deliver here", not "delete my folder": a delete /
+        move-SOURCE at the root itself is refused, inside it is fine."""
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        for cmd in (
+            f"rm -rf {AUTH}",
+            f"python3 -c \"import shutil; shutil.rmtree('{AUTH}')\"",
+            f"python3 -c \"import shutil; shutil.move('{AUTH}','./moved')\"",
+            f"python3 -c \"import os; os.rename('{AUTH}','./moved')\"",
+        ):
+            verdict = v(cmd, rt)
+            assert not verdict.allowed, cmd
+            assert verdict.reason_code == "authorized_root", cmd
+        # contents are mutable
+        assert v(f"python3 -c \"open('{AUTH}/a.txt','w').write('x')\"", rt).allowed
+        assert v(f"rm -rf {AUTH}/sub", rt).allowed
+
+    def test_sibling_still_denied(self, tmp_path):
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        verdict = v(
+            f'python3 -c "from pathlib import Path; '
+            f"Path('{SIBLING}/a.txt').write_text('x')\"",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+
+    def test_system_path_beats_authorized_root(self, tmp_path):
+        """Defense in depth: a grant covering a system path still loses."""
+        rt = sandbox_rt(tmp_path, roots=("/etc",))
+        verdict = v(
+            "python3 -c \"from pathlib import Path; "
+            "Path('/etc/guard984/x').write_text('x')\"",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "system_path"
+
+    def test_host_home_and_config_home_beats_authorized_root(self, tmp_path):
+        """POSIX-native paths reach the host home / config home directly in
+        the sandbox (no /mnt/<drive> mapping) — ``_is_system_path`` still
+        wins over a per-call grant."""
+        rt = sandbox_rt(tmp_path, roots=("/srv/home/.ssh", "/srv/home/.miqi"))
+        rt = RuntimePaths(
+            **{**rt.__dict__, "host_home": "/srv/home",
+               "miqi_home": "/srv/home/.miqi"}
+        )
+        for target in ("/srv/home/.ssh/id_rsa", "/srv/home/.miqi/config.json"):
+            verdict = v(
+                f'python3 -c "open(\'{target}\',\'w\').write(\'x\')"', rt,
+            )
+            assert not verdict.allowed, target
+            assert verdict.reason_code == "system_path", target
+
+    def test_authorized_heredoc_delivery_allowed(self, tmp_path):
+        """The delivery shape the issue says must not break: a heredoc
+        writing into the directory the user asked for."""
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        verdict = v(
+            "python3 - <<'PYEOF'\n"
+            "from pathlib import Path\n"
+            f"Path('{AUTH}/report.md').write_text('ok')\n"
+            "PYEOF",
+            rt,
+        )
+        assert verdict.allowed
+
+    def test_session_scope_still_allowed(self, tmp_path):
+        rt = sandbox_rt(tmp_path)
+        assert v("python3 -c \"open('./out/a.txt','w').write('x')\"", rt).allowed
+        assert v(
+            "python3 -c \"open('/home/miqi/workspace/a.txt','w').write('x')\"",
+            rt,
+        ).allowed
+        assert v("python3 -c \"open('/tmp/a.txt','w').write('x')\"", rt).allowed
+
+
+# ── heredoc 正文保真（引号不被 tokenizer 吃掉） ─────────────────────────
+
+
+class TestHeredocFidelity:
+    def test_heredoc_path_literals_are_classified_not_uncertain(self, tmp_path):
+        """Before the raw-body read, the payload was rebuilt from tokens
+        (quotes stripped) → no literals → blanket ``script_uncertain``."""
+        rt = sandbox_rt(tmp_path)
+        verdict = v(
+            "python3 - <<'PYEOF'\n"
+            "import shutil; shutil.rmtree('/etc/x')\n"
+            "PYEOF",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "system_path"
+
+    def test_heredoc_without_literals_still_uncertain(self, tmp_path):
+        rt = sandbox_rt(tmp_path)
+        verdict = v(
+            "python3 - <<'PYEOF'\n"
+            "import shutil, sys; shutil.rmtree(sys.argv[1])\n"
+            "PYEOF",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "script_uncertain"
+
+    def test_heredoc_double_quoted_delimiter(self, tmp_path):
+        rt = sandbox_rt(tmp_path)
+        verdict = v(
+            'python3 - <<"PYEOF"\n'
+            f'open("{SIBLING}/a.txt","w").write("x")\n'
+            "PYEOF",
+            rt,
+        )
+        assert not verdict.allowed
+        assert verdict.reason_code == "outside_workspace"
+
+    def test_nested_shell_python_write_denied(self, tmp_path):
+        """``bash -c "python3 -c ..."`` must not evade the vocabulary one
+        level down (the nested launcher payload is checked too)."""
+        rt = sandbox_rt(tmp_path)
+        cmd = (
+            "bash -c \"python3 -c \\\"open('"
+            f"{SIBLING}/a.txt','w').write('x')\\\"\""
+        )
+        verdict = v(cmd, rt)
+        assert not verdict.allowed, cmd
+        assert verdict.reason_code == "outside_workspace"
+        # an in-scope nested write stays allowed
+        ok_cmd = "bash -c \"python3 -c \\\"open('./out.txt','w').write('x')\\\"\""
+        assert v(ok_cmd, rt).allowed
+        # nested READ stays allowed (fail-open)
+        read_cmd = "bash -c \"python3 -c \\\"print(open('/etc/hosts').read())\\\"\""
+        assert v(read_cmd, rt).allowed
+
+
+# ── ExecTool 接线：per-call _user_roots 进入 guard 的授权范围 ─────────────
+
+
+class TestExecToolPlumbing:
+    def test_guard_write_roots_tracks_allow_user_dirs(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        on = ExecTool(working_dir=str(tmp_path), allow_user_dirs=True)
+        off = ExecTool(working_dir=str(tmp_path), allow_user_dirs=False)
+        assert on._guard_write_roots([str(out)]) == (os.path.normpath(str(out)),)
+        assert off._guard_write_roots([str(out)]) == ()
+
+    def test_guard_write_roots_drops_non_absolute(self, tmp_path):
+        tool = ExecTool(working_dir=str(tmp_path))
+        assert tool._guard_write_roots(["relative/dir", "", None, 42]) == ()
+
+    def test_guard_write_roots_resolves_spelling(self, tmp_path):
+        """The classifier resolves every operand; an unresolved spelling
+        (``..`` / trailing separator / 8.3 / symlink) must still match."""
+        out = tmp_path / "out"
+        out.mkdir()
+        weird = f"{out}{os.sep}..{os.sep}{out.name}{os.sep}"
+        tool = ExecTool(working_dir=str(tmp_path))
+        assert tool._guard_write_roots([weird]) == (str(out.resolve()),)
+
+    def test_static_shared_roots_are_not_a_guard_scope(self, tmp_path):
+        """Documented asymmetry: ``tools.extra_roots`` feeds the file tools
+        and the layer-1 bind, but the exec static guard keeps its
+        session-scope rule (the static set contains the WORKSPACE root, so
+        adopting it wholesale would make Level 1 writable)."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        extra = tmp_path / "extra"
+        extra.mkdir()
+        tool = ExecTool(working_dir=str(ws), shared_roots=[ws, extra])
+        assert tool._guard_write_roots(None) == ()
+        assert str(extra) in tool._exec_rw_binds(None)
+        # the same dir DOES become a scope when the user mentions it
+        assert tool._guard_write_roots([str(extra)]) == (str(extra.resolve()),)
+
+    def test_runtime_paths_carry_user_roots(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        sess = tmp_path / "ws" / "sessions" / "k" / "files"
+        sess.mkdir(parents=True)
+        tool = ExecTool(working_dir=str(sess))
+        rt = tool._guard_runtime_paths(str(sess), False, [str(out)])
+        assert rt.extra_write_roots == (os.path.normpath(str(out)),)
+        assert tool._guard_runtime_paths(str(sess), False).extra_write_roots == ()
+
+    def test_guard_command_honours_user_roots(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        sess = tmp_path / "ws" / "sessions" / "k" / "files"
+        sess.mkdir(parents=True)
+        target = _posix(out / "report.md")
+        cmd = (
+            "python3 -c \"from pathlib import Path; "
+            f"Path('{target}').write_text('x')\""
+        )
+        tool = ExecTool(working_dir=str(sess))
+        assert tool._guard_command(cmd, str(sess), user_roots=[str(out)]) is None
+        assert tool._guard_command(cmd, str(sess)) is not None
+        # the switch that gates the bind gates the guard too
+        gated = ExecTool(working_dir=str(sess), allow_user_dirs=False)
+        assert gated._guard_command(cmd, str(sess), user_roots=[str(out)]) is not None
+
+    def test_guard_write_roots_matches_bind_set(self, tmp_path):
+        """Same condition as layer 1: a root is writable in the guard iff
+        it is bound rw in the sandbox."""
+        out = tmp_path / "out"
+        out.mkdir()
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        for allow in (True, False):
+            tool = ExecTool(
+                working_dir=str(ws), shared_roots=[], allow_user_dirs=allow,
+            )
+            binds = tool._exec_rw_binds([str(out)])
+            roots = tool._guard_write_roots([str(out)])
+            assert (str(out) in binds) == (bool(roots)), allow
+
+
+class TestRegistryChokePoint:
+    """``ToolRegistry.execute`` is the funnel for callers that skip the
+    orchestrator (legacy SubagentManager): a MODEL-authored ``_user_roots``
+    must not survive there — only the harness ``**extra`` channel may
+    carry it (R4 review F3)."""
+
+    async def test_registry_strips_model_user_roots(self, tmp_path):
+        from miqi.agent.tools.registry import ToolRegistry
+
+        seen: dict = {}
+
+        class _Recorder:
+            name = "exec"
+            execution_timeout = None
+
+            def validate_params(self, params):
+                return []
+
+            async def execute(self, **kwargs):
+                seen.update(kwargs)
+                return "ok"
+
+        registry = ToolRegistry()
+        registry.register(_Recorder())
+
+        await registry.execute(
+            "exec", {"command": "echo x", "_user_roots": [str(tmp_path)]},
+        )
+        assert "_user_roots" not in seen
+
+        await registry.execute(
+            "exec", {"command": "echo x"}, _user_roots=[str(tmp_path)],
+        )
+        assert seen["_user_roots"] == [str(tmp_path)]

--- a/tests/agent/test_command_guard_python_writes_984.py
+++ b/tests/agent/test_command_guard_python_writes_984.py
@@ -187,6 +187,60 @@ class TestWriteSpellingsDenied:
             rt,
         ).allowed
 
+    @pytest.mark.parametrize(
+        "call",
+        ["copy", "copy2", "copyfile", "copytree"],
+    )
+    def test_copy_keyword_dst_first_target_is_still_a_write(self, tmp_path, call):
+        """``dst=`` may be written BEFORE ``src=`` (#1007 review).
+
+        The guard used to take ``args[0]`` as the source unconditionally,
+        so in this order it labelled the out-of-scope TARGET a copy source
+        → ``for_write=False`` → "reads anywhere else are unrestricted" →
+        the write was allowed.  The source here is in-scope (the ordinary
+        case: the agent copies a file it may write to a directory it may
+        not), which is what makes the target the only thing the guard has
+        to get right.
+        """
+        rt = sandbox_rt(tmp_path)
+        payload = (
+            f"import shutil; shutil.{call}(dst='{SIBLING}/evil.txt', "
+            "src='./in.txt')"
+        )
+        verdict = v(f'python3 -c "{payload}"', rt)
+        assert not verdict.allowed, payload
+        assert verdict.reason_code == "outside_workspace", payload
+
+    def test_copy_keyword_order_does_not_matter(self, tmp_path):
+        """Both keyword orders classify identically to the positional form:
+        source = read, target = write."""
+        rt = sandbox_rt(tmp_path)
+        for payload in (
+            f"import shutil; shutil.copy('./in.txt','{SIBLING}/evil.txt')",
+            f"import shutil; shutil.copy(src='./in.txt', dst='{SIBLING}/evil.txt')",
+            f"import shutil; shutil.copy(dst='{SIBLING}/evil.txt', src='./in.txt')",
+        ):
+            verdict = v(f'python3 -c "{payload}"', rt)
+            assert not verdict.allowed, payload
+            assert verdict.reason_code == "outside_workspace", payload
+        # ...and an in-scope target stays allowed in either order
+        for payload in (
+            "import shutil; shutil.copy(src='/etc/hostname', dst='./out.txt')",
+            "import shutil; shutil.copy(dst='./out.txt', src='/etc/hostname')",
+        ):
+            assert v(f'python3 -c "{payload}"', rt).allowed, payload
+
+    def test_copy_keyword_source_is_read_even_when_dst_first(self, tmp_path):
+        """The authorised-root parity case: keyword order must not turn the
+        granted target into a read and the read source into a write."""
+        rt = sandbox_rt(tmp_path, roots=(AUTH,))
+        for payload in (
+            f"import shutil; shutil.copy(src='/etc/hostname', dst='{AUTH}/a.txt')",
+            f"import shutil; shutil.copy(dst='{AUTH}/a.txt', src='/etc/hostname')",
+        ):
+            verdict = v(f'python3 -c "{payload}"', rt)
+            assert verdict.allowed, payload
+
 
 # ── fail-open：读写法与无法识别的写法不得误报 ───────────────────────────
 

--- a/tests/agent/tools/test_filesystem_write_boundary_984.py
+++ b/tests/agent/tools/test_filesystem_write_boundary_984.py
@@ -12,6 +12,7 @@ Two fixes:
 from __future__ import annotations
 
 import base64
+import logging
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,7 @@ from miqi.agent.tools.filesystem import (
 
 _IS_WINDOWS = sys.platform == "win32"
 _BASH = shutil.which("bash")
+_FS_LOGGER = "miqi.agent.tools.filesystem"
 
 
 class _RecordingSandbox:
@@ -159,3 +161,47 @@ class TestBootstrapSandboxRoots:
         a, b = tmp_path / "a", tmp_path / "b"
         assert bootstrap_sandbox_roots([a, b]) == [str(a), str(b)]
         assert a.is_dir() and b.is_dir()
+
+
+# ── #1007 review: the log calls are stdlib-logging, so ``%s`` not ``{}`` ──
+
+
+class TestBootstrapSandboxRootsLogging:
+    """``_log`` is a ``logging.Logger`` (filesystem.py:16): it formats with
+    ``msg % args``.  The ``{}`` placeholders raised ``TypeError: not all
+    arguments converted`` INSIDE logging, so the message was dropped and only
+    a bare ``--- Logging error ---`` reached stderr — the operator saw neither
+    the path nor the reason.
+    """
+
+    _LOGGER = _FS_LOGGER
+
+    @staticmethod
+    def _messages(caplog) -> list[str]:
+        return [r.getMessage() for r in caplog.records if r.name == _FS_LOGGER]
+
+    def test_create_failure_logs_path_and_reason(
+        self, tmp_path: Path, monkeypatch, caplog,
+    ) -> None:
+        target = tmp_path / "sub" / "out"
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        with caplog.at_level(logging.WARNING, logger=self._LOGGER):
+            assert bootstrap_sandbox_roots([target]) == []
+        assert "cannot create" in caplog.text
+        assert self._messages(caplog) == [
+            f"bootstrap_sandbox_roots: cannot create {target}: disk full"
+        ]
+
+    def test_created_roots_are_logged(self, tmp_path: Path, caplog) -> None:
+        target = tmp_path / "made" / "later"
+        with caplog.at_level(logging.INFO, logger=self._LOGGER):
+            created = bootstrap_sandbox_roots([target])
+        assert created == [str(target)]
+        assert "bootstrap_sandbox_roots: created" in caplog.text
+        assert self._messages(caplog) == [
+            f"bootstrap_sandbox_roots: created {[str(target)]}"
+        ]

--- a/tests/agent/tools/test_filesystem_write_boundary_984.py
+++ b/tests/agent/tools/test_filesystem_write_boundary_984.py
@@ -162,6 +162,37 @@ class TestBootstrapSandboxRoots:
         assert bootstrap_sandbox_roots([a, b]) == [str(a), str(b)]
         assert a.is_dir() and b.is_dir()
 
+    # ── #1007 review: drive-relative spellings name no fixed root ────────
+
+    @pytest.mark.parametrize("raw", ["C:out", "C:", "C:relative", r"C:foo\bar"])
+    def test_drive_relative_not_created(self, raw: str, monkeypatch) -> None:
+        """``C:out`` is relative to the C: drive's CWD — not a bind source.
+
+        The old ``len(s) >= 2 and s[1] == ":"`` judge treated it as a drive
+        path, so bootstrap mkdir-ed a directory nobody named and handed it to
+        the sandbox as an rw ``--bind`` source (the same tightening as
+        ``bwrap._host_path_to_sandbox``, 34907420).  ``Path.mkdir`` is
+        recorded, not run: the pre-fix code created the junk directory for
+        real (on POSIX it landed in the test runner's CWD).
+        """
+        calls: list = []
+        monkeypatch.setattr(
+            Path, "mkdir", lambda self, **kw: calls.append(self),
+        )
+        # Nothing exists yet — the "new output dir" case this function is
+        # written for.  Without it ``C:`` (the drive's current directory)
+        # short-circuits on ``exists()`` and the regression hides.
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        assert bootstrap_sandbox_roots([raw]) == []
+        assert calls == [], f"drive-relative {raw!r} reached mkdir"
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive spellings are Windows-only")
+    def test_drive_absolute_still_created(self, tmp_path: Path) -> None:
+        """The tightened judge must not change any absolute spelling."""
+        target = tmp_path / "drive_abs" / "sub"
+        assert bootstrap_sandbox_roots([target]) == [str(target)]
+        assert target.is_dir()
+
 
 # ── #1007 review: the log calls are stdlib-logging, so ``%s`` not ``{}`` ──
 

--- a/tests/agent/tools/test_filesystem_write_boundary_984.py
+++ b/tests/agent/tools/test_filesystem_write_boundary_984.py
@@ -1,0 +1,161 @@
+"""File-tool write boundary (#984 PR1).
+
+Two fixes:
+  * ``_sandbox_write_file`` computed its parent with a *single-quoted*
+    command substitution, so ``mkdir -p '$(dirname "…")'`` created a literal
+    ``$(dirname "…")`` directory and every write into a new subdirectory
+    failed with rc=1.  The parent is now computed in Python.
+  * authorized roots that do not exist yet are created on the host before the
+    sandbox binds them (a hard ``--bind`` would otherwise fail).
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from miqi.agent.tools.filesystem import (
+    _sandbox_write_file,
+    bootstrap_sandbox_roots,
+)
+
+_IS_WINDOWS = sys.platform == "win32"
+_BASH = shutil.which("bash")
+
+
+class _RecordingSandbox:
+    """Sandbox stub that records the command and can really execute it."""
+
+    def __init__(self, *, run: bool = False):
+        self.commands: list[str] = []
+        self.kwargs: list[dict] = []
+        self._run = run
+
+    async def run_command(self, command: str, **kwargs):
+        self.commands.append(command)
+        self.kwargs.append(kwargs)
+        if not self._run:
+            return (0, "", "")
+        proc = subprocess.run(  # noqa: S603 — fixed test command
+            [_BASH, "-c", command], capture_output=True, text=True,
+        )
+        return (proc.returncode, proc.stdout, proc.stderr)
+
+
+# ── _sandbox_write_file mkdir fix ────────────────────────────────────────
+
+
+class TestSandboxWriteFileMkdir:
+    @pytest.mark.asyncio
+    async def test_parent_computed_in_python(self) -> None:
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/mnt/c/out/sub/file.txt", "hi")
+        cmd = sandbox.commands[0]
+        assert "mkdir -p '/mnt/c/out/sub'" in cmd
+        assert "$(" not in cmd, "no shell command substitution (#984)"
+        assert "dirname" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_parent_stays_single_quoted(self) -> None:
+        """Double quotes would turn $ and ` in Windows names into injection."""
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/mnt/c/out/a$b/file.txt", "hi")
+        assert "mkdir -p '/mnt/c/out/a$b'" in sandbox.commands[0]
+
+    @pytest.mark.asyncio
+    async def test_single_quote_in_parent_escaped(self) -> None:
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/mnt/c/o'brien/file.txt", "hi")
+        assert "mkdir -p '/mnt/c/o'\\''brien'" in sandbox.commands[0]
+
+    @pytest.mark.asyncio
+    async def test_root_level_path_uses_dot(self) -> None:
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/file.txt", "hi")
+        assert "mkdir -p '.'" in sandbox.commands[0]
+
+    @pytest.mark.asyncio
+    async def test_content_is_base64_encoded(self) -> None:
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/mnt/c/out/f.txt", "hello 世界")
+        encoded = base64.b64encode("hello 世界".encode("utf-8")).decode("ascii")
+        assert f"echo '{encoded}' | base64 -d > '/mnt/c/out/f.txt'" in sandbox.commands[0]
+
+    @pytest.mark.asyncio
+    async def test_extra_rw_binds_forwarded(self, tmp_path: Path) -> None:
+        """Without the binds the write hits EROFS under the read-only /mnt."""
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(
+            sandbox, "/mnt/c/out/f.txt", "x", extra_rw_binds=[tmp_path],
+        )
+        assert sandbox.kwargs[0]["extra_rw_binds"] == [str(tmp_path)]
+
+    @pytest.mark.asyncio
+    async def test_no_binds_sends_none(self) -> None:
+        sandbox = _RecordingSandbox()
+        await _sandbox_write_file(sandbox, "/mnt/c/out/f.txt", "x")
+        assert sandbox.kwargs[0]["extra_rw_binds"] is None
+
+    @pytest.mark.asyncio
+    async def test_failure_raises_ioerror(self) -> None:
+        class _Fail:
+            async def run_command(self, command: str, **kwargs):
+                return (1, "", "no such dir")
+
+        with pytest.raises(IOError, match="Cannot write"):
+            await _sandbox_write_file(_Fail(), "/mnt/c/out/f.txt", "x")
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(_BASH is None, reason="bash not available")
+    async def test_new_subdirectory_write_succeeds_for_real(self, tmp_path: Path) -> None:
+        """Regression: the old form failed on any not-yet-created parent."""
+        sandbox = _RecordingSandbox(run=True)
+        target = (tmp_path / "fresh" / "nested" / "out.txt").as_posix()
+        await _sandbox_write_file(sandbox, target, "written by #984")
+        assert (tmp_path / "fresh" / "nested" / "out.txt").read_text(
+            encoding="utf-8"
+        ) == "written by #984"
+        # The buggy form created a literal '$(dirname "...")' directory.
+        assert not (tmp_path / "$(dirname ").exists()
+
+
+# ── bootstrap_sandbox_roots ──────────────────────────────────────────────
+
+
+class TestBootstrapSandboxRoots:
+    def test_creates_missing_dir(self, tmp_path: Path) -> None:
+        target = tmp_path / "a" / "b"
+        created = bootstrap_sandbox_roots([target])
+        assert target.is_dir()
+        assert created == [str(target)]
+
+    def test_existing_dir_untouched(self, tmp_path: Path) -> None:
+        assert bootstrap_sandbox_roots([tmp_path]) == []
+
+    def test_unc_skipped(self) -> None:
+        assert bootstrap_sandbox_roots([r"\\wsl$\Ubuntu\home\x"]) == []
+
+    def test_relative_skipped(self) -> None:
+        assert bootstrap_sandbox_roots(["relative/dir"]) == []
+
+    def test_invalid_entries_skipped(self) -> None:
+        assert bootstrap_sandbox_roots([None, 123, b"bytes"]) == []
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="POSIX paths are WSL-native on Windows")
+    def test_wsl_native_path_skipped_on_windows(self) -> None:
+        assert bootstrap_sandbox_roots(["/home/miqi/out"]) == []
+
+    @pytest.mark.skipif(_IS_WINDOWS, reason="POSIX paths are host paths on POSIX")
+    def test_posix_path_created_on_posix(self, tmp_path: Path) -> None:
+        target = tmp_path / "posix_out"
+        assert bootstrap_sandbox_roots([target]) == [str(target)]
+
+    def test_multiple_roots(self, tmp_path: Path) -> None:
+        a, b = tmp_path / "a", tmp_path / "b"
+        assert bootstrap_sandbox_roots([a, b]) == [str(a), str(b)]
+        assert a.is_dir() and b.is_dir()

--- a/tests/agent/tools/test_session_workspace_isolation.py
+++ b/tests/agent/tools/test_session_workspace_isolation.py
@@ -519,7 +519,8 @@ async def test_write_file_wsl_sandbox_redirects_absolute_root_path(tmp_path):
         def __init__(self):
             self.calls = []
 
-        async def run_command(self, cmd, timeout=30):
+        async def run_command(self, cmd, timeout=30, **kwargs):
+            # **kwargs mirrors BwrapSandbox.run_command (extra_rw_binds, #984)
             self.calls.append(cmd)
             if cmd.startswith("test "):
                 return (1, "", "")  # target does not exist yet

--- a/tests/agent/tools/test_user_roots.py
+++ b/tests/agent/tools/test_user_roots.py
@@ -159,14 +159,22 @@ class TestExtractUserMentionedRoots:
 
 
 class TestProtectedPrefix:
-    """Subtree filtering: depth-1 system dirs were handled, deeper ones not."""
+    """Subtree filtering: depth-1 system dirs were handled, deeper ones not.
 
+    ``_is_protected_prefix`` walks ``Path.parts``, so drive-letter paths only
+    split into components on Windows; on POSIX they are one relative component
+    and the Windows-only cases below are skipped rather than asserted.
+    """
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter paths split only on Windows")
     def test_windows_system_subtree(self) -> None:
         assert _is_protected_prefix(Path(r"C:\Windows\Temp\x")) is True
 
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter paths split only on Windows")
     def test_programdata_subtree(self) -> None:
         assert _is_protected_prefix(Path(r"C:\ProgramData\pkg\out")) is True
 
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter paths split only on Windows")
     def test_appdata_anywhere(self) -> None:
         assert _is_protected_prefix(
             Path(r"C:\Users\x\AppData\Local\Temp\o")

--- a/tests/agent/tools/test_user_roots.py
+++ b/tests/agent/tools/test_user_roots.py
@@ -21,6 +21,7 @@ from miqi.agent.tools.user_roots import (
     _is_protected_prefix,
     _raw_mentions,
     extract_user_mentioned_roots,
+    sanitize_user_roots,
 )
 from miqi.paths import get_config_path
 
@@ -273,3 +274,92 @@ class TestEffectiveSharedRoots:
         base = [tmp_path / "ws"]
         merged = _effective_shared_roots(base, [None, 123, b"bytes"], True)
         assert merged == base
+
+
+# ── sanitize_user_roots (#1007 review) ───────────────────────────────────
+
+
+class TestSanitizeUserRoots:
+    """Untrusted root strings (an IPC ``user_roots`` param) get the same
+    filtering the mention extractor applies.
+
+    They travel the job path straight into ``ToolExecutionContext
+    .user_mentioned_roots`` — no ``extract_user_mentioned_roots`` call sits
+    on that hop — so they reach both the bwrap rw binds and the command
+    guard's write scope unfiltered.
+    """
+
+    def test_protected_system_subtrees_dropped(self, tmp_path: Path) -> None:
+        assert sanitize_user_roots(
+            [r"C:\Windows\Temp\x", r"C:\ProgramData\pkg\out"],
+            workspace=tmp_path / "ws",
+        ) == []
+
+    def test_relative_and_bare_drive_forms_dropped(self) -> None:
+        assert sanitize_user_roots(
+            ["relative/dir", "C:", "C:relative", r"\\wsl$\Ubuntu\home\out", ""],
+            workspace=None,
+        ) == []
+
+    def test_invalid_entries_dropped(self) -> None:
+        assert sanitize_user_roots(
+            [None, 123, b"bytes", {"a": 1}], workspace=None,
+        ) == []
+
+    def test_malformed_payload_dropped_not_raised(self) -> None:
+        """A non-list payload must not crash the IPC handler — nor have its
+        characters / keys read as roots."""
+        out = str(Path.home() / "Desktop" / "out")
+        assert sanitize_user_roots(out, workspace=None) == []
+        assert sanitize_user_roots(5, workspace=None) == []
+        assert sanitize_user_roots({out: 1}, workspace=None) == []
+        assert sanitize_user_roots(None, workspace=None) == []
+
+    def test_config_home_dropped(self) -> None:
+        config_dir = Path(get_config_path()).parent
+        assert sanitize_user_roots([str(config_dir)], workspace=None) == []
+
+    def test_workspace_root_dropped(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        assert sanitize_user_roots([str(ws)], workspace=ws) == []
+
+    def test_workspace_child_outside_sessions_dropped(self, tmp_path: Path) -> None:
+        """Anything already inside the workspace needs no extra root."""
+        ws = tmp_path / "ws"
+        (ws / "sub").mkdir(parents=True)
+        assert sanitize_user_roots([str(ws / "sub")], workspace=ws) == []
+
+    def test_sessions_subtree_dropped(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        (ws / "sessions" / "k").mkdir(parents=True)
+        assert sanitize_user_roots([str(ws / "sessions" / "k")], workspace=ws) == []
+
+    def test_ordinary_output_dir_kept(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        assert sanitize_user_roots([str(out)], workspace=ws) == [str(out.resolve())]
+
+    def test_not_yet_created_output_dir_kept(self, tmp_path: Path) -> None:
+        """The #821 scenario: the user's output dir may not exist yet."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "not_yet"
+        assert sanitize_user_roots([str(out)], workspace=ws) == [str(out.resolve())]
+
+    def test_duplicates_and_cap(self, tmp_path: Path) -> None:
+        dirs = [tmp_path / f"d{i}" for i in range(DEFAULT_MAX_USER_ROOTS + 3)]
+        for d in dirs:
+            d.mkdir()
+        paths = [str(d) for d in dirs] + [str(dirs[0])]
+        roots = sanitize_user_roots(paths, workspace=tmp_path / "ws", max_roots=4)
+        assert len(roots) == 4
+        assert len(set(roots)) == 4
+
+    def test_posix_system_subtree_dropped(self) -> None:
+        assert sanitize_user_roots(["/etc/cron.d/x"], workspace=None) == []
+
+    def test_home_root_dropped(self) -> None:
+        assert sanitize_user_roots([str(Path.home())], workspace=None) == []

--- a/tests/agent/tools/test_user_roots.py
+++ b/tests/agent/tools/test_user_roots.py
@@ -18,6 +18,7 @@ from miqi.agent.tools.filesystem import _effective_shared_roots
 from miqi.agent.tools.user_roots import (
     DEFAULT_MAX_USER_ROOTS,
     _is_protected_extra_root,
+    _is_protected_prefix,
     _raw_mentions,
     extract_user_mentioned_roots,
 )
@@ -152,6 +153,65 @@ class TestExtractUserMentionedRoots:
         out = tmp_path / "out"
         out.mkdir()
         assert extract_user_mentioned_roots([str(out)], workspace=None) == [out.resolve()]
+
+
+# ── protected prefix table (#984) ────────────────────────────────────────
+
+
+class TestProtectedPrefix:
+    """Subtree filtering: depth-1 system dirs were handled, deeper ones not."""
+
+    def test_windows_system_subtree(self) -> None:
+        assert _is_protected_prefix(Path(r"C:\Windows\Temp\x")) is True
+
+    def test_programdata_subtree(self) -> None:
+        assert _is_protected_prefix(Path(r"C:\ProgramData\pkg\out")) is True
+
+    def test_appdata_anywhere(self) -> None:
+        assert _is_protected_prefix(
+            Path(r"C:\Users\x\AppData\Local\Temp\o")
+        ) is True
+
+    def test_posix_system_subtree(self) -> None:
+        assert _is_protected_prefix(Path("/etc/cron.d/x")) is True
+
+    def test_posix_tmp_subtree(self) -> None:
+        assert _is_protected_prefix(Path("/tmp/out")) is True
+
+    def test_user_desktop_not_protected(self) -> None:
+        # The primary #821 scenario must keep working.
+        assert _is_protected_prefix(Path(r"C:\Users\x\Desktop\test_result")) is False
+
+    def test_posix_home_not_protected(self) -> None:
+        assert _is_protected_prefix(Path("/home/alice/out")) is False
+
+    def test_config_home_subtree(self) -> None:
+        assert _is_protected_prefix(Path(get_config_path()).parent / "sub") is True
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter mentions Windows-only")
+    def test_windows_temp_mention_rejected(self) -> None:
+        roots = extract_user_mentioned_roots([r"结果放 C:\Windows\Temp\x 里"])
+        assert roots == []
+
+    @pytest.mark.skipif(not _IS_WINDOWS, reason="drive-letter mentions Windows-only")
+    def test_windows_programdata_mention_rejected(self) -> None:
+        roots = extract_user_mentioned_roots([r"输出到 C:\ProgramData\pkg\out"])
+        assert roots == []
+
+    def test_posix_system_subtree_mention_rejected(self) -> None:
+        assert extract_user_mentioned_roots(["看下 /etc/cron.d/backdoor"]) == []
+
+    @pytest.mark.skipif(_IS_WINDOWS, reason="POSIX host paths only")
+    def test_posix_home_mention_allowed(self, tmp_path: Path) -> None:
+        out = tmp_path / "out"
+        out.mkdir()
+        assert extract_user_mentioned_roots([f"输出到 {out}"]) == [out.resolve()]
+
+    def test_config_subtree_mention_rejected(self) -> None:
+        roots = extract_user_mentioned_roots(
+            [f"写到 {Path(get_config_path()).parent / 'evil'}"]
+        )
+        assert roots == []
 
 
 # ── _is_protected_extra_root ─────────────────────────────────────────────

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -571,3 +571,87 @@ async def test_drain_loop_dispatches_concurrently() -> None:
         pass
     if loop._shutdown_event is not None:
         loop._shutdown_event.set()
+
+
+# ── agent.spawn must sanitize the IPC-supplied roots (#1007 review) ───────
+
+
+class _SpawnCapture:
+    """Fake AgentControl recording the spawn() kwargs."""
+
+    def __init__(self, workspace) -> None:
+        self.workspace = workspace
+        self.calls: list[dict] = []
+
+    async def spawn(self, **kwargs):
+        self.calls.append(kwargs)
+        handle = type("_Agent", (), {"agent_id": "a1", "thread_id": "t1"})()
+        return handle
+
+
+class _SpawnRegistry:
+    def __init__(self, session) -> None:
+        self._session = session
+
+    async def get_session(self, client_id, session_id):
+        return self._session
+
+
+def _spawn_loop_and_registry(tmp_path):
+    from miqi.bridge.loop import BridgeRuntimeLoop
+
+    loop = BridgeRuntimeLoop(
+        send_func=_CaptureSend().send,
+        dispatch_legacy_func=_dispatch_legacy,
+        dev_mode=False,
+    )
+    ac = _SpawnCapture(tmp_path / "ws")
+    session = type("_Session", (), {"services": type("_S", (), {"agent_control": ac})()})()
+    return loop, _SpawnRegistry(session), ac
+
+
+@pytest.mark.asyncio
+async def test_agent_spawn_sanitizes_user_roots(tmp_path):
+    """A root that skips the mention filter must not reach AgentJob.  A UNC
+    path, a protected system subtree and the workspace itself are all
+    rejected; the legitimate output dir survives."""
+    loop, registry, ac = _spawn_loop_and_registry(tmp_path)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+
+    await loop._agent_spawn_handler(
+        "req-1",
+        {
+            "agent_type": "code-agent",
+            "task": "do the thing",
+            "user_roots": [
+                str(out),
+                str(ws),
+                str(ws / "sessions" / "k"),
+                r"\\wsl$\Ubuntu\home\out",
+                "relative/dir",
+                "C:relative",
+            ],
+        },
+        "client-1",
+        "session-1",
+        registry,
+    )
+
+    assert len(ac.calls) == 1
+    assert ac.calls[0]["user_roots"] == [str(out.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_agent_spawn_without_user_roots_passes_empty(tmp_path):
+    loop, registry, ac = _spawn_loop_and_registry(tmp_path)
+    await loop._agent_spawn_handler(
+        "req-2",
+        {"agent_type": "code-agent", "task": "x"},
+        "client-1",
+        "session-1",
+        registry,
+    )
+    assert ac.calls[0]["user_roots"] == []

--- a/tests/bridge/test_bridge_loop.py
+++ b/tests/bridge/test_bridge_loop.py
@@ -573,7 +573,7 @@ async def test_drain_loop_dispatches_concurrently() -> None:
         loop._shutdown_event.set()
 
 
-# ── agent.spawn must sanitize the IPC-supplied roots (#1007 review) ───────
+# ── agent.spawn never takes roots from the request (#1007 review) ─────────
 
 
 class _SpawnCapture:
@@ -611,13 +611,16 @@ def _spawn_loop_and_registry(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_agent_spawn_sanitizes_user_roots(tmp_path):
-    """A root that skips the mention filter must not reach AgentJob.  A UNC
-    path, a protected system subtree and the workspace itself are all
-    rejected; the legitimate output dir survives."""
+async def test_agent_spawn_ignores_request_user_roots(tmp_path):
+    """A ``user_roots`` field in the request must NOT become the sub-agent's
+    authorization scope.
+
+    The field is request-supplied, so it is forgeable — filtering it would
+    still let the caller pick the scope.  The handler passes no roots at
+    all, so a request that asks for an out-of-scope directory (and, for the
+    same reason, one that asks for a legitimate one) has no effect.
+    """
     loop, registry, ac = _spawn_loop_and_registry(tmp_path)
-    ws = tmp_path / "ws"
-    ws.mkdir()
     out = tmp_path / "out"
     out.mkdir()
 
@@ -626,14 +629,7 @@ async def test_agent_spawn_sanitizes_user_roots(tmp_path):
         {
             "agent_type": "code-agent",
             "task": "do the thing",
-            "user_roots": [
-                str(out),
-                str(ws),
-                str(ws / "sessions" / "k"),
-                r"\\wsl$\Ubuntu\home\out",
-                "relative/dir",
-                "C:relative",
-            ],
+            "user_roots": [str(out)],
         },
         "client-1",
         "session-1",
@@ -641,17 +637,50 @@ async def test_agent_spawn_sanitizes_user_roots(tmp_path):
     )
 
     assert len(ac.calls) == 1
-    assert ac.calls[0]["user_roots"] == [str(out.resolve())]
+    assert ac.calls[0]["user_roots"] is None
 
 
 @pytest.mark.asyncio
-async def test_agent_spawn_without_user_roots_passes_empty(tmp_path):
+async def test_agent_spawn_ignores_forged_roots_payload(tmp_path):
+    """The review's shape: every hostile spelling in the field — the very
+    ones the old ``sanitize_user_roots`` pass used to filter — is irrelevant
+    now, because none of them is read."""
     loop, registry, ac = _spawn_loop_and_registry(tmp_path)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    hostile = tmp_path / "hostile"
+    hostile.mkdir()
+
     await loop._agent_spawn_handler(
         "req-2",
+        {
+            "agent_type": "code-agent",
+            "task": "x",
+            "user_roots": [
+                str(hostile),
+                str(ws),
+                str(ws / "sessions" / "k"),
+                r"\\wsl$\Ubuntu\home\out",
+                "relative/dir",
+                "C:relative",
+                "/etc",
+            ],
+        },
+        "client-1",
+        "session-1",
+        registry,
+    )
+    assert ac.calls[0]["user_roots"] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_spawn_without_user_roots_passes_none(tmp_path):
+    loop, registry, ac = _spawn_loop_and_registry(tmp_path)
+    await loop._agent_spawn_handler(
+        "req-3",
         {"agent_type": "code-agent", "task": "x"},
         "client-1",
         "session-1",
         registry,
     )
-    assert ac.calls[0]["user_roots"] == []
+    assert ac.calls[0]["user_roots"] is None

--- a/tests/execution/test_exec_write_boundary_984.py
+++ b/tests/execution/test_exec_write_boundary_984.py
@@ -15,6 +15,7 @@ Covers the exec half of the sandbox write boundary:
 from __future__ import annotations
 
 import inspect
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -114,6 +115,161 @@ class TestExecRwBinds:
         ws.mkdir()
         tool = ExecTool(working_dir=str(ws))
         assert tool._exec_rw_binds([None, 123, b"x"]) == [str(ws)]
+
+
+# ── #1007 review: a UNC static root is not a bind source ─────────────────
+
+
+class TestUncStaticRoot:
+    """``\\\\wsl$\\…`` exists on the host but cannot be bound.
+
+    ``_add(strict=False)`` keeps a static root whose ``os.path.exists()``
+    succeeds — for a UNC entry that is true, and the resulting hard
+    ``--bind`` then died inside ``_host_path_to_sandbox`` (which raises on
+    UNC), surfacing as the generic 「沙箱执行失败」 for EVERY command.  The
+    root extractors never produce UNC, so such entries are dropped instead.
+    """
+
+    _UNC = r"\\wsl$\Ubuntu\home\out"
+
+    def _tool_with_unc_shared_root(self, ws: Path, monkeypatch) -> ExecTool:
+        """Build the tool with ``os.path.exists`` reporting the UNC as reachable."""
+        real_exists = os.path.exists
+
+        def _exists(p: object) -> bool:
+            if str(p).replace("\\", "/").startswith("//"):
+                return True  # a WSL share IS reachable from the Windows host
+            return real_exists(p)
+
+        monkeypatch.setattr(os.path, "exists", _exists)
+        return ExecTool(
+            timeout=5, working_dir=str(ws), shared_roots=[self._UNC],
+        )
+
+    def test_unc_static_root_not_bound(self, tmp_path: Path, monkeypatch) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        tool = self._tool_with_unc_shared_root(ws, monkeypatch)
+        binds = tool._exec_rw_binds(None)
+        assert str(ws) in binds  # the reachable roots are untouched
+        assert not any(
+            str(b).replace("\\", "/").startswith(("//", "\\\\")) for b in binds
+        )
+
+    def test_unc_not_reported_as_missing_source(self) -> None:
+        """It is not a bind source at all — not a 'missing' one either.
+
+        The pre-flight report turned it into a hard refusal for every
+        command (and a missing bind never falls back to the host).
+        """
+        assert ExecTool._missing_bind_sources([self._UNC]) == []
+
+
+# ── #1007 review: the BWRAP→host fallback keeps the per-call grant ───────
+
+
+class TestHostFallbackRoots:
+    """``_execute_with_sandbox_selection`` must hand the per-call roots to
+    the host-fallback guard.
+
+    When BWRAP is selected but no sandbox is live, execution falls back to
+    the host and the guard is re-run with HOST path semantics.  That re-check
+    was called without ``user_roots``, so ``_guard_write_roots`` saw ``None``
+    and refused a write into the very directory the user had just authorized
+    (the legacy no-selection fallback already passed them).
+    """
+
+    def _tool(self, tmp_path: Path):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        tool = ExecTool(timeout=5, working_dir=str(ws), allow_user_dirs=True)
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=None)  # sandbox never starts
+        mgr.active_sandbox = None
+        tool._sandbox_manager = mgr
+        return tool, out
+
+    @pytest.mark.asyncio
+    async def test_fallback_guard_receives_user_roots(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        tool, out = self._tool(tmp_path)
+        seen: dict = {}
+
+        def _fake_guard(command: str, cwd: str, user_roots=None):
+            seen["user_roots"] = user_roots
+            return None
+
+        async def _fake_direct(command, cwd, **kwargs):
+            return MagicMock(exit_code=0, output="host", duration_ms=0,
+                             cancelled=False, timed_out=False)
+
+        monkeypatch.setattr(tool, "_guard_host_fallback", _fake_guard)
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        await tool.execute(
+            "echo hi",
+            _sandbox=_selection(SandboxType.BWRAP),
+            _user_roots=[str(out)],
+        )
+        assert seen["user_roots"] == [str(out)]
+
+    @pytest.mark.asyncio
+    async def test_authorized_write_not_refused_on_fallback(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """Behavioural half: the real guard must let the granted write run."""
+        tool, out = self._tool(tmp_path)
+        target = (out / "result.txt").as_posix()
+        ran: dict = {}
+
+        async def _fake_direct(command, cwd, **kwargs):
+            ran["yes"] = True
+            return MagicMock(exit_code=0, output="ok", duration_ms=0,
+                             cancelled=False, timed_out=False)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        result = await tool.execute(
+            f'echo written > "{target}"',
+            _sandbox=_selection(SandboxType.BWRAP),
+            _user_roots=[str(out)],
+        )
+        assert ran.get("yes") is True, f"guard refused the granted write: {result}"
+
+    @pytest.mark.asyncio
+    async def test_ungranted_write_still_refused_on_fallback(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """The opposite direction: no grant → the host re-check still fires.
+
+        ``/home/miqi/...`` is a legitimate in-sandbox path (the pre-flight
+        guard, running with SANDBOX semantics, allows it) that is a real
+        out-of-scope host path once the sandbox is gone — exactly what the
+        re-check exists for.  Emptying ``user_roots`` must not turn the
+        fallback guard off.
+        """
+        tool, _out = self._tool(tmp_path)
+        ran: dict = {}
+
+        async def _fake_direct(command, cwd, **kwargs):
+            ran["yes"] = True
+            return MagicMock(exit_code=0, output="ok", duration_ms=0,
+                             cancelled=False, timed_out=False)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        result = await tool.execute(
+            'echo written > "/home/miqi/out/x.txt"',
+            _sandbox=_selection(SandboxType.BWRAP),
+        )
+        assert ran.get("yes") is None, "ungranted host write must not run"
+        assert "拦截" in result
 
 
 # ── signatures + splat sites ─────────────────────────────────────────────

--- a/tests/execution/test_exec_write_boundary_984.py
+++ b/tests/execution/test_exec_write_boundary_984.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from miqi.agent.tools.shell import ExecTool
+from miqi.execution.orchestrator import ToolExecutionContext, ToolOrchestrator
 from miqi.execution.sandbox_policy import SandboxSelection, SandboxType
 from miqi.protocol.permissions import (
     FileSystemAccessMode,
@@ -337,3 +338,107 @@ class TestNoHostFallback:
         )
         binds = sandbox.run_command_streaming.await_args.kwargs["extra_rw_binds"]
         assert str(out_dir) not in binds
+
+
+# ── #984 R2: the harness owns ``_user_roots`` ────────────────────────────
+
+
+class _RecordingTool:
+    """Records the kwargs ToolOrchestrator._execute_in_sandbox injects."""
+
+    name = "write_file"
+    parameters = {"type": "object", "properties": {"path": {"type": "string"}}}
+
+    def __init__(self) -> None:
+        self.last_kwargs: dict | None = None
+
+    async def execute(self, **kwargs) -> str:
+        self.last_kwargs = dict(kwargs)
+        return "ok"
+
+
+class _Registry:
+    def __init__(self, tool: _RecordingTool) -> None:
+        self._tool = tool
+
+    def get(self, name: str) -> _RecordingTool:
+        return self._tool
+
+
+def _orchestrator(tool: _RecordingTool) -> ToolOrchestrator:
+    return ToolOrchestrator(
+        permission_engine=MagicMock(),
+        sandbox_engine=MagicMock(),
+        hook_runtime=MagicMock(),
+        tool_registry=_Registry(tool),
+        event_emitter=MagicMock(),
+    )
+
+
+def _ctx(arguments: dict, roots: list[str], tool_name: str = "write_file"):
+    return ToolExecutionContext(
+        tool_name=tool_name,
+        tool_call_id="c1",
+        arguments=arguments,
+        turn_id="t1",
+        thread_id="th1",
+        agent_type="primary",
+        user_mentioned_roots=roots,
+    )
+
+
+class TestUserRootsOwnership:
+    """``_user_roots`` is injected by the harness, never by the model.
+
+    It is in no tool schema, and object validation only walks declared keys
+    (base.py:112-114), so a model-authored ``_user_roots`` would otherwise
+    ride through ``ctx.arguments`` and re-open the write boundary the turn's
+    sensed roots are meant to gate.
+    """
+
+    @pytest.mark.asyncio
+    async def test_model_supplied_roots_dropped_when_turn_has_none(self) -> None:
+        tool = _RecordingTool()
+        ctx = _ctx(
+            {
+                "path": "C:/Users/me/Documents/report.md",
+                "_user_roots": ["C:/Users/me/Documents"],
+            },
+            roots=[],
+        )
+        await _orchestrator(tool)._execute_in_sandbox(
+            ctx, _selection(SandboxType.BWRAP),
+        )
+        assert tool.last_kwargs is not None
+        assert tool.last_kwargs["_user_roots"] == []
+
+    @pytest.mark.asyncio
+    async def test_harness_roots_win_over_model_supplied(self) -> None:
+        tool = _RecordingTool()
+        ctx = _ctx(
+            {
+                "path": "C:/Users/me/Desktop/out/report.md",
+                "_user_roots": ["C:/Users/me/Documents"],
+            },
+            roots=["C:/Users/me/Desktop/out"],
+        )
+        await _orchestrator(tool)._execute_in_sandbox(
+            ctx, _selection(SandboxType.BWRAP),
+        )
+        assert tool.last_kwargs is not None
+        assert tool.last_kwargs["_user_roots"] == ["C:/Users/me/Desktop/out"]
+
+    @pytest.mark.asyncio
+    async def test_model_supplied_roots_dropped_for_non_file_tools(self) -> None:
+        """The strip is unconditional — no tool name keeps a model-authored root."""
+        tool = _RecordingTool()
+        ctx = _ctx(
+            {"text": "hi", "_user_roots": ["C:/Users/me/Documents"]},
+            roots=[],
+            tool_name="message",
+        )
+        await _orchestrator(tool)._execute_in_sandbox(
+            ctx, _selection(SandboxType.BWRAP),
+        )
+        assert tool.last_kwargs is not None
+        assert "_user_roots" not in tool.last_kwargs

--- a/tests/execution/test_exec_write_boundary_984.py
+++ b/tests/execution/test_exec_write_boundary_984.py
@@ -687,3 +687,49 @@ class TestWorkingDirNotABindSource:
 
         await tool.execute("echo t", working_dir=str(other))
         assert seen["cwd"] == str(other)
+
+
+# ── #1007 review: the cross-session guard reaches the sandbox ────────────
+
+
+class TestCrossSessionGuardWiring:
+    """``ExecTool`` must hand bwrap the workspace root + session files dir.
+
+    The mount ordering itself is asserted in
+    ``tests/sandbox/test_sandbox_write_boundary_984.py``; this locks the
+    shell.py half — both kwargs default to ``None`` in bwrap (old args), so a
+    dropped call site would silently leave ``<ws>/sessions/**`` writable.
+    """
+
+    @staticmethod
+    def _tool(tmp_path: Path):
+        ws = tmp_path / "ws"
+        files = ws / "sessions" / "desktop_1" / "files"
+        files.mkdir(parents=True)
+        tool = ExecTool(
+            timeout=5, working_dir=str(files), shared_roots=[ws],
+            workspace_root=str(ws), session_files_dir=str(files),
+        )
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+        return tool, sandbox, ws, files
+
+    def test_defaults_disable_the_guard(self) -> None:
+        tool = ExecTool(timeout=5, working_dir=str(Path.cwd()))
+        assert tool._workspace_root is None
+        assert tool._session_files_dir is None
+
+    @pytest.mark.asyncio
+    async def test_execute_forwards_guard_paths(self, tmp_path) -> None:
+        tool, sandbox, ws, files = self._tool(tmp_path)
+        await tool.execute("echo hi", _sandbox=_selection(SandboxType.BWRAP))
+        kwargs = sandbox.run_command_streaming.await_args.kwargs
+        assert kwargs["workspace_root"] == str(ws)
+        assert kwargs["session_files_dir"] == str(files)
+        # The workspace root is still a bind source (the guard narrows it,
+        # it does not replace it) — and so is the session's own files dir.
+        assert str(ws) in kwargs["extra_rw_binds"]
+        assert str(files) in kwargs["extra_rw_binds"]

--- a/tests/execution/test_exec_write_boundary_984.py
+++ b/tests/execution/test_exec_write_boundary_984.py
@@ -7,7 +7,9 @@ Covers the exec half of the sandbox write boundary:
   * a missing bind source failing the command WITHOUT falling back to host
     execution,
   * ``_execute_restricted``'s explicit ``_execute_direct`` call staying valid
-    without the new kwarg (plan v6 §3).
+    without the new kwarg (plan v6 §3),
+  * the per-call ``working_dir`` argument NEVER becoming a bind source (R3
+    contract hardening).
 """
 
 from __future__ import annotations
@@ -442,3 +444,90 @@ class TestUserRootsOwnership:
         )
         assert tool.last_kwargs is not None
         assert "_user_roots" not in tool.last_kwargs
+
+
+# ── #984 R3: the per-call ``working_dir`` is not a bind source ────────────
+
+
+class TestWorkingDirNotABindSource:
+    """``execute(working_dir=...)`` is model-controlled and must stay cwd-only.
+
+    It selects the process cwd (and the workspace-diff root); the rw bind set
+    is fixed at construction (``self.working_dir`` + ``self._shared_roots``)
+    plus the harness-injected ``_user_roots``.  If the per-call value leaked
+    into ``_exec_rw_binds``, a model could name ANY existing host directory as
+    ``working_dir`` and have it re-opened writable inside the sandbox with no
+    grant — the exact boundary #984 exists to enforce.  The contract is stated
+    in ``ExecTool._exec_rw_binds``'s docstring; this test locks it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_per_call_working_dir_is_not_a_bind_source(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        shared = tmp_path / "static_shared"
+        shared.mkdir()
+        # An EXISTING directory outside the workspace — the shape a
+        # model-supplied ``working_dir`` takes when it is honoured as a bind
+        # source (a missing one would be skipped by the static-root check).
+        secret = tmp_path / "outside_secret"
+        secret.mkdir()
+        (secret / "credentials.txt").write_text("x", encoding="utf-8")
+
+        tool = ExecTool(timeout=5, working_dir=str(ws), shared_roots=[shared])
+        # Never walk the model-named cwd on disk during this test.
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        before = tool._exec_rw_binds([])
+        assert before == [str(ws), str(shared)]
+
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+
+        # Exactly the way the model reaches the tool: ``working_dir`` is a
+        # declared schema parameter, ``_sandbox``/``_session_key`` are
+        # harness-injected.
+        await tool.execute(
+            command="echo t",
+            working_dir=str(secret),
+            _sandbox=_selection(SandboxType.BWRAP),
+            _session_key="k",
+        )
+
+        # (1) what the sandbox was actually asked to re-open writable
+        binds = sandbox.run_command_streaming.await_args.kwargs["extra_rw_binds"]
+        assert binds == before
+        assert str(secret) not in binds
+        # (2) the instance's bind set is unchanged after the call
+        after = tool._exec_rw_binds([])
+        assert after == before
+        assert str(secret) not in after
+
+    @pytest.mark.asyncio
+    async def test_per_call_working_dir_still_sets_cwd(
+        self, monkeypatch, tmp_path,
+    ) -> None:
+        """The hardening must not break the parameter it constrains."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        other = tmp_path / "other_cwd"
+        other.mkdir()
+
+        tool = ExecTool(timeout=5, working_dir=str(ws))
+        seen: dict = {}
+
+        async def _fake_direct(command, cwd, **kwargs):
+            seen["cwd"] = cwd
+            return MagicMock(exit_code=0, output="ok", duration_ms=0,
+                             cancelled=False, timed_out=False)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        await tool.execute("echo t", working_dir=str(other))
+        assert seen["cwd"] == str(other)

--- a/tests/execution/test_exec_write_boundary_984.py
+++ b/tests/execution/test_exec_write_boundary_984.py
@@ -1,0 +1,339 @@
+"""ExecTool write boundary (#984 PR1) — layer 1 plumbing tests.
+
+Covers the exec half of the sandbox write boundary:
+  * the per-call rw bind SET (workspace ∪ static shared roots ∪ gated
+    ``_user_roots``; #864 card grants are deliberately excluded),
+  * the four ``_execute_*`` signatures and all eight ``**splat`` call sites,
+  * a missing bind source failing the command WITHOUT falling back to host
+    execution,
+  * ``_execute_restricted``'s explicit ``_execute_direct`` call staying valid
+    without the new kwarg (plan v6 §3).
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.agent.tools.shell import ExecTool
+from miqi.execution.sandbox_policy import SandboxSelection, SandboxType
+from miqi.protocol.permissions import (
+    FileSystemAccessMode,
+    FileSystemSandboxPolicy,
+    NetworkSandboxPolicy,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _selection(kind: SandboxType) -> SandboxSelection:
+    return SandboxSelection(
+        sandbox_type=kind,
+        filesystem_policy=FileSystemSandboxPolicy(
+            default_mode=FileSystemAccessMode.READ,
+        ),
+        network_policy=NetworkSandboxPolicy.ALLOW_ALL,
+        env_passthrough=[],
+        timeout_ms=30_000,
+        reason=f"test {kind.value}",
+    )
+
+
+def _mock_sandbox(*, is_running: bool = True) -> MagicMock:
+    sb = MagicMock()
+    sb.is_running = is_running
+    sb.get_sandbox_env = MagicMock(return_value={})
+    # Raise after recording the call so _execute_in_sandbox returns its
+    # error result without needing a real stream handle.
+    sb.run_command_streaming = AsyncMock(side_effect=RuntimeError("boom"))
+    return sb
+
+
+# ── bind set composition ─────────────────────────────────────────────────
+
+
+class TestExecRwBinds:
+    def test_workspace_and_shared_roots_included(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        shared = tmp_path / "extra"
+        shared.mkdir()
+        tool = ExecTool(working_dir=str(ws), shared_roots=[shared])
+        assert tool._exec_rw_binds(None) == [str(ws), str(shared)]
+
+    def test_user_roots_added_when_enabled(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        tool = ExecTool(working_dir=str(ws), allow_user_dirs=True)
+        assert tool._exec_rw_binds([str(out)]) == [str(ws), str(out)]
+
+    def test_user_roots_ignored_when_disabled(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        tool = ExecTool(working_dir=str(ws), allow_user_dirs=False)
+        assert tool._exec_rw_binds([str(out)]) == [str(ws)]
+
+    def test_missing_static_root_skipped(self, tmp_path: Path) -> None:
+        """A stale tools.extra_roots entry must not break every command."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        tool = ExecTool(
+            working_dir=str(ws), shared_roots=[tmp_path / "gone"],
+        )
+        assert tool._exec_rw_binds(None) == [str(ws)]
+
+    def test_missing_user_root_kept_for_loud_failure(self, tmp_path: Path) -> None:
+        """A granted root is never silently dropped — it fails with guidance."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        gone = tmp_path / "not_yet"
+        tool = ExecTool(working_dir=str(ws), allow_user_dirs=True)
+        assert str(gone) in tool._exec_rw_binds([str(gone)])
+
+    def test_dedupe(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        tool = ExecTool(working_dir=str(ws), shared_roots=[ws])
+        assert tool._exec_rw_binds([str(ws)]) == [str(ws)]
+
+    def test_no_working_dir_no_shared_roots(self) -> None:
+        assert ExecTool()._exec_rw_binds(None) == []
+
+    def test_invalid_entries_ignored(self, tmp_path: Path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        tool = ExecTool(working_dir=str(ws))
+        assert tool._exec_rw_binds([None, 123, b"x"]) == [str(ws)]
+
+
+# ── signatures + splat sites ─────────────────────────────────────────────
+
+
+class TestSignatures:
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "_execute_in_sandbox",
+            "_execute_with_sandbox_selection",
+            "_execute_restricted",
+            "_execute_direct",
+        ],
+    )
+    def test_extra_rw_binds_accepted(self, method: str) -> None:
+        sig = inspect.signature(getattr(ExecTool, method))
+        assert "extra_rw_binds" in sig.parameters
+        assert sig.parameters["extra_rw_binds"].default is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kind,expected",
+        [
+            (SandboxType.NONE, "_execute_direct"),
+            (SandboxType.BWRAP, "_execute_in_sandbox"),
+            (SandboxType.RESTRICTED, "_execute_restricted"),
+            (SandboxType.LANDLOCK, None),
+        ],
+    )
+    async def test_selection_splat_sites(self, kind, expected, monkeypatch) -> None:
+        """``**common`` reaches every sub-executor (shell.py:1176/1188/1206/1225)."""
+        tool = ExecTool(timeout=5, working_dir=str(Path.cwd()))
+        seen: dict[str, dict] = {}
+
+        def _capture(name):
+            async def _fn(*args, **kwargs):
+                seen[name] = kwargs
+                return MagicMock(exit_code=0, output="", duration_ms=0, cancelled=False,
+                                 timed_out=False)
+            return _fn
+
+        for name in ("_execute_direct", "_execute_in_sandbox", "_execute_restricted"):
+            monkeypatch.setattr(tool, name, _capture(name))
+
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+
+        await tool._execute_with_sandbox_selection(
+            _selection(kind), "echo hi", str(Path.cwd()),
+            session_key="k",
+            extra_rw_binds=["/tmp/out"],
+        )
+        if expected is None:
+            assert seen == {}  # LANDLOCK fails closed, no sub-executor
+        else:
+            assert seen[expected]["extra_rw_binds"] == ["/tmp/out"]
+
+    @pytest.mark.asyncio
+    async def test_execute_splat_sites(self, monkeypatch) -> None:
+        """``**exec_kwargs`` reaches the orchestrator/legacy/host branches."""
+        tool = ExecTool(timeout=5, working_dir=str(Path.cwd()))
+        seen: dict[str, dict] = {}
+
+        def _capture(name):
+            async def _fn(*args, **kwargs):
+                seen[name] = kwargs
+                return MagicMock(exit_code=0, output="", duration_ms=0, cancelled=False,
+                                 timed_out=False)
+            return _fn
+
+        for name in ("_execute_with_sandbox_selection", "_execute_in_sandbox",
+                     "_execute_direct"):
+            monkeypatch.setattr(tool, name, _capture(name))
+        monkeypatch.setattr(tool, "_snapshot_workspace", lambda cwd: {})
+
+        # 1) orchestrator-injected selection — workspace root is always bound
+        await tool.execute("echo hi", _sandbox=_selection(SandboxType.NONE))
+        assert seen["_execute_with_sandbox_selection"]["extra_rw_binds"] == [
+            str(Path.cwd())
+        ]
+
+        # 2) legacy manager path with a running sandbox
+        tool._sandbox_manager = MagicMock()
+        tool._sandbox_manager.get_or_create = AsyncMock(return_value=_mock_sandbox())
+        tool._sandbox_manager.active_sandbox = _mock_sandbox()
+        await tool.execute("echo hi", _session_key="k")
+        assert "extra_rw_binds" in seen["_execute_in_sandbox"]
+
+        # 3) legacy manager path with no sandbox → direct
+        tool._sandbox_manager.get_or_create = AsyncMock(return_value=None)
+        await tool.execute("echo hi", _session_key="k")
+        assert "extra_rw_binds" in seen["_execute_direct"]
+
+        # 4) no manager at all → direct
+        tool._sandbox_manager = None
+        await tool.execute("echo hi")
+        assert "extra_rw_binds" in seen["_execute_direct"]
+
+    @pytest.mark.asyncio
+    async def test_restricted_explicit_direct_call_without_bind(self, monkeypatch) -> None:
+        """_execute_restricted passes no bind to _execute_direct (v6 §3)."""
+        ws = Path.cwd()
+        tool = ExecTool(timeout=5, working_dir=str(ws))
+        captured: dict = {}
+
+        async def _fake_direct(command, cwd, **kwargs):
+            captured.update(kwargs)
+            return MagicMock(exit_code=0, output="ok", duration_ms=0, cancelled=False,
+                             timed_out=False)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+        sel = _selection(SandboxType.RESTRICTED)
+        result = await tool._execute_restricted(
+            "echo hi", str(ws), sandbox_selection=sel, extra_rw_binds=["/tmp/out"],
+        )
+        assert result.exit_code == 0
+        assert "extra_rw_binds" not in captured
+
+
+# ── failure must not downgrade to host execution ─────────────────────────
+
+
+class TestNoHostFallback:
+    @pytest.mark.asyncio
+    async def test_missing_bind_fails_with_guidance(self, monkeypatch, tmp_path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        missing = tmp_path / "not_yet_created"
+        tool = ExecTool(timeout=5, working_dir=str(ws), allow_user_dirs=True)
+        sandbox = _mock_sandbox()
+
+        direct_called = False
+
+        async def _fake_direct(*args, **kwargs):
+            nonlocal direct_called
+            direct_called = True
+            return MagicMock(exit_code=0, output="host", duration_ms=0)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+
+        result = await tool._execute_in_sandbox(
+            sandbox, "echo hi", str(ws),
+            extra_rw_binds=[str(missing)],
+        )
+        assert result.exit_code != 0
+        assert str(missing) in result.output
+        assert "文件工具" in result.output  # guidance text
+        sandbox.run_command_streaming.assert_not_awaited()
+        assert direct_called is False, "must not fall back to host execution"
+
+    @pytest.mark.asyncio
+    async def test_execute_reports_missing_user_root(self, monkeypatch, tmp_path) -> None:
+        """End-to-end through execute(): error + zero host fallback."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        missing = tmp_path / "nope"
+        tool = ExecTool(timeout=5, working_dir=str(ws), allow_user_dirs=True)
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+
+        direct_called = False
+
+        async def _fake_direct(*args, **kwargs):
+            nonlocal direct_called
+            direct_called = True
+            return MagicMock(exit_code=0, output="host", duration_ms=0)
+
+        monkeypatch.setattr(tool, "_execute_direct", _fake_direct)
+
+        out = await tool.execute(
+            "echo hi",
+            _sandbox=_selection(SandboxType.BWRAP),
+            _user_roots=[str(missing)],
+        )
+        assert "命令未执行" in out
+        assert direct_called is False
+
+    @pytest.mark.asyncio
+    async def test_existing_user_root_reaches_sandbox(self, tmp_path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        tool = ExecTool(timeout=5, working_dir=str(ws), allow_user_dirs=True)
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+
+        await tool.execute(
+            "echo hi",
+            _sandbox=_selection(SandboxType.BWRAP),
+            _user_roots=[str(out_dir)],
+        )
+        binds = sandbox.run_command_streaming.await_args.kwargs["extra_rw_binds"]
+        assert str(out_dir) in binds
+        assert str(ws) in binds
+
+    @pytest.mark.asyncio
+    async def test_user_roots_gated_by_config(self, tmp_path) -> None:
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        tool = ExecTool(timeout=5, working_dir=str(ws), allow_user_dirs=False)
+        sandbox = _mock_sandbox()
+        mgr = MagicMock()
+        mgr.get_or_create = AsyncMock(return_value=sandbox)
+        mgr.active_sandbox = sandbox
+        tool._sandbox_manager = mgr
+
+        await tool.execute(
+            "echo hi",
+            _sandbox=_selection(SandboxType.BWRAP),
+            _user_roots=[str(out_dir)],
+        )
+        binds = sandbox.run_command_streaming.await_args.kwargs["extra_rw_binds"]
+        assert str(out_dir) not in binds

--- a/tests/kun_runtime/test_tool_host.py
+++ b/tests/kun_runtime/test_tool_host.py
@@ -468,7 +468,57 @@ class TestUserRootsInjection:
         call = ToolCallLike(call_id="c1", tool_name="write_file", arguments={"path": "a.txt"})
         await host.execute(call, ctx)
         assert tool.last_kwargs is not None
-        assert "_user_roots" not in tool.last_kwargs
+        # #984 R2: injected unconditionally — an empty list is the harness
+        # saying "no roots this turn", never a fall-through to the model's.
+        assert tool.last_kwargs["_user_roots"] == []
+
+    @pytest.mark.asyncio
+    async def test_model_supplied_user_roots_not_adopted(self) -> None:
+        """``_user_roots`` is harness-owned: the model's copy must not reach
+        the tool.  It is in no schema and unknown keys pass validation, so
+        without the strip it would arrive verbatim (and, when the harness also
+        injects, collide as a duplicate keyword in ``execute(**args, **extra)``).
+        """
+        tool = _RecordingWriteTool()
+        reg = ToolRegistry()
+        reg.register(tool)
+        host = MiQiToolHost(reg)
+
+        ctx = ToolHostContext(thread_id="th1", turn_id="t1", workspace="/tmp")
+        call = ToolCallLike(
+            call_id="c1", tool_name="write_file",
+            arguments={
+                "path": "C:/Users/me/Documents/report.md",
+                "_user_roots": ["C:/Users/me/Documents"],
+            },
+        )
+        result = await host.execute(call, ctx)
+        assert result.item["isError"] is False, result.item
+        assert tool.last_kwargs is not None
+        assert tool.last_kwargs["_user_roots"] == []
+
+    @pytest.mark.asyncio
+    async def test_harness_roots_win_over_model_supplied(self) -> None:
+        tool = _RecordingWriteTool()
+        reg = ToolRegistry()
+        reg.register(tool)
+        host = MiQiToolHost(reg)
+
+        ctx = ToolHostContext(
+            thread_id="th1", turn_id="t1", workspace="/tmp",
+            user_mentioned_roots=["C:/Users/x/Desktop/test_result"],
+        )
+        call = ToolCallLike(
+            call_id="c1", tool_name="write_file",
+            arguments={
+                "path": "C:/Users/x/Desktop/test_result/report.md",
+                "_user_roots": ["C:/Users/me/Documents"],
+            },
+        )
+        result = await host.execute(call, ctx)
+        assert result.item["isError"] is False, result.item
+        assert tool.last_kwargs is not None
+        assert tool.last_kwargs["_user_roots"] == ["C:/Users/x/Desktop/test_result"]
 
     def test_graph_render_receives_session_key(self) -> None:
         # Parity with the legacy orchestrator (CodeRabbit #761): graph_render

--- a/tests/runtime/test_subagent_roots_984.py
+++ b/tests/runtime/test_subagent_roots_984.py
@@ -1,0 +1,294 @@
+"""Sub-agent root inheritance (#984 PR1, B2).
+
+Roots travel explicitly through the spawn chain
+(``SpawnTool`` → ``AgentControl.spawn`` → ``AgentJobRuntime.start`` →
+``AgentJob.user_roots`` → ``TurnRunner.run_agent_job`` → ``TurnContext``),
+and the sub-agent turn never re-extracts roots from its own task text —
+that text is model-authored, so extraction there would re-open the
+injection channel issue #821 closed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.providers.base import LLMResponse
+from miqi.runtime.agent_jobs import AgentJob, AgentJobRuntime
+from miqi.runtime.turn_context import TurnContext
+from miqi.runtime.turn_runner import TurnRunner
+
+# ── fakes ────────────────────────────────────────────────────────────────
+
+
+class _StopProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_default_model(self) -> str:
+        return "fake-model"
+
+    async def stream_chat(self, **kwargs):
+        self.calls += 1
+        yield SimpleNamespace(
+            kind="completed",
+            response=LLMResponse(
+                content="done", finish_reason="stop", tool_calls=[],
+            ),
+        )
+
+
+class _FakeContext:
+    def build_initial_messages(self, **kwargs):
+        return [{"role": "user", "content": kwargs.get("user_content", "")}]
+
+    def trim_for_model(self, messages, model):
+        return messages
+
+    def add_assistant_message(self, *, messages, content, tool_calls=None,
+                              reasoning_content=None):
+        return messages + [{"role": "assistant", "content": content}]
+
+    def add_tool_result(self, *, messages, tool_call_id, name, content,
+                        arguments=None):
+        return messages + [{"role": "tool", "content": content}]
+
+
+class _FakeTools:
+    async def execute_many(self, turn, tool_calls):
+        return []
+
+
+class _FakeEmitter:
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def emit(self, event) -> None:
+        self.events.append(event)
+
+
+def _mk_runner() -> TurnRunner:
+    return TurnRunner(
+        provider=_StopProvider(),
+        tool_runtime=_FakeTools(),
+        context_runtime=_FakeContext(),
+        event_emitter=_FakeEmitter(),
+        max_iterations=2,
+    )
+
+
+def _mk_turn(**overrides) -> TurnContext:
+    base = dict(
+        turn_id="t1",
+        agent_metadata=SimpleNamespace(system_prompt="", name="code-agent"),
+        thread_id="th1",
+        workspace=Path.cwd(),
+        model="fake",
+        provider=SimpleNamespace(),
+    )
+    base.update(overrides)
+    return TurnContext(**base)
+
+
+# ── AgentJob / AgentJobRuntime ───────────────────────────────────────────
+
+
+class TestAgentJobRoots:
+    def test_default_is_empty(self) -> None:
+        job = AgentJob(
+            job_id="j", agent_type="code-agent", task="t",
+            thread_id="th", parent_thread_id="p",
+        )
+        assert job.user_roots == []
+
+    @pytest.mark.asyncio
+    async def test_start_stores_roots(self) -> None:
+        services = MagicMock()
+        services.session_id = "s"
+        services.turn_runner.run_agent_job = AsyncMock(
+            return_value=SimpleNamespace(final_content="ok")
+        )
+        services.agent_control = None
+        runtime = AgentJobRuntime(services=services)
+        job = await runtime.start(
+            agent_type="code-agent", task="t", parent_thread_id="p",
+            user_roots=["C:/out"],
+        )
+        assert job.user_roots == ["C:/out"]
+
+    @pytest.mark.asyncio
+    async def test_start_defaults_to_empty(self) -> None:
+        services = MagicMock()
+        services.session_id = "s"
+        services.turn_runner.run_agent_job = AsyncMock(
+            return_value=SimpleNamespace(final_content="ok")
+        )
+        services.agent_control = None
+        runtime = AgentJobRuntime(services=services)
+        job = await runtime.start(
+            agent_type="code-agent", task="t", parent_thread_id="p",
+        )
+        assert job.user_roots == []
+
+
+# ── TurnRunner.run_agent_job ─────────────────────────────────────────────
+
+
+class TestRunAgentJobTurn:
+    @pytest.mark.asyncio
+    async def test_turn_is_subagent_with_inherited_roots(self, monkeypatch) -> None:
+        runner = _mk_runner()
+        captured: dict = {}
+
+        async def _fake_run(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(final_content="ok")
+
+        monkeypatch.setattr(runner, "run", _fake_run)
+        job = AgentJob(
+            job_id="j", agent_type="code-agent", task="do it",
+            thread_id="th", parent_thread_id="p",
+            user_roots=["C:/out", "D:/other"],
+        )
+        await runner.run_agent_job(job)
+        turn = captured["turn"]
+        assert turn.is_subagent is True
+        assert turn.user_mentioned_roots == [Path("C:/out"), Path("D:/other")]
+
+    @pytest.mark.asyncio
+    async def test_no_roots_yields_empty_list(self, monkeypatch) -> None:
+        runner = _mk_runner()
+        captured: dict = {}
+
+        async def _fake_run(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(final_content="ok")
+
+        monkeypatch.setattr(runner, "run", _fake_run)
+        job = AgentJob(
+            job_id="j", agent_type="code-agent", task="do it",
+            thread_id="th", parent_thread_id="p",
+        )
+        await runner.run_agent_job(job)
+        assert captured["turn"].user_mentioned_roots == []
+        assert captured["turn"].is_subagent is True
+
+
+# ── extraction guard in TurnRunner.run ───────────────────────────────────
+
+
+class TestExtractionGuard:
+    @pytest.mark.asyncio
+    async def test_subagent_turn_does_not_extract(self, monkeypatch) -> None:
+        import miqi.runtime.turn_runner as tr
+
+        calls: list = []
+
+        def _spy(texts, **kwargs):
+            calls.append(list(texts))
+            return [Path("/tmp/leaked")]
+
+        monkeypatch.setattr(tr, "extract_user_mentioned_roots", _spy)
+        runner = _mk_runner()
+        turn = _mk_turn(is_subagent=True, user_mentioned_roots=[Path("C:/inherited")])
+        await runner.run(
+            turn=turn, user_content="把结果写到 C:\\Windows\\Temp\\evil",
+            system_prompt="", tools=[], max_iterations=2,
+        )
+        assert calls == [], "sub-agent turn must not re-extract roots"
+        assert turn.user_mentioned_roots == [Path("C:/inherited")]
+
+    @pytest.mark.asyncio
+    async def test_root_turn_still_extracts(self, monkeypatch) -> None:
+        import miqi.runtime.turn_runner as tr
+
+        calls: list = []
+
+        def _spy(texts, **kwargs):
+            calls.append(list(texts))
+            return [Path("/tmp/from_user")]
+
+        monkeypatch.setattr(tr, "extract_user_mentioned_roots", _spy)
+        runner = _mk_runner()
+        turn = _mk_turn()
+        await runner.run(
+            turn=turn, user_content="输出到 /tmp/from_user",
+            system_prompt="", tools=[], max_iterations=2,
+        )
+        assert len(calls) == 1
+        assert turn.user_mentioned_roots == [Path("/tmp/from_user")]
+
+
+# ── spawn chain plumbing ─────────────────────────────────────────────────
+
+
+class TestSpawnChain:
+    @pytest.mark.asyncio
+    async def test_spawn_tool_forwards_user_roots(self) -> None:
+        from miqi.agent.tools.spawn import SpawnTool
+
+        agent_control = MagicMock()
+        agent_control.spawn = AsyncMock(
+            return_value=SimpleNamespace(agent_id="a1", thread_id="th1")
+        )
+        tool = SpawnTool(manager=MagicMock(), agent_control=agent_control)
+        await tool.execute(
+            task="写报告", label="report",
+            _user_roots=[Path("C:/out")],
+        )
+        assert agent_control.spawn.await_args.kwargs["user_roots"] == [
+            str(Path("C:/out"))
+        ]
+
+    @pytest.mark.asyncio
+    async def test_spawn_tool_without_roots(self) -> None:
+        from miqi.agent.tools.spawn import SpawnTool
+
+        agent_control = MagicMock()
+        agent_control.spawn = AsyncMock(
+            return_value=SimpleNamespace(agent_id="a1", thread_id="th1")
+        )
+        tool = SpawnTool(manager=MagicMock(), agent_control=agent_control)
+        await tool.execute(task="写报告")
+        assert agent_control.spawn.await_args.kwargs["user_roots"] == []
+
+    @pytest.mark.asyncio
+    async def test_agent_control_passes_roots_to_job_runtime(self) -> None:
+        from miqi.runtime.agent_control import AgentControl
+
+        ac = AgentControl.__new__(AgentControl)
+        ac.registry = MagicMock()
+        ac.registry.resolve = MagicMock(
+            return_value=SimpleNamespace(name="code-agent")
+        )
+        ac._lock = __import__("asyncio").Lock()
+        ac._agents = {}
+        ac._thread_agents = {}
+        ac.max_concurrent = 4
+        ac.session_id = "s"
+        ac._store = None
+        ac._events = MagicMock()
+        ac._events.emit = AsyncMock()
+        ac._hooks = None
+        ac._agent_jobs = MagicMock()
+        ac._agent_jobs.start = AsyncMock(
+            return_value=SimpleNamespace(job_id="j1", thread_id="th1")
+        )
+        ac._provider = None
+        ac._running_tasks = {}
+
+        await ac.spawn(
+            agent_type="code-agent", task="t", user_roots=["C:/out"],
+        )
+        assert ac._agent_jobs.start.await_args.kwargs["user_roots"] == ["C:/out"]
+
+    def test_spawn_registered_as_root_carrier(self) -> None:
+        """Both tool hosts must inject _user_roots into spawn."""
+        from miqi.execution.orchestrator import _FILE_MUTATION_TOOLS
+        from miqi.kun_runtime.tool_host import _USER_ROOTS_TOOLS
+
+        assert "spawn" in _FILE_MUTATION_TOOLS
+        assert "spawn" in _USER_ROOTS_TOOLS

--- a/tests/runtime/test_tool_registry_factory.py
+++ b/tests/runtime/test_tool_registry_factory.py
@@ -321,6 +321,47 @@ def test_file_tools_receive_dot_skills_and_configured_extra_roots(fake_config, t
         assert expected.issubset(roots), f"{tool_name} missing shared roots: {expected - roots}"
 
 
+def test_exec_tool_receives_cross_session_guard_paths(fake_config, tmp_path, monkeypatch):
+    """#1007 review: exec is handed the workspace root + its own files dir.
+
+    The workspace root is in the rw bind set, which re-opens
+    ``<ws>/sessions/**`` (every other session) writable inside the sandbox.
+    ``bwrap._cross_session_guard_args`` can only close that again if it is
+    told which path is the workspace root and which is THIS session's files
+    dir — both default to ``None`` in bwrap, so a factory that stops passing
+    them turns the guard into dead code with no test failing elsewhere.
+    """
+    from miqi.agent.tools import filesystem as fs
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    # The per-session files layout exists for the DEFAULT workspace only
+    # (``_session_files_dir_for_key``); this tmp dir stands in for it.
+    monkeypatch.setattr(fs, "_is_default_workspace", lambda path: True)
+
+    registry = create_runtime_tool_registry(
+        config=fake_config, workspace=tmp_path, session_id="desktop:1",
+    )
+    exec_tool = registry.get("exec")
+    assert exec_tool is not None
+    assert exec_tool._workspace_root == str(tmp_path.resolve())
+    own = tmp_path / "sessions" / fs._session_files_dir_key("desktop:1") / "files"
+    assert exec_tool._session_files_dir == str(own)
+    # The guard re-opens this very dir after the read-only re-mount; it must
+    # be the dir the factory actually created (not a re-derived spelling).
+    assert own.is_dir()
+
+
+def test_exec_tool_guard_paths_absent_without_session(fake_config, tmp_path):
+    """No session key → no per-session dir → no guard (old args, exactly)."""
+    from miqi.runtime.tool_registry_factory import create_runtime_tool_registry
+
+    registry = create_runtime_tool_registry(config=fake_config, workspace=tmp_path)
+    exec_tool = registry.get("exec")
+    assert exec_tool is not None
+    assert exec_tool._workspace_root == str(tmp_path.resolve())
+    assert exec_tool._session_files_dir is None
+
+
 @pytest.mark.asyncio
 async def test_factory_native_file_tools_respect_extra_roots_when_restricted(fake_config, tmp_path):
     """tools.extra_roots must also work for native paths under workspace restriction."""

--- a/tests/runtime/test_turn_runner_user_roots.py
+++ b/tests/runtime/test_turn_runner_user_roots.py
@@ -276,8 +276,14 @@ async def test_orchestrator_injects_user_roots_kwargs(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_skips_user_roots_when_empty(tmp_path: Path) -> None:
-    """No user roots on ctx → no `_user_roots` kwarg injected."""
+async def test_orchestrator_injects_empty_user_roots_when_none(tmp_path: Path) -> None:
+    """No user roots on ctx → an explicit empty list (#984 R2).
+
+    The kwarg is injected unconditionally so a model-authored ``_user_roots``
+    riding in ``ctx.arguments`` can never be the value the tool ends up with;
+    ``[]`` and "absent" are equivalent downstream (``_effective_shared_roots``
+    early-returns on falsy ``user_roots``).
+    """
     components: dict[str, Any] = {
         "permission_engine": MagicMock(),
         "sandbox_engine": MagicMock(),
@@ -330,4 +336,4 @@ async def test_orchestrator_skips_user_roots_when_empty(tmp_path: Path) -> None:
     await orch.execute(ctx)
 
     kwargs = tool_mock.execute.call_args.kwargs
-    assert "_user_roots" not in kwargs
+    assert kwargs["_user_roots"] == []

--- a/tests/sandbox/test_sandbox_write_boundary_984.py
+++ b/tests/sandbox/test_sandbox_write_boundary_984.py
@@ -79,6 +79,29 @@ class TestHostPathToSandbox:
         with pytest.raises(BwrapSandboxError):
             _host_path_to_sandbox("relative/dir")
 
+    # #1007 review: the drive test used to be ``p[1] == ":"`` alone, so a
+    # drive-RELATIVE spelling was silently mapped to a path nobody named
+    # (``C:relative`` → ``/mnt/crelative``, ``C:`` → ``/mnt/c``) instead of
+    # failing loudly as the docstring promises.  Only ``C:/…`` maps.
+
+    def test_drive_relative_raises(self) -> None:
+        with pytest.raises(BwrapSandboxError):
+            _host_path_to_sandbox("C:relative")
+
+    def test_bare_drive_letter_raises(self) -> None:
+        with pytest.raises(BwrapSandboxError):
+            _host_path_to_sandbox("C:")
+
+    def test_drive_relative_with_separator_raises(self) -> None:
+        with pytest.raises(BwrapSandboxError):
+            _host_path_to_sandbox(r"C:foo\bar")
+
+    def test_drive_absolute_forms_unchanged(self) -> None:
+        """The tightened condition must not change any absolute spelling."""
+        assert _host_path_to_sandbox("C:/") == "/mnt/c/"
+        assert _host_path_to_sandbox(r"C:\x") == "/mnt/c/x"
+        assert _host_path_to_sandbox("d:/data/mof") == "/mnt/d/data/mof"
+
 
 # ── layer 2: /mnt is read-only ───────────────────────────────────────────
 

--- a/tests/sandbox/test_sandbox_write_boundary_984.py
+++ b/tests/sandbox/test_sandbox_write_boundary_984.py
@@ -55,6 +55,14 @@ def _index_of_triplet(args: list[str], flag: str, src: str) -> int:
     raise AssertionError(f"{flag} {src} not in args")
 
 
+def _indexes_of_triplet(args: list[str], flag: str, src: str) -> list[int]:
+    """Every position of ``flag src src`` — a path bound twice needs both."""
+    return [
+        i for i, a in enumerate(args[:-1])
+        if a == flag and args[i + 1] == src
+    ]
+
+
 # ── _host_path_to_sandbox ────────────────────────────────────────────────
 
 
@@ -186,6 +194,121 @@ class TestPerCallRwBinds:
         assert ("/srv/data", "/srv/data") in _bind_pairs(args)
 
 
+# ── #1007 review: <ws>/sessions stays read-only ──────────────────────────
+
+
+class TestCrossSessionGuard:
+    """Re-opening the workspace root must not re-open other sessions.
+
+    ``_exec_rw_binds`` always includes the workspace root, and
+    ``<workspace>/sessions/**`` — every other session's files dir — lives
+    under it, so layer 1 quietly undid layer 2's read-only ``/mnt`` for the
+    cross-session subtree.  bwrap mounts in order, so the fix appends a
+    read-only ``<ws>/sessions`` AFTER the rw workspace bind and then re-opens
+    THIS session's own files dir after that.
+
+    Pure argument-construction assertions: the mount ORDER is the whole
+    mechanism, and it is observable without running bwrap (which needs
+    WSL + bubblewrap and cannot run on the Windows dev host).
+    """
+
+    _WS = r"C:\Users\x\.miqi\workspace"
+    _FILES = r"C:\Users\x\.miqi\workspace\sessions\desktop_1\files"
+    _OUT = r"C:\Users\x\Desktop\out"
+    _WS_SB = "/mnt/c/Users/x/.miqi/workspace"
+    _SESSIONS_SB = "/mnt/c/Users/x/.miqi/workspace/sessions"
+    _FILES_SB = "/mnt/c/Users/x/.miqi/workspace/sessions/desktop_1/files"
+
+    def _args(self, extra_rw_binds: list[str], **kwargs) -> list[str]:
+        sb = _make_sandbox(workspace=self._WS)
+        return sb._build_bwrap_args(
+            "echo hi",
+            extra_rw_binds=extra_rw_binds,
+            workspace_root=self._WS,
+            session_files_dir=self._FILES,
+            **kwargs,
+        )
+
+    def test_sessions_rebound_read_only_after_workspace(self) -> None:
+        """(a) + (b): the ro sessions bind exists and follows the rw ws bind."""
+        args = self._args([self._FILES, self._WS, self._OUT])
+        ws_idx = _index_of_triplet(args, "--bind", self._WS_SB)
+        ro_idx = _index_of_triplet(args, "--ro-bind-try", self._SESSIONS_SB)
+        assert ws_idx < ro_idx, "a later ro bind must override the rw workspace"
+        # The ro bind must not be a hard --ro-bind: the dir may legitimately
+        # not exist yet, and this mount only ever narrows.
+        assert ("--ro-bind", self._SESSIONS_SB) not in [
+            (args[i], args[i + 1]) for i in range(len(args) - 1)
+        ]
+
+    def test_own_session_dir_still_writable_after_the_guard(self) -> None:
+        """(c): this session's files dir is re-bound rw AFTER the ro bind."""
+        args = self._args([self._FILES, self._WS, self._OUT])
+        ro_idx = _index_of_triplet(args, "--ro-bind-try", self._SESSIONS_SB)
+        own_idx = _indexes_of_triplet(args, "--bind", self._FILES_SB)
+        assert len(own_idx) == 2, (
+            "expected the session dir in the rw set AND re-opened after the "
+            f"guard, got {own_idx}"
+        )
+        assert own_idx[-1] > ro_idx, "the session's own files dir must stay rw"
+
+    def test_other_roots_untouched(self) -> None:
+        """(4): memory/skills/extra roots keep their plain rw bind."""
+        args = self._args([self._FILES, self._WS, self._OUT])
+        assert _indexes_of_triplet(args, "--bind", "/mnt/c/Users/x/Desktop/out") == [
+            _index_of_triplet(args, "--bind", "/mnt/c/Users/x/Desktop/out"),
+        ]
+
+    def test_guard_absent_when_workspace_root_not_writable(self) -> None:
+        """(d): no rw bind of the ws root → the old arg list, unchanged."""
+        args = self._args([self._FILES])
+        assert self._SESSIONS_SB not in args
+
+    def test_guard_absent_without_a_workspace_root(self) -> None:
+        sb = _make_sandbox(workspace=self._WS)
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[self._FILES, self._WS],
+        )
+        assert args == sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[self._FILES, self._WS],
+            workspace_root=None, session_files_dir=None,
+        )
+        assert self._SESSIONS_SB not in args
+
+    def test_guard_absent_without_session_files_dir(self) -> None:
+        """Custom workspace: no per-session layout, so none of it is touched.
+
+        ``<project>/sessions`` there is the project's own directory (only
+        snapshots live in miqi's subdirs), and making it read-only inside
+        exec would break legitimate writes.
+        """
+        sb = _make_sandbox(workspace=self._WS)
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[self._WS],
+            workspace_root=self._WS, session_files_dir=None,
+        )
+        assert self._SESSIONS_SB not in args
+
+    def test_ancestor_bind_also_triggers_the_guard(self) -> None:
+        """A PARENT of the workspace re-opens sessions just as well."""
+        sb = _make_sandbox(workspace=self._WS)
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[r"C:\Users\x\.miqi"],
+            workspace_root=self._WS, session_files_dir=self._FILES,
+        )
+        assert _index_of_triplet(args, "--ro-bind-try", self._SESSIONS_SB) >= 0
+
+    def test_sibling_dir_is_not_matched_as_workspace(self) -> None:
+        """Path-boundary check: ``…/workspace-other`` is not the workspace."""
+        sb = _make_sandbox(workspace=self._WS)
+        args = sb._build_bwrap_args(
+            "echo hi",
+            extra_rw_binds=[r"C:\Users\x\.miqi\workspace-other"],
+            workspace_root=self._WS, session_files_dir=self._FILES,
+        )
+        assert self._SESSIONS_SB not in args
+
+
 # ── run_command / run_command_streaming passthrough ──────────────────────
 
 
@@ -196,7 +319,10 @@ class TestRunCommandPassthrough:
         sb._running = True
         seen: dict = {}
 
-        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+        def _fake_build(
+            command, env=None, cwd=None, extra_rw_binds=None,
+            workspace_root=None, session_files_dir=None,
+        ):
             seen["binds"] = extra_rw_binds
             return ["/usr/bin/bwrap", "true"]
 
@@ -219,7 +345,10 @@ class TestRunCommandPassthrough:
         sb._running = True
         seen: dict = {}
 
-        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+        def _fake_build(
+            command, env=None, cwd=None, extra_rw_binds=None,
+            workspace_root=None, session_files_dir=None,
+        ):
             seen["binds"] = extra_rw_binds
             return ["/usr/bin/bwrap", "true"]
 
@@ -237,7 +366,10 @@ class TestRunCommandPassthrough:
         sb._running = True
         seen: dict = {}
 
-        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+        def _fake_build(
+            command, env=None, cwd=None, extra_rw_binds=None,
+            workspace_root=None, session_files_dir=None,
+        ):
             seen["binds"] = extra_rw_binds
             return ["/usr/bin/bwrap", "true"]
 
@@ -253,3 +385,39 @@ class TestRunCommandPassthrough:
 
         await sb.run_command("echo hi")
         assert seen["binds"] is None
+
+    @pytest.mark.asyncio
+    async def test_guard_kwargs_reach_build(self, monkeypatch) -> None:
+        """The guard is dead code unless the caller's paths arrive here."""
+        sb = _make_sandbox(use_wsl=False)
+        sb._running = True
+        seen: dict = {}
+
+        def _fake_build(
+            command, env=None, cwd=None, extra_rw_binds=None,
+            workspace_root=None, session_files_dir=None,
+        ):
+            seen["workspace_root"] = workspace_root
+            seen["session_files_dir"] = session_files_dir
+            return ["/usr/bin/bwrap", "true"]
+
+        monkeypatch.setattr(sb, "_build_bwrap_args", _fake_build)
+        monkeypatch.setattr(sb, "_run_linux_command", AsyncMock(return_value=(0, "", "")))
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        monkeypatch.setattr(
+            "miqi.sandbox.bwrap._create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+
+        await sb.run_command(
+            "echo hi",
+            extra_rw_binds=[r"C:\Users\x\.miqi\workspace"],
+            workspace_root=r"C:\Users\x\.miqi\workspace",
+            session_files_dir=r"C:\Users\x\.miqi\workspace\sessions\k\files",
+        )
+        assert seen["workspace_root"] == r"C:\Users\x\.miqi\workspace"
+        assert seen["session_files_dir"] == (
+            r"C:\Users\x\.miqi\workspace\sessions\k\files"
+        )

--- a/tests/sandbox/test_sandbox_write_boundary_984.py
+++ b/tests/sandbox/test_sandbox_write_boundary_984.py
@@ -1,0 +1,232 @@
+"""Sandbox write boundary (#984 PR1) — layer 1 + layer 2 unit tests.
+
+Layer 1: per-call ``extra_rw_binds`` on ``run_command`` /
+``run_command_streaming`` → ``_build_bwrap_args``, hard ``--bind`` only.
+Layer 2: ``/mnt`` is ``--ro-bind-try`` (read-only) since #984, with the
+per-call rw binds applied AFTER it so authorized subtrees stay writable.
+
+These are pure argument-construction tests — no bwrap/WSL needed.  The
+kernel-level behaviour (drvfs read-only) is verified in CI / on a WSL host;
+see the PR body for what could not be run locally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from miqi.sandbox.bwrap import (
+    BwrapSandbox,
+    BwrapSandboxError,
+    _host_path_to_sandbox,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_sandbox(*, use_wsl: bool = True, workspace: str = "/tmp/ws") -> BwrapSandbox:
+    sb = BwrapSandbox(
+        session_key="desktop:984",
+        workspace=Path(workspace),
+        sandbox_base_dir=Path("/tmp/miqi-sandboxes"),
+        wsl_distro="Ubuntu",
+        wsl_base_dir="/tmp/miqi-sandboxes",
+    )
+    sb._bwrap_path = "/usr/bin/bwrap"
+    sb._use_wsl = use_wsl
+    sb._linux_workspace = None
+    return sb
+
+
+def _bind_pairs(args: list[str]) -> list[tuple[str, str]]:
+    return [
+        (args[i + 1], args[i + 2])
+        for i, a in enumerate(args[:-1])
+        if a == "--bind"
+    ]
+
+
+def _index_of_triplet(args: list[str], flag: str, src: str) -> int:
+    for i, a in enumerate(args[:-1]):
+        if a == flag and args[i + 1] == src:
+            return i
+    raise AssertionError(f"{flag} {src} not in args")
+
+
+# ── _host_path_to_sandbox ────────────────────────────────────────────────
+
+
+class TestHostPathToSandbox:
+    def test_windows_drive_path(self) -> None:
+        assert _host_path_to_sandbox(r"C:\Users\x\Desktop\out") == "/mnt/c/Users/x/Desktop/out"
+
+    def test_drive_letter_lowercased(self) -> None:
+        assert _host_path_to_sandbox("D:/data/mof") == "/mnt/d/data/mof"
+
+    def test_forward_slashes_accepted(self) -> None:
+        assert _host_path_to_sandbox("C:/Users/x/out") == "/mnt/c/Users/x/out"
+
+    def test_posix_path_unchanged(self) -> None:
+        assert _host_path_to_sandbox("/home/miqi/out") == "/home/miqi/out"
+
+    def test_unc_raises(self) -> None:
+        with pytest.raises(BwrapSandboxError):
+            _host_path_to_sandbox(r"\\wsl$\Ubuntu\home\x")
+
+    def test_relative_raises(self) -> None:
+        with pytest.raises(BwrapSandboxError):
+            _host_path_to_sandbox("relative/dir")
+
+
+# ── layer 2: /mnt is read-only ───────────────────────────────────────────
+
+
+class TestMntReadOnly:
+    def test_wsl_mount_is_ro_bind_try(self) -> None:
+        sb = _make_sandbox(use_wsl=True)
+        args = sb._build_bwrap_args("echo hi")
+        assert _index_of_triplet(args, "--ro-bind-try", "/mnt") >= 0
+
+    def test_no_writable_mnt_bind(self) -> None:
+        sb = _make_sandbox(use_wsl=True)
+        args = sb._build_bwrap_args("echo hi")
+        assert ("/mnt", "/mnt") not in _bind_pairs(args)
+
+    def test_no_mnt_mount_outside_wsl(self) -> None:
+        sb = _make_sandbox(use_wsl=False)
+        args = sb._build_bwrap_args("echo hi")
+        assert "/mnt" not in args
+
+
+# ── layer 1: per-call rw binds ───────────────────────────────────────────
+
+
+class TestPerCallRwBinds:
+    def test_per_call_bind_is_hard_bind_not_try(self) -> None:
+        sb = _make_sandbox()
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[r"C:\Users\x\Desktop\out"],
+        )
+        assert ("/mnt/c/Users/x/Desktop/out", "/mnt/c/Users/x/Desktop/out") in _bind_pairs(args)
+        # Hard --bind only: --bind-try would silently drop a missing source.
+        assert "--bind-try" not in args
+
+    def test_rw_bind_comes_after_ro_mnt(self) -> None:
+        sb = _make_sandbox()
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=[r"C:\Users\x\Desktop\out"],
+        )
+        ro_idx = _index_of_triplet(args, "--ro-bind-try", "/mnt")
+        rw_idx = _index_of_triplet(args, "--bind", "/mnt/c/Users/x/Desktop/out")
+        assert ro_idx < rw_idx, "rw bind must override the read-only /mnt mount"
+
+    def test_workspace_and_static_roots_bindable_under_layer2(self) -> None:
+        """Workspace on /mnt/c + a configured extra root stay writable."""
+        sb = _make_sandbox(workspace=r"C:\Users\x\.miqi\workspace")
+        args = sb._build_bwrap_args(
+            "echo hi",
+            extra_rw_binds=[
+                r"C:\Users\x\.miqi\workspace",
+                r"C:\Users\x\Desktop\shared_out",
+            ],
+        )
+        pairs = _bind_pairs(args)
+        assert ("/mnt/c/Users/x/.miqi/workspace",) * 2 in pairs
+        assert ("/mnt/c/Users/x/Desktop/shared_out",) * 2 in pairs
+
+    def test_multiple_binds_keep_order(self) -> None:
+        sb = _make_sandbox()
+        args = sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=["/a/one", "/b/two"],
+        )
+        pairs = _bind_pairs(args)
+        assert pairs.index(("/a/one", "/a/one")) < pairs.index(("/b/two", "/b/two"))
+
+    def test_no_per_call_binds_keeps_old_args(self) -> None:
+        sb = _make_sandbox()
+        assert sb._build_bwrap_args("echo hi") == sb._build_bwrap_args(
+            "echo hi", extra_rw_binds=None,
+        )
+
+    def test_unmappable_bind_raises_not_silently_dropped(self) -> None:
+        sb = _make_sandbox()
+        with pytest.raises(BwrapSandboxError):
+            sb._build_bwrap_args("echo hi", extra_rw_binds=["relative/path"])
+
+    def test_static_extra_rw_binds_still_applied(self) -> None:
+        """Constructor-level binds (sandbox creation) keep working."""
+        sb = _make_sandbox()
+        sb.extra_rw_binds = ["/srv/data"]
+        args = sb._build_bwrap_args("echo hi")
+        assert ("/srv/data", "/srv/data") in _bind_pairs(args)
+
+
+# ── run_command / run_command_streaming passthrough ──────────────────────
+
+
+class TestRunCommandPassthrough:
+    @pytest.mark.asyncio
+    async def test_run_command_forwards_extra_rw_binds(self, monkeypatch) -> None:
+        sb = _make_sandbox(use_wsl=False)
+        sb._running = True
+        seen: dict = {}
+
+        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+            seen["binds"] = extra_rw_binds
+            return ["/usr/bin/bwrap", "true"]
+
+        monkeypatch.setattr(sb, "_build_bwrap_args", _fake_build)
+        monkeypatch.setattr(sb, "_run_linux_command", AsyncMock(return_value=(0, "", "")))
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        monkeypatch.setattr(
+            "miqi.sandbox.bwrap._create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+
+        await sb.run_command("echo hi", extra_rw_binds=[r"C:\Users\x\out"])
+        assert seen["binds"] == [r"C:\Users\x\out"]
+
+    @pytest.mark.asyncio
+    async def test_run_command_streaming_forwards_extra_rw_binds(self, monkeypatch) -> None:
+        sb = _make_sandbox(use_wsl=False)
+        sb._running = True
+        seen: dict = {}
+
+        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+            seen["binds"] = extra_rw_binds
+            return ["/usr/bin/bwrap", "true"]
+
+        monkeypatch.setattr(sb, "_build_bwrap_args", _fake_build)
+        monkeypatch.setattr(
+            sb, "_run_bwrap_streaming_native", AsyncMock(return_value=MagicMock()),
+        )
+
+        await sb.run_command_streaming("echo hi", extra_rw_binds=["/srv/out"])
+        assert seen["binds"] == ["/srv/out"]
+
+    @pytest.mark.asyncio
+    async def test_run_command_default_is_none(self, monkeypatch) -> None:
+        sb = _make_sandbox(use_wsl=False)
+        sb._running = True
+        seen: dict = {}
+
+        def _fake_build(command, env=None, cwd=None, extra_rw_binds=None):
+            seen["binds"] = extra_rw_binds
+            return ["/usr/bin/bwrap", "true"]
+
+        monkeypatch.setattr(sb, "_build_bwrap_args", _fake_build)
+        monkeypatch.setattr(sb, "_run_linux_command", AsyncMock(return_value=(0, "", "")))
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        monkeypatch.setattr(
+            "miqi.sandbox.bwrap._create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        )
+
+        await sb.run_command("echo hi")
+        assert seen["binds"] is None

--- a/tests/sandbox/test_write_sites_rw_binds_984.py
+++ b/tests/sandbox/test_write_sites_rw_binds_984.py
@@ -1,0 +1,161 @@
+"""All four sandbox write sites pass their authorized roots as rw binds (#984).
+
+With ``/mnt`` read-only (layer 2), a file-tool write that lands on
+``/mnt/c/...`` needs the root re-opened with a per-call ``--bind``.  The
+plan pins exactly four writers — ``write_file``, ``edit_file``,
+``apply_patch`` and ``graph_render`` — and each must pass its OWN ``shared``
+set (workspace ∪ static roots ∪ gated user roots ∪ #864 grants).
+
+The sandbox is mocked and ``_sandbox_write_file`` is replaced with a
+recorder, so these tests assert the plumbing, not bwrap itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _mock_wsl_sandbox(workspace: Path) -> MagicMock:
+    sb = MagicMock()
+    sb._use_wsl = True
+    sb.is_running = True
+    sb.workspace = workspace
+    sb.run_command = AsyncMock(return_value=(0, "", ""))
+    return sb
+
+
+def _mock_manager(sandbox: MagicMock) -> MagicMock:
+    mgr = MagicMock()
+    mgr.active_sandbox = sandbox
+    mgr.get_or_create = AsyncMock(return_value=sandbox)
+    return mgr
+
+
+def _recorder(captured: dict):
+    async def _fake(sandbox, sandbox_path, content, **kwargs):
+        captured["sandbox_path"] = sandbox_path
+        captured["extra_rw_binds"] = [
+            str(r) for r in (kwargs.get("extra_rw_binds") or [])
+        ]
+    return _fake
+
+
+def _assert_binds(captured: dict, *roots: Path) -> None:
+    for root in roots:
+        assert str(root) in captured["extra_rw_binds"], (
+            f"{root} missing from {captured['extra_rw_binds']}"
+        )
+
+
+# ── write_file ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_file_passes_binds(monkeypatch, tmp_path: Path) -> None:
+    import miqi.agent.tools.filesystem as fs
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    captured: dict = {}
+    monkeypatch.setattr(fs, "_sandbox_write_file", _recorder(captured))
+
+    tool = fs.WriteFileTool(
+        workspace=ws, sandbox_manager=_mock_manager(_mock_wsl_sandbox(ws)),
+        shared_roots=[ws],
+    )
+    result = await tool.execute(
+        str(out / "report.md"), "hello", _session_key="s1",
+        _user_roots=[str(out)],
+    )
+    assert result.startswith("Successfully wrote")
+    _assert_binds(captured, ws, out)
+
+
+# ── edit_file ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_edit_file_passes_binds(monkeypatch, tmp_path: Path) -> None:
+    import miqi.agent.tools.filesystem as fs
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    captured: dict = {}
+    monkeypatch.setattr(fs, "_sandbox_write_file", _recorder(captured))
+    monkeypatch.setattr(fs, "_sandbox_file_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(fs, "_sandbox_read_file", AsyncMock(return_value="old text"))
+
+    tool = fs.EditFileTool(
+        workspace=ws, sandbox_manager=_mock_manager(_mock_wsl_sandbox(ws)),
+        shared_roots=[ws],
+    )
+    result = await tool.execute(
+        str(out / "report.md"), "old text", "new text",
+        _session_key="s1", _user_roots=[str(out)],
+    )
+    assert result.startswith("Successfully edited")
+    _assert_binds(captured, ws, out)
+
+
+# ── apply_patch ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_patch_passes_binds(monkeypatch, tmp_path: Path) -> None:
+    import miqi.agent.tools.apply_patch as ap
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    captured: dict = {}
+    monkeypatch.setattr(ap, "_sandbox_write_file", _recorder(captured))
+    monkeypatch.setattr(ap, "_sandbox_file_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(ap, "_sandbox_read_file", AsyncMock(return_value="old\n"))
+
+    tool = ap.ApplyPatchTool(
+        workspace=ws, sandbox_manager=_mock_manager(_mock_wsl_sandbox(ws)),
+        shared_roots=[ws, out], base_workspace=ws,
+    )
+    target = ws / "report.md"
+    result = await tool.execute(
+        patch=(
+            f"--- a/{target}\n+++ b/{target}\n"
+            "@@ -1 +1 @@\n-old\n+new\n"
+        ),
+        _session_key="s1",
+    )
+    assert "Applied patch" in result, result
+    _assert_binds(captured, ws, out)
+
+
+# ── graph_render ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_graph_render_passes_binds(monkeypatch, tmp_path: Path) -> None:
+    import miqi.agent.tools.graph_render as gr
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    captured: dict = {}
+    monkeypatch.setattr(gr, "_sandbox_write_file", _recorder(captured))
+
+    tool = gr.GraphRenderTool(
+        workspace=ws, sandbox_manager=_mock_manager(_mock_wsl_sandbox(ws)),
+        shared_roots=[ws],
+    )
+    await tool._write_text(
+        out / "graph.svg", "<svg/>", _mock_wsl_sandbox(ws),
+        session_key="s1", shared=[ws, out],
+    )
+    _assert_binds(captured, ws, out)

--- a/tests/sandbox/test_write_sites_rw_binds_984.py
+++ b/tests/sandbox/test_write_sites_rw_binds_984.py
@@ -12,6 +12,7 @@ recorder, so these tests assert the plumbing, not bwrap itself.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -23,7 +24,26 @@ def _mock_wsl_sandbox(workspace: Path) -> MagicMock:
     sb._use_wsl = True
     sb.is_running = True
     sb.workspace = workspace
+    sb.workspace_path = str(workspace)
     sb.run_command = AsyncMock(return_value=(0, "", ""))
+    return sb
+
+
+def _render_sandbox(workspace: Path) -> MagicMock:
+    """WSL-shaped double whose ``test -d`` fails and ``test -f`` succeeds.
+
+    ``GraphRenderTool._collect_targets`` probes the source with both, so the
+    double must answer them differently or the JSON file is mistaken for a
+    directory and no write happens at all.
+    """
+    sb = _mock_wsl_sandbox(workspace)
+
+    async def _run(cmd: str, *args, **kwargs):
+        if cmd.startswith("test -d "):
+            return (1, "", "")
+        return (0, "", "")
+
+    sb.run_command = AsyncMock(side_effect=_run)
     return sb
 
 
@@ -138,24 +158,80 @@ async def test_apply_patch_passes_binds(monkeypatch, tmp_path: Path) -> None:
 
 # ── graph_render ─────────────────────────────────────────────────────────
 
+_GRAPH_JSON = {
+    "schema_version": "1.0",
+    "graph_type": "step-nodes",
+    "skill": "test",
+    "nodes": [{"id": "S1", "title": "步骤一", "category": "compute"}],
+    "edges": [],
+}
+
+
+def _write_recorder(captured: list):
+    async def _fake(sandbox, sandbox_path, content, **kwargs):
+        captured.append({
+            "sandbox_path": sandbox_path,
+            "extra_rw_binds": [
+                str(r) for r in (kwargs.get("extra_rw_binds") or [])
+            ],
+        })
+    return _fake
+
 
 @pytest.mark.asyncio
-async def test_graph_render_passes_binds(monkeypatch, tmp_path: Path) -> None:
+async def test_graph_render_execute_forwards_its_own_shared(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Drives ``GraphRenderTool.execute`` — the real write site.
+
+    ``_write_text`` falls back to ``self._shared_roots`` when ``shared`` is
+    omitted, so calling it directly (as this test used to) stays green even if
+    ``execute`` stops forwarding ``shared=shared`` (graph_render.py:836/841/852).
+    Going through ``execute`` and asserting the forwarded set exactly is what
+    makes the 4th writer provable.
+    """
     import miqi.agent.tools.graph_render as gr
 
     ws = tmp_path / "ws"
     ws.mkdir()
     out = tmp_path / "out"
     out.mkdir()
-    captured: dict = {}
-    monkeypatch.setattr(gr, "_sandbox_write_file", _recorder(captured))
+    src = ws / "step-graph.json"
+    src.write_text(json.dumps(_GRAPH_JSON), encoding="utf-8")
+
+    seen_shared: list = []
+    writes: list = []
+    real_write_text = gr.GraphRenderTool._write_text
+
+    async def _spy(self, resolved, content, sandbox, **kwargs):
+        seen_shared.append(kwargs.get("shared"))
+        await real_write_text(self, resolved, content, sandbox, **kwargs)
+
+    monkeypatch.setattr(gr.GraphRenderTool, "_write_text", _spy)
+    monkeypatch.setattr(gr, "_sandbox_write_file", _write_recorder(writes))
+    monkeypatch.setattr(gr, "_sandbox_read_file", AsyncMock(
+        return_value=json.dumps(_GRAPH_JSON),
+    ))
 
     tool = gr.GraphRenderTool(
-        workspace=ws, sandbox_manager=_mock_manager(_mock_wsl_sandbox(ws)),
+        workspace=ws, sandbox_manager=_mock_manager(_render_sandbox(ws)),
         shared_roots=[ws],
     )
-    await tool._write_text(
-        out / "graph.svg", "<svg/>", _mock_wsl_sandbox(ws),
-        session_key="s1", shared=[ws, out],
-    )
-    _assert_binds(captured, ws, out)
+
+    # svg → 1 write (graph_render.py:852); html → 2 writes (:836, :841).
+    for fmt, expected_writes in (("svg", 1), ("html", 2)):
+        seen_shared.clear()
+        writes.clear()
+        result = await tool.execute(
+            str(src), format=fmt, out_dir=str(out),
+            _session_key="s1", _user_roots=[str(out)],
+        )
+        payload = json.loads(result)
+        assert payload["ok"] is True, result
+        assert len(seen_shared) == expected_writes, seen_shared
+        # EXACTLY workspace ∪ static roots ∪ gated user roots — the fallback
+        # (`self._shared_roots` = [ws]) would drop `out` and fail here.
+        assert all(shared == [ws, out] for shared in seen_shared), seen_shared
+        assert len(writes) == expected_writes, writes
+        for write in writes:
+            _assert_binds(write, ws, out)


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复
- [x] ✨ 新功能

## 变更概述

沙箱写边界层 1+2+3：`/mnt` 改只读（内核强制），授权目录用 per-call 硬 `--bind` 重新打开，python 写系拼写补进静态词表。
R2 按代码评审处置 3 条（正文数字更正、graph_render 写入方用例改为可证伪、`_user_roots` 注入通道代码层根治）；
R3 处置复核留下的非阻塞项 P2-1（per-call `working_dir` 不得成为 bind 源：契约写死 + 回归测试），P2-2 为只读面审计、不改代码；
R4 落地层 3（`command_guard.py` 补 python 写系词表 + 授权根不误拦），#984 期望 1/2/3 在本 PR 收口。

## 背景/问题

#984 期望 1：写保护要按**目录粒度**覆盖全部写入口，shell 与运行时（python 等）**一致生效**。

现状（代码核实）：真正的强制层是 bwrap 挂载，而 `/mnt` 是 **rw**（`bwrap.py` `--bind-try /mnt /mnt`），
所以 `python -c "open('C:\\...','w')"`、`write_text`、`shutil.copy` 等任意拼写都能直接写穿
`command_guard.py` 的静态词表（该词表只认 `tee/mkdir/touch/ln` 等 shell 写法）。层 1 的授权通道
（#821 的 `_user_roots`）此前只给文件工具用，exec 侧拿不到。

本 PR 做 **层 1 + 层 2 + 层 3**（层 3 = `command_guard.py` 补 python 写系词表，R4 已在本 PR 落地，见「层 3」小节）。

## 关联 issue

- Closes #984（层 1+2+3 均在本 PR 落地；**残余缺口如实声明**：宿主回退 / 非 bwrap 路由 / KUN exec /
  沙箱内路径写仍不受层 2/层 3 约束——清单见「行为变更与残余缺口」与 `docs/dev-notes/sandbox-write-boundary-984.md` 的「已知缺口」节）

## 变更内容

| 层 | 改动 | 文件 |
|---|---|---|
| 层 2 | `--bind-try /mnt /mnt` → `--ro-bind-try /mnt /mnt` | `miqi/sandbox/bwrap.py` |
| 层 1 | `run_command` / `run_command_streaming` 新增 per-call `extra_rw_binds`，透传 `_build_bwrap_args`，**硬 `--bind`** 排在 ro `/mnt` 之后覆盖回来（禁 `--bind-try`：源缺失必须大声失败，不得静默丢权限或回退宿主）；`_host_path_to_sandbox` 本地 helper（顶层导入 `manager.windows_path_to_mnt` 会循环导入） | `miqi/sandbox/bwrap.py` |
| 层 1 | ExecTool 加 `shared_roots` + `allow_user_dirs`；`execute` pop `_user_roots` 组 bind 集合；4 个 `_execute_*` 签名 + 8 处 splat 全打通；bind 源缺失时返回引导文案且**不**回退宿主 | `miqi/agent/tools/shell.py`、`miqi/runtime/tool_registry_factory.py` |
| 层 1 | 文件工具 4 个写入方各传自己的 `shared` 给 `_sandbox_write_file` | `filesystem.py`、`apply_patch.py`、`graph_render.py` |
| 修复 | `_sandbox_write_file` 的 `mkdir -p '$(dirname "…")'`（单引号内不做命令替换 → 建出字面目录、写新子目录必 rc=1）改为 **Python 算 dirname**，外层引号保持单引号防注入；写入前宿主侧 mkdir bootstrap（4 条边界） | `miqi/agent/tools/filesystem.py` |
| 修复 | `extract_user_mentioned_roots` 加受保护前缀表（`C:\Windows\Temp\x`、`/etc/…`、`~/.miqi/…` 不再成为可写根；`users`/`home`/`mnt` 留在表外以免打断主场景） | `miqi/agent/tools/user_roots.py` |
| B2 | 子 agent 根继承：`AgentJob.user_roots` + `TurnContext.is_subagent`；spawn 两入口带根；子 agent turn 不再从自身任务文本抽根；删 legacy 自抽取 | `agent_jobs.py`、`turn_context.py`、`turn_runner.py`、`agent_control.py`、`spawn.py`、`orchestrator.py`、`kun_runtime/tool_host.py`、`bridge/loop.py` |
| **R2 ②** | graph_render 写入方用例改经 `GraphRenderTool.execute()` 真实传参点（原用例直接调 `_write_text(..., shared=[ws,out])`，被 `else self._shared_roots` 兜底掩盖，只证到 3/4）；断言转发的 `shared` 精确等于 `[ws, out]` | `tests/sandbox/test_write_sites_rw_binds_984.py` |
| **R2 ③** | `_user_roots` 改为 harness **无条件覆盖**（空列表也覆盖）：先剥掉模型自带副本，再注入 `list(ctx.user_mentioned_roots or [])`；两侧同口径 | `miqi/execution/orchestrator.py`、`miqi/kun_runtime/tool_host.py` |
| **R2 CI** | 前缀表 3 个 Windows 专用用例加 `skipif(not _IS_WINDOWS)`：`_is_protected_prefix` 走 `Path.parts`，盘符路径在 POSIX 上不拆段 → `test (ubuntu-latest)` 必红（57cebace 起已存在） | `tests/agent/tools/test_user_roots.py` |
| **R3 P2-1** | `_exec_rw_binds` docstring 增补 **CONTRACT** 段：除 harness 注入的 `user_roots` 外，bind 源必须在**构造期**确定，**不得**从单次 `execute()` 的模型参数派生 | `miqi/agent/tools/shell.py` |
| **R3 P2-1** | 回归 `TestWorkingDirNotABindSource`（2 例）：经 `execute(working_dir=<工作区外现存目录>, _sandbox=BWRAP, _session_key=k)` 真实传参点，断言交给沙箱的 `extra_rw_binds` 精确等于构造期集合、敏感目录不在其中；另一例保证 `working_dir` 仍决定 cwd | `tests/execution/test_exec_write_boundary_984.py` |
| **层 3** | `_DESTRUCTIVE_CALL_RE` 补 python 写系拼写：`write_text`/`write_bytes`、`mkdir(`/`makedirs(`、`shutil.copy\w*`、`os.rename`/`os.replace`；`open(...)` 的写模式无法用单条正则判（模式在实参里），改 `_open_call_writes` **线性扫描**模式位（`open(f,'w')`、`X.open('w')`、`mode='w'`），**读模式与未识别拼写不触发**（fail-open，强制层仍是 bwrap 挂载） | `miqi/agent/command_guard.py` |
| **层 3** | 授权根不误拦：`RuntimePaths.extra_write_roots` 承接 per-call `_user_roots`（与层 1 同一开关 `tools.auto_user_dirs`），授权**子树内**的写/改名/移动/删放行，授权目录**本身不可删**（`_is_authorized_root_itself`），系统路径/宿主 home 优先于授权根 | `miqi/agent/command_guard.py` |
| **层 3** | heredoc 正文保真：`_raw_heredoc_body` 从**原始文本**取正文——tokenizer 拼接会吃掉引号、路径字面量全丢，授权目录的 `python3 - <<EOF` 交付会被误判 `script_uncertain`；嵌套 `bash -c "python3 -c …"` 的内联 payload 也检查（`_check_script_payload`）；`shutil.copy*` **源侧按读**（与 shell `cp` 对齐） | `miqi/agent/command_guard.py` |
| **层 3** | `ExecTool._guard_command` / `_guard_host_fallback` 把 per-call `_user_roots` 作为授权根传给 guard，与 bind 集合**同口径**（层 1 绑成 rw 的目录，层 3 不得拒） | `miqi/agent/tools/shell.py` |
| **层 3** | `ToolRegistry.execute` 剥掉模型自带的 `_user_roots`：`params` 在这条路径上**是模型写的**，跳 orchestrator 的调用方（如 legacy `SubagentManager`）会让模型自带值同时变成 bind 源与 guard 授权根；只允许 harness 的 `**extra` 携带 | `miqi/agent/tools/registry.py` |

**bind 集合**

```
exec 侧  = 工作区根 ∪ 静态 _shared_roots ∪ (auto_user_dirs ? _user_roots : ∅)
文件工具 = 工作区根 ∪ 静态 _shared_roots ∪ (allow_user_roots ? _user_roots : ∅) ∪ #864 已授权(shared)
```

## 日志/验证证据

```
# 真机 WSL（distro AIShadowSandbox，bwrap 可用）实证 —— 层 1/层 2
[mounts] /dev/sde on /mnt type ext4 (ro,nosuid,nodev,relatime,discard,errors=remount-ro,...)

A no-bind python write  rc=1
  OSError: [Errno 30] Read-only file system: '/mnt/c/Users/.../_984_probe/ws/unauthorized.txt'
B no-bind shell write   rc=1
  /bin/bash: line 1: /mnt/c/Users/.../_984_probe/ws/unauthorized2.txt: Read-only file system
C bind python write     rc=0 (host file=layer1-ok)          # extra_rw_binds=[authorized_out]
D missing bind source   rc=1
  bwrap: Can't find source path /mnt/c/.../does_not_exist: No such file or directory
E file-tool nested write rc=0 host= mkdir fix ok            # 授权根下新建 new_sub/deeper/
F no-bind file-tool write blocked: OSError mkdir: cannot create directory
  '/mnt/c/.../_984_probe/ws/denied': Read-only file system

# 单元/集成测试（本机，Python 3.14 venv）
$ python -m pytest tests/sandbox tests/agent/tools tests/execution tests/runtime tests/kun_runtime -q -m "not wsl"
2696 passed, 7 skipped, 7 deselected, 4 warnings in 261.14s (0:04:21)      # R3 最终 HEAD 68d9c6b5
（R2 最终 HEAD 6d430146 同命令：2694 passed；R3 新增 2 例 = 2696）

$ python -m pytest -q -m "not sandbox and not wsl"
3678 passed, 22 skipped, 9 deselected, 4 warnings in 379.72s (0:06:19)   # R2 最终 HEAD c88ac428
（首轮：1 个真实失败已修 + 1 个既有 flaky —— test_write_file_wsl_sandbox_redirects_absolute_root_path
  是测试替身 FakeSandbox.run_command 未收 **kwargs，已同步更新替身签名；
  test_process_handle_reused_after_exit 单跑 27 passed，属全量负载下的既有 flaky）

# R2 CI：ubuntu-latest 必红（57cebace 起）→ 已修
$ gh api repos/.../actions/jobs/102381028440/logs | grep FAILED     # 上一版 57cebace 的 run 34325287748
FAILED tests/agent/tools/test_user_roots.py::TestProtectedPrefix::test_windows_system_subtree
FAILED tests/agent/tools/test_user_roots.py::TestProtectedPrefix::test_programdata_subtree
FAILED tests/agent/tools/test_user_roots.py::TestProtectedPrefix::test_appdata_anywhere
  3 failed, 3659 passed, 33 skipped, 9 deselected in 271.19s

# 根因：_is_protected_prefix 走 Path.parts，盘符路径只在 Windows 上拆成多段
$ python -c "from pathlib import PurePosixPath, PureWindowsPath; p=r'C:\Windows\Temp\x'; \
             print(PurePosixPath(p).parts); print(PureWindowsPath(p).parts)"
('C:\\Windows\\Temp\\x',)
('C:\\', 'Windows', 'Temp', 'x')

# 修法：3 个用例加 @pytest.mark.skipif(not _IS_WINDOWS, ...)（与本文件既有 drive-letter 用例同款）
$ python -m pytest tests/agent/tools/test_user_roots.py -q -m "not wsl"    # 本机 Windows
41 passed, 1 skipped in 0.29s

$ uvx ruff check .        → All checks passed!

# 本机 3 个 WSL 用例失败（环境，非本改动）：已用 git stash 在纯净代码上复现同样失败
tests/sandbox/test_bwrap_auto_install.py::test_wsl_sandbox_auto_install
tests/sandbox/test_wsl_detect_readiness.py::test_ensure_wsl_deps_installs_python_toolchain
tests/sandbox/test_wsl_detect_readiness.py::test_detect_falls_back_to_another_distro_when_preferred_missing_pip
  → 根因：测试取首个 distro `Ubuntu-22.04`，该 distro 无免密 sudo，apt-get 装
    bwrap/unzip/venv 失败（E: Could not open lock file /var/lib/dpkg/lock-frontend ... are you root?）

# ── R2 ① 正文数字复现（评审指出「共 90 用例」「前缀表 12 例」不成立）──────
$ git show --name-status --pretty=format: 57cebace -- tests/
A  tests/agent/tools/test_filesystem_write_boundary_984.py
M  tests/agent/tools/test_session_workspace_isolation.py
M  tests/agent/tools/test_user_roots.py
A  tests/execution/test_exec_write_boundary_984.py
A  tests/runtime/test_subagent_roots_984.py
A  tests/sandbox/test_sandbox_write_boundary_984.py
A  tests/sandbox/test_write_sites_rw_binds_984.py

$ git show 57cebace -- tests/ | grep -cE '^\+\s*(async )?def test_'
80

$ python -m pytest --collect-only -q \
    tests/sandbox/test_sandbox_write_boundary_984.py \
    tests/sandbox/test_write_sites_rw_binds_984.py \
    tests/execution/test_exec_write_boundary_984.py \
    tests/agent/tools/test_filesystem_write_boundary_984.py \
    tests/runtime/test_subagent_roots_984.py
73 tests collected

$ python -m pytest --collect-only -q tests/agent/tools/test_user_roots.py -k TestProtectedPrefix
13/42 tests collected (29 deselected)          # 前缀表 = 13 例（原正文写 12）

$ python -m pytest --collect-only -q <上面 5 个新文件> tests/agent/tools/test_user_roots.py
115 tests collected                            # 6 个涉及文件（57cebace 时点）
# 新增用例 = 73 + 13 = 86

# ── R2 ② graph_render 写入方：真实传参点 + 变异验证 ──────────────────────
$ python -m pytest tests/sandbox/test_write_sites_rw_binds_984.py -q -m "not wsl"
4 passed in 0.19s

# 变异：删掉 graph_render.py execute() 里 3 处 shared=shared（:836/:841/:852）
$ python -m pytest tests/sandbox/test_write_sites_rw_binds_984.py -q -m "not wsl"
FAILED tests/sandbox/test_write_sites_rw_binds_984.py::test_graph_render_execute_forwards_its_own_shared
E  AssertionError: {"ok": false, "error": "渲染失败", "errors": [{"source": "step-graph.json",
   "error": "PermissionError: 路径 '.../out/step-graph.svg' ... 不在任何合法根目录
   [.../ws, .../ws] 内。"}]}
E  assert False is True
1 failed, 3 passed in 0.32s

$ git checkout -- miqi/agent/tools/graph_render.py
$ python -m pytest tests/sandbox/test_write_sites_rw_binds_984.py -q -m "not wsl"
4 passed in 0.19s

# ── R2 ③ `_user_roots` 旁路关闭：回归 + 变异 ─────────────────────────────
$ python -m pytest \
    tests/execution/test_exec_write_boundary_984.py::TestUserRootsOwnership \
    tests/kun_runtime/test_tool_host.py::TestUserRootsInjection \
    tests/runtime/test_turn_runner_user_roots.py::test_orchestrator_injects_empty_user_roots_when_none \
    -q -m "not wsl"
9 passed in 1.24s

# 变异：把两处源码回退到 R2 之前
$ git checkout 57cebace -- miqi/execution/orchestrator.py miqi/kun_runtime/tool_host.py
$ python -m pytest 同上
FAILED ...TestUserRootsOwnership::test_model_supplied_roots_dropped_when_turn_has_none
FAILED ...TestUserRootsOwnership::test_model_supplied_roots_dropped_for_non_file_tools
FAILED ...TestUserRootsInjection::test_no_user_roots_when_context_empty
FAILED ...TestUserRootsInjection::test_model_supplied_user_roots_not_adopted
FAILED ...TestUserRootsInjection::test_harness_roots_win_over_model_supplied
FAILED tests/runtime/test_turn_runner_user_roots.py::test_orchestrator_injects_empty_user_roots_when_none
  KeyError: '_user_roots'
  ERROR miqi.agent.tools.registry:execute:189 - Tool 'write_file' raised TypeError:
    _RecordingWriteTool.execute() got multiple values for keyword argument '_user_roots'
6 failed, 3 passed in 1.73s

$ git checkout HEAD -- miqi/execution/orchestrator.py miqi/kun_runtime/tool_host.py
$ python -m pytest 同上
9 passed in 1.24s

# ── R3 P2-1 per-call `working_dir` 不是 bind 源：回归 + 变异 ──────────────
$ python -m pytest tests/execution/test_exec_write_boundary_984.py::TestWorkingDirNotABindSource -q -m "not wsl"
2 passed in 0.13s

# 变异（内存 patch，未改源码）：`_exec_rw_binds` 首个 bind 源改成
# `working_dir or self.working_dir`（per-call 值优先）
$ PYTHONPATH=<worktree> python <临时脚本 mutate_984r3.py>
[mutant] _exec_rw_binds first bind source = working_dir or self.working_dir
>       assert binds == before
E       AssertionError: assert ['C:\\code\\m...tatic_shared'] == ['C:\\code\\m...tatic_shared']
E         At index 0 diff: '...\\outside_secret' != '...\\ws'
E         Use -v to get more diff
tests\execution\test_exec_write_boundary_984.py:504: AssertionError
FAILED tests/execution/test_exec_write_boundary_984.py::TestWorkingDirNotABindSource::test_per_call_working_dir_is_not_a_bind_source
1 failed, 1 passed in 0.23s
# → 模型传的 `working_dir`（工作区外现存目录）被当成 bind 源，契约用例变红；
#   `test_per_call_working_dir_still_sets_cwd` 仍绿（变异只被契约断言抓到）

# 变异脚本是内存 patch（只替换类属性），源码未动 —— 复原即等于未变异：
$ git status --porcelain
（空）
$ python -m pytest tests/execution/test_exec_write_boundary_984.py -q -m "not wsl"
27 passed in 0.29s

$ uvx ruff check miqi/agent/tools/shell.py tests/execution/test_exec_write_boundary_984.py
All checks passed!

# ── R4 / 层 3：新增用例 + 变异可证伪（HEAD 3be853d5）──────────────────────
$ python -m pytest tests/agent/test_command_guard_python_writes_984.py -q
55 passed in 0.43s              # 29 个 test def → 55 个参数化用例（513 行新文件）

$ python -m pytest tests/sandbox tests/agent/tools tests/execution tests/runtime tests/kun_runtime -q -m "not wsl"
2696 passed, 7 skipped, 7 deselected, 4 warnings in 284.89s (0:04:44)      # R4 最终 HEAD 3be853d5

$ python -m pytest -q -m "not sandbox and not wsl"
3735 passed, 22 skipped, 9 deselected, 4 warnings in 381.03s (0:06:21)     # R4 最终 HEAD 3be853d5
（R3 时点 c88ac428 同命令：3678 passed；+55 = 层 3 新文件，+2 = R3 的 2 例）

$ uv tool run ruff check miqi/agent/command_guard.py miqi/agent/tools/registry.py \
      miqi/agent/tools/shell.py tests/agent/test_command_guard_python_writes_984.py
All checks passed!

# 变异 ①（内存 patch，源码未动）：从 _DESTRUCTIVE_CALL_RE 去掉 `\bwrite_text\b` 条目
$ python <临时脚本 mutate_984.py> A tests/agent/test_command_guard_python_writes_984.py
[mutant A] dropped `write_text` from _DESTRUCTIVE_CALL_RE
FAILED ...::TestWriteSpellingsDenied::test_spelling_out_of_scope_denied[from pathlib import Path; Path('/srv/data/other/a.txt').write_text('x')]
FAILED ...::TestWriteSpellingsDenied::test_shell_and_python_now_agree
FAILED ...::TestWriteSpellingsDenied::test_heredoc_write_denied
FAILED ...::TestAuthorizedRootsAllowed::test_sibling_still_denied
FAILED ...::TestAuthorizedRootsAllowed::test_system_path_beats_authorized_root
FAILED ...::TestExecToolPlumbing::test_guard_command_honours_user_roots
  E  assert None is not None            # write_text 不再命中词表 → guard 放行
6 failed, 49 passed in 0.87s

# 变异 ②（内存 patch）：_open_call_writes() 恒返回 False（open 写模式不再被识别）
$ python <临时脚本 mutate_984.py> B tests/agent/test_command_guard_python_writes_984.py
[mutant B] _open_call_writes() -> constant False
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','w').write('x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','a').write('x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','x').write('x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','wb').write(b'x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','ab').write(b'x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt','r+').write('x')]
FAILED ...::test_spelling_out_of_scope_denied[open('/srv/data/other/a.txt', mode='w').write('x')]
FAILED ...::test_spelling_out_of_scope_denied[from pathlib import Path; Path('/srv/data/other/a.txt').open('w')]
FAILED ...::TestAuthorizedRootsAllowed::test_host_home_and_config_home_beats_authorized_root
FAILED ...::TestHeredocFidelity::test_heredoc_double_quoted_delimiter
FAILED ...::TestHeredocFidelity::test_nested_shell_python_write_denied
  E  AssertionError: bash -c "python3 -c \"open('/srv/data/other/a.txt','w').write('x')\""
  E  assert not True            # GuardVerdict(allowed=True) —— 写模式漏判
11 failed, 44 passed in 0.70s

# 变异只在内存里，源码从未改动 —— 复原即等于未变异：
$ git status --porcelain
（空）
$ python -m pytest tests/agent/test_command_guard_python_writes_984.py -q
55 passed in 0.51s

# ── #1007 CodeRabbit 5 条：实跑 + 变异验证（HEAD 3cc91d32）──────────────
$ git log --oneline -2
3cc91d32 fix(runtime): agent.spawn 落库前过滤 user_roots + bootstrap 日志占位符（#984 / #1007 review）
34907420 fix(sandbox): UNC 不作 bind 源、BWRAP 回退带上授权根、drive-relative 响亮失败（#984 / #1007 review）

$ uv run --extra dev python -m pytest tests/agent/tools -p no:cacheprovider -q
311 passed, 2 skipped in 4.06s

$ uv run --extra dev python -m pytest tests/execution -p no:cacheprovider -q
502 passed in 160.22s (0:02:40)

$ uv run --extra dev python -m pytest tests/sandbox -p no:cacheprovider -q
FAILED tests/sandbox/test_bwrap_auto_install.py::test_wsl_sandbox_auto_install
FAILED tests/sandbox/test_wsl_detect_readiness.py::test_ensure_wsl_deps_installs_python_toolchain
FAILED tests/sandbox/test_wsl_detect_readiness.py::test_detect_falls_back_to_another_distro_when_preferred_missing_pip
E   AssertionError: distro should be ready after restore
E   assert False
3 failed, 250 passed, 1 skipped in 29.41s
# ↑ 这 3 例是本机 WSL 环境用例（把真实 distro 的 pip 改名后再恢复、恢复失败），单独跑同样红；
#   断言只碰 distro 供给状态，与 _host_path_to_sandbox（纯字符串映射）无关 → 既有基线，非本改动。
#   CI 侧 windows-latest 的 wsl-sandbox / wsl-e2e job 才真跑 WSL，以那边结果为准。

$ uv run --extra dev python -m pytest tests/bridge -p no:cacheprovider -q
249 passed in 24.39s

$ uv run --extra dev python -m pytest tests/runtime -p no:cacheprovider -q
1371 passed, 5 skipped in 82.11s (0:01:22)
# ↑ 额外跑的（不在四组必跑里）：本次把 extract_user_mentioned_roots 的判定抽成
#   _root_for / _accept_root 供 sanitize_user_roots 复用，而 turn_runner.py 是前者的活调用方。

$ uv run --extra dev ruff check .
All checks passed!

# ── 变异 ①  filesystem.py：两处 %s 回退成 {}（改完即复原，下同）──────────
$ uv run --extra dev python -m pytest tests/agent/tools/test_filesystem_write_boundary_984.py -p no:cacheprovider -q
        self = <LogRecord: miqi.agent.tools.filesystem, 20, ...filesystem.py, 1146, "bootstrap_sandbox_roots: created {}">
>           msg = msg % self.args
E           TypeError: not all arguments converted during string formatting
FAILED tests/agent/tools/test_filesystem_write_boundary_984.py::TestBootstrapSandboxRootsLogging::test_create_failure_logs_path_and_reason
FAILED tests/agent/tools/test_filesystem_write_boundary_984.py::TestBootstrapSandboxRootsLogging::test_created_roots_are_logged
2 failed, 16 passed, 1 skipped in 0.71s
#   ↑ 正是「日志在 logging 内部炸掉、整条消息被丢弃」的现场
$ cp <备份> miqi/agent/tools/filesystem.py && sha1sum miqi/agent/tools/filesystem.py
964b41eec38d5696d0d576e51d312f645203286a
$ uv run --extra dev python -m pytest tests/agent/tools/test_filesystem_write_boundary_984.py -p no:cacheprovider -q
18 passed, 1 skipped in 0.35s

# ── 变异 ②  shell.py：删掉 _add 的 UNC 跳过 + _missing_bind_sources 回退 continue→append ──
$ uv run --extra dev python -m pytest tests/execution/test_exec_write_boundary_984.py -p no:cacheprovider -q
>       assert ExecTool._missing_bind_sources([self._UNC]) == []
E       AssertionError: assert ['\\\\wsl$\\U...u\\home\\out'] == []
E         Left contains one more item: '\\\\wsl$\\Ubuntu\\home\\out'
FAILED tests/execution/test_exec_write_boundary_984.py::TestUncStaticRoot::test_unc_static_root_not_bound
FAILED tests/execution/test_exec_write_boundary_984.py::TestUncStaticRoot::test_unc_not_reported_as_missing_source
2 failed, 30 passed in 0.87s
$ cp <备份> miqi/agent/tools/shell.py && sha1sum miqi/agent/tools/shell.py
ce4be57085080b19ca7eeefb43332085d4d591ba
$ uv run --extra dev python -m pytest tests/execution/test_exec_write_boundary_984.py -p no:cacheprovider -q
32 passed in 0.39s

# ── 变异 ③  shell.py：_guard_host_fallback(command, cwd) 去掉 user_roots ──
$ uv run --extra dev python -m pytest "tests/execution/test_exec_write_boundary_984.py::TestHostFallbackRoots" -p no:cacheprovider -q
>       assert ran.get("yes") is True, f"guard refused the granted write: {result}"
E       AssertionError: guard refused the granted write: Error: 命令被沙箱护栏拦截。
E         原因：检测到写入操作（重定向），目标解析后位于当前 session 可操作范围之外。
FAILED tests/execution/test_exec_write_boundary_984.py::TestHostFallbackRoots::test_fallback_guard_receives_user_roots
FAILED tests/execution/test_exec_write_boundary_984.py::TestHostFallbackRoots::test_authorized_write_not_refused_on_fallback
2 failed, 1 passed in 0.32s
#   ↑ 用户刚授权的目录被守卫拒掉，正是该意见描述的现网症状
#   （第 3 例 test_ungranted_write_still_refused_on_fallback 变异前后都绿——它断言的是反方向）
$ cp <备份> miqi/agent/tools/shell.py && sha1sum miqi/agent/tools/shell.py
ce4be57085080b19ca7eeefb43332085d4d591ba
$ uv run --extra dev python -m pytest tests/execution/test_exec_write_boundary_984.py -p no:cacheprovider -q
32 passed in 0.39s

# ── 变异 ④  loop.py：去掉 sanitize_user_roots，直接 params.get(...) 落库 ──
$ uv run --extra dev python -m pytest tests/bridge/test_bridge_loop.py -p no:cacheprovider -q -k spawn
>       assert ac.calls[0]["user_roots"] == [str(out.resolve())]
E       AssertionError: assert ['C:\\code\\m... 'C:relative'] == ['C:\\code\\m...es_use0\\out']
E         Left contains 5 more items, first extra item: 'C:\\code\\miqi-github\\MiQi\\.claude\\worktrees\\fix-984\\.pytest-basetemp-pid19788\\test_agent_spawn_sanitizes_use0\\ws'
FAILED tests/bridge/test_bridge_loop.py::test_agent_spawn_sanitizes_user_roots
1 failed, 1 passed, 17 deselected in 0.26s
#   ↑ 落库的 6 项里 5 项原样放行（pytest 自身把长列表按 '...' 折行了）
$ cp <备份> miqi/bridge/loop.py && sha1sum miqi/bridge/loop.py
494b1b721eccac12488a13fe7d379640454fd75e
$ uv run --extra dev python -m pytest tests/bridge/test_bridge_loop.py -p no:cacheprovider -q -k spawn
2 passed, 17 deselected in 0.10s

# ── 变异 ⑤  bwrap.py：条件回退成 len(p) >= 2 and p[1] == ":" ────────────
$ uv run --extra dev python -m pytest tests/sandbox/test_sandbox_write_boundary_984.py -p no:cacheprovider -q
FAILED tests/sandbox/test_sandbox_write_boundary_984.py::TestHostPathToSandbox::test_drive_relative_raises
FAILED tests/sandbox/test_sandbox_write_boundary_984.py::TestHostPathToSandbox::test_bare_drive_letter_raises
FAILED tests/sandbox/test_sandbox_write_boundary_984.py::TestHostPathToSandbox::test_drive_relative_with_separator_raises
E       Failed: DID NOT RAISE <class 'miqi.sandbox.bwrap.BwrapSandboxError'>
3 failed, 20 passed in 0.37s
#   ↑ 5 个既有映射用例（含 test_drive_absolute_forms_unchanged）变异前后都绿 —— 只抓到 drive-relative
$ cp <备份> miqi/sandbox/bwrap.py && sha1sum miqi/sandbox/bwrap.py
04f90f667ea716c37716b405388ee0c7c3c3f5c6
$ uv run --extra dev python -m pytest tests/sandbox/test_sandbox_write_boundary_984.py -p no:cacheprovider -q
23 passed in 0.26s
# 最后一次改动：条件按评审口径逐字写成 p[2] in "/\\"（与 p[2] == "/" 等价——p 在上面
# 已 .replace("\\", "/")），改后重跑 tests/sandbox/test_sandbox_write_boundary_984.py
# = 23 passed、ruff check . = All checks passed!；该版本即上面四组实跑的 HEAD。
```

## CodeRabbit 意见处置（#1007，5 条逐条）

| # | 意见（`file:line`） | 判定 | 处置 | 证据 |
|---|---|---|---|---|
| 1 | `agent/tools/filesystem.py:1140` — stdlib logger 要用 `%s` 不是 `{}` | 属实（实测 `TypeError`，整条消息被丢） | 两处改 `%s`；回归用 `caplog` 锁死文案 | 变异 ① RED → 复绿 |
| 2 | `agent/tools/shell.py:578` — UNC 静态根变成无条件的命令失败 | 属实（根因在 `_exec_rw_binds`，只修预检文案不够） | `_add` 跳过 UNC；`_missing_bind_sources` 的 `//` 分支改 `continue`；docstring 自相矛盾处修正 | 变异 ② RED → 复绿 |
| 3 | `agent/tools/shell.py:833` — BWRAP 回退丢 `_user_roots` | 属实 | `_execute_with_sandbox_selection` 加 `user_roots` 并透传给 `_guard_host_fallback`（**不**传 `extra_rw_binds`） | 变异 ③ RED → 复绿 |
| 4 | `bridge/loop.py:1532` — spawn 的 `user_roots` 未校验 | 部分成立（latent） | 抽出 `sanitize_user_roots`，落库前过滤；`extract_user_mentioned_roots` 改用同一组判定，两条通道不再漂移 | 变异 ④ RED → 复绿 |
| 5 | `sandbox/bwrap.py:73` — drive-relative 被静默误映射 | 属实（实测） | 条件收紧为 `len(p) >= 3 and p[1] == ":" and p[2] in "/\\"`；`C:/`、`C:\x` 等绝对写法逐字不变 | 变异 ⑤ RED → 复绿 |

**第 4 条如实标注**：该路径当前 Desktop IPC **不接线**（`AgentSpawnInput` 无 `user_roots` 字段），模型也没有对应 RPC 工具 → **属纵深防御（CWE-862 形态），不是现网活跃口子**。改动意义是在信任边界上补一道过滤，与第 1 条同属一致性/健壮性修复，不代表现网存在可利用的提权路径。

**5 条全部只读核实过**（含实测复现）；每一处修复都做了「回退 → 对应用例变红 → 复原 → 复绿」的变异验证，原始输出见上节。

## 测试情况

**层 1+2（57cebace）**：新增 **5** 个测试文件（A）、修改 **2** 个既有测试文件（M）；新增 `test def` **80** 个、
新增用例 **86** 个；6 个涉及文件 collected **115**（复现命令见「日志/验证证据」节 R2 ① 段）。

- `tests/sandbox/test_sandbox_write_boundary_984.py`（A）— `/mnt` 为 `--ro-bind-try`、per-call 硬 `--bind` 且下标在 ro 之后、`_host_path_to_sandbox` 映射/UNC 抛错、两个 API 透传
- `tests/sandbox/test_write_sites_rw_binds_984.py`（A）— 4 个写入方各传自己的 `shared`（R2 改为经 `execute()` 真实传参点，见下）
- `tests/execution/test_exec_write_boundary_984.py`（A）— bind 集合组成（含 `auto_user_dirs` 闸门、静态根缺失跳过、user 根缺失保留）、4 签名、8 处 splat、`_execute_restricted` 显式调 `_execute_direct` 不传 bind 不 TypeError、**bind 缺失不降级宿主**
- `tests/agent/tools/test_filesystem_write_boundary_984.py`（A）— mkdir 修复（含真实 bash 执行回归）+ bootstrap 4 条边界
- `tests/runtime/test_subagent_roots_984.py`（A）— `AgentJob` 默认 `[]`、`run_agent_job` 置 `is_subagent` 并继承根、子 agent turn 不抽根（父 turn 仍抽）、spawn 链转发
- `tests/agent/tools/test_user_roots.py`（**M**，非新增）— 新增 `TestProtectedPrefix`，前缀表 **13 例**
- `tests/agent/tools/test_session_workspace_isolation.py`（**M**，仅同步测试替身签名，无新增用例）

**R2（评审处置）**：新增 `test def` 7 个（其中 1 个为改写）、改写既有契约用例 1 个。

- `tests/sandbox/test_write_sites_rw_binds_984.py::test_graph_render_execute_forwards_its_own_shared`（改写）— ②：经 `GraphRenderTool.execute()` 走 svg(1 写)/html(2 写) 两个分支，断言每次转发给 `_write_text` 的 `shared` 精确等于 `[ws, out]`，并保留 `_sandbox_write_file` 的 `extra_rw_binds` 断言
- `tests/execution/test_exec_write_boundary_984.py::TestUserRootsOwnership`（3 例）— ③ legacy 侧：模型自带 `_user_roots` + 本 turn 无提及根 → 工具实收 `[]`；harness 根压过模型自带；非文件工具也剥
- `tests/kun_runtime/test_tool_host.py::TestUserRootsInjection`（+2 例、改写 1 例）— ③ KUN 侧同口径，并覆盖「模型副本与注入值撞重复关键字」这一原 TypeError 路径
- `tests/runtime/test_turn_runner_user_roots.py`（**M**，既有契约用例同步）— `test_orchestrator_skips_user_roots_when_empty` → `test_orchestrator_injects_empty_user_roots_when_none`，断言由「键不存在」改为「键为 `[]`」（③ 的契约变更）
- `tests/agent/tools/test_user_roots.py`（**M**，CI 修复）— 前缀表 3 个 Windows 专用用例加 `skipif`，ubuntu-latest 由 `3 failed` 转绿

**R3（非阻塞项 P2-1）**：新增 `test def` **2** 个，均在 `tests/execution/test_exec_write_boundary_984.py::TestWorkingDirNotABindSource`。

- `test_per_call_working_dir_is_not_a_bind_source` — 构造 `ExecTool(working_dir=ws, shared_roots=[static])`，记 `before = tool._exec_rw_binds([])`；以模型传参方式 `execute(command="echo t", working_dir=<工作区外现存目录>, _sandbox=BWRAP, _session_key=k)`；断言 (1) 沙箱实收 `extra_rw_binds == before` 且敏感目录不在其中，(2) 调用后 `tool._exec_rw_binds([]) == before` 且敏感目录不在其中。变异可证伪（见证据节 R3 段）。
- `test_per_call_working_dir_still_sets_cwd` — 硬化不得破坏被约束的参数：per-call `working_dir` 仍决定 cwd。

**层 3（R4，3be853d5）**：新增 `test def` **29** 个、**513** 行，全部在 `tests/agent/test_command_guard_python_writes_984.py`（新文件），collected **55** 例。

- `TestWriteSpellingsDenied`（19 参数化 + 5 例）— `open(...,'w'/'a'/'x'/'wb'/'ab'/'r+'/mode='w')`、`Path(...).open('w')`、`write_text`/`write_bytes`、`os.mkdir`/`makedirs`、`shutil.copy/copy2/copyfile/copytree/move`、`os.rename`/`replace` 在会话外**全部拒绝**且 `reason_code == outside_workspace`；`test_shell_and_python_now_agree` 复现 issue 原对比（shell 拒 → python 也拒）
- `TestNoFalsePositives`（10 参数化 + 2 例）— 读写法（`open(f)`、`open(f,'r')`、`open(f,'rb')`）与未识别拼写 **fail-open 放行**
- `TestAuthorizedRootsAllowed`（7 例）— 授权子树内写/改名/移动放行、授权目录**本身不可删**、同树兄弟目录仍拒、系统路径与宿主 home **压过**授权根、授权目录 heredoc 交付放行、session 域仍放行
- `TestHeredocFidelity`（4 例）— heredoc 路径字面量**不被**降级成 `script_uncertain`；无字面量的 heredoc 仍判 uncertain；双引号定界符；嵌套 `bash -c "python3 -c …"` 写入仍拒
- `TestExecToolPlumbing`（6 例）— `_guard_command` 的授权根随 `allow_user_dirs` 闸门、丢弃非绝对路径、解析拼写、静态 `_shared_roots` **不进** guard 授权面、`RuntimePaths.extra_write_roots` 承载 per-call 根、授权根集合与 bind 集合同口径
- `TestRegistryChokePoint`（1 例）— `ToolRegistry.execute(params={"_user_roots": [...]})` 被剥离，harness 的 `**extra` 仍可携带

**变异可证伪（2 个内存变异，源码未动，见证据节 R4 段）**：①去掉词表 `write_text` 条目 → **6 例变红**；②`_open_call_writes` 恒返回 `False` → **11 例变红**。

**计数（R4 复测）**：分支累计新增 `test def` **117**（层 1+2 的 80 + R2 净增 6 + R3 的 2 + 层 3 的 29；R2 那 7 个里有 1 个是改写既有用例）；本 PR 相对 `origin/develop`：`29 files changed, 3111 insertions(+), 87 deletions(-)`；层 3 单 commit `5 files changed, 1014 insertions(+), 67 deletions(-)`。

**只在本机验证、CI 才能覆盖的**：`wsl` 标记的真实 WSL 集成用例（CI `wsl-sandbox` job 跑 windows-latest）。

## 非阻塞项处置（复核 P2-1 / P2-2）

复核结论 APPROVE、无 P0/P1 blocker，留两条非阻塞项。**R3 只处置 P2-1，P2-2 不改代码。**

**P2-1 契约硬化（已做）**——「per-call `working_dir` 不得成为 `extra_rw_binds` 来源」

- 问题性质：现状**安全**，但安全性只来自实现巧合、**没有任何测试锁死**。bind 源全部取自构造期属性（`self.working_dir` / `self._shared_roots`）加 harness 注入的 `_user_roots`；`execute(working_dir=...)` 的 per-call 值只用于 cwd 与 workspace diff 根。若有人把首 bind 源写成 `working_dir or self.working_dir`，模型只需一个参数就能把**任意现存宿主目录**重新打开为沙箱内可写，绕过 #984 的 per-call 授权通道——而此前 25 个用例**全绿**。
- 处置：①`_exec_rw_binds` docstring 增补 CONTRACT 段（构造期确定；不得从单次 `execute()` 的模型参数派生）；②新增 `TestWorkingDirNotABindSource` 2 例走真实传参点；③变异可证伪（内存 patch → 目标用例变红，`outside_secret` 出现在 bind 下标 0）。
- 边界：**未改** `working_dir` 的运行时语义（cwd / snapshot 根不变），R3 是纯契约 + 测试，无行为变更。

**P2-2 只读面审计（不改代码）**——`working_dir → _snapshot_workspace / _track_workspace_changes`

- 结论：只记录**元数据** `{abs_path: (mtime_ns, size)}`（`shell.py:3043-3085`），无内容读取、无 hash、无外传；带 `_WORKSPACE_SNAPSHOT_MAX_FILES = 5000` 上限与目录排除 → 低风险 scope pollution。
- 本轮**未改** `working_dir` 的运行时语义。

## 截图

无需截图（无 UI 变更）。

## 后续计划

- #984 层 1+2+3 已在本 PR 收口；「行为变更与残余缺口」/ dev-note「已知缺口」里列出的项（宿主回退、非 bwrap 路由、KUN exec、沙箱内路径写、#821 显式授权动作）**不在本 PR 范围**，需要时另开 issue
- 审批卡 + AppServer 读侧另开 issue

## 行为变更与残余缺口（必读）

1. **删了 legacy 子 agent 自抽取**（`agent_control.py` `_run_agent` 路径）：该路径仅在 `_agent_jobs is None` 时可达，现在子 agent 无任何根（job 路径由 `AgentJob.user_roots` 继承）。
2. **`AgentJob.user_roots` 不持久化**：`AgentGraphStore` schema 固定 + 显式关键字，`_load_jobs` 走默认 `[]` → **重启丢根**。
3. **AppServer `agent.spawn`**：已加 `user_roots=params.get("user_roots") or []`，Desktop 不发即子 agent 无根（服务端无其它根来源）。
4. **KUN 链**：`kun_runtime/tool_host.py` 的 `_USER_ROOTS_TOOLS` 不含 `exec`，且只对白名单工具注入 `_user_roots` → 层 2 后 KUN 链 exec 写用户提及目录会失效（KUN 未接入主执行路径）。R2 后模型自带的 `_user_roots` 也一律被剥，KUN exec 侧因此**永远**拿不到任何根（与 legacy 侧含 `exec` 不对称）；若 KUN exec 需要用户点名目录的 per-call rw bind，需把 `"exec"` 加入 `_USER_ROOTS_TOOLS`，属未做的后续项。
5. **exec 能写**的条件：`auto_user_dirs` 默认开 + 不在前缀表 + **根已存在**；**文件工具能写**多一路 #864 卡片授权（4 个写入方 `shared`）。
6. **残余缺口**：(i) **仅卡片授权**的目录 → 文件工具可写、exec 在 ro `/mnt` 下 EROFS（授权存在文件工具实例 `self._granted`，ExecTool 无引用）；(ii) **提及但未创建**的目录 → exec 硬 `--bind` 直接失败（引导文案让模型先用文件工具），需文件工具先 bootstrap，**顺序敏感**。
7. 边界只覆盖 exec + 文件工具的 bwrap 沙箱；宿主回退 / `sandbox.enabled=false` / 非 WSL / 安装路由 / 非沙箱写入方（documents 工具、MCP）不受约束，读+外传不受限。详见 `docs/dev-notes/sandbox-write-boundary-984.md`。
8. **R2 ③ 行为变更**：`_user_roots` 现在**无条件**由 harness 覆盖——`ctx.user_mentioned_roots` 为空时也注入 `[]`（此前该键根本不注入，模型若自带同名参数会被原样采纳）。模型自带的 `_user_roots` 在两侧一律先剥除，永不生效；`_effective_shared_roots` 对 `[]` 与 `None` 等价（`not user_roots` 早退），`ExecTool._exec_rw_binds` 对 `[]` 不新增 bind，故合法路径无行为差异。KUN 侧顺带修掉「模型副本 + 注入值撞成重复关键字 TypeError」的报错路径。既有契约用例 `test_orchestrator_skips_user_roots_when_empty` 已随契约改名并改为断言 `[]`。
9. **R2 ③ 的剥离点范围**：只覆盖两个**活**漏斗——legacy `ToolOrchestrator._execute_in_sandbox`（所有 `ctx.arguments` 入口与 hook 的 modify patch 都汇入此处）与 KUN `MiQiToolHost.execute`。死代码 `miqi/agent/subagent.py:254`（`SubagentManager`，Phase 13 后无生产实例化）仍是裸 `tools.execute(name, arguments)`；**层 3 已把剥离下沉到 `ToolRegistry.execute`**（`params` 里模型自带的 `_user_roots` 一律剥掉，只允许 harness 的 `**extra` 携带），这条死代码路径也一并关闭。
10. **R3 无行为变更**：只加 docstring 契约与回归测试，`working_dir` 的运行时语义（cwd / snapshot 根）与 bind 集合均未变。
11. **层 3 是体验层、不是强制层（取舍声明）**：静态词表**不可能完备**——没命中的写法一律 **fail-open 放行**，由层 2 的挂载兜底；层 3 的价值是「更早、更可读的拒绝 + 安全替代提示」。因此 `open(...,'w')` 之外的新拼写、f-string 拼路径、`os.open`/`io.open`、`exec/eval` 动态构造等都不会被拦。同理，`RuntimePaths.extra_write_roots` 只影响**报错时机**，可写范围本身由层 1 的 bind 决定，两侧同口径（`test_guard_write_roots_matches_bind_set` 锁死）。完整三层定位与「已知缺口」清单见 `docs/dev-notes/sandbox-write-boundary-984.md`（`## 三层各是什么` 表 + `## 已知缺口（不覆盖）` 节）。


