### PR TITLE
fix(desktop): 内置 slurm MCP 网关放行 http 连接与凭据注入

### DIFF
--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -56,9 +56,12 @@ describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
   let page: Page;
 
   test.beforeAll(async () => {
-    // 清掉开发机 config 残留的 mcpServers（让内置默认 miqroforge-slurm 生效），
-    // 并注入官方 DeepSeek provider + 官方模型（本机 config 无 provider；
-    // 默认模型 deepseek-v4-flash 是平台网关模型，官方 API 用 deepseek-chat）。
+    // 清掉开发机 config 残留的 mcpServers（让内置默认 miqroforge-slurm 生效）。
+    // 登录后平台会自动下发 AI 网关 encryptedApiKey（token.json 的 aiGateway 块），
+    // 默认模型 deepseek-v4-flash 走网关即可回复 LLM；但网关真实 LLM 对「调用
+    // submit_slurm_job」这类工具调用推理慢、方差大无法收敛（见记忆
+    // slurm-mcp-billing-map），故这里注入官方 DeepSeek + deepseek-chat，让工具
+    // 调用确定性收敛、测试快——不是「登录后无 key」。
     fixture = await launchElectronApp((config: any) => {
       if (config.tools && typeof config.tools === 'object') {
         delete config.tools.mcpServers;

--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * 托管 slurm MCP 网关计费 live E2E（opt-in，需真实登录 + 可用 LLM 凭据；
+ * CI 无凭据自动跳过）：
+ *   真实登录 → 内置 miqroforge-slurm（http + insecure_http 默认放行）→
+ *   真实 LLM 调用 mcp_miqroforge-slurm_submit_slurm_job 提交作业 →
+ *   check_job_status 轮询到 RUNNING → Desktop 扣 10 积分 → 聊天区提示。
+ *
+ * 与 billing-live.spec.ts 的区别：后者走自部署本地回环服务器（127.0.0.1）
+ * + 显式 Bearer header；本 spec 走 #1029 开启的内置托管网关（登录态注入
+ * 共享 mcpGatewayKey，零配置）。覆盖「登录后调托管 slurm MCP + 计费」全链。
+ *
+ * Run（真实消耗：测试账号 10 积分 + 一个集群作业）：
+ *   QRAFT_PHONE=… QRAFT_PASSWORD=… DEEPSEEK_API_KEY=… npx playwright test \
+ *     --config=playwright.config.ts --project=electron tests/e2e/billing-hosted-live.spec.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  LLM_TIMEOUT,
+  sendMessage,
+  waitForResponseComplete,
+  createNewConversation,
+  launchElectronApp,
+  closeElectronApp,
+  browserLogin,
+  type ElectronFixture,
+} from './helpers/electron-setup';
+
+const HAS_CREDS =
+  !!process.env.QRAFT_PHONE && !!process.env.QRAFT_PASSWORD && !!process.env.DEEPSEEK_API_KEY;
+
+const describeFn = HAS_CREDS ? test.describe : test.describe.skip;
+
+async function approveLoop(page: Page, timeout = 180_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const btn = page
+      .getByRole('button', { name: '持久允许' })
+      .or(page.getByRole('button', { name: '永久允许' }));
+    if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await btn.click();
+    }
+    const thinking = await page
+      .getByText('Thinking…')
+      .isVisible()
+      .catch(() => false);
+    if (!thinking) break;
+    await page.waitForTimeout(1000);
+  }
+}
+
+describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
+  let fixture: ElectronFixture;
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    // 清掉开发机 config 残留的 mcpServers（让内置默认 miqroforge-slurm 生效），
+    // 并注入官方 DeepSeek provider + 官方模型（本机 config 无 provider；
+    // 默认模型 deepseek-v4-flash 是平台网关模型，官方 API 用 deepseek-chat）。
+    fixture = await launchElectronApp((config: any) => {
+      if (config.tools && typeof config.tools === 'object') {
+        delete config.tools.mcpServers;
+        delete config.tools.mcp_servers;
+      }
+      config.providers = {
+        ...(config.providers ?? {}),
+        deepseek: { apiKey: process.env.DEEPSEEK_API_KEY },
+      };
+      config.agents = {
+        ...(config.agents ?? {}),
+        defaults: { ...(config.agents?.defaults ?? {}), model: 'deepseek/deepseek-chat' },
+      };
+      return config;
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    if (electronApp) await closeElectronApp(electronApp, fixture?.miqiHome);
+  });
+
+  test(
+    '真实登录 → 托管 slurm MCP 提交作业 → RUNNING 扣 10 积分 → 聊天区提示',
+    { timeout: 360_000 },
+    async () => {
+      // 1. 设置页真实登录（幂等：dev userData 可能残留上次登录态）
+      const loggedInBadge = page.getByText('已登录');
+      if (!(await loggedInBadge.isVisible({ timeout: 5000 }).catch(() => false))) {
+        await browserLogin(
+          page,
+          electronApp,
+          process.env.QRAFT_PHONE!,
+          process.env.QRAFT_PASSWORD!
+        );
+      }
+      await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
+
+      // 2. 新会话 + 预授权（避免审批卡住工具执行）
+      await createNewConversation(page);
+      await page.evaluate(() => (window as any).miqi.approvals.addPermanent('*:*', 'always'));
+
+      // 3. 指示模型用托管网关工具提交作业并轮询到 RUNNING
+      //（工具注册名为 mcp_miqroforge-slurm_<tool>；只提交一次避免多作业噪音）
+      await sendMessage(
+        page,
+        '使用 mcp_miqroforge-slurm_submit_slurm_job 工具提交作业（script 参数用 ' +
+          '"#!/bin/bash\\nsleep 30\\nhostname"，保证轮询时作业仍在运行），只提交一次，不要重复提交。' +
+          '然后用 mcp_miqroforge-slurm_check_job_status 轮询该作业，直到状态为 RUNNING 后，最后只回复 DONE_SLURM'
+      );
+      await approveLoop(page);
+
+      // 4. RUNNING 扣费提示（10 积分）——出现即截图，作为证据
+      await expect(page.getByText(/已扣 10 积分/).first()).toBeVisible({ timeout: 300_000 });
+      await page.screenshot({ path: 'test-results/slurm-billing-hosted-charge.png', fullPage: true });
+
+      // 5. 回合正常收尾
+      await waitForResponseComplete(page, 300_000);
+      await expect(
+        page
+          .getByTestId('chat-message-assistant')
+          .getByText(/DONE_SLURM/)
+          .first()
+      ).toBeVisible({ timeout: 30_000 });
+
+      await page.screenshot({ path: 'test-results/slurm-billing-hosted-live.png', fullPage: true });
+    }
+  );
+});

--- a/apps/desktop/tests/e2e/mcp-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/mcp-hosted-live.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Hosted slurm MCP 网关 live E2E（opt-in，需真实登录凭据；CI 无凭据跳过）：
+ *   真实登录 → 启动会话 → 内置 miqroforge-slurm（http + insecure_http 默认
+ *   放行 + 登录态注入 mcpGatewayKey）连上平台托管网关，注册 9 个工具。
+ *
+ * 断言方式：读 bridge 日志（workspace/logs/bridge-*.log）里的两条确定性
+ * 标记——「登录态注入网关凭据」与「connected, 9 tools registered」。会话
+ * 是懒加载（首条消息/首个 thread 才 RuntimeSession.start → _connect_mcp），
+ * 故直接用 threads.start 触发，不依赖 LLM、不消耗积分、不提交集群作业，
+ * 是 #1029 改动（http 放行 + 凭据注入）的最小闭环。
+ *
+ * Run（无真实资源消耗：仅登录 + 连接）：
+ *   QRAFT_PHONE=… QRAFT_PASSWORD=… npx playwright test \
+ *     --config=playwright.config.ts --project=electron tests/e2e/mcp-hosted-live.spec.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  launchElectronApp,
+  closeElectronApp,
+  browserLogin,
+  type ElectronFixture,
+} from './helpers/electron-setup';
+
+const HAS_CREDS = !!process.env.QRAFT_PHONE && !!process.env.QRAFT_PASSWORD;
+
+const describeFn = HAS_CREDS ? test.describe : test.describe.skip;
+
+/** 读全部 bridge 日志（workspace/logs/bridge-YYYY-MM-DD.log），跨文件拼接。 */
+function allBridgeLogs(miqiHome: string): string {
+  const logDir = join(miqiHome, 'workspace', 'logs');
+  if (!existsSync(logDir)) return '';
+  return readdirSync(logDir)
+    .filter((f) => /^bridge-\d{4}-\d{2}-\d{2}\.log$/.test(f))
+    .sort()
+    .map((f) => readFileSync(join(logDir, f), 'utf8'))
+    .join('\n');
+}
+
+describeFn('Hosted slurm MCP 网关 live E2E（opt-in）', () => {
+  let fixture: ElectronFixture;
+  let electronApp: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    // 清掉用户真实 config 里残留的 mcpServers/mcp_servers（开发机 config
+    // 常带本地 slurmmcp 回环服务器），让内置默认 miqroforge-slurm 生效——
+    // 这正是被测对象。两个键都要删（camelCase 键清不掉会遮蔽默认）。
+    fixture = await launchElectronApp((config: any) => {
+      if (config.tools && typeof config.tools === 'object') {
+        delete config.tools.mcpServers;
+        delete config.tools.mcp_servers;
+      }
+      return config;
+    });
+    electronApp = fixture.electronApp;
+    page = fixture.page;
+  }, 180_000);
+
+  test.afterAll(async () => {
+    if (electronApp) await closeElectronApp(electronApp, fixture?.miqiHome);
+  });
+
+  test(
+    '真实登录 → 启动会话 → 内置 slurm 网关注入凭据并注册工具',
+    { timeout: 180_000 },
+    async () => {
+      // 1. 设置页真实登录（幂等：dev userData 可能残留上次登录态）
+      const loggedInBadge = page.getByText('已登录');
+      if (!(await loggedInBadge.isVisible({ timeout: 5000 }).catch(() => false))) {
+        await browserLogin(
+          page,
+          electronApp,
+          process.env.QRAFT_PHONE!,
+          process.env.QRAFT_PASSWORD!
+        );
+      }
+      await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
+
+      // 2. 启动会话（懒加载：首个 thread 才 RuntimeSession.start → _connect_mcp）
+      await page
+        .evaluate(() =>
+          (window as any).miqi.threads.start({
+            session_key: 'live-hosted-mcp',
+            title: 'live-hosted-mcp',
+          })
+        )
+        .catch((e: any) => {
+          throw new Error(`threads.start failed: ${String(e)}`);
+        });
+
+      // 3. 轮询 bridge 日志：连接是异步后台任务，等待两条确定性标记出现
+      const deadline = Date.now() + 60_000;
+      let log = '';
+      while (Date.now() < deadline) {
+        log = allBridgeLogs(fixture.miqiHome);
+        if (log.includes('登录态注入网关凭据') && log.includes('connected, 9 tools registered')) {
+          break;
+        }
+        await page.waitForTimeout(1000);
+      }
+
+      const mcpLines = log
+        .split('\n')
+        .filter((l) => /mcp|slurm|非回环|注入|connected|make_provider|No API/i.test(l))
+        .join('\n');
+      console.log(`[test] MCP-related bridge log lines:\n${mcpLines || '(none)'}`);
+
+      expect(log, 'bridge 日志应包含登录态注入网关凭据').toContain('登录态注入网关凭据');
+      expect(log).toContain('connected, 9 tools registered');
+    }
+  );
+});

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -551,10 +551,22 @@ def _gateway_key_from_token_file(token_file) -> str | None:
 
 
 def _is_https_url(url: str) -> bool:
-    """URL 是否为 https（网关凭据只注入 https 端点，CWE-319）。"""
+    """URL 是否为 https。"""
     from urllib.parse import urlsplit
 
     return urlsplit(url or "").scheme.lower() == "https"
+
+
+def _inject_gateway_key_over_url(cfg) -> bool:
+    """登录态网关凭据是否允许随该端点发送。
+
+    https 一律允许；明文 http 仅在该服务器显式 opt-in ``insecure_http``
+    时允许（平台暂无 https 网关域名，内置网关默认 opt-in——共享 token
+    明文传输的已知权衡，见 schema.DEFAULT_MCP_SERVERS）。
+    """
+    return _is_https_url(getattr(cfg, "url", "")) or bool(
+        getattr(cfg, "insecure_http", False)
+    )
 
 
 def _url_matches_trusted_gateway(url: str) -> bool:
@@ -608,18 +620,18 @@ async def _connect_one_server(
                 if _url_error:
                     logger.error("MCP server '{}': {}", name, _url_error)
                     return
-            # 登录态注入（CodeRabbit #951 三重收口）：仅当 ① 默认网关
-            # 服务器未显式配置 headers；② 名称与 URL 都匹配内置可信
-            # 端点（防止同名服务器把 workspace 凭据导向其他地址）；
-            # ③ URL 为 https（网关 token 绝不随明文 http 发送，含
-            # opt-in 端点）。平台 https 上线前默认不注入、fail-closed。
+            # 登录态注入：仅当 ① 默认网关服务器未显式配置 headers；
+            # ② 名称与 URL 都匹配内置可信端点（防止同名服务器把
+            # workspace 凭据导向其他地址）；③ 端点允许携带凭据——https，
+            # 或该服务器已显式 opt-in insecure_http（平台暂无 https，内置
+            # 网关默认 opt-in 明文 http）。三者缺一即不注入、fail-closed。
             effective_headers = dict(getattr(cfg, "headers", None) or {})
             if (
                 not effective_headers
                 and name == _DEFAULT_GATEWAY_NAME
                 and workspace is not None
                 and _url_matches_trusted_gateway(getattr(cfg, "url", ""))
-                and _is_https_url(getattr(cfg, "url", ""))
+                and _inject_gateway_key_over_url(cfg)
             ):
                 _gw_key = _gateway_key_from_token_file(workspace / ".qraft" / "token.json")
                 if _gw_key:

--- a/miqi/config/schema.py
+++ b/miqi/config/schema.py
@@ -552,16 +552,16 @@ class MCPServerConfig(Base):
 # 写入 workspace/.qraft/token.json（0600，字段 mcpGatewayKey；未来平台
 # 按用户下发时 userinfo 字段优先覆盖），Python 连接本服务器时自动注入
 # Authorization Bearer（见 _connect_one_server）。
-# 默认 fail-closed（CWE-319，CodeRabbit #949 评审）：非回环 http 且未
-# 显式 opt-in 时连接被拒、绝不发送登录凭据——用户在设置页勾选
-# 「允许非回环 HTTP」或平台提供 https 后启用。键名含 "slurm" 使作业
-# 进入计费范围（#936：RUNNING 时扣 10 分）。用户显式配置 mcp_servers
-# （含空对象）即覆盖此默认。
+# insecure_http 默认 true（2026-09-10）：平台暂无 https 网关域名，上线
+# 需走明文 http；内置条目显式 opt-in（共享 token 明文传输的已知权衡，
+# 用户可改回 false 关闭）。键名含 "slurm" 使作业进入计费范围
+# （#936：RUNNING 时扣 10 分）。用户显式配置 mcp_servers（含空对象）
+# 即覆盖此默认。
 DEFAULT_MCP_SERVERS: dict = {
     "miqroforge-slurm": {
         "type": "sse",
         "url": "http://124.220.57.194:9000/sse",
-        "insecure_http": False,
+        "insecure_http": True,
         "tool_timeout": 90,
         "description": "MiQroForge 平台托管 SLURM 集群：作业提交/状态监控/取消、分区查询、输出与文件传输",
     },

--- a/tests/agent/test_mcp_transport.py
+++ b/tests/agent/test_mcp_transport.py
@@ -92,6 +92,23 @@ class TestInjectionGuards:
         assert _url_matches_trusted_gateway("http://evil.example.com/sse") is False
         assert _url_matches_trusted_gateway("") is False
 
+    def test_gateway_key_injection_allowed_over_url(self):
+        from miqi.agent.tools.mcp import _inject_gateway_key_over_url
+
+        # https 一律允许（无论是否 opt-in）
+        assert _inject_gateway_key_over_url(_cfg(url="https://mcp.example.com/sse")) is True
+        # 明文 http 未 opt-in：不允许（fail-closed）
+        assert _inject_gateway_key_over_url(_cfg(url="http://124.220.57.194:9000/sse")) is False
+        # 明文 http 显式 opt-in：允许（平台暂无 https 的过渡）
+        assert (
+            _inject_gateway_key_over_url(
+                _cfg(url="http://124.220.57.194:9000/sse", insecure_http=True)
+            )
+            is True
+        )
+        # 空 url：不允许
+        assert _inject_gateway_key_over_url(_cfg()) is False
+
 
 # ── #975 Artifact Boundary：wrapper 接线（C2）───────────────────────────────
 

--- a/tests/config/test_default_mcp.py
+++ b/tests/config/test_default_mcp.py
@@ -1,9 +1,9 @@
 """内置默认 MCP 服务器（平台托管 slurm 网关）测试。
 
 2026-09-05 产品确认：`miqroforge-slurm` 作为开箱即用的默认 MCP
-服务器（SSE + insecure_http opt-in）；凭据不入仓库——登录后平台经
-userinfo 下发 mcpGatewayKey，Desktop 写入 0600 token 文件，Python
-连接时自动注入 Authorization Bearer。用户显式配置 mcp_servers
+服务器（SSE，insecure_http 默认开启——平台暂无 https）；凭据不入仓库——
+登录后平台经 userinfo 下发 mcpGatewayKey，Desktop 写入 0600 token 文件，
+Python 连接时自动注入 Authorization Bearer。用户显式配置 mcp_servers
 （含空对象）即覆盖默认。
 """
 
@@ -15,9 +15,9 @@ def test_default_config_includes_hosted_slurm_gateway():
     assert isinstance(srv, MCPServerConfig)
     assert srv.type == "sse"
     assert srv.url == "http://124.220.57.194:9000/sse"
-    # 默认 fail-closed（CWE-319）：非回环 http 未经显式 opt-in 不连接、
-    # 绝不发送登录凭据；用户勾选设置页开关或平台 https 后启用
-    assert srv.insecure_http is False
+    # 平台暂无 https：内置网关默认 opt-in 明文 http（共享 token 明文传输
+    # 的已知权衡），登录后自动连接 + 注入凭据；用户可改回 false 关闭
+    assert srv.insecure_http is True
     # 凭据不入仓库：默认条目不含 headers，运行时从 token 文件注入
     assert srv.headers == {}
     assert srv.tool_timeout == 90


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

内置 slurm MCP 网关（`miqroforge-slurm`）此前 fail-closed 实际不可用，改为默认放行 http，登录后零配置即可连接托管网关并调用 slurm 工具。

## 背景/问题

平台暂无 https 网关域名（#923），内置网关 URL 是 `http://124.220.57.194:9000/sse`。此前两道门都 fail-closed：

- `insecure_http=False` → `_validate_mcp_http_url` 拒绝非回环 http，默认服务器根本不连接；
- 注入门要求 `_is_https_url` → 登录态 `mcpGatewayKey` 永不随明文 http 注入。

结果登录后既连不上、也不带 token，网关返回 401，「开箱即用」的托管 slurm MCP 实际不可用。

## 变更内容

- `miqi/config/schema.py`：`DEFAULT_MCP_SERVERS["miqroforge-slurm"].insecure_http` 由 `False` → `True`（平台暂无 https，上线需明文 http；共享 token 明文传输为已知权衡，用户可改回 `False` 关闭）
- `miqi/agent/tools/mcp.py`：新增 `_inject_gateway_key_over_url`，注入门在显式 `insecure_http` opt-in 时也允许明文 http（仍锁定名称 + 可信网关 URL，token 不会导向其他地址）
- `tests/config/test_default_mcp.py`：默认值断言改为 `is True`
- `tests/agent/test_mcp_transport.py`：新增 `test_gateway_key_injection_allowed_over_url` 覆盖 https / http+opt-in / http+未opt-in
- `apps/desktop/tests/e2e/mcp-hosted-live.spec.ts`：新增托管网关 live E2E（登录 → 会话 → 注入凭据 → 9 工具注册）
- `apps/desktop/tests/e2e/billing-hosted-live.spec.ts`：新增托管网关计费 live E2E（登录 → 提交作业 → RUNNING → 扣 10 积分）

## 日志/验证证据

```
$ python -m pytest tests/config/ tests/agent/test_mcp_transport.py tests/agent/test_billing_resolver.py -q
77 passed in 2.26s

# 连接 live E2E（真实登录 + threads.start 触发懒加载会话）：
[INFO] miqi.agent.tools.mcp:_connect_one_server | MCP server 'miqroforge-slurm': 登录态注入网关凭据（… 文件）
[INFO] miqi.agent.tools.mcp:_connect_one_server | MCP server 'miqroforge-slurm': connected, 9 tools registered

# 计费 live E2E（真实登录 + DeepSeek 驱动 LLM 调 submit_slurm_job）：
已扣 10 积分  ← 作业 RUNNING 后 Desktop 扣费提示出现，回合以 DONE_SLURM 收尾（32.3s 通过）
```

## 测试情况

- `tests/config/` + `tests/agent/test_mcp_transport.py` + `tests/agent/test_billing_resolver.py`：77 passed
- `mcp-hosted-live.spec.ts`：本地真实账号实测通过（登录 → 会话启动 → 注入登录态凭据 → 9 工具注册）
- `billing-hosted-live.spec.ts`：本地真实账号实测通过（登录 → 提交作业 → RUNNING → 扣 10 积分）

## 截图

无需截图（无 UI 变更）

## 后续计划

- 平台提供 https 网关域名后，把默认 `insecure_http` 改回 `False`（凭据改走 https 注入）
