### PR TITLE
fix(providers): 平台内容安全 403 被误判为认证失败——内容拦截独立分类并给出正确指引

### DIFF
--- a/miqi/providers/resilience.py
+++ b/miqi/providers/resilience.py
@@ -17,6 +17,7 @@ class ErrorKind(str, Enum):
     RATE_LIMIT = "rate_limit"
     AUTH = "auth"
     PAYMENT_REQUIRED = "payment_required"
+    CONTENT_BLOCKED = "content_blocked"
     CONTEXT_LENGTH = "context_length"
     INVALID_REQUEST = "invalid_request"
     FATAL = "fatal"
@@ -103,6 +104,10 @@ def _classify_by_message(exc: BaseException) -> ErrorKind | None:
     # "forbidden"-ish wording would otherwise be misread as authentication.
     if _is_payment_required_error(exc):
         return ErrorKind.PAYMENT_REQUIRED
+    # 平台内容安全拦截同样带 "forbidden"/403 特征（网关实测 403 + security_violation），
+    # 必须在 AUTH 之前判定，否则用户被引导去改 API Key（真因是内容被拦）。
+    if _is_content_policy_error(exc):
+        return ErrorKind.CONTENT_BLOCKED
     if "invalid api key" in message or "unauthorized" in message or "forbidden" in message:
         return ErrorKind.AUTH
     if _is_context_length_error(exc):
@@ -159,6 +164,28 @@ def _is_payment_required_error(exc: BaseException) -> bool:
     return any(s in message for s in _PAYMENT_REQUIRED_SIGNALS)
 
 
+# 内容安全/审核拦截的信号词。平台 AI 网关实测返回
+# ``403 {"code": "sensitive_word_detected", "type": "security_violation"}``
+# —— 403 在 AUTH 之前必须让位给本判定，否则用户看到「模型服务认证失败，
+# 请检查 API Key」并被引导去重选模型，而真因是提示词/附件触发了平台的
+# 敏感词过滤（改密钥永远修不好）。
+# 只收录审核专用词，不含宽泛的 "forbidden"：真正的 403 权限拒绝仍归 AUTH
+#（Azure 的 content_filter / OpenAI 的 content_policy_violation 一并覆盖）。
+_CONTENT_POLICY_SIGNALS = (
+    "sensitive_word_detected",
+    "security_violation",
+    "content_filter",
+    "content_policy",
+    "content policy violation",
+)
+
+
+def _is_content_policy_error(exc: BaseException) -> bool:
+    """Detect provider/gateway content-moderation rejections from message text."""
+    message = str(exc).lower()
+    return any(s in message for s in _CONTENT_POLICY_SIGNALS)
+
+
 def _classify_by_status_code(exc: BaseException) -> ErrorKind | None:
     """Classify a retry error by HTTP status code."""
     code = _status_code(exc)
@@ -168,6 +195,10 @@ def _classify_by_status_code(exc: BaseException) -> ErrorKind | None:
     if code == 429:
         return ErrorKind.RATE_LIMIT
     if code in (401, 403):
+        # 平台网关的内容安全拦截同样是 403：先按审核信号分流，否则会被当成
+        # 认证失败（用户被引导去改密钥/换模型，真因是内容被拦）。
+        if _is_content_policy_error(exc):
+            return ErrorKind.CONTENT_BLOCKED
         return ErrorKind.AUTH
     if code == 402:
         # Issue #528: Payment Required — balance/quota exhausted. Distinct
@@ -244,6 +275,10 @@ def classify_error(exc: BaseException) -> ErrorKind:
         if isinstance(exc, rate_limit_error):
             return ErrorKind.RATE_LIMIT
         if isinstance(exc, (authentication_error, permission_denied_error)):
+            # PermissionDeniedError 也承载内容审核 403（网关实测）：审核信号
+            # 优先，避免把内容拦截报成认证失败。
+            if _is_content_policy_error(exc):
+                return ErrorKind.CONTENT_BLOCKED
             return ErrorKind.AUTH
         if isinstance(exc, not_found_error):
             if _is_context_length_error(exc):
@@ -304,6 +339,10 @@ def classify_error(exc: BaseException) -> ErrorKind:
         if isinstance(exc, rate_limit_error):
             return ErrorKind.RATE_LIMIT
         if isinstance(exc, (authentication_error, permission_denied_error)):
+            # PermissionDeniedError 也承载内容审核 403（网关实测）：审核信号
+            # 优先，避免把内容拦截报成认证失败。
+            if _is_content_policy_error(exc):
+                return ErrorKind.CONTENT_BLOCKED
             return ErrorKind.AUTH
         if isinstance(exc, not_found_error):
             if _is_context_length_error(exc):

--- a/miqi/runtime/task_runner.py
+++ b/miqi/runtime/task_runner.py
@@ -1077,6 +1077,16 @@ class TaskRunner:
                 # AUTH is sensitive — surface a fixed, non-leaking message
                 # instead of the raw provider exception text (Plan 58.2).
                 user_message = "模型服务认证失败，请检查 Provider 的 API Key、API Base 或当前模型配置。"
+            elif prov_err.kind is ErrorKind.CONTENT_BLOCKED:
+                # 平台内容安全拦截（网关实测 403 sensitive_word_detected）：
+                # 与认证无关，必须给出可执行的正确指引——此前被归为 AUTH，
+                # 用户被引导去检查 API Key / 重选模型，而改密钥永远修不好。
+                # 文案刻意不含 "api key"/"模型服务认证失败" 等关键词，
+                # 避免前端 isProviderConfigurationProblem 再挂上「去选择模型」。
+                user_message = (
+                    "请求被平台内容安全策略拦截（触发敏感词检测），"
+                    "请调整提问或上传的内容后重试。"
+                )
             elif prov_err.kind is ErrorKind.PAYMENT_REQUIRED:
                 # Issue #528: 402 / balance / quota exhausted — account
                 # status, not auth. Fixed non-leaking billing hint

--- a/tests/test_provider_resilience.py
+++ b/tests/test_provider_resilience.py
@@ -99,6 +99,39 @@ def test_classify_error_auth_message() -> None:
     assert classify_error(Exception("invalid api key")) == ErrorKind.AUTH
 
 
+# ── 平台内容安全拦截：403 但不是认证失败 ──────────────────────────────────
+
+
+def test_classify_error_content_blocked_from_gateway_403() -> None:
+    """平台 AI 网关实测返回 403 sensitive_word_detected —— 认证失败是误报，
+    真因是内容被审核拦截（用户改 API Key / 换模型永远修不好）。"""
+    exc = _StatusError(
+        "Error code: 403 - {'error': {'code': 'sensitive_word_detected', "
+        "'message': '我们换一个话题吧', 'type': 'security_violation'}}",
+        status_code=403,
+    )
+    assert classify_error(exc) == ErrorKind.CONTENT_BLOCKED
+
+
+def test_classify_error_content_blocked_from_message_only() -> None:
+    """无 status_code 时也要按审核信号分流（SDK 包装层可能丢掉状态码）。"""
+    assert classify_error(
+        Exception("content_policy_violation: your request was rejected")
+    ) == ErrorKind.CONTENT_BLOCKED
+
+
+def test_classify_error_content_blocked_not_retryable() -> None:
+    """同一份内容重试必然再次被拦，不得进入重试链。"""
+    assert is_retryable(ErrorKind.CONTENT_BLOCKED) is False
+    assert ProviderError(kind=ErrorKind.CONTENT_BLOCKED, message="blocked").recoverable is False
+
+
+def test_plain_403_still_auth() -> None:
+    """回归护栏：真正的 403 权限拒绝仍归 AUTH，不被审核判定抢走。"""
+    assert classify_error(_StatusError("forbidden", status_code=403)) == ErrorKind.AUTH
+    assert classify_error(Exception("Forbidden: billing access denied")) == ErrorKind.AUTH
+
+
 # ── Issue #528: 402 / balance / quota → PAYMENT_REQUIRED ───────────────────
 
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

平台 AI 网关的内容安全拦截（403 `sensitive_word_detected`）被误判成「模型服务认证失败」，用户被引导去检查 API Key / 重选模型，而真因是内容触发了敏感词过滤——新增独立的 `CONTENT_BLOCKED` 分类并给出可执行的正确指引。

## 背景/问题

**现象**：登录用户经平台 AI 网关发送时，界面弹出「模型服务认证失败，请检查 Provider 的 API Key、API Base 或当前模型配置。」并附带「去选择模型」按钮，但凭据完全正常——用户按指引改密钥、换模型都无法解决。

**根因**：平台网关对命中敏感词的内容返回 `403 {"code": "sensitive_word_detected", "type": "security_violation"}`；而 `classify_error` 把所有 401/403 统一归为 `AUTH`（`anthropic.PermissionDeniedError` / `openai.PermissionDeniedError` 分支同样如此），`task_runner` 的 AUTH 分支随即输出固定的认证失败文案。前端 `isProviderConfigurationProblem` 命中「模型服务认证失败」关键词后又挂上「去选择模型」按钮，把用户导向完全错误的修复路径。

**影响**：任何被平台内容安全策略拦截的请求都会给出误导性的认证失败指引，用户无法自助解决，也无法得知真实原因。

## 变更内容

| 文件 | 改动 |
|------|------|
| `miqi/providers/resilience.py` | 新增 `ErrorKind.CONTENT_BLOCKED` 与 `_is_content_policy_error()` 审核信号判定（`sensitive_word_detected` / `security_violation` / `content_filter` / `content_policy`）；在**状态码层**（403）、**消息层**（`forbidden` 分支前）、**openai 与 anthropic SDK 分支**（`permission_denied_error` 前）四处均先于 AUTH 判定。信号词刻意不含宽泛的 `forbidden`，真正的 403 权限拒绝仍归 AUTH |
| `miqi/runtime/task_runner.py` | 新增 `CONTENT_BLOCKED` 分支，输出「请求被平台内容安全策略拦截（触发敏感词检测），请调整提问或上传的内容后重试。」——不再提 API Key；文案不含 provider-config 关键词，前端不会再挂「去选择模型」误导弹按钮 |
| `tests/test_provider_resilience.py` | 4 个用例：网关实测报文体逐字复现、仅消息无状态码也分流、不可重试/不可恢复、以及「普通 403 仍归 AUTH」回归护栏 |

`CONTENT_BLOCKED` 不在 `_RETRYABLE` 中——同一份内容重试必然再次被拦，不应进入重试链。

## 日志/验证证据

**修复前**（真实账号 dev app 桥日志，用户实测截图对应的原始报错）：

```
[ERROR] [bridge] miqi.runtime.task_runner:_handle_user_message:1074 |
  Agent processing error in turn 9abbf4a8-cf2: Error calling LLM: Error code: 403 -
  {'error': {'code': 'sensitive_word_detected', 'message': '我们换一个话题吧', 'type': 'security_violation'}}
```

→ 界面显示「模型服务认证失败，请检查 Provider 的 API Key…」+「去选择模型」（误报认证问题）

**修复后**：同一报文体现归类为 `CONTENT_BLOCKED`，界面显示内容安全指引。

```
$ python -m pytest tests/test_provider_resilience.py -q
84 passed in 63.06s

$ python -m pytest tests/providers tests/runtime tests/test_provider_resilience.py -q
1500 passed, 1 skipped in 158.83s (0:02:38)

# 关键用例
tests/test_provider_resilience.py::test_classify_error_content_blocked_from_gateway_403 PASSED
tests/test_provider_resilience.py::test_classify_error_content_blocked_from_message_only PASSED
tests/test_provider_resilience.py::test_classify_error_content_blocked_not_retryable PASSED
tests/test_provider_resilience.py::test_plain_403_still_auth PASSED
```

前端渲染确认：新文案经 `sanitizeUiMessage` 的 URL/路径/token/关键词清洗后原样保留，且不匹配 `isProviderConfigurationProblem` 的任何关键词（无 `api key`、无 `模型服务认证失败`），因此渲染为普通错误气泡、不带「去选择模型」按钮。

## 测试情况

- **Python 单测**：`tests/test_provider_resilience.py` 84 通过（含 4 个新增）；`tests/providers` + `tests/runtime` + resilience 合计 1500 通过 / 1 skipped
- **回归护栏**：既有 `test_classify_error_auth`（401/403 → AUTH）与 `test_bare_billing_word_is_not_payment_required`（`Forbidden: billing access denied` → AUTH）均保持通过，确认真正的权限类 403 未被误分流
- **前端**：本次无前端代码改动；已核对 `sanitizeUiMessage` 清洗规则与 `isProviderConfigurationProblem` 关键词，确认新文案原样渲染且不触发误导弹按钮
- 内容安全拦截需触发平台敏感词策略，未构造真实内容复现端到端；分类逻辑以用户实测的逐字报文体验证

## 截图

无需截图：本次为后端错误分类与用户文案修复，无 UI 布局/样式变更（错误气泡文案变化已在上方「日志/验证证据」中说明）。
