### PR TITLE
feat(desktop): 平台登录失效全局告知——横幅、顶栏失效 chip、发送拦截重登引导

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import { RestartRequiredProvider } from './contexts/RestartRequiredContext';
 import { ConfigHotReloadListener } from './components/ConfigHotReloadListener';
 import { GatewayModelAutoSync } from './components/GatewayModelAutoSync';
 import { InstallWarningToaster } from './components/InstallWarningToaster';
+import { QraftReloginNotifier } from './components/QraftReloginNotifier';
 import { ApprovalModal } from './features/approvals/ApprovalModal';
 import { CronPage } from './features/cron/CronPage';
 import { MemoryPage } from './features/memory/MemoryPage';
@@ -383,6 +384,13 @@ function AppShell() {
         <InstallWarningToaster
           onOpenSandboxSettings={() => {
             setSettingsTab('general');
+            setActiveNav('settings');
+          }}
+        />
+        {/* 平台登录失效的全局告知：横幅常驻可关闭，顶栏 chip 持续提示 */}
+        <QraftReloginNotifier
+          onOpenQraft={() => {
+            setSettingsTab('qraft');
             setActiveNav('settings');
           }}
         />

--- a/apps/desktop/src/renderer/components/QraftReloginNotifier.test.ts
+++ b/apps/desktop/src/renderer/components/QraftReloginNotifier.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { nextReloginNotifyState, reloginNotifyCopy } from './QraftReloginNotifier';
+
+describe('reloginNotifyCopy', () => {
+  it('REFRESH_TOKEN_INVALID → 永久失效文案，引导重新登录', () => {
+    expect(reloginNotifyCopy('REFRESH_TOKEN_INVALID')).toEqual({
+      text: 'MiQroForge 平台登录已失效，请重新登录恢复平台功能。',
+      action: '去重新登录',
+    });
+  });
+
+  it('瞬时失败（REFRESH_FAILED / 未分类）→ 自动重试文案', () => {
+    expect(reloginNotifyCopy('REFRESH_FAILED')).toEqual({
+      text: 'MiQroForge 平台登录刷新失败，部分平台功能暂不可用（将自动重试）。',
+      action: '去查看',
+    });
+    expect(reloginNotifyCopy(undefined)).toEqual({
+      text: 'MiQroForge 平台登录刷新失败，部分平台功能暂不可用（将自动重试）。',
+      action: '去查看',
+    });
+  });
+});
+
+describe('nextReloginNotifyState', () => {
+  const idle = { notified: false, visible: false };
+
+  it('false → true 转变：弹横幅并标记已告知', () => {
+    expect(nextReloginNotifyState(idle, true)).toEqual({ notified: true, visible: true });
+  });
+
+  it('初始快照即失效（notified=false, requiresRelogin=true）：同样弹横幅', () => {
+    expect(nextReloginNotifyState(idle, true)).toEqual({ notified: true, visible: true });
+  });
+
+  it('已告知期间（含用户关闭横幅）不重复弹', () => {
+    const dismissed = { notified: true, visible: false };
+    expect(nextReloginNotifyState(dismissed, true)).toEqual(dismissed);
+    expect(nextReloginNotifyState({ notified: true, visible: true }, true)).toEqual({
+      notified: true,
+      visible: true,
+    });
+  });
+
+  it('requiresRelogin 回 false（重新登录/登出）→ 复位，下次失效再告知', () => {
+    expect(nextReloginNotifyState({ notified: true, visible: true }, false)).toEqual(idle);
+    expect(nextReloginNotifyState({ notified: true, visible: false }, false)).toEqual(idle);
+    // 复位后再次失效 → 重新弹横幅
+    expect(nextReloginNotifyState(idle, true).visible).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/components/QraftReloginNotifier.tsx
+++ b/apps/desktop/src/renderer/components/QraftReloginNotifier.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useQraftStatus } from '../hooks/useQraftStatus';
+import type { QraftErrorCode } from '../../shared/ipc';
+
+/**
+ * 平台登录失效的全局告知 —— 主进程自动刷新失败置 requiresRelogin 时，
+ * 无论用户身处哪个页面都弹出顶部横幅：
+ *   - REFRESH_TOKEN_INVALID（refresh_token 被平台作废）：永久失效，
+ *     引导重新登录；
+ *   - 其他瞬时失败（网络等）：提示"将自动重试"，主进程 30 分钟后
+ *     重试成功（requiresRelogin 复位）时横幅自动消失。
+ *
+ * 横幅常驻（不自动消失），可手动关闭；顶栏账号 chip 同时切换为
+ * 失效态（见 TopBar），保证关闭横幅后仍有持续提示。
+ */
+
+/** 失效告知的横幅文案：按最近一次刷新错误码区分"永久作废"与"瞬时失败"。 */
+export function reloginNotifyCopy(refreshError: QraftErrorCode | undefined): {
+  text: string;
+  action: string;
+} {
+  if (refreshError === 'REFRESH_TOKEN_INVALID') {
+    return {
+      text: 'MiQroForge 平台登录已失效，请重新登录恢复平台功能。',
+      action: '去重新登录',
+    };
+  }
+  return {
+    text: 'MiQroForge 平台登录刷新失败，部分平台功能暂不可用（将自动重试）。',
+    action: '去查看',
+  };
+}
+
+/**
+ * 告知状态机（纯函数，便于单测）：
+ *   - requiresRelogin 由 false 变 true → 弹横幅并标记已告知；
+ *   - 初始快照即 true（应用启动即发现 token 已作废）→ 同样弹横幅；
+ *   - 已告知期间（用户关闭横幅）不再重复弹；
+ *   - requiresRelogin 回 false（重新登录/登出）→ 复位，下次失效再告知。
+ */
+export function nextReloginNotifyState(
+  prev: { notified: boolean; visible: boolean },
+  requiresRelogin: boolean
+): { notified: boolean; visible: boolean } {
+  if (!requiresRelogin) return { notified: false, visible: false };
+  if (prev.notified) return prev;
+  return { notified: true, visible: true };
+}
+
+export function QraftReloginNotifier({ onOpenQraft }: { onOpenQraft: () => void }) {
+  const { status } = useQraftStatus();
+  const requiresRelogin = status?.requiresRelogin === true;
+  const [state, setState] = useState({ notified: false, visible: false });
+
+  useEffect(() => {
+    setState((prev) => nextReloginNotifyState(prev, requiresRelogin));
+  }, [requiresRelogin]);
+
+  if (!state.visible) return null;
+
+  const { text, action } = reloginNotifyCopy(status?.refreshError);
+
+  return (
+    <div
+      data-testid="qraft-relogin-notify"
+      role="alert"
+      className="fixed left-1/2 top-16 z-50 flex max-w-[min(640px,calc(100vw-24px))] -translate-x-1/2 items-center gap-2.5 rounded-xl border px-4 py-2.5 text-xs backdrop-blur animate-banner-in"
+      style={{
+        background: 'color-mix(in srgb, var(--approval-warning-bg) 92%, white)',
+        borderColor: 'var(--approval-warning-border)',
+        color: 'var(--approval-warning)',
+      }}
+    >
+      <AlertTriangle size={14} className="shrink-0" />
+      <span className="min-w-0 flex-1 font-medium">{text}</span>
+      <button
+        type="button"
+        data-testid="qraft-relogin-notify-action"
+        onClick={() => {
+          setState((prev) => ({ ...prev, visible: false }));
+          onOpenQraft();
+        }}
+        className="shrink-0 rounded-md px-2.5 py-1 text-size-2xs font-semibold transition-colors hover:bg-[rgba(124,45,18,0.08)]"
+      >
+        {action}
+      </button>
+      <button
+        type="button"
+        data-testid="qraft-relogin-notify-close"
+        aria-label="关闭提醒"
+        title="关闭提醒"
+        onClick={() => setState((prev) => ({ ...prev, visible: false }))}
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[rgba(124,45,18,0.12)]"
+      >
+        <X size={13} />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/TopBar.tsx
@@ -78,6 +78,8 @@ export function TopBar({
   // #1000: 顶栏登录入口 —— 未登录显示一键登录 chip（错误经 title 提示，
   // 不内联渲染避免顶栏抖动）；已登录显示账号 chip，点击进平台账号页。
   const { status: qraftStatus, loggedIn } = useQraftStatus();
+  // 登录失效（token 刷新失败且未恢复）：账号 chip 切换为警示态，点击去重新登录。
+  const needsRelogin = qraftStatus?.requiresRelogin === true;
   const [approvalBypass, setApprovalBypass] = useState<ApprovalBypassStatus | null>(null);
   const [bypassHovered, setBypassHovered] = useState(false);
   const [autoMode, setAutoMode] = useState(() => sessionStorage.getItem('miqi:mode:auto') === '1');
@@ -268,22 +270,41 @@ export function TopBar({
 
       {/* Right: account entry + user avatar */}
       <div className="flex items-center gap-2">
-        {/* #1000 登录入口：未登录一键登录；已登录账号 chip 点击进平台账号页 */}
+        {/* #1000 登录入口：未登录一键登录；已登录账号 chip 点击进平台账号页；
+            登录失效时 chip 切换为警示态（配合全局横幅的持续提示） */}
         {loggedIn ? (
-          <button
-            type="button"
-            onClick={onOpenQraft}
-            className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors hover:brightness-95"
-            style={{
-              background: 'var(--accent-soft)',
-              color: 'var(--accent)',
-            }}
-            data-testid="topbar-account-chip"
-            title="查看平台账号（设置 → MiQroForge 平台）"
-          >
-            <UserRound size={12} />
-            {qraftStatus?.account?.nickname || qraftStatus?.account?.username || '已登录'}
-          </button>
+          needsRelogin ? (
+            <button
+              type="button"
+              data-testid="topbar-relogin-chip"
+              onClick={onOpenQraft}
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors hover:brightness-95"
+              style={{
+                background: 'color-mix(in srgb, var(--approval-warning-bg) 60%, transparent)',
+                color: 'var(--approval-warning)',
+                border: '1px solid var(--approval-warning-border)',
+              }}
+              title="MiQroForge 平台登录已失效，点击去重新登录"
+            >
+              <AlertTriangle size={12} />
+              登录已失效
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onOpenQraft}
+              className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors hover:brightness-95"
+              style={{
+                background: 'var(--accent-soft)',
+                color: 'var(--accent)',
+              }}
+              data-testid="topbar-account-chip"
+              title="查看平台账号（设置 → MiQroForge 平台）"
+            >
+              <UserRound size={12} />
+              {qraftStatus?.account?.nickname || qraftStatus?.account?.username || '已登录'}
+            </button>
+          )
         ) : (
           <QraftLoginButton
             testId="topbar-login-btn"

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -473,6 +473,31 @@ function createGatewayBlockedMessage(): Message {
   };
 }
 
+/** 登录失效时的统一拦截文案（发送拦截与流错误路径共用，避免气泡正文与登录按钮语义冲突）。 */
+export const RELOGIN_INTERCEPT_TEXT = 'MiQroForge 平台登录已失效，请重新登录后继续会话。';
+
+/**
+ * 登录失效拦截的消息列表变换（纯函数，便于单测）：
+ *  - 普通发送：乐观 user 气泡按时间戳匹配替换为重登引导；
+ *  - 恢复中断回合（#740）：无乐观 user 气泡，且 handleResumeTurn 已移除
+ *    中断卡——恢复卡片（resumeMsg）并追加重登引导，避免上下文丢失；
+ *  - 时间戳不匹配且无恢复卡片（会话已切换等）：原样返回。
+ */
+export function applyReloginIntercept(
+  prev: Message[],
+  userMsg: Message,
+  resumeMsg: Message | null
+): Message[] {
+  const last = prev[prev.length - 1];
+  if (last?.timestamp === userMsg.timestamp) {
+    return [...prev.slice(0, -1), createProviderConfigMessage(RELOGIN_INTERCEPT_TEXT, 'login')];
+  }
+  if (resumeMsg) {
+    return [...prev, resumeMsg, createProviderConfigMessage(RELOGIN_INTERCEPT_TEXT, 'login')];
+  }
+  return prev;
+}
+
 /* ─── Tracked file from tool hints ───────────────────────────────── */
 interface TrackedFile {
   path: string;
@@ -4082,6 +4107,9 @@ export function ChatConsole({
    *  so the resume request flows through the full send pipeline (listeners,
    *  streaming render) instead of a bare chat.send call. */
   const resumeTurnIdRef = useRef<string | null>(null);
+  // 恢复中断回合时被移除的中断卡：登录失效拦截需恢复它并追加重登引导
+  //（resume 无乐观 user 气泡，否则上下文丢失、登录按钮无处可点）。
+  const resumeRemovedMsgRef = useRef<Message | null>(null);
   /** Per-session send id of the send currently in its pre-stream pending phase
    *  (issue #364).  A session is "pending" while its optimistic bubble waits on
    *  the non-blocking provider check / thread init.  The double-Enter guard
@@ -4105,7 +4133,9 @@ export function ChatConsole({
     const meta = msg.interruptedMeta;
     if (!meta?.turnId) return;
     resumeTurnIdRef.current = meta.turnId;
-    // 移除中断卡——resume 的新回复由流式事件接管渲染
+    // 移除中断卡——resume 的新回复由流式事件接管渲染。卡片暂存 ref：
+    // 若预检被登录失效拦截，需恢复卡片并追加重登引导（applyReloginIntercept）。
+    resumeRemovedMsgRef.current = msg;
     setMessages((prev) => prev.filter((m) => m !== msg));
     handleSendRef.current();
   }, []);
@@ -4294,25 +4324,20 @@ export function ChatConsole({
       // token 刷新失败且未恢复（requiresRelogin）时拦截发送：把乐观气泡换成
       // 重登引导（一键登录成功后气泡自动移除）。先于网关门禁/无 provider 判定
       // —— 失效后网关状态仍是旧快照里的 active，必须优先给出重登指引。
-      if (gatewayStatus?.loggedIn === true && gatewayStatus.requiresRelogin === true) {
+      // 快照读取失败（qraft.status() 抛错）时回退到订阅状态 refs，拦截不失效。
+      const gatewayLoggedIn = gatewayStatus?.loggedIn ?? loggedInRef.current;
+      const gatewayRequiresRelogin = gatewayStatus?.requiresRelogin ?? requiresReloginRef.current;
+      if (gatewayLoggedIn && gatewayRequiresRelogin) {
         pendingSendIdsRef.current.delete(sendSessionKey);
         streamingBySession.delete(sendSessionKey);
         setSendingFor(sendSessionKey, null);
         if (currentSessionRef.current === sendSessionKey) {
           setStreaming(false);
-          setMessages((prev) => {
-            const last = prev[prev.length - 1];
-            if (last?.timestamp === userMsg.timestamp) {
-              return [
-                ...prev.slice(0, -1),
-                createProviderConfigMessage(
-                  'MiQroForge 平台登录已失效，请重新登录后继续会话。',
-                  'login'
-                ),
-              ];
-            }
-            return prev;
-          });
+          // 恢复中断回合（#740）：无乐观 user 气泡，取回被 handleResumeTurn
+          // 移除的中断卡并追加重登引导；随后复位 ref 防陈旧引用。
+          const resumeRemovedMsg = _resumeId ? resumeRemovedMsgRef.current : null;
+          resumeRemovedMsgRef.current = null;
+          setMessages((prev) => applyReloginIntercept(prev, userMsg, resumeRemovedMsg));
           setInput(text);
           setAttachments(atts);
         }
@@ -5325,7 +5350,7 @@ export function ChatConsole({
         ...prev.filter((m) => !m.isLiveReasoning),
         isProviderConfigurationProblem(message, data.code)
           ? createProviderConfigMessage(
-              message,
+              requiresReloginRef.current ? RELOGIN_INTERCEPT_TEXT : message,
               loggedInRef.current && !requiresReloginRef.current
                 ? 'open-provider-settings'
                 : 'login'
@@ -5530,7 +5555,7 @@ export function ChatConsole({
         setMessages((prev) => [
           ...prev,
           createProviderConfigMessage(
-            errMsg,
+            requiresReloginRef.current ? RELOGIN_INTERCEPT_TEXT : errMsg,
             loggedInRef.current && !requiresReloginRef.current ? 'open-provider-settings' : 'login'
           ),
         ]);

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -478,19 +478,31 @@ export const RELOGIN_INTERCEPT_TEXT = 'MiQroForge 平台登录已失效，请重
 
 /**
  * 登录失效拦截的消息列表变换（纯函数，便于单测）：
- *  - 普通发送：乐观 user 气泡按时间戳匹配替换为重登引导；
+ *  - 普通发送：乐观 user 气泡按（role + 时间戳）就地替换为重登引导。
+ *    从尾部向前查找——等待 qraft.status() 期间其他监听器（如子代理
+ *    持久事件）可能追加消息，尾部未必是 user 气泡；
  *  - 恢复中断回合（#740）：无乐观 user 气泡，且 handleResumeTurn 已移除
  *    中断卡——恢复卡片（resumeMsg）并追加重登引导，避免上下文丢失；
- *  - 时间戳不匹配且无恢复卡片（会话已切换等）：原样返回。
+ *  - 找不到匹配且无恢复卡片（会话已切换等）：原样返回。
  */
 export function applyReloginIntercept(
   prev: Message[],
   userMsg: Message,
   resumeMsg: Message | null
 ): Message[] {
-  const last = prev[prev.length - 1];
-  if (last?.timestamp === userMsg.timestamp) {
-    return [...prev.slice(0, -1), createProviderConfigMessage(RELOGIN_INTERCEPT_TEXT, 'login')];
+  let userIndex = -1;
+  for (let i = prev.length - 1; i >= 0; i -= 1) {
+    if (prev[i].role === 'user' && prev[i].timestamp === userMsg.timestamp) {
+      userIndex = i;
+      break;
+    }
+  }
+  if (userIndex >= 0) {
+    return [
+      ...prev.slice(0, userIndex),
+      createProviderConfigMessage(RELOGIN_INTERCEPT_TEXT, 'login'),
+      ...prev.slice(userIndex + 1),
+    ];
   }
   if (resumeMsg) {
     return [...prev, resumeMsg, createProviderConfigMessage(RELOGIN_INTERCEPT_TEXT, 'login')];

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -2415,10 +2415,13 @@ export function ChatConsole({
   const [messages, setMessages] = useState<Message[]>([]);
   // #1000: 首屏登录卡片与发送拦截共用登录态；旧 preload 无 qraft 命名空间时
   // useQraftStatus 内部兜底为空态（视为未登录）。
-  const { loggedIn } = useQraftStatus();
+  const { loggedIn, status: qraftStatus } = useQraftStatus();
   // 流错误路径同步读取最新登录态：handleSend 闭包可能捕获旧值（CodeRabbit #1010）。
   const loggedInRef = useRef(loggedIn);
   loggedInRef.current = loggedIn;
+  // 登录已失效（token 刷新失败且未恢复）：流错误路径据此给重登引导而非模型配置指引。
+  const requiresReloginRef = useRef(qraftStatus?.requiresRelogin === true);
+  requiresReloginRef.current = qraftStatus?.requiresRelogin === true;
   // #875 D1（外部评估 P0/A1）：系统包安装的 persist/runtime 失败标记只写在
   // 工具输出里，模型可能摘要掉——用户会误以为「允许并记住」已永久生效。
   // 扫描消息中的失败标记并发 window 事件，由 App 级 toast 呈现（不依赖模型）。
@@ -4287,6 +4290,34 @@ export function ChatConsole({
         typeof window.miqi.qraft?.status === 'function'
           ? await window.miqi.qraft.status().catch(() => null)
           : null;
+      // ── 登录已失效拦截 ──
+      // token 刷新失败且未恢复（requiresRelogin）时拦截发送：把乐观气泡换成
+      // 重登引导（一键登录成功后气泡自动移除）。先于网关门禁/无 provider 判定
+      // —— 失效后网关状态仍是旧快照里的 active，必须优先给出重登指引。
+      if (gatewayStatus?.loggedIn === true && gatewayStatus.requiresRelogin === true) {
+        pendingSendIdsRef.current.delete(sendSessionKey);
+        streamingBySession.delete(sendSessionKey);
+        setSendingFor(sendSessionKey, null);
+        if (currentSessionRef.current === sendSessionKey) {
+          setStreaming(false);
+          setMessages((prev) => {
+            const last = prev[prev.length - 1];
+            if (last?.timestamp === userMsg.timestamp) {
+              return [
+                ...prev.slice(0, -1),
+                createProviderConfigMessage(
+                  'MiQroForge 平台登录已失效，请重新登录后继续会话。',
+                  'login'
+                ),
+              ];
+            }
+            return prev;
+          });
+          setInput(text);
+          setAttachments(atts);
+        }
+        return;
+      }
       // ── #922 AI 网关门禁 ──
       // 登录后网关状态明确非 active（provisioning/failed/disabled）时拒绝发起
       // 会话：把乐观气泡换成网关提示并恢复输入框。未登录 / 平台未下发网关状态
@@ -5295,7 +5326,9 @@ export function ChatConsole({
         isProviderConfigurationProblem(message, data.code)
           ? createProviderConfigMessage(
               message,
-              loggedInRef.current ? 'open-provider-settings' : 'login'
+              loggedInRef.current && !requiresReloginRef.current
+                ? 'open-provider-settings'
+                : 'login'
             )
           : { role: 'error', content: message, timestamp: Date.now() },
       ]);
@@ -5498,7 +5531,7 @@ export function ChatConsole({
           ...prev,
           createProviderConfigMessage(
             errMsg,
-            loggedInRef.current ? 'open-provider-settings' : 'login'
+            loggedInRef.current && !requiresReloginRef.current ? 'open-provider-settings' : 'login'
           ),
         ]);
       } else if (e?.code) {

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -11,6 +11,8 @@ import {
   sessionMsgsToUi,
   toolCommandText,
   formatToolCallHint,
+  applyReloginIntercept,
+  RELOGIN_INTERCEPT_TEXT,
 } from '../src/renderer/features/chat/ChatConsole';
 
 describe('sessionMsgsToUi', () => {
@@ -440,5 +442,48 @@ describe('toolCommandText (issue #902)', () => {
     expect(toolCommandText(undefined)).toBeUndefined();
     expect(toolCommandText(null)).toBeUndefined();
     expect(toolCommandText([])).toBeUndefined();
+  });
+});
+
+describe('applyReloginIntercept (平台登录失效拦截)', () => {
+  const userMsg = { role: 'user' as const, content: '继续之前的工作', timestamp: 42 };
+  const interruptedCard = {
+    role: 'assistant' as const,
+    content: '（中断回合）',
+    interrupted: true,
+    timestamp: 41,
+  };
+  const prevMsg = { role: 'assistant' as const, content: '历史回复', timestamp: 1 };
+
+  it('普通发送：乐观 user 气泡按时间戳匹配替换为重登引导', () => {
+    const next = applyReloginIntercept([prevMsg, userMsg], userMsg, null);
+    expect(next).toHaveLength(2);
+    expect(next[0]).toBe(prevMsg);
+    expect(next[1].role).toBe('error');
+    expect(next[1].action).toBe('login');
+    expect(next[1].content).toBe(RELOGIN_INTERCEPT_TEXT);
+  });
+
+  it('恢复中断回合：无乐观气泡时恢复被移除的中断卡并追加重登引导', () => {
+    // handleResumeTurn 已把中断卡从列表移除，resume 路径不再推 user 气泡
+    const next = applyReloginIntercept([prevMsg], userMsg, interruptedCard);
+    expect(next).toHaveLength(3);
+    expect(next[0]).toBe(prevMsg);
+    expect(next[1]).toBe(interruptedCard);
+    expect(next[2].role).toBe('error');
+    expect(next[2].action).toBe('login');
+    expect(next[2].content).toBe(RELOGIN_INTERCEPT_TEXT);
+  });
+
+  it('时间戳不匹配且无恢复卡片（会话已切换等）：原样返回', () => {
+    const next = applyReloginIntercept([prevMsg], userMsg, null);
+    expect(next).toBe(next);
+    expect(next).toEqual([prevMsg]);
+  });
+
+  it('user 气泡匹配优先于恢复卡片（异常共存时按普通发送处理）', () => {
+    const next = applyReloginIntercept([prevMsg, userMsg], userMsg, interruptedCard);
+    expect(next).toHaveLength(2);
+    expect(next[1].role).toBe('error');
   });
 });

--- a/apps/desktop/tests/chatConsoleMessages.test.ts
+++ b/apps/desktop/tests/chatConsoleMessages.test.ts
@@ -486,4 +486,16 @@ describe('applyReloginIntercept (平台登录失效拦截)', () => {
     expect(next).toHaveLength(2);
     expect(next[1].role).toBe('error');
   });
+
+  it('等待预检期间其他监听器追加消息：就地替换 user 气泡并保留后续消息', () => {
+    // qraft.status() 等待期间子代理等监听器可能把消息追加到 user 气泡之后，
+    // 尾部不再匹配——必须按 role+时间戳定位原气泡就地替换（CodeRabbit #1016）。
+    const laterMsg = { role: 'assistant' as const, content: '子代理持久事件', timestamp: 43 };
+    const next = applyReloginIntercept([prevMsg, userMsg, laterMsg], userMsg, null);
+    expect(next).toHaveLength(3);
+    expect(next[0]).toBe(prevMsg);
+    expect(next[1].role).toBe('error');
+    expect(next[1].content).toBe(RELOGIN_INTERCEPT_TEXT);
+    expect(next[2]).toBe(laterMsg);
+  });
 });

--- a/apps/desktop/tests/e2e/qraft-login.spec.ts
+++ b/apps/desktop/tests/e2e/qraft-login.spec.ts
@@ -55,6 +55,65 @@ function buildSeededStoreContent(overrides: { baseUrl?: string; expiresAt?: numb
   });
 }
 
+/**
+ * 本地 mock 刷新端点：与真实平台一致，返回 Sa-Token 失效响应并
+ * 回显请求中实际收到的 refresh_token（HTTP 200 + code 500）。
+ * 其他 qraft 请求（设置页会自动拉取积分余额）不参与失效断言，
+ * 返回正常空余额信封即可。
+ */
+async function startInvalidRefreshMock(onRefresh?: () => void): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const mock = createServer((req, res) => {
+    if (!(req.url ?? '').includes('/oauth2/refresh')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          code: 200,
+          msg: 'ok',
+          data: { availablePoints: 0, heldPoints: 0, totalEarned: 0, totalSpent: 0 },
+        })
+      );
+      return;
+    }
+    onRefresh?.();
+    let body = '';
+    req.on('data', (d) => (body += d));
+    req.on('end', () => {
+      const echoed = new URLSearchParams(body).get('refresh_token') ?? '';
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          code: 500,
+          msg: '未知错误',
+          data: {
+            message: '未知错误',
+            originalMessage: `SaOAuth2RefreshTokenException: 无效refresh_token: ${echoed}`,
+          },
+        })
+      );
+    });
+  });
+  await new Promise<void>((resolve) => mock.listen(0, '127.0.0.1', resolve));
+  return {
+    port: (mock.address() as AddressInfo).port,
+    close: () => new Promise<void>((resolve) => mock.close(() => resolve())),
+  };
+}
+
+/** 预置「已过期 token + baseUrl 指向本地 mock」的登录态（重启后应用立即自动刷新失败）。 */
+function seedExpiredStore(mockPort: number): void {
+  writeFileSync(
+    storePath,
+    buildSeededStoreContent({
+      baseUrl: `http://127.0.0.1:${mockPort}/api`,
+      expiresAt: Date.now() - 1000,
+    }),
+    'utf8'
+  );
+}
+
 async function gotoQraftTab(page: Page): Promise<void> {
   await page.getByText(/^(System Settings|系统设置)$/).click();
   await page
@@ -167,43 +226,11 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
   );
 
   test('refresh_token 已失效（平台作废）→ 停止自动重试并引导重新登录', async () => {
-    // 本地 mock 刷新端点：与真实平台一致，返回 Sa-Token 失效响应并
-    // 回显请求中实际收到的 refresh_token（HTTP 200 + code 500）。
-    // 其他 qraft 请求（设置页会自动拉取积分余额）不参与本用例断言，
-    // 返回正常空余额信封即可。
     let refreshCalls = 0;
-    const mock = createServer((req, res) => {
-      if (!(req.url ?? '').includes('/oauth2/refresh')) {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            code: 200,
-            msg: 'ok',
-            data: { availablePoints: 0, heldPoints: 0, totalEarned: 0, totalSpent: 0 },
-          })
-        );
-        return;
-      }
+    const mockServer = await startInvalidRefreshMock(() => {
       refreshCalls += 1;
-      let body = '';
-      req.on('data', (d) => (body += d));
-      req.on('end', () => {
-        const echoed = new URLSearchParams(body).get('refresh_token') ?? '';
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            code: 500,
-            msg: '未知错误',
-            data: {
-              message: '未知错误',
-              originalMessage: `SaOAuth2RefreshTokenException: 无效refresh_token: ${echoed}`,
-            },
-          })
-        );
-      });
     });
-    await new Promise<void>((resolve) => mock.listen(0, '127.0.0.1', resolve));
-    const mockPort = (mock.address() as AddressInfo).port;
+    const mockPort = mockServer.port;
 
     // 无论启动、UI 等待或断言是否失败都关掉 mock：Playwright 不管理该
     // 服务器，close() 是异步的，必须 await 完成避免残留句柄。
@@ -211,19 +238,29 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
       // 预置登录态：token 已过期 + baseUrl 指向本地 mock。
       // 应用启动时（service 构造）发现已过期 → 立即自动刷新一次 → 平台判定失效。
       await closeElectronApp(electronApp, fixture.miqiHome);
-      writeFileSync(
-        storePath,
-        buildSeededStoreContent({
-          baseUrl: `http://127.0.0.1:${mockPort}/api`,
-          expiresAt: Date.now() - 1000,
-        }),
-        'utf8'
-      );
+      seedExpiredStore(mockPort);
 
       const f2 = await launchElectronApp();
       electronApp = f2.electronApp;
       page = f2.page;
       fixture = f2;
+
+      // 平台登录失效的全局告知：无需进入设置页，chat 页即弹横幅，
+      // 顶栏账号 chip 同步切换为失效警示态。
+      await expect(page.getByTestId('qraft-relogin-notify')).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByTestId('qraft-relogin-notify')).toContainText('登录已失效');
+      await expect(page.getByTestId('qraft-relogin-notify-action')).toContainText('去重新登录');
+      await expect(page.getByTestId('topbar-relogin-chip')).toBeVisible();
+      await expect(page.getByTestId('topbar-relogin-chip')).toContainText('登录已失效');
+      await page.screenshot({
+        path: 'test-results/qraft-e2e-relogin-notify.png',
+        fullPage: true,
+      });
+
+      // 关闭横幅后不再出现；顶栏 chip 持续提示
+      await page.getByTestId('qraft-relogin-notify-close').click();
+      await expect(page.getByTestId('qraft-relogin-notify')).toHaveCount(0);
+      await expect(page.getByTestId('topbar-relogin-chip')).toBeVisible();
 
       await gotoQraftTab(page);
 
@@ -249,7 +286,57 @@ test.describe('MiQroForge 平台登录 E2E (issue #726)', () => {
         fullPage: true,
       });
     } finally {
-      await new Promise<void>((resolve) => mock.close(() => resolve()));
+      await mockServer.close();
+    }
+  });
+
+  test('登录已失效：发送消息被拦截，给出重登引导气泡（一键登录按钮）', async () => {
+    const mockServer = await startInvalidRefreshMock();
+    const mockPort = mockServer.port;
+
+    try {
+      await closeElectronApp(electronApp, fixture.miqiHome);
+      seedExpiredStore(mockPort);
+
+      const f2 = await launchElectronApp();
+      electronApp = f2.electronApp;
+      page = f2.page;
+      fixture = f2;
+
+      // 全局告知横幅出现后关闭，专注验证发送拦截分支
+      await expect(page.getByTestId('qraft-relogin-notify')).toBeVisible({ timeout: 15_000 });
+      await page.getByTestId('qraft-relogin-notify-close').click();
+
+      // 发送消息：登录失效拦截先于无 provider 判定，乐观气泡被换成
+      // 重登引导（chat-error-login-btn 一键登录），输入草稿被恢复。
+      const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+      await textarea.fill('继续之前的工作');
+      await page.evaluate(() => {
+        const ta = document.querySelector<HTMLTextAreaElement>(
+          '[data-testid="chat-input-container"] textarea'
+        );
+        if (!ta) throw new Error('textarea not found');
+        ta.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Enter',
+            code: 'Enter',
+            keyCode: 13,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      await expect(page.getByTestId('chat-error-login-btn')).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId('chat-error-login-btn')).toContainText('登录 MiQroForge 账号');
+      await expect(textarea).toHaveValue('继续之前的工作');
+
+      await page.screenshot({
+        path: 'test-results/qraft-e2e-relogin-send-intercept.png',
+        fullPage: true,
+      });
+    } finally {
+      await mockServer.close();
     }
   });
 });


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] ✨ 新功能

## 变更概述

平台登录失效（token 刷新失败）时全局告知用户：顶部常驻横幅 + 顶栏警示 chip + 发送拦截重登引导，三处均直达重新登录入口。

## 背景/问题

主进程自动刷新失败（requiresRelogin）此前只在「设置 → MiQroForge 平台」页有横幅——用户身处聊天等页面时完全无感知：顶栏仍显示「已登录」，发送消息还会放行到网关、报出令人困惑的错误（平台 2026-09-02 作废全部存量 refresh_token 后，用户只能碰壁发现）。需要在失效发生的当下主动告知用户，并给出直达的重新登录入口。

## 变更内容

- 新增 `QraftReloginNotifier`（App.tsx 挂载）：`requiresRelogin` 变真（含应用启动即发现 token 作废）时任何页面顶部弹出常驻横幅；按 `refreshError` 区分文案——`REFRESH_TOKEN_INVALID` 提示「登录已失效，请重新登录」，瞬时失败提示「将自动重试」（30 分钟重试成功后横幅自动消失）；可手动关闭，「去重新登录 / 去查看」按钮跳设置 → MiQroForge 平台。
- TopBar 账号 chip 在登录失效时切换为警示态「登录已失效」（`topbar-relogin-chip`），横幅关闭后仍有持续提示；登录恢复后回退为账号 chip。
- ChatConsole 发送拦截新增「已登录但登录失效」分支（先于网关门禁与无 provider 判定——失效后网关状态仍是旧快照里的 active），乐观气泡换成重登引导 + 一键登录按钮（复用 `chat-error-login-btn` 机制，登录成功后气泡自动移除），草稿恢复；流错误路径在失效时给重登引导而非「去配置模型」。
- 单测：状态机与文案纯函数（`QraftReloginNotifier.test.ts`，6 用例）。
- E2E：`qraft-login.spec.ts` 既有「refresh_token 已失效」用例新增全局告知断言（横幅/关闭后不重现/顶栏 chip）；新增「登录已失效：发送拦截给出重登引导气泡」用例；本地 mock 服务器抽取共享 helper。

## 日志/验证证据

```
npx vitest run
  → Test Files  38 passed | 2 skipped (40)
    Tests       474 passed | 5 skipped (479)

npm run typecheck
  → typecheck:node ✓  typecheck:web ✓

npx prettier --check <changed files>
  → All matched files use Prettier code style!

PLAYWRIGHT_SKIP_WEB_SERVER=1 npx playwright test --project=electron qraft-login.spec.ts
  → 4 passed (1.0m)
```

## 测试情况

- 单元测试：全仓 vitest 474 用例通过；新增 `QraftReloginNotifier` 状态机/文案 6 用例（false→true 弹横幅、初始即失效也弹、关闭后不重复弹、重登后复位再武装、两种错误码文案）。
- E2E：`qraft-login.spec.ts` 4 用例全部通过（含本次新增的全局告知断言与发送拦截新用例；mock 刷新端点返回 Sa-Token 失效响应）。
- `npm run typecheck`（node + web）与 prettier 检查通过。

## 截图

全局横幅 + 顶栏失效 chip（无需进入设置页，chat 页即弹出）：

![qraft-e2e-relogin-notify](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/f20ba0a363d238d5.png)

发送拦截：登录失效时乐观气泡换成重登引导（一键登录按钮，草稿恢复）：

![qraft-e2e-relogin-send-intercept](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/b63aef6283a90998.png)
