### PR TITLE
feat(web_search): 接入平台网关联网搜索

### DIFF
--- a/miqi/agent/tools/gateway_web.py
+++ b/miqi/agent/tools/gateway_web.py
@@ -1,0 +1,211 @@
+"""Platform gateway web-search provider.
+
+The platform AI gateway already owns authentication and model routing. This
+module adds the corresponding search capability as a separate provider, using
+an explicit ``POST <gateway>/v1/web_search`` contract rather than probing the
+LLM ``/responses`` endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from miqi.agent.tools.web import SearchProvider, SearchProviderManager, SearchResult, WebSearchTool
+
+_log = logging.getLogger(__name__)
+
+
+class GatewaySearchProvider(SearchProvider):
+    """Search through the Qraft platform gateway."""
+
+    name = "gateway"
+
+    def __init__(self, api_key: str, origin: str, prefix: str = "/miqroera-deepseek"):
+        self.api_key = api_key
+        self.origin = (origin or "").rstrip("/")
+        self.prefix = "/" + prefix.strip("/")
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.origin}{self.prefix}/v1/web_search"
+
+    @property
+    def secure(self) -> bool:
+        try:
+            return urlparse(self.origin).scheme == "https"
+        except ValueError:
+            return False
+
+    async def search(self, query: str, count: int) -> SearchResult:
+        if not self.api_key:
+            return SearchResult(False, error_type="NO_KEY", provider=self.name)
+        if not self.secure:
+            return SearchResult(False, error_type="UNSUPPORTED", provider=self.name)
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(10.0, connect=8.0, write=8.0, pool=8.0)
+            ) as client:
+                response = await client.post(
+                    self.endpoint,
+                    json={"query": query, "max_results": count},
+                    headers={
+                        "X-Api-Key": self.api_key,
+                        "Accept": "application/json",
+                        "Content-Type": "application/json",
+                    },
+                )
+
+            if response.status_code == 429:
+                return SearchResult(False, error_type="RATE_LIMIT", provider=self.name)
+            if response.status_code in (401, 403):
+                return SearchResult(False, error_type="AUTH_ERROR", provider=self.name)
+            if response.status_code in (404, 405):
+                # Endpoint not deployed / contract not enabled yet.
+                return SearchResult(False, error_type="UNSUPPORTED", provider=self.name)
+            if response.status_code >= 500:
+                return SearchResult(False, error_type="SERVER_ERROR", provider=self.name)
+            response.raise_for_status()
+
+            payload = response.json()
+            items = payload.get("results", [])
+            if not isinstance(items, list):
+                return SearchResult(False, error_type="SERVER_ERROR", provider=self.name)
+
+            results: list[dict[str, str]] = []
+            for item in items[:count]:
+                if not isinstance(item, dict):
+                    continue
+                url = str(item.get("url") or "")
+                if not url:
+                    continue
+                results.append({
+                    "title": str(item.get("title") or ""),
+                    "url": url,
+                    "snippet": str(item.get("snippet") or item.get("content") or ""),
+                })
+
+            if not results:
+                return SearchResult(True, error_type="NO_RESULT", provider=self.name)
+            return SearchResult(True, results, provider=self.name)
+        except (asyncio.TimeoutError, httpx.TimeoutException):
+            return SearchResult(False, error_type="NETWORK", provider=self.name)
+        except httpx.HTTPStatusError:
+            return SearchResult(False, error_type="SERVER_ERROR", provider=self.name)
+        except Exception as exc:  # noqa: BLE001 - provider boundary must fallback
+            _log.warning("gateway web_search failed: %s", type(exc).__name__)
+            return SearchResult(False, error_type="NETWORK", provider=self.name)
+
+
+class GatewaySearchProviderManager(SearchProviderManager):
+    """Existing search manager with gateway prepended in auto mode."""
+
+    def __init__(
+        self,
+        *args: Any,
+        gateway_api_key: str = "",
+        gateway_origin: str = "",
+        gateway_prefix: str = "/miqroera-deepseek",
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+        self.gateway_api_key = gateway_api_key
+        self.gateway_origin = gateway_origin
+        self.gateway_prefix = gateway_prefix
+
+    def _gateway_provider(self) -> GatewaySearchProvider | None:
+        provider = GatewaySearchProvider(
+            self.gateway_api_key,
+            self.gateway_origin,
+            self.gateway_prefix,
+        )
+        if not self.gateway_api_key or not provider.secure:
+            return None
+        return provider
+
+    def _chain(self) -> list[SearchProvider]:
+        chain = super()._chain()
+        if self.provider == "auto":
+            gateway = self._gateway_provider()
+            if gateway is not None:
+                chain.insert(0, gateway)
+        return chain
+
+    async def search(self, query: str, count: int) -> SearchResult:
+        # Keep the established fallback semantics, with one extra case:
+        # a missing gateway endpoint is a capability miss and must not stop
+        # the existing auto chain.
+        return await _search_with_gateway_fallback(self, query, count)
+
+
+async def _search_with_gateway_fallback(
+    manager: GatewaySearchProviderManager,
+    query: str,
+    count: int,
+) -> SearchResult:
+    chain = manager._chain()
+    last_auth_warned = False
+    last_failure: SearchResult | None = None
+    for provider in chain:
+        result = await provider.search(query, count)
+        if result.success:
+            return result
+        if not result.provider:
+            result.provider = provider.name
+        last_failure = result
+        if result.error_type == "UNSUPPORTED" and provider.name == "gateway":
+            _log.info("web_search: platform gateway search unavailable, falling back")
+            continue
+        if result.error_type in {"RATE_LIMIT", "NETWORK", "SERVER_ERROR", "NO_RESULT", "BALANCE_ERROR"}:
+            _log.warning(
+                "web_search: %s failed (%s), trying next provider",
+                provider.name,
+                result.error_type,
+            )
+            continue
+        if result.error_type in {"AUTH_ERROR", "NO_KEY"}:
+            if not last_auth_warned:
+                _log.warning(
+                    "web_search: %s authentication failed — check credentials",
+                    provider.name,
+                )
+                last_auth_warned = True
+            continue
+        return result
+    if last_failure is not None:
+        return SearchResult(
+            False,
+            error_type=last_failure.error_type or "SERVER_ERROR",
+            provider=last_failure.provider,
+        )
+    return SearchResult(False, error_type="SERVER_ERROR")
+
+
+class GatewayWebSearchTool(WebSearchTool):
+    """Drop-in WebSearchTool using the platform gateway as auto-chain priority."""
+
+    def __init__(
+        self,
+        gateway_api_key: str | None = None,
+        gateway_origin: str | None = None,
+        gateway_prefix: str = "/miqroera-deepseek",
+        **kwargs: Any,
+    ):
+        super().__init__(**kwargs)
+        self.manager = GatewaySearchProviderManager(
+            self.manager.provider,
+            model=self.manager.model,
+            model_provider=self.manager._model_provider,
+            tavily_api_key=self.manager.tavily_api_key,
+            brave_api_key=self.manager.brave_api_key,
+            deepseek_api_key=self.manager.deepseek_api_key,
+            deepseek_api_base=self.manager.deepseek_api_base,
+            gateway_api_key=gateway_api_key or "",
+            gateway_origin=gateway_origin or "",
+            gateway_prefix=gateway_prefix,
+        )

--- a/miqi/providers/gateway.py
+++ b/miqi/providers/gateway.py
@@ -38,7 +38,7 @@ def gateway_origin() -> str | None:
     """网关 origin（末尾斜杠已归一化）；配置非法返回 None，调用方回退直连。
 
     显式配置的 QRAFT_GATEWAY_BASE 必须为 https:// 开头，否则拒绝接受
-    （CWE-319：明文通道不能承载密钥）。未配置时回退 test env 实测
+    （CWE-319：明文通道禁止承载密钥）。未配置时回退 test env 实测
     http IP（见模块注释），使测试环境仍可实测网关。
     """
     raw = os.environ.get("QRAFT_GATEWAY_BASE")
@@ -55,8 +55,16 @@ def gateway_origin() -> str | None:
 
 
 def gateway_token_file(config: Any) -> Path:
-    """Python 侧 token 文件路径(与 services._build_billing 同源)。"""
-    return Path(config.workspace_path) / ".qraft" / "token.json"
+    """Python 侧 token 文件路径（与 services._build_billing 同源）。
+
+    轻量测试配置或尚未完成配置加载的调用方可能没有 ``workspace_path``。
+    此时返回一个不存在的哨兵路径，让上层凭据读取按“无凭据”安全降级，
+    避免网关接线影响与其无关的 runtime/tool-registry 测试。
+    """
+    workspace = getattr(config, "workspace_path", None)
+    if not isinstance(workspace, (str, os.PathLike)) or not str(workspace):
+        return Path("__miqi_missing_workspace__") / ".qraft" / "token.json"
+    return Path(workspace) / ".qraft" / "token.json"
 
 
 def read_gateway_creds(token_file: Path) -> dict[str, Any] | None:

--- a/miqi/runtime/tool_registry_factory.py
+++ b/miqi/runtime/tool_registry_factory.py
@@ -81,13 +81,10 @@ def apply_system_installs_toggle(
         try:
             sandbox_manager.allow_system_installs = enabled
         except Exception as exc:  # noqa: BLE001 - config 已持久化，重启自愈
-            # #875 review: this is an AUTHOR-recognized failure mode —
-            # surface it instead of swallowing it, or the user sees
-            # "允许并记住" accepted while the current runtime still denies
-            # installs (config=true / runtime=false).
             _log.warning(
                 "system install allow: runtime update failed (config "
-                "persisted, restart will apply): %s", exc,
+                "persisted, restart will apply): %s",
+                exc,
             )
             runtime_failed = True
     return persist_failed, runtime_failed
@@ -510,7 +507,8 @@ def create_runtime_tool_registry(
     )
 
     # 3. Web tools
-    from miqi.agent.tools.web import WebFetchTool, WebSearchTool
+    from miqi.agent.tools.gateway_web import GatewayWebSearchTool
+    from miqi.agent.tools.web import WebFetchTool
 
     if web_cfg is not None:
         search_cfg = getattr(web_cfg, "search", None)
@@ -529,8 +527,21 @@ def create_runtime_tool_registry(
         _defaults = getattr(getattr(config, "agents", None), "defaults", None)
         return getattr(_defaults, "model", "") if _defaults is not None else ""
 
+    from miqi.providers.gateway import (
+        GATEWAY_PREFIX,
+        gateway_origin,
+        gateway_token_file,
+        read_gateway_creds,
+    )
+
+    _gateway_origin = gateway_origin() or ""
+    _gateway_creds = read_gateway_creds(gateway_token_file(config))
+    _gateway_key = ""
+    if _gateway_creds is not None:
+        _gateway_key = str(_gateway_creds.get("encryptedApiKey") or "")
+
     registry.register(
-        WebSearchTool(
+        GatewayWebSearchTool(
             provider=getattr(search_cfg, "provider", "auto") if search_cfg is not None else "auto",
             api_key=getattr(search_cfg, "api_key", None) if search_cfg is not None else None,
             tavily_api_key=getattr(search_cfg, "tavily_api_key", None) if search_cfg is not None else None,
@@ -539,6 +550,9 @@ def create_runtime_tool_registry(
             deepseek_api_base=deepseek_api_base or "https://api.deepseek.com",
             model_provider=_current_model_name,
             max_results=getattr(search_cfg, "max_results", 5) if search_cfg is not None else 5,
+            gateway_api_key=_gateway_key,
+            gateway_origin=_gateway_origin,
+            gateway_prefix=GATEWAY_PREFIX,
         )
     )
     registry.register(

--- a/tests/agent/tools/test_gateway_web.py
+++ b/tests/agent/tools/test_gateway_web.py
@@ -1,0 +1,151 @@
+"""Tests for platform gateway web search."""
+
+import pytest
+
+from miqi.agent.tools.gateway_web import GatewaySearchProvider, GatewaySearchProviderManager
+from miqi.agent.tools.web import DDGSProvider, SearchResult, TavilyProvider
+
+
+async def test_gateway_search_success(monkeypatch):
+    calls = []
+
+    async def _fake_post(self, url, **kwargs):
+        calls.append((url, kwargs))
+
+        class _Response:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "results": [
+                        {
+                            "title": "官方结果",
+                            "url": "https://example.com/article",
+                            "snippet": "摘要",
+                        }
+                    ]
+                }
+
+            def raise_for_status(self):
+                return None
+
+        return _Response()
+
+    monkeypatch.setattr("miqi.agent.tools.gateway_web.httpx.AsyncClient.post", _fake_post)
+    provider = GatewaySearchProvider("gateway-secret", "https://gateway.example.com")
+    result = await provider.search("MiQroForge", 5)
+
+    assert result.success
+    assert result.provider == "gateway"
+    assert result.results == [
+        {
+            "title": "官方结果",
+            "url": "https://example.com/article",
+            "snippet": "摘要",
+        }
+    ]
+    assert calls[0][0] == "https://gateway.example.com/miqroera-deepseek/v1/web_search"
+    assert calls[0][1]["headers"]["X-Api-Key"] == "gateway-secret"
+    assert calls[0][1]["json"] == {"query": "MiQroForge", "max_results": 5}
+
+
+@pytest.mark.asyncio
+async def test_gateway_search_404_is_unsupported(monkeypatch):
+    async def _fake_post(self, url, **kwargs):
+        class _Response:
+            status_code = 404
+
+            def raise_for_status(self):
+                return None
+
+        return _Response()
+
+    monkeypatch.setattr("miqi.agent.tools.gateway_web.httpx.AsyncClient.post", _fake_post)
+    result = await GatewaySearchProvider("k", "https://gateway.example.com").search("q", 5)
+    assert not result.success and result.error_type == "UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_gateway_search_http_origin_fails_closed():
+    result = await GatewaySearchProvider("k", "http://gateway.example.com").search("q", 5)
+    assert not result.success and result.error_type == "UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_gateway_search_401_is_auth_error(monkeypatch):
+    async def _fake_post(self, url, **kwargs):
+        class _Response:
+            status_code = 401
+
+            def raise_for_status(self):
+                return None
+
+        return _Response()
+
+    monkeypatch.setattr("miqi.agent.tools.gateway_web.httpx.AsyncClient.post", _fake_post)
+    result = await GatewaySearchProvider("k", "https://gateway.example.com").search("q", 5)
+    assert not result.success and result.error_type == "AUTH_ERROR"
+
+
+def test_gateway_manager_is_first_in_auto_chain():
+    manager = GatewaySearchProviderManager(
+        "auto",
+        gateway_api_key="gateway-key",
+        gateway_origin="https://gateway.example.com",
+        tavily_api_key="tavily-key",
+        brave_api_key="brave-key",
+        deepseek_api_key="deepseek-key",
+        deepseek_api_base="https://api.deepseek.com",
+        model="deepseek/deepseek-v4-flash",
+    )
+    assert [p.name for p in manager._chain()] == [
+        "gateway", "deepseek", "tavily", "brave", "ddgs"
+    ]
+
+
+def test_gateway_manager_skips_insecure_or_missing_gateway():
+    manager = GatewaySearchProviderManager(
+        "auto", gateway_api_key="gateway-key", gateway_origin="http://gateway.example.com"
+    )
+    assert [p.name for p in manager._chain()] == ["ddgs"]
+
+    manager = GatewaySearchProviderManager(
+        "auto", gateway_origin="https://gateway.example.com"
+    )
+    assert [p.name for p in manager._chain()] == ["ddgs"]
+
+
+@pytest.mark.asyncio
+async def test_gateway_unsupported_falls_back_to_existing_chain(monkeypatch):
+    manager = GatewaySearchProviderManager(
+        "auto",
+        gateway_api_key="gateway-key",
+        gateway_origin="https://gateway.example.com",
+        tavily_api_key="tavily-key",
+    )
+
+    async def _gateway_unsupported(self, query, count):
+        return SearchResult(False, error_type="UNSUPPORTED", provider="gateway")
+
+    async def _tavily_ok(self, query, count):
+        return SearchResult(
+            True,
+            [{"title": "T", "url": "https://example.com", "snippet": "S"}],
+            provider="tavily",
+        )
+
+    monkeypatch.setattr(GatewaySearchProvider, "search", _gateway_unsupported)
+    monkeypatch.setattr(TavilyProvider, "search", _tavily_ok)
+    result = await manager.search("q", 5)
+
+    assert result.success and result.provider == "tavily"
+
+
+def test_gateway_explicit_provider_semantics_are_unchanged():
+    manager = GatewaySearchProviderManager(
+        "tavily",
+        gateway_api_key="gateway-key",
+        gateway_origin="https://gateway.example.com",
+        tavily_api_key="tavily-key",
+    )
+    assert [p.name for p in manager._chain()] == ["tavily"]

--- a/tests/agent/tools/test_gateway_web.py
+++ b/tests/agent/tools/test_gateway_web.py
@@ -3,7 +3,7 @@
 import pytest
 
 from miqi.agent.tools.gateway_web import GatewaySearchProvider, GatewaySearchProviderManager
-from miqi.agent.tools.web import DDGSProvider, SearchResult, TavilyProvider
+from miqi.agent.tools.web import SearchResult, TavilyProvider
 
 
 async def test_gateway_search_success(monkeypatch):


### PR DESCRIPTION
## 类型
- [x] 功能

## 变更概述
平台登录模式下新增独立 `GatewaySearchProvider`，复用现有 Qraft 网关凭据，auto 搜索链优先走平台搜索：

`Gateway → DeepSeek 官方 → Tavily → Brave → DDGS`

## 背景/问题
#844 的 DeepSeek 官方联网搜索要求本地 `providers.deepseek` key + 官方 base。平台登录用户的模型调用走 Qraft AI Gateway，凭据存在 `.qraft/token.json`，因此当前 auto 链只能退化到 DDGS。

本 PR 落客户端能力边界：平台搜索作为独立 Search Provider 接入；平台端 `/v1/web_search` 尚未在本客户端仓库中实现，因此端点未部署时必须透明回落现有搜索链。

## 变更内容
- 新增 `miqi/agent/tools/gateway_web.py`
  - `POST {origin}{GATEWAY_PREFIX}/v1/web_search`
  - `X-Api-Key` 复用现有 `aiGateway.encryptedApiKey`
  - 仅允许 HTTPS，避免把网关密钥发送到明文地址
  - 404/405 视为平台搜索能力未部署并回落
  - 429/401/403/5xx/timeout 映射到现有 fallback/error 语义
  - 接受 `{results:[{title,url,snippet}]}` 结构，转换为现有 `SearchResult`
- `tool_registry_factory.py` 接入 `GatewayWebSearchTool`
- `gateway_token_file()` 对轻量 `FakeConfig`/无 `workspace_path` 调用 fail-closed，避免影响既有 runtime/tool-registry 测试
- 新增网关 provider 单测：成功解析、认证失败、404 降级、HTTPS fail-closed、链路顺序和显式 provider 语义
- 不修改现有 DeepSeek/Tavily/Brave/DDGS 实现，不增加新的用户 key 配置项

## 日志/验证证据
```
PR #1026 最新 head: acb43dd51b448cfd2fe24ccc86b734d4bec74105
上一轮 Windows Python Runtime Tests：9 failed / 3706 passed；9 个失败全部是同一根因：runtime tool registry 对轻量 FakeConfig/dict 直接读取 config.workspace_path，已修复为缺失时返回不存在哨兵路径并 fail-closed。
上一轮 Ruff lint：已通过。
上一轮 WSL sandbox / bwrap / WSL E2E / Desktop Lint & Typecheck / Prettier / 标题语义：已通过。
PR 模板校验此前仅因日志代码块写成 ```text 不符合仓库 regex，现已改为纯 ```。
```

## 测试情况
`tests/agent/tools/test_gateway_web.py` 覆盖：
- gateway 成功响应与请求参数
- 401 / 404 分类
- HTTP origin fail-closed
- auto 链路 Gateway 首位与安全配置过滤
- gateway 不可用时回落现有 provider
- explicit provider 不被 gateway 静默插入

CI 继续作为最终验证门禁；本 PR 不宣称平台端到端搜索已通过，因为平台 `/v1/web_search` 服务端契约尚待实现。

## 截图
无 UI 变更。本 PR 只增加 Python 搜索 provider 与运行时接线；设置页“当前引擎”状态会在平台搜索服务端契约稳定后单独处理。

## 有意不做
- 不探测 `/responses`：避免用真实业务请求做 capability discovery，也避免错误缓存污染。
- 不在本 PR 实现平台侧搜索服务。
- 不做客户端计费；搜索配额/计量由平台网关侧负责。

## 相关
Refs #844 #922 #923