### PR TITLE
fix(desktop): 登录后发送仍被拦成「未配置模型服务」——发送门禁改用 active_model_resolvable 判定

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -4392,8 +4392,7 @@ export function ChatConsole({
       // 判定（含网关路由）给出 active_model_resolvable；旧版 bridge 无该字段
       // 时回退到 configured（保持原行为）。
       const modelServable =
-        result.active_model_resolvable ??
-        result.providers.some((provider) => provider.configured);
+        result.active_model_resolvable ?? result.providers.some((provider) => provider.configured);
       if (!modelServable) {
         // No servable model — replace the optimistic bubble with the
         // provider-config guidance.  The send is refused: the user should

--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -452,13 +452,14 @@ function isProviderConfigurationProblem(message: string, code?: string) {
 
 function createProviderConfigMessage(
   content?: string,
-  action: 'open-provider-settings' | 'login' = 'open-provider-settings'
+  action: 'open-provider-settings' | 'login' = 'open-provider-settings',
+  actionLabel?: string
 ): Message {
   return {
     role: 'error',
     content: content || '尚未配置模型服务。请先配置 Provider/API Key 后再发送消息。',
     action,
-    actionLabel: action === 'login' ? '登录 MiQroForge 账号' : '去配置模型',
+    actionLabel: actionLabel ?? (action === 'login' ? '登录 MiQroForge 账号' : '去配置模型'),
     timestamp: Date.now(),
   };
 }
@@ -4316,9 +4317,17 @@ export function ChatConsole({
         return;
       }
       const result = await window.miqi.providers.list();
-      const hasConfiguredProvider = result.providers.some((provider) => provider.configured);
-      if (!hasConfiguredProvider) {
-        // No configured provider — replace the optimistic bubble with the
+      // 判定「当前默认模型能否发起会话」而不是「有没有已配置的本地 provider」：
+      // 登录后经平台 AI 网关路由的默认模型不需要任何本地凭据（make_provider
+      // 的网关分支），只看 configured 会把「登录即可用」误拦成「未配置模型
+      // 服务」——用户登录后仍被要求配置模型即由此而来。后端用与运行时同一套
+      // 判定（含网关路由）给出 active_model_resolvable；旧版 bridge 无该字段
+      // 时回退到 configured（保持原行为）。
+      const modelServable =
+        result.active_model_resolvable ??
+        result.providers.some((provider) => provider.configured);
+      if (!modelServable) {
+        // No servable model — replace the optimistic bubble with the
         // provider-config guidance.  The send is refused: the user should
         // configure a provider before sending.  The draft is restored to the
         // input so they can re-send once configured.  Only touch the composer /
@@ -4327,9 +4336,14 @@ export function ChatConsole({
         // setAttachments / setMessages act on the currently displayed session.
         // #1000：未登录时没有 Provider 可配置（#835 合规收口后凭据配置已移除），
         // 拦截气泡直接给出一键登录按钮，登录后经网关自动获得平台内置模型。
+        // 已登录时凭据配置同样不存在，引导落点是「设置 → 模型」选平台内置模型。
         const guidance =
           gatewayStatus?.loggedIn === true
-            ? createProviderConfigMessage()
+            ? createProviderConfigMessage(
+                '当前默认模型没有可用的模型服务。请到 设置 → 模型 选择平台内置模型后重试。',
+                'open-provider-settings',
+                '去选择模型'
+              )
             : createProviderConfigMessage(
                 '尚未登录平台账号。登录 MiQroForge 账号后即可使用平台内置模型发起会话，模型调用将经平台 AI 网关转发。',
                 'login'
@@ -5295,7 +5309,10 @@ export function ChatConsole({
         isProviderConfigurationProblem(message, data.code)
           ? createProviderConfigMessage(
               message,
-              loggedInRef.current ? 'open-provider-settings' : 'login'
+              loggedInRef.current ? 'open-provider-settings' : 'login',
+              // 已登录时凭据配置入口已不存在（#835 收口）：NO_API_KEY 只可能
+              // 是当前模型不走平台网关，落点是重选模型而非「配置模型」。
+              loggedInRef.current ? '去选择模型' : undefined
             )
           : { role: 'error', content: message, timestamp: Date.now() },
       ]);

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -384,6 +384,12 @@ export interface ProvidersListResult {
   providers: ProviderInfo[];
   active_model?: string;
   active_provider?: string | null;
+  /**
+   * 当前默认模型在运行时是否真的能发起会话。登录后经平台 AI 网关路由的默认
+   * 模型不需要任何本地 provider 凭据，只看 `configured` 会误判为不可用。
+   * 旧版 bridge 不返回该字段时为 undefined（前端回退到 configured 判定）。
+   */
+  active_model_resolvable?: boolean;
 }
 
 export interface ProviderUpdateResult {

--- a/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
+++ b/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
@@ -245,9 +245,7 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
     expect(sends).toBe(1);
   });
 
-  test('登录 + 网关 active + 无本地凭据 + 模型不可解析：拦截并引导去选择模型', async ({
-    page,
-  }) => {
+  test('登录 + 网关 active + 无本地凭据 + 模型不可解析：拦截并引导去选择模型', async ({ page }) => {
     // 已登录但默认模型运行时不可用（非网关模型且无本地凭据）——引导落点是
     // 重选平台内置模型，而不是「去配置模型」（#835 收口后凭据配置已不存在）。
     await page.addInitScript({

--- a/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
+++ b/apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts
@@ -193,6 +193,109 @@ test.describe('Issue #922 — AI 网关状态门禁', () => {
     expect(sends).toBe(1);
   });
 
+  test('登录 + 网关 active + 无本地凭据：默认网关模型可直接发送（chat.send 被调用）', async ({
+    page,
+  }) => {
+    // 登录用户没有任何本地 provider 凭据 —— 此前只看 providers[].configured
+    // 会把这条路径拦成「尚未配置模型服务」（用户登录后仍被要求配置模型）。
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [],
+        // 真实后端按运行时判定：网关路由可用 → 模型可发起会话
+        activeModelResolvable: true,
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'active', configVersion: 1 },
+        },
+      }),
+    });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+
+    await page.evaluate(() => {
+      (window as any).__chatSends = 0;
+      const orig = (window as any).miqi.chat.send.bind((window as any).miqi.chat);
+      (window as any).miqi.chat.send = (...args: unknown[]) => {
+        (window as any).__chatSends += 1;
+        return orig(...args);
+      };
+    });
+
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await expect(textarea).toBeVisible({ timeout: 10_000 });
+    await textarea.fill('hello gateway no local key');
+    await textarea.press('Enter');
+
+    // 用户气泡保留，未被替换为「未配置模型服务」或登录引导
+    await expect(
+      page.getByTestId('chat-message-user').getByText('hello gateway no local key')
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/尚未配置模型服务/)).not.toBeVisible();
+    await expect(page.getByText(/尚未登录平台账号/)).not.toBeVisible();
+    await page.waitForTimeout(500);
+    const sends = await page.evaluate(() => (window as any).__chatSends);
+    expect(sends).toBe(1);
+  });
+
+  test('登录 + 网关 active + 无本地凭据 + 模型不可解析：拦截并引导去选择模型', async ({
+    page,
+  }) => {
+    // 已登录但默认模型运行时不可用（非网关模型且无本地凭据）——引导落点是
+    // 重选平台内置模型，而不是「去配置模型」（#835 收口后凭据配置已不存在）。
+    await page.addInitScript({
+      content: buildMockBridgeScript({
+        providers: [],
+        activeModelResolvable: false,
+        qraftStatus: {
+          loggedIn: true,
+          account: {
+            phone: '18500000000',
+            sub: '19',
+            username: 'U-GW',
+            nickname: '网关用户',
+          },
+          env: 'test',
+          baseUrl: 'https://test.forge.miqroera.com/api',
+          aiGateway: { status: 'active', configVersion: 1 },
+        },
+      }),
+    });
+    await page.goto('/');
+    await page.waitForSelector('#root', { state: 'visible' });
+
+    await page.evaluate(() => {
+      (window as any).__chatSends = 0;
+      const orig = (window as any).miqi.chat.send.bind((window as any).miqi.chat);
+      (window as any).miqi.chat.send = (...args: unknown[]) => {
+        (window as any).__chatSends += 1;
+        return orig(...args);
+      };
+    });
+
+    const textarea = page.locator('[data-testid="chat-input-container"] textarea');
+    await expect(textarea).toBeVisible({ timeout: 10_000 });
+    await textarea.fill('ping unresolvable');
+    await textarea.press('Enter');
+
+    await expect(page.getByText(/当前默认模型没有可用的模型服务/)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('button', { name: '去选择模型' })).toBeVisible();
+    await expect(textarea).toHaveValue('ping unresolvable');
+
+    await page.waitForTimeout(500);
+    const sends = await page.evaluate(() => (window as any).__chatSends);
+    expect(sends).toBe(0);
+  });
+
   test('网关非 active（provisioning）：论文无直链的 AI 下载 fallback 同样被拦截（chat.send 零调用）', async ({
     page,
   }) => {

--- a/apps/desktop/tests/smoke/mocks.ts
+++ b/apps/desktop/tests/smoke/mocks.ts
@@ -16,6 +16,12 @@ export interface MockBridgeOptions {
   models?: Array<Record<string, unknown>>;
   activeModel?: string;
   activeProvider?: string | null;
+  /**
+   * providers.list 的 active_model_resolvable（真实后端按运行时判定计算，
+   * 含登录后经平台 AI 网关路由的模型）。省略时镜像「任一 provider 已配置」——
+   * 无本地凭据的场景需显式传 true 才等价于网关路由可用。
+   */
+  activeModelResolvable?: boolean;
   config?: Record<string, unknown>;
   /** MiQroForge 登录态（issue #726 设置页）。默认未登录。 */
   qraftStatus?: Record<string, unknown>;
@@ -84,6 +90,9 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   );
   const activeModelJson = JSON.stringify(opts.activeModel || '');
   const activeProviderJson = JSON.stringify(opts.activeProvider ?? null);
+  // null → 每次调用按「任一 provider 已配置」动态计算（镜像无网关时的真实后端）
+  const activeModelResolvableJson =
+    opts.activeModelResolvable === undefined ? 'null' : String(opts.activeModelResolvable);
   const configJson = JSON.stringify(opts.config || {});
   const qraftStatusJson = JSON.stringify(opts.qraftStatus || { loggedIn: false });
   const qraftLoginResultJson = JSON.stringify(
@@ -153,6 +162,7 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
   var _providers = ${providersJson};
   var _activeModel = ${activeModelJson};
   var _activeProvider = ${activeProviderJson};
+  var _activeModelResolvableOpt = ${activeModelResolvableJson};
 
   // ── Interactive helpers ──────────────────────────────────────────
   var _callbacks = {
@@ -304,7 +314,14 @@ export function buildMockBridgeScript(opts: MockBridgeOptions = {}): string {
       onUpdated: function(cb) { return _on('config:updated', cb); },    },
 
     providers: {
-      list: function() { return Promise.resolve({ providers: JSON.parse(JSON.stringify(_providers)), active_model: _activeModel, active_provider: _activeProvider }); },
+      list: function() {
+        var providersCopy = JSON.parse(JSON.stringify(_providers));
+        var resolvable = _activeModelResolvableOpt;
+        if (resolvable === null) {
+          resolvable = providersCopy.some(function(p) { return !!p.configured; });
+        }
+        return Promise.resolve({ providers: providersCopy, active_model: _activeModel, active_provider: _activeProvider, active_model_resolvable: resolvable });
+      },
       test: function() { return Promise.resolve({ ok: true }); },
       update: function(providerName, apiKey, apiBase, headers, model) {
         // 镜像真实后端：model 覆盖写为默认模型，并归属 provider

--- a/miqi/providers/factory.py
+++ b/miqi/providers/factory.py
@@ -41,8 +41,13 @@ def make_provider(config: Any) -> Any:
     # 模型时,把该模型调用经 AnthropicProvider(Anthropic Messages 兼容)指向平台
     # 网关 —— 走用户 encryptedApiKey,计入平台消费组配额。前提不满足则落回直连。
     # 必须位于下方 API-key 守卫之前:登录用户即使未激活内置密钥也能经网关调用。
+    # 注意不能用 provider_name == "deepseek" 作前置条件:零本地凭据时
+    # _match_provider 返回 (None, None),provider_name 为 None,网关分支会被
+    # 跳过而落到 API-key 守卫报 NO_API_KEY —— 与 providers.list 的
+    # active_model_resolvable 判定(不依赖 _match_provider)不一致(实测复现:
+    # 登录+网关 active+无本地 key 发送即失败)。直接用模型前缀判定。
     workspace = getattr(config, "workspace_path", None)
-    if provider_name == "deepseek" and workspace:
+    if workspace and model.startswith("deepseek/"):
         from miqi.providers.gateway import (
             GATEWAY_MODEL,
             GATEWAY_PREFIX,
@@ -51,7 +56,7 @@ def make_provider(config: Any) -> Any:
             read_gateway_creds,
         )
 
-        bare = model[len("deepseek/") :] if model.startswith("deepseek/") else model
+        bare = model[len("deepseek/"):]
         if bare == GATEWAY_MODEL:
             creds = read_gateway_creds(gateway_token_file(config))
             # 网关 origin 必须可用（显式配置强制 https，非法则回退直连）

--- a/miqi/runtime/provider_handlers.py
+++ b/miqi/runtime/provider_handlers.py
@@ -265,6 +265,12 @@ async def providers_list_handler(
             "providers": providers_out,
             "active_model": model,
             "active_provider": model_provider,
+            # 发送门禁的判定依据（#1010 后续）：前端只看得见「本地 provider 是否
+            # 有凭据」，登录后经平台网关路由的默认模型却不需要任何本地凭据
+            # （make_provider 的网关分支），只看 configured 会把可用模型误判成
+            # 「未配置模型服务」。这里用与运行时同一套判定（含网关路由）告诉
+            # 前端当前默认模型是否可以真正发起会话。
+            "active_model_resolvable": _model_provider_resolvable(config, model),
         }
     }
 

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -153,6 +153,40 @@ class TestMakeProviderGatewayRoute:
         assert provider.api_base == f"{gateway_origin()}{GATEWAY_PREFIX}"
         assert provider._resolve_model("deepseek/deepseek-v4-flash") == "deepseek-v4-flash"
 
+    def test_zero_local_credentials_routes_via_gateway(self, tmp_path: Path):
+        """回归（#1010 后续）：真实 Config 无任何本地凭据时 _match_provider
+        返回 (None, None)——get_provider_name() 为 None。网关分支此前把
+        provider_name == "deepseek" 当前置条件，零凭据登录用户（登录后经网关
+        用平台内置模型）会落到 API-key 守卫报 NO_API_KEY，与前端发送门禁的
+        active_model_resolvable 判定不一致（实测复现：登录+网关 active+无本地
+        key 发送即失败）。网关路由必须只看模型前缀 + 网关凭据。"""
+        from miqi.config.schema import Config
+
+        _token_for(tmp_path, _active_gateway())
+        config = Config()
+        config.agents.defaults.model = "deepseek/deepseek-v4-flash"
+        config.agents.defaults.workspace = str(tmp_path)
+        # 真实零凭据形态：_match_provider 解析不到任何已配置 provider
+        assert config.get_provider_name(config.agents.defaults.model) is None
+
+        provider = make_provider(config)
+
+        assert isinstance(provider, AnthropicProvider)
+        assert provider.api_key == SK
+        assert provider.api_base == f"{gateway_origin()}{GATEWAY_PREFIX}"
+
+    def test_zero_local_credentials_no_gateway_still_raises(self, tmp_path: Path):
+        """零凭据 + 无网关凭据：仍按「未配置 API Key」报错（守卫语义不变）。"""
+        from miqi.config.schema import Config
+
+        _token_for(tmp_path, None)
+        config = Config()
+        config.agents.defaults.model = "deepseek/deepseek-v4-flash"
+        config.agents.defaults.workspace = str(tmp_path)
+
+        with pytest.raises(ValueError, match="No API key configured"):
+            make_provider(config)
+
     def test_https_gateway_base_accepted_with_trailing_slash_normalized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/runtime/test_provider_handlers_regression.py
+++ b/tests/runtime/test_provider_handlers_regression.py
@@ -7,6 +7,8 @@ providers.update 的自定义凭据写入路径,该行为不再存在。替换�
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from miqi.runtime.app_server import AppServerError, ClientSessionRegistry
@@ -69,6 +71,80 @@ async def test_providers_list_reports_model_when_it_belongs_to_provider():
 
     deepseek = providers["deepseek"]
     assert deepseek["configured_model"] == "deepseek-v4-flash"
+
+
+# ── active_model_resolvable（#1010 后续）：发送门禁的判定依据 ──────────────
+
+
+@pytest.mark.asyncio
+async def test_providers_list_active_model_unresolvable_without_credentials(
+    tmp_path, monkeypatch
+):
+    """无任何凭据（未登录/无本地 key、无网关）时默认模型不可发起会话。"""
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    registry = _make_registry("deepseek/deepseek-v4-flash")
+    cfg = registry.bridge_context["state"].load_config()
+    cfg.agents.defaults.workspace = str(tmp_path)
+
+    result = await providers_list_handler("r1", {}, "client-1", None, registry)
+
+    assert result["result"]["active_model_resolvable"] is False
+
+
+@pytest.mark.asyncio
+async def test_providers_list_active_model_resolvable_via_ai_gateway(tmp_path, monkeypatch):
+    """登录后网关凭据 active 且默认模型为网关模型时，没有任何本地 provider
+    凭据也可发起会话 —— 前端发送门禁只看 configured 会把这条路径拦成
+    「尚未配置模型服务」（用户登录后仍被要求配置模型）。"""
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    registry = _make_registry("deepseek/deepseek-v4-flash")
+    cfg = registry.bridge_context["state"].load_config()
+    cfg.agents.defaults.workspace = str(tmp_path)
+
+    qraft_dir = tmp_path / ".qraft"
+    qraft_dir.mkdir()
+    (qraft_dir / "token.json").write_text(
+        json.dumps({
+            "aiGateway": {
+                "status": "active",
+                "encryptedApiKey": "enc-key",
+                "configVersion": 1,
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    result = await providers_list_handler("r1", {}, "client-1", None, registry)
+
+    assert all(p["configured"] is False for p in result["result"]["providers"])
+    assert result["result"]["active_model_resolvable"] is True
+
+
+@pytest.mark.asyncio
+async def test_providers_list_gateway_creds_do_not_resolve_other_models(tmp_path, monkeypatch):
+    """网关只路由实测网关模型：默认模型是别的模型时仍不可发起会话
+    （make_provider 会落回直连并因无凭据报 NO_API_KEY）。"""
+    monkeypatch.delenv("QRAFT_GATEWAY_BASE", raising=False)
+    registry = _make_registry("openai/gpt-4o")
+    cfg = registry.bridge_context["state"].load_config()
+    cfg.agents.defaults.workspace = str(tmp_path)
+
+    qraft_dir = tmp_path / ".qraft"
+    qraft_dir.mkdir()
+    (qraft_dir / "token.json").write_text(
+        json.dumps({
+            "aiGateway": {
+                "status": "active",
+                "encryptedApiKey": "enc-key",
+                "configVersion": 1,
+            }
+        }),
+        encoding="utf-8",
+    )
+
+    result = await providers_list_handler("r1", {}, "client-1", None, registry)
+
+    assert result["result"]["active_model_resolvable"] is False
 
 
 # ── 后端收口（#835）：providers.update 拒绝自配凭据 ─────────────────────────


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

登录后发送消息仍被拦成「尚未配置模型服务」（前端门禁误判），且门禁放行后运行时也报 NO_API_KEY（make_provider 网关路由失效）——两层判定与运行时不一致。修复后登录用户零本地凭据即可经平台 AI 网关正常对话。

## 背景/问题

**现象**：用户登录 MiQroForge 账号后（网关状态 active），发送消息被拦截为「尚未配置模型服务。请先配置 Provider/API Key 后再发送消息。」——但 #835 合规收口后凭据配置入口已移除，用户无路可配；修复前端门禁后进一步实测发现运行时也会报 `No API key configured`。

**根因（两层）**：

1. **前端发送门禁只看 `providers.list()` 的 `configured`**（仅反映本地 api_key/api_base）。登录用户经平台 AI 网关路由默认模型（`deepseek/deepseek-v4-flash`）时，运行时 `make_provider` 的网关分支（#922）直接读 `.qraft/token.json` 的网关凭据，不需要任何本地凭据 → `configured` 恒为 false → 发送被误拦。
2. **`make_provider` 的网关分支前置条件 `provider_name == "deepseek"` 依赖 `_match_provider`**，而 `_match_provider` 只在 provider「已配置凭据」时返回名字——零凭据时 `get_provider_name()` 为 None，网关分支永不生效，落到 API-key 守卫报 NO_API_KEY。与前端门禁判定（`_qraft_gateway_routable`，不依赖 `_match_provider`）不一致：门禁放行、运行时拒绝。

**影响**：所有「登录 + 网关 active + 无本地凭据」的用户（#1000 登录入口的目标用户）登录后无法发起任何会话。此前 #946 的网关 live E2E 因真实账号恰有本地配置未覆盖此路径。

## 变更内容

| 文件 | 改动 |
|------|------|
| `miqi/runtime/provider_handlers.py` | `providers.list` 新增 `active_model_resolvable`：与运行时同一套判定（`_model_provider_resolvable`，含 #922 网关路由分支） |
| `miqi/providers/factory.py` | 网关分支改用模型前缀（`model.startswith("deepseek/")` + 网关实测模型）判定，不再依赖 `_match_provider`；与 `_qraft_gateway_routable` 完全对齐。零凭据 + 无网关仍按原守卫报错 |
| `apps/desktop/src/shared/ipc.ts` | `ProvidersListResult` 补 `active_model_resolvable?: boolean` |
| `apps/desktop/src/renderer/features/chat/ChatConsole.tsx` | 发送门禁改为 `modelServable = active_model_resolvable ?? configured`（旧 bridge 回退原判定）；已登录但模型不可用时的引导改为「设置 → 模型」选平台内置模型，按钮「去选择模型」；流错误路径同步改文案，并保留 #1016 的登录失效重登拦截优先 |
| `apps/desktop/tests/smoke/mocks.ts` | mock 支持 `activeModelResolvable`（省略时按「任一 provider 已配置」动态计算） |
| `apps/desktop/tests/smoke/issue-922-ai-gateway.spec.ts` | 回归用例：登录 + 网关 active + 无本地凭据可直接发送；模型不可解析时拦截为「去选择模型」引导 |
| `tests/runtime/test_provider_handlers_regression.py` | 3 个用例：无凭据 false、网关凭据 active 时 true、非网关模型不误判 |
| `tests/providers/test_gateway.py` | 2 个用例：真实 `Config` 零凭据 + 网关 active 路由 AnthropicProvider（回归本 bug 的测试桩盲区）；零凭据 + 无网关仍抛 No API key configured |

## 日志/验证证据

```
修复前（真实账号 live E2E 实测）：登录成功、消息已发出，桥日志显示发送后立即报错：
[WARNING] thread_app_handlers:_get_or_create_session | make_provider failed: No API key configured.
[WARNING] bridge.loop:_chat_send_handler | make_provider failed during chat.send: No API key configured.

修复后（真实账号 live E2E，QRAFT_LIVE=1，临时 MIQI_HOME 零本地凭据）：
登录 → 网关可用 → 新会话发送 ping → 经平台网关真实回复：
$ QRAFT_LIVE=1 ... npx playwright test --config=playwright.config.ts --project=electron ai-gateway-live.spec.ts
1 passed (18.4s)          # 真实登录 → 网关可用 → 新会话消息经网关真实回复

$ npx playwright test --config=playwright.config.ts --project=smoke tests/smoke/issue-922-ai-gateway.spec.ts
7 passed (5.5s)

$ python -m pytest tests/providers tests/runtime/test_provider_handlers_regression.py tests/runtime/test_thread_app_handlers.py -q
85 passed in 14.82s

$ python -m pytest tests/runtime tests/bridge tests/config tests/providers tests/test_commands.py tests/test_tui_runtime.py -q
1710 passed, 1 skipped in 129.99s
```

## 截图

修复后：真实账号登录 → 网关可用 → 零本地凭据发送 ping → 经平台网关真实回复「pong」（live E2E 截图）：

![live E2E 真实回复](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/560067ac843d47cd.png)

修复后：登录 + 网关 active + 零本地 provider（smoke mock）发送通过、无拦截：

![发送通过](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/ec27e0d79c441a20.png)

模型不可解析时的拦截引导（指向「设置 → 模型」，不再指向已不存在的凭据配置）：

![拦截引导](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/72e71a9477a4e0fd.png)

## 测试情况

- **真实账号 live E2E**（本地实测）：`ai-gateway-live.spec.ts` 通过——真实登录 → 网关状态「可用」→ 零本地凭据发送 → 助手真实回复「pong」；修复前同一 spec 失败（等待 180s 无回复）
- **Python 单测**：`tests/providers`（含 2 个新增 factory 用例）+ `test_provider_handlers_regression.py`（含 3 个新增 resolvable 用例）+ `test_thread_app_handlers.py` 共 85 通过；`tests/runtime tests/bridge tests/config` 等全量 1710 passed
- **smoke**：`issue-922-ai-gateway.spec.ts` 7/7 通过（含 2 个新增回归用例）
- **类型检查**：`tsconfig.web.json` / `tsconfig.node.json` 通过；vitest `ChatConsole.test.ts` + `chatConsoleMessages.test.ts` 共 67 通过
