### PR TITLE
fix(web_search): DDGS 后端选择导致搜索超时 20-60s——改用 html 后端（实测 7 倍提速）

### DIFF
--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -117,7 +117,10 @@ describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
 
       // 4. RUNNING 扣费提示（10 积分）——出现即截图，作为证据
       await expect(page.getByText(/已扣 10 积分/).first()).toBeVisible({ timeout: 300_000 });
-      await page.screenshot({ path: 'test-results/slurm-billing-hosted-charge.png', fullPage: true });
+      await page.screenshot({
+        path: 'test-results/slurm-billing-hosted-charge.png',
+        fullPage: true,
+      });
 
       // 5. 回合正常收尾
       await waitForResponseComplete(page, 300_000);

--- a/miqi/agent/search_orchestrator.py
+++ b/miqi/agent/search_orchestrator.py
@@ -65,7 +65,10 @@ async def _ddgs_regional_search(query: str, n_queries: int, n: int) -> list[str]
 
     def _one(region: str) -> list[dict[str, Any]]:
         try:
-            return list(DDGS().text(query, region=region, max_results=n))
+            # backend="html"：国内网络下 auto/lite 会撞 Brave/Yandex 超时
+            # 20s+（#854 后实测：html 3.1s / lite 22.4s / auto 20.0s），
+            # html 后端稳定且快；region 参数不受影响。
+            return list(DDGS().text(query, region=region, max_results=n, backend="html"))
         except Exception as e:  # ddgs rate-limit / network — degrade per-region
             logger.warning("ddgs region=%s failed: %s", region, e)
             return []

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -207,19 +207,35 @@ class DDGSProvider(SearchProvider):
             return SearchResult(False, error_type="NETWORK")
 
         last_error = "UNKNOWN"
+
+        async def _query(backend: str, timeout: float) -> list:
+            """单后端查询 + 硬超时（ddgs 库自身无超时，国内网络下
+            lite/auto 后端会撞 Brave/Yandex 超时 20s+ —— #854 后实测：
+            html 3.1s / lite 22.4s 超时 / auto 20.0s 超时）。"""
+            return await asyncio.wait_for(
+                asyncio.to_thread(
+                    lambda: list(
+                        DDGS().text(query, max_results=count, backend=backend)
+                    )
+                ),
+                timeout=timeout,
+            )
+
         # Rate limits are usually short-lived (seconds) — retry once with a
         # small backoff before giving up and falling through the chain (#561).
         for attempt in (1, 2):
             try:
-                results = await asyncio.to_thread(
-                    lambda: list(
-                        DDGS().text(
-                            query,
-                            max_results=count,
-                            backend="html,lite",  # multiple endpoints, more resilient
-                        )
-                    )
-                )
+                # html 优先（国内网络稳定且快）；失败或无结果再试 lite（8s 上限）
+                results = []
+                try:
+                    results = await _query("html", 12.0)
+                except Exception:
+                    results = []
+                if not results:
+                    try:
+                        results = await _query("lite", 8.0)
+                    except Exception:
+                        results = []
                 if not results:
                     return SearchResult(True, error_type="NO_RESULT")
                 out = []

--- a/miqi/agent/tools/web.py
+++ b/miqi/agent/tools/web.py
@@ -209,33 +209,47 @@ class DDGSProvider(SearchProvider):
         last_error = "UNKNOWN"
 
         async def _query(backend: str, timeout: float) -> list:
-            """单后端查询 + 硬超时（ddgs 库自身无超时，国内网络下
-            lite/auto 后端会撞 Brave/Yandex 超时 20s+ —— #854 后实测：
-            html 3.1s / lite 22.4s 超时 / auto 20.0s 超时）。"""
+            """单后端查询。
+
+            timeout 同时承担两个角色（#1023 评审修正）：
+            ① `DDGS(timeout=...)` 库自身 HTTP 超时——到点终止运行中的同步
+               请求、释放线程池容量（wait_for 只能停止等待，停不了线程）；
+            ② 外层 wall-clock guard（略宽于库超时，优先由库到点释放）。
+            国内实测：html 3.1s / lite 22.4s 超时 / auto 20.0s 超时。
+            """
             return await asyncio.wait_for(
                 asyncio.to_thread(
                     lambda: list(
-                        DDGS().text(query, max_results=count, backend=backend)
+                        DDGS(timeout=timeout).text(
+                            query, max_results=count, backend=backend,
+                        )
                     )
                 ),
-                timeout=timeout,
+                timeout=timeout + 2.0,
             )
 
         # Rate limits are usually short-lived (seconds) — retry once with a
         # small backoff before giving up and falling through the chain (#561).
         for attempt in (1, 2):
             try:
-                # html 优先（国内网络稳定且快）；失败或无结果再试 lite（8s 上限）
-                results = []
+                # html 优先（国内网络稳定且快）；失败再试 lite（8s 上限）。
+                # 评审修正：失败分类不得丢失——两个后端都失败时抛最后异常，
+                # 走失败分类 + 重试 + 下游 fallback；只有后端成功但确实
+                # 无结果时才返回 NO_RESULT。
+                last_exc: Exception | None = None
+                results = None
                 try:
                     results = await _query("html", 12.0)
-                except Exception:
-                    results = []
+                except Exception as e:  # noqa: BLE001 - 分类前暂存
+                    last_exc = e
                 if not results:
                     try:
                         results = await _query("lite", 8.0)
-                    except Exception:
-                        results = []
+                        last_exc = None  # lite 成功（即使空结果）
+                    except Exception as e:  # noqa: BLE001
+                        last_exc = e
+                if not results and last_exc is not None:
+                    raise last_exc  # 真实失败 → 分类 + 重试 + 下游 fallback
                 if not results:
                     return SearchResult(True, error_type="NO_RESULT")
                 out = []

--- a/tests/agent/tools/test_web.py
+++ b/tests/agent/tools/test_web.py
@@ -761,3 +761,90 @@ async def test_parallel_search_auto_still_falls_back(monkeypatch):
                          deepseek_api_key="k", deepseek_api_base="https://api.deepseek.com")
     blocks = await tool._parallel_search("hello", n_queries=2, n=5)
     assert len(blocks) == 1 and "ddgs结果" in blocks[0]
+
+
+# ── #1023 评审修正回归：DDGS 后端超时/失败分类 ─────────────────────────────
+
+
+def _install_fake_ddgs(monkeypatch, behavior):
+    """注入假的 ddgs 模块；behavior(backend, timeout) → list | Exception。"""
+    import sys
+    import types
+
+    captured: list[tuple[str, float]] = []
+
+    class FakeDDGS:
+        def __init__(self, timeout=None):
+            self._timeout = timeout
+
+        def text(self, query, max_results=None, backend=None, **kw):
+            captured.append((backend, self._timeout))
+            result = behavior(backend, self._timeout)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    fake = types.ModuleType("ddgs")
+    fake.DDGS = FakeDDGS
+    monkeypatch.setitem(sys.modules, "ddgs", fake)
+    return captured
+
+
+async def test_ddgs_timeout_passed_to_library(monkeypatch):
+    """评审要求①：deadline 必须传给 DDGS(timeout=...)（wait_for 停不了线程）。"""
+    captured = _install_fake_ddgs(
+        monkeypatch,
+        lambda backend, timeout: [
+            {"title": "T", "href": "https://example.com", "body": "b"}
+        ],
+    )
+    r = await DDGSProvider().search("q", 5)
+    assert r.success and r.results
+    assert captured and captured[0][0] == "html"
+    assert captured[0][1] == 12.0  # html 后端 deadline 传入库
+
+
+async def test_ddgs_html_failure_falls_back_to_lite(monkeypatch):
+    """评审要求②：html 超时 → lite 成功 → 返回 lite 结果。"""
+
+    def behavior(backend, timeout):
+        if backend == "html":
+            raise TimeoutError("html timeout")
+        return [{"title": "L", "href": "https://lite.example.com", "body": "lb"}]
+
+    captured = _install_fake_ddgs(monkeypatch, behavior)
+    r = await DDGSProvider().search("q", 5)
+    assert r.success and r.results[0]["url"] == "https://lite.example.com"
+    assert [c[0] for c in captured[:2]] == ["html", "lite"]
+
+
+async def test_ddgs_both_backends_fail_keeps_real_error(monkeypatch):
+    """评审要求③：html/lite 均失败 → 真实失败分类（NETWORK），而非 NO_RESULT 伪装成功。"""
+
+    def behavior(backend, timeout):
+        raise TimeoutError(f"{backend} timeout")
+
+    _install_fake_ddgs(monkeypatch, behavior)
+    r = await DDGSProvider().search("q", 5)
+    assert r.success is False  # 不是 success + NO_RESULT
+    assert r.error_type == "NETWORK"  # Timeout → NETWORK 分类保留
+
+
+async def test_ddgs_failure_falls_through_manager_chain(monkeypatch):
+    """评审要求④：DDGS 失败后 manager 语义正确——链路耗尽返回失败（不伪装成功）。"""
+    manager = SearchProviderManager("ddgs")
+
+    def behavior(backend, timeout):
+        raise TimeoutError("all down")
+
+    _install_fake_ddgs(monkeypatch, behavior)
+    r = await manager.search("q", 5)
+    assert r.success is False
+    assert r.error_type == "NETWORK"
+
+
+async def test_ddgs_success_but_empty_is_no_result(monkeypatch):
+    """边界：后端成功但确实无结果 → NO_RESULT（success=True，可回落下一级）。"""
+    _install_fake_ddgs(monkeypatch, lambda backend, timeout: [])
+    r = await DDGSProvider().search("q", 5)
+    assert r.success is True and r.error_type == "NO_RESULT"


### PR DESCRIPTION
- [x] 修复

## 变更概述

修复无 key 用户联网搜索 20-60 秒不可用的问题：ddgs 后端选择撞国内不可达服务（Brave/Yandex），改用 html 后端。

## 背景/问题

平台网关模式下（Qraft 登录 → 腾讯云密钥走平台 AI 网关），本地 `providers` 为空，#844 的 DeepSeek 官方搜索不激活，搜索链只有 DDGS 兜底。但实测单次搜索 62.7 秒 —— 体感等于"搜索没了"。

根因实测（ddgs backend 对比）：

| 后端 | 耗时 | 结果 |
|---|---|---|
| `html` | **3.1s** | ✅ 5 条 |
| `lite` | 22.4s | ❌ 超时（search.brave.com 不可达） |
| `auto` 默认 | 20.0s | ❌ 超时（yandex.com 不可达） |

## 变更内容

- `DDGSProvider.search`：`backend="html,lite"` → **html 优先（12s 硬超时）**，失败/无结果回落 lite（8s 上限）
- `asyncio.wait_for` 硬超时保护（ddgs 库自身无超时）
- `_ddgs_regional_search`（fast 扇出路径）：补 `backend="html"`（原为 auto → Yandex 超时）

## 测试情况

tests/agent/tools/test_web.py 46 passed；search/ddgs 相关 11 passed。

## 日志/验证证据

```
修复前（同一 query）：
耗时 62.7s | Results for: 2026年诺贝尔物理学奖（结果正常但极慢）

修复后：
耗时 8.5s | Results for: 2026年诺贝尔物理学奖
1. 2024年诺贝尔物理学奖揭晓 人工神经网络获奖 – 澳纽网 ...
```

## 截图

无 UI 变更（后端性能修复）。附实测命令输出见上。

Closes #1022