### PR TITLE
fix(desktop): WSL2 一键安装失败原因被兜底文案掩盖，回传提权退出码并按场景分类

### DIFF
--- a/apps/desktop/src/main/ipc.test.ts
+++ b/apps/desktop/src/main/ipc.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
 import {
+  classifyKernelInstall,
   classifyWslFeatureState,
+  decodeWslOutput,
+  ELEVATION_CANCELLED,
   hasNonRootUser,
   isBashCapableDistro,
   readFeatureStates,
+  runElevated,
+  summarizeElevated,
+  wslKernelPresent,
   wslPackageInstalled,
   wslStatusWorks,
 } from './ipc/wsl-state';
@@ -14,10 +21,24 @@ vi.mock('child_process', () => ({
   spawnSync: vi.fn(),
 }));
 
-const mockedSpawnSync = vi.mocked(spawnSync);
+// ...and touch the filesystem only through the trampoline temp dir.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(() => 'C:\\Temp\\miqi-elev-test'),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(),
+    rmSync: vi.fn(),
+  };
+});
 
-function mockSpawn(result: Partial<ReturnType<typeof spawnSync>>) {
-  mockedSpawnSync.mockReturnValue({
+const mockedSpawnSync = vi.mocked(spawnSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+
+function spawnResult(result: Partial<ReturnType<typeof spawnSync>>) {
+  return {
     status: 0,
     stdout: '',
     stderr: '',
@@ -26,7 +47,11 @@ function mockSpawn(result: Partial<ReturnType<typeof spawnSync>>) {
     pid: 1,
     output: [],
     ...result,
-  } as unknown as ReturnType<typeof spawnSync>);
+  } as unknown as ReturnType<typeof spawnSync>;
+}
+
+function mockSpawn(result: Partial<ReturnType<typeof spawnSync>>) {
+  mockedSpawnSync.mockReturnValue(spawnResult(result));
 }
 
 beforeEach(() => {
@@ -254,5 +279,199 @@ describe('wslPackageInstalled', () => {
   it('reports absent when the query returns nothing', () => {
     mockSpawn({ status: 0, stdout: '' });
     expect(wslPackageInstalled()).toBe(false);
+  });
+});
+
+describe('wslKernelPresent', () => {
+  it('accepts the first probe when wsl --status works', () => {
+    mockSpawn({ status: 0 });
+    expect(wslKernelPresent(3, 0)).toBe(true);
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the Appx package probe when wsl --status fails', () => {
+    mockedSpawnSync
+      .mockReturnValueOnce(spawnResult({ status: 1 }))
+      .mockReturnValueOnce(spawnResult({ status: 0, stdout: 'MicrosoftCorporationII.WSL' }));
+    expect(wslKernelPresent(3, 0)).toBe(true);
+  });
+
+  it('retries before giving up (registration lag)', () => {
+    mockSpawn({ status: 1, stdout: '' });
+    expect(wslKernelPresent(2, 0)).toBe(false);
+    // Two probes per attempt.
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(4);
+  });
+});
+
+// ── Elevated run trampoline ─────────────────────────────────────────
+
+describe('decodeWslOutput', () => {
+  it('decodes BOM-prefixed UTF-16LE output', () => {
+    expect(decodeWslOutput(Buffer.from('﻿安装失败', 'utf16le'))).toBe('安装失败');
+  });
+
+  it('decodes UTF-16LE without a BOM (wsl.exe writes NUL bytes)', () => {
+    expect(decodeWslOutput(Buffer.from('Invalid command line option', 'utf16le'))).toBe(
+      'Invalid command line option'
+    );
+  });
+
+  it('decodes UTF-16LE coded CJK without a BOM (no NUL bytes to detect)', () => {
+    expect(decodeWslOutput(Buffer.from('系统找不到指定的文件。', 'utf16le'))).toBe(
+      '系统找不到指定的文件。'
+    );
+  });
+
+  it('decodes plain UTF-8 output', () => {
+    expect(decodeWslOutput(Buffer.from('plain text'))).toBe('plain text');
+  });
+
+  it('treats empty input as empty', () => {
+    expect(decodeWslOutput(null)).toBe('');
+    expect(decodeWslOutput(Buffer.alloc(0))).toBe('');
+  });
+});
+
+describe('summarizeElevated', () => {
+  it('surfaces the trampoline error for unknown results', () => {
+    expect(
+      summarizeElevated({ kind: 'unknown', exitCode: null, output: '', error: 'spawn ENOENT' })
+    ).toBe('spawn ENOENT');
+  });
+
+  it('combines exit code and output for failed results', () => {
+    const summary = summarizeElevated({
+      kind: 'failed',
+      exitCode: 1,
+      output: 'WSL 内核更新失败\n更多信息请访问 https://aka.ms/wsl2kernel',
+    });
+    expect(summary).toContain('退出码 1');
+    expect(summary).toContain('WSL 内核更新失败');
+  });
+
+  it('returns 无输出 when nothing at all was captured', () => {
+    expect(summarizeElevated({ kind: 'failed', exitCode: null, output: '' })).toBe('无输出');
+  });
+});
+
+describe('classifyKernelInstall', () => {
+  const failed = { kind: 'failed' as const, exitCode: 1, output: 'boom' };
+  const ok = { kind: 'ok' as const, exitCode: 0, output: '' };
+  const cancelled = { kind: 'cancelled' as const, exitCode: null, output: '' };
+
+  it('trusts system state over a non-zero exit code', () => {
+    expect(classifyKernelInstall(failed, true)).toEqual({ status: 'installed' });
+  });
+
+  it('treats exit code 0 as installed even when the probe lags', () => {
+    expect(classifyKernelInstall(ok, false)).toEqual({ status: 'installed' });
+  });
+
+  it('reports a declined UAC prompt as cancelled', () => {
+    expect(classifyKernelInstall(cancelled, false)).toEqual({ status: 'cancelled' });
+  });
+
+  it('reports the exit code and output when the install really failed', () => {
+    expect(classifyKernelInstall(failed, false)).toEqual({
+      status: 'failed',
+      detail: expect.stringContaining('退出码 1'),
+    });
+  });
+
+  it('reports the transport error when the trampoline itself failed', () => {
+    expect(
+      classifyKernelInstall({ kind: 'unknown', exitCode: null, output: '', error: 'EPERM' }, false)
+    ).toEqual({ status: 'failed', detail: 'EPERM' });
+  });
+});
+
+describe('runElevated', () => {
+  function mockFiles(files: { out?: string | Buffer; exit?: string; trampoline?: string }) {
+    mockedReadFileSync.mockImplementation(((p: string) => {
+      const name = String(p);
+      const out = files.out;
+      if (name.endsWith('out.txt') && out !== undefined) {
+        return Buffer.isBuffer(out) ? out : Buffer.from(out);
+      }
+      if (name.endsWith('exit.txt') && files.exit !== undefined) return Buffer.from(files.exit);
+      if (name.endsWith('trampoline.txt') && files.trampoline !== undefined) {
+        return Buffer.from(files.trampoline);
+      }
+      throw new Error(`ENOENT: ${name}`);
+    }) as any);
+  }
+
+  it('reports ok when the elevated process exited 0', () => {
+    mockFiles({ out: 'installed', exit: '0' });
+    mockSpawn({ status: 0 });
+    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+      kind: 'ok',
+      exitCode: 0,
+      output: 'installed',
+    });
+  });
+
+  it('reports failed with the recovered exit code and output', () => {
+    mockFiles({ out: Buffer.from('内核更新失败', 'utf16le'), exit: '1' });
+    mockSpawn({ status: 0 });
+    const r = runElevated({ command: 'wsl.exe --install' });
+    expect(r.kind).toBe('failed');
+    expect(r.exitCode).toBe(1);
+    expect(r.output).toBe('内核更新失败');
+    expect(summarizeElevated(r)).toContain('退出码 1');
+  });
+
+  it('reports cancelled when the trampoline exits with ERROR_CANCELLED', () => {
+    mockFiles({});
+    mockSpawn({ status: ELEVATION_CANCELLED });
+    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+      kind: 'cancelled',
+      exitCode: null,
+      output: '',
+    });
+  });
+
+  it('reports unknown with the trampoline message when no exit code was written', () => {
+    mockFiles({ trampoline: 'This operation has been cancelled' });
+    mockSpawn({ status: 99 });
+    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+      kind: 'unknown',
+      exitCode: null,
+      output: '',
+      error: 'This operation has been cancelled',
+    });
+  });
+
+  it('reports unknown when powershell itself cannot be spawned', () => {
+    mockFiles({});
+    mockSpawn({ error: new Error('spawn powershell.exe ENOENT') as any, status: null });
+    expect(runElevated({ command: 'wsl.exe --install' })).toMatchObject({
+      kind: 'unknown',
+      error: 'spawn powershell.exe ENOENT',
+    });
+  });
+
+  it('writes the elevated command and its exit-code echo into run.cmd', () => {
+    mockFiles({ exit: '0' });
+    mockSpawn({ status: 0 });
+    runElevated({ command: 'wsl.exe --install --no-distribution' });
+    const [, content] = mockedWriteFileSync.mock.calls.find(([p]) =>
+      String(p).endsWith('run.cmd')
+    )!;
+    expect(String(content)).toContain('wsl.exe --install --no-distribution');
+    expect(String(content)).toContain('%~dp0out.txt');
+    expect(String(content)).toContain('> "%~dp0exit.txt" echo %EC%');
+  });
+
+  it('writes a BOM-prefixed payload.ps1 in powershell mode', () => {
+    mockFiles({ exit: '0' });
+    mockSpawn({ status: 0 });
+    runElevated({ powershell: 'Enable-WindowsOptionalFeature -Online' });
+    const [, content] = mockedWriteFileSync.mock.calls.find(([p]) =>
+      String(p).endsWith('payload.ps1')
+    )!;
+    expect(String(content).startsWith('﻿')).toBe(true);
+    expect(String(content)).toContain('Enable-WindowsOptionalFeature');
   });
 });

--- a/apps/desktop/src/main/ipc.test.ts
+++ b/apps/desktop/src/main/ipc.test.ts
@@ -350,6 +350,12 @@ describe('summarizeElevated', () => {
     expect(summary).toContain('WSL 内核更新失败');
   });
 
+  it('omits a zero exit code — in a failure path it explains nothing', () => {
+    expect(summarizeElevated({ kind: 'ok', exitCode: 0, output: '拒绝访问: 需要管理员权限' })).toBe(
+      '拒绝访问: 需要管理员权限'
+    );
+  });
+
   it('returns 无输出 when nothing at all was captured', () => {
     expect(summarizeElevated({ kind: 'failed', exitCode: null, output: '' })).toBe('无输出');
   });
@@ -387,13 +393,19 @@ describe('classifyKernelInstall', () => {
 });
 
 describe('runElevated', () => {
-  function mockFiles(files: { out?: string | Buffer; exit?: string; trampoline?: string }) {
+  function mockFiles(files: {
+    out?: string | Buffer;
+    err?: string;
+    exit?: string;
+    trampoline?: string;
+  }) {
     mockedReadFileSync.mockImplementation(((p: string) => {
       const name = String(p);
       const out = files.out;
       if (name.endsWith('out.txt') && out !== undefined) {
         return Buffer.isBuffer(out) ? out : Buffer.from(out);
       }
+      if (name.endsWith('err.txt') && files.err !== undefined) return Buffer.from(files.err);
       if (name.endsWith('exit.txt') && files.exit !== undefined) return Buffer.from(files.exit);
       if (name.endsWith('trampoline.txt') && files.trampoline !== undefined) {
         return Buffer.from(files.trampoline);
@@ -402,10 +414,21 @@ describe('runElevated', () => {
     }) as any);
   }
 
+  /** The PowerShell script runElevated asked Windows to run elevated. */
+  function elevatedScript(): string {
+    const args = (mockedSpawnSync.mock.calls.at(-1) as any[])[1] as string[];
+    const outer = Buffer.from(args[args.indexOf('-EncodedCommand') + 1], 'base64').toString(
+      'utf16le'
+    );
+    const inner = outer.match(/-EncodedCommand','([A-Za-z0-9+/=]+)'/);
+    expect(inner).not.toBeNull();
+    return Buffer.from(inner![1], 'base64').toString('utf16le');
+  }
+
   it('reports ok when the elevated process exited 0', () => {
     mockFiles({ out: 'installed', exit: '0' });
     mockSpawn({ status: 0 });
-    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+    expect(runElevated({ command: { file: 'wsl.exe', args: ['--install'] } })).toEqual({
       kind: 'ok',
       exitCode: 0,
       output: 'installed',
@@ -415,17 +438,23 @@ describe('runElevated', () => {
   it('reports failed with the recovered exit code and output', () => {
     mockFiles({ out: Buffer.from('内核更新失败', 'utf16le'), exit: '1' });
     mockSpawn({ status: 0 });
-    const r = runElevated({ command: 'wsl.exe --install' });
+    const r = runElevated({ command: { file: 'wsl.exe' } });
     expect(r.kind).toBe('failed');
     expect(r.exitCode).toBe(1);
     expect(r.output).toBe('内核更新失败');
     expect(summarizeElevated(r)).toContain('退出码 1');
   });
 
+  it('merges stderr into the captured output', () => {
+    mockFiles({ err: '拒绝访问', exit: '1' });
+    mockSpawn({ status: 0 });
+    expect(runElevated({ command: { file: 'wsl.exe' } }).output).toBe('拒绝访问');
+  });
+
   it('reports cancelled when the trampoline exits with ERROR_CANCELLED', () => {
     mockFiles({});
     mockSpawn({ status: ELEVATION_CANCELLED });
-    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+    expect(runElevated({ command: { file: 'wsl.exe' } })).toEqual({
       kind: 'cancelled',
       exitCode: null,
       output: '',
@@ -435,7 +464,7 @@ describe('runElevated', () => {
   it('reports unknown with the trampoline message when no exit code was written', () => {
     mockFiles({ trampoline: 'This operation has been cancelled' });
     mockSpawn({ status: 99 });
-    expect(runElevated({ command: 'wsl.exe --install' })).toEqual({
+    expect(runElevated({ command: { file: 'wsl.exe' } })).toEqual({
       kind: 'unknown',
       exitCode: null,
       output: '',
@@ -446,32 +475,45 @@ describe('runElevated', () => {
   it('reports unknown when powershell itself cannot be spawned', () => {
     mockFiles({});
     mockSpawn({ error: new Error('spawn powershell.exe ENOENT') as any, status: null });
-    expect(runElevated({ command: 'wsl.exe --install' })).toMatchObject({
+    expect(runElevated({ command: { file: 'wsl.exe' } })).toMatchObject({
       kind: 'unknown',
       error: 'spawn powershell.exe ENOENT',
     });
   });
 
-  it('writes the elevated command and its exit-code echo into run.cmd', () => {
+  it('delivers the payload as an encoded command line, never as a %TEMP% script', () => {
     mockFiles({ exit: '0' });
     mockSpawn({ status: 0 });
-    runElevated({ command: 'wsl.exe --install --no-distribution' });
-    const [, content] = mockedWriteFileSync.mock.calls.find(([p]) =>
-      String(p).endsWith('run.cmd')
-    )!;
-    expect(String(content)).toContain('wsl.exe --install --no-distribution');
-    expect(String(content)).toContain('%~dp0out.txt');
-    expect(String(content)).toContain('> "%~dp0exit.txt" echo %EC%');
+    runElevated({ command: { file: 'wsl.exe', args: ['--install', '--no-distribution'] } });
+
+    // Nothing executable may be written to the user-writable temp dir: a
+    // same-user process could replace it before the UAC-elevated launch.
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+
+    const script = elevatedScript();
+    expect(script).toContain("Start-Process -FilePath 'wsl.exe'");
+    expect(script).toContain("-ArgumentList @('--install','--no-distribution')");
+    expect(script).toContain('-RedirectStandardOutput');
   });
 
-  it('writes a BOM-prefixed payload.ps1 in powershell mode', () => {
+  it('omits -ArgumentList when the command has no arguments', () => {
+    // Start-Process rejects an empty @() with a parameter binding error.
+    mockFiles({ exit: '0' });
+    mockSpawn({ status: 0 });
+    runElevated({ command: { file: 'wsl.exe' } });
+    expect(elevatedScript()).not.toContain('-ArgumentList @()');
+  });
+
+  it('runs a powershell payload through the same encoded channel', () => {
     mockFiles({ exit: '0' });
     mockSpawn({ status: 0 });
     runElevated({ powershell: 'Enable-WindowsOptionalFeature -Online' });
-    const [, content] = mockedWriteFileSync.mock.calls.find(([p]) =>
-      String(p).endsWith('payload.ps1')
-    )!;
-    expect(String(content).startsWith('﻿')).toBe(true);
-    expect(String(content)).toContain('Enable-WindowsOptionalFeature');
+
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+
+    const script = elevatedScript();
+    expect(script).toContain('Enable-WindowsOptionalFeature -Online');
+    // Merging the error stream is what keeps a failed cmdlet's message visible.
+    expect(script).toContain('*>&1');
   });
 });

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -55,12 +55,14 @@ import type {
 } from '../../shared/ipc';
 import { registerQraftIpcHandlers } from '../qraft/ipc';
 import {
+  classifyKernelInstall,
   classifyWslFeatureState,
   hasNonRootUser,
   isBashCapableDistro,
   readFeatureStates,
-  wslPackageInstalled,
-  wslStatusWorks,
+  runElevated,
+  summarizeElevated,
+  wslKernelPresent,
 } from './wsl-state';
 import {
   getConfigDir,
@@ -974,22 +976,34 @@ for m in ("pydantic", "httpx", "loguru"):
           message: '正在启用 Windows 可选功能 (WSL + 虚拟机平台)...',
         } satisfies WslInstallProgress);
 
-        // Exit codes of UAC-elevated processes cannot be read reliably
-        // (Select-Object ExitCode throws after RunAs elevation), so run
-        // without -PassThru and verify the result by re-reading the feature
-        // states afterwards.
-        const r = spawnSync(
-          'powershell.exe',
-          [
-            '-NoProfile',
-            '-Command',
-            'Start-Process powershell -ArgumentList "-NoProfile -Command ' +
-              'Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart; ' +
-              'Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart" ' +
-              '-Verb RunAs -Wait',
-          ],
-          { timeout: 120000, encoding: 'utf8', windowsHide: true }
+        // The elevated process runs Enable-WindowsOptionalFeature and reports
+        // its own output/exit code through the trampoline files: a declined
+        // UAC prompt used to be indistinguishable from a DISM failure here.
+        const r = runElevated(
+          {
+            powershell: [
+              '$ErrorActionPreference = "Continue"',
+              'Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart',
+              'Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart',
+            ].join('\r\n'),
+          },
+          120000
         );
+
+        if (r.kind === 'cancelled') {
+          safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
+            phase: 'error',
+            message: '启用 Windows 功能被取消：管理员权限请求被拒绝',
+            error: 'ELEVATION_CANCELLED',
+          } satisfies WslInstallProgress);
+          return {
+            success: false,
+            phase: 'error',
+            errorCode: 'ELEVATION_CANCELLED',
+            error: '启用 Windows 功能被取消',
+            nextStep: '重新点击「一键安装 WSL2」，并在弹出的 UAC 窗口中点击「是」',
+          } satisfies WslInstallAndProvisionResult;
+        }
 
         // Verification requires a successful read with the WSL feature on.
         // VirtualMachinePlatform is intentionally not required: on machines
@@ -997,11 +1011,12 @@ for m in ("pydantic", "httpx", "loguru"):
         // it is functional (observed in live testing) — gating on it would
         // recreate the false-failure bug this step was fixed for.
         const featuresAfter = readFeatureStates();
-        if (r.error || r.status !== 0 || !featuresAfter.ok || !featuresAfter.featureWsl) {
+        if (!featuresAfter.ok || !featuresAfter.featureWsl) {
+          const detail = r.kind === 'ok' ? '功能状态未变化' : summarizeElevated(r);
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
             phase: 'error',
-            message: `启用 Windows 功能失败: ${r.error?.message ?? '功能状态未变化'}`,
-            error: r.error?.message ?? 'feature state unchanged after enable',
+            message: `启用 Windows 功能失败: ${detail}`,
+            error: detail,
           } satisfies WslInstallProgress);
           return {
             success: false,
@@ -1035,30 +1050,44 @@ for m in ("pydantic", "httpx", "loguru"):
           message: '正在安装 WSL2 内核...',
         } satisfies WslInstallProgress);
 
-        const r = spawnSync(
-          'powershell.exe',
-          [
-            '-NoProfile',
-            '-Command',
-            'Start-Process wsl -ArgumentList "--install --no-distribution --no-launch" -Verb RunAs -Wait',
-          ],
-          { timeout: 300000, encoding: 'utf8', windowsHide: true }
+        const r = runElevated(
+          { command: 'wsl.exe --install --no-distribution --no-launch' },
+          300000
         );
 
-        // Verify by system state: the WSL app package must exist after the
-        // install (wsl --status may keep failing until the next reboot).
-        const kernelOk = wslStatusWorks() || wslPackageInstalled();
-        if (r.error || r.status !== 0 || !kernelOk) {
+        // Only ask the system when the elevated run itself was inconclusive:
+        // exit code 0 already proves the install, and a declined UAC prompt
+        // proves nothing was attempted, so probing would just add latency.
+        const kernelPresent =
+          r.kind === 'failed' || r.kind === 'unknown' ? wslKernelPresent() : false;
+        const outcome = classifyKernelInstall(r, kernelPresent);
+
+        if (outcome.status === 'cancelled') {
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
             phase: 'error',
-            message: `WSL2 内核安装失败: ${r.error?.message ?? '未检测到 WSL 包'}`,
-            error: r.error?.message ?? 'WSL package not found after install',
+            message: 'WSL2 内核安装被取消：管理员权限请求被拒绝',
+            error: 'ELEVATION_CANCELLED',
+          } satisfies WslInstallProgress);
+          return {
+            success: false,
+            phase: 'error',
+            errorCode: 'ELEVATION_CANCELLED',
+            error: 'WSL2 内核安装被取消',
+            nextStep: '重新点击「一键安装 WSL2」，并在弹出的 UAC 窗口中点击「是」',
+          } satisfies WslInstallAndProvisionResult;
+        }
+
+        if (outcome.status === 'failed') {
+          safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
+            phase: 'error',
+            message: `WSL2 内核安装失败: ${outcome.detail}`,
+            error: outcome.detail,
           } satisfies WslInstallProgress);
           return {
             success: false,
             phase: 'error',
             errorCode: 'KERNEL_INSTALL_FAILED',
-            error: 'WSL2 内核安装失败',
+            error: `WSL2 内核安装失败: ${outcome.detail}`,
             nextStep: '以管理员身份打开 PowerShell 并运行: wsl --install --no-distribution',
           } satisfies WslInstallAndProvisionResult;
         }
@@ -1086,28 +1115,39 @@ for m in ("pydantic", "httpx", "loguru"):
           message: '正在安装 Ubuntu 发行版（可能需要几分钟）...',
         } satisfies WslInstallProgress);
 
-        const r = spawnSync(
-          'powershell.exe',
-          [
-            '-NoProfile',
-            '-Command',
-            'Start-Process wsl -ArgumentList "--install -d Ubuntu --no-launch" -Verb RunAs -Wait',
-          ],
-          { timeout: 300000, encoding: 'utf8', windowsHide: true }
-        );
+        const r = runElevated({ command: 'wsl.exe --install -d Ubuntu --no-launch' }, 300000);
 
-        const postCheck = runWslCheckInternal();
-        if (r.error || r.status !== 0 || postCheck.distros.length === 0) {
+        if (r.kind === 'cancelled') {
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
             phase: 'error',
-            message: 'Ubuntu 安装失败',
-            error: r.error?.message ?? 'DISTRO_INSTALL_FAILED',
+            message: 'Ubuntu 安装被取消：管理员权限请求被拒绝',
+            error: 'ELEVATION_CANCELLED',
+          } satisfies WslInstallProgress);
+          return {
+            success: false,
+            phase: 'error',
+            errorCode: 'ELEVATION_CANCELLED',
+            error: 'Ubuntu 发行版安装被取消',
+            nextStep: '重新点击「一键安装 WSL2」，并在弹出的 UAC 窗口中点击「是」',
+          } satisfies WslInstallAndProvisionResult;
+        }
+
+        const postCheck = runWslCheckInternal();
+        if (postCheck.distros.length === 0) {
+          // Exit code 0 with no registered distro means the install asked for a
+          // reboot — reporting the raw "退出码 0" here would read as success.
+          const detail =
+            r.kind === 'ok' ? '发行版未注册，可能需要重启后重试' : summarizeElevated(r);
+          safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
+            phase: 'error',
+            message: `Ubuntu 安装失败: ${detail}`,
+            error: detail,
           } satisfies WslInstallProgress);
           return {
             success: false,
             phase: 'error',
             errorCode: 'DISTRO_INSTALL_FAILED',
-            error: 'Ubuntu 发行版安装失败',
+            error: `Ubuntu 发行版安装失败: ${detail}`,
             nextStep: '以管理员身份打开 PowerShell 并运行: wsl --install -d Ubuntu',
           } satisfies WslInstallAndProvisionResult;
         }

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1012,7 +1012,11 @@ for m in ("pydantic", "httpx", "loguru"):
         // recreate the false-failure bug this step was fixed for.
         const featuresAfter = readFeatureStates();
         if (!featuresAfter.ok || !featuresAfter.featureWsl) {
-          const detail = r.kind === 'ok' ? '功能状态未变化' : summarizeElevated(r);
+          // A failed DISM cmdlet leaves the exit code at 0, so the captured
+          // output is the only place the real reason appears — fall back to the
+          // generic text only when the elevated run produced nothing at all.
+          const produced = r.kind === 'unknown' || r.exitCode !== 0 || r.output.trim().length > 0;
+          const detail = produced ? summarizeElevated(r) : '功能状态未变化';
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
             phase: 'error',
             message: `启用 Windows 功能失败: ${detail}`,
@@ -1051,7 +1055,12 @@ for m in ("pydantic", "httpx", "loguru"):
         } satisfies WslInstallProgress);
 
         const r = runElevated(
-          { command: 'wsl.exe --install --no-distribution --no-launch' },
+          {
+            command: {
+              file: 'wsl.exe',
+              args: ['--install', '--no-distribution', '--no-launch'],
+            },
+          },
           300000
         );
 
@@ -1115,7 +1124,10 @@ for m in ("pydantic", "httpx", "loguru"):
           message: '正在安装 Ubuntu 发行版（可能需要几分钟）...',
         } satisfies WslInstallProgress);
 
-        const r = runElevated({ command: 'wsl.exe --install -d Ubuntu --no-launch' }, 300000);
+        const r = runElevated(
+          { command: { file: 'wsl.exe', args: ['--install', '-d', 'Ubuntu', '--no-launch'] } },
+          300000
+        );
 
         if (r.kind === 'cancelled') {
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
@@ -1134,10 +1146,24 @@ for m in ("pydantic", "httpx", "loguru"):
 
         const postCheck = runWslCheckInternal();
         if (postCheck.distros.length === 0) {
-          // Exit code 0 with no registered distro means the install asked for a
-          // reboot — reporting the raw "退出码 0" here would read as success.
-          const detail =
-            r.kind === 'ok' ? '发行版未注册，可能需要重启后重试' : summarizeElevated(r);
+          // The command succeeded but no distro is registered yet: as with the
+          // kernel step that means "installed, reboot pending", not a failure.
+          // Only a non-zero exit code is an install failure.
+          if (r.kind === 'ok') {
+            safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
+              phase: 'installing_distro',
+              rebootRequired: true,
+              message: 'Ubuntu 已安装，需要重启系统以继续。',
+            } satisfies WslInstallProgress);
+            return {
+              success: true,
+              phase: 'installing_distro',
+              rebootRequired: true,
+              nextStep: '请重启系统，重新打开 MiQroForge 后向导将自动继续',
+            } satisfies WslInstallAndProvisionResult;
+          }
+
+          const detail = summarizeElevated(r);
           safeSend(IPC_EVENTS.WSL_INSTALL_PROGRESS, {
             phase: 'error',
             message: `Ubuntu 安装失败: ${detail}`,

--- a/apps/desktop/src/main/ipc/wsl-state.ts
+++ b/apps/desktop/src/main/ipc/wsl-state.ts
@@ -11,9 +11,14 @@
  * - `Start-Process -Verb RunAs -Wait -PassThru | Select-Object ExitCode`
  *   throws "Process must exit before requested information can be
  *   determined" after UAC elevation, so exit codes of elevated commands
- *   must never be relied on — verify the resulting system state instead.
+ *   must never be *returned* by Start-Process.  They can still be recovered
+ *   by having the elevated process write them to a file (see runElevated) —
+ *   without that, every failure mode collapses into one fallback message.
  */
 import { spawnSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import type { WslFeatureState } from '../../shared/ipc';
 
 export interface FeatureStates {
@@ -112,6 +117,200 @@ export function wslPackageInstalled(timeoutMs = 10000): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Kernel presence with retries.  A single probe misreports a successful
+ * `wsl --install` as "package not found": the Appx registration can lag a few
+ * seconds behind the elevated process exiting, and `wsl --status` keeps
+ * failing until the next reboot.  Retrying is preferred over widening the
+ * Appx query with `-AllUsers`, which itself requires elevation.
+ */
+export function wslKernelPresent(attempts = 3, intervalMs = 3000): boolean {
+  for (let i = 0; i < attempts; i++) {
+    if (wslStatusWorks() || wslPackageInstalled()) return true;
+    if (i < attempts - 1) sleepSync(intervalMs);
+  }
+  return false;
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// ---------------------------------------------------------------------------
+// Elevation trampoline — recovers the exit code / output of a UAC-elevated
+// process.  Start-Process cannot return them (`ExitCode` throws after RunAs),
+// so the elevated child is launched through a generated batch file that
+// redirects its combined output and exit code to files next to it.
+// ---------------------------------------------------------------------------
+
+/** Exit code the trampoline reports when the user declines the UAC prompt. */
+export const ELEVATION_CANCELLED = 1223; // Win32 ERROR_CANCELLED
+
+export interface ElevatedRunResult {
+  /**
+   * `ok` = elevated process ran and exited 0; `failed` = it ran and exited
+   * non-zero; `cancelled` = the UAC prompt was declined; `unknown` = the
+   * trampoline itself failed (nothing can be said about the command).
+   */
+  kind: 'ok' | 'failed' | 'cancelled' | 'unknown';
+  exitCode: number | null;
+  /** Combined stdout+stderr of the elevated process. */
+  output: string;
+  /** Transport-level error detail, only set when kind is `unknown`. */
+  error?: string;
+}
+
+export interface ElevatedPayload {
+  /** Command line executed inside the elevated cmd.exe. */
+  command?: string;
+  /** PowerShell script executed elevated via a generated payload.ps1. */
+  powershell?: string;
+}
+
+/** Decode wsl.exe output, which is UTF-16LE even when redirected to a file. */
+export function decodeWslOutput(buf: Buffer | string | null | undefined): string {
+  if (!buf || buf.length === 0) return '';
+  if (typeof buf === 'string') return buf.replace(/\0/g, '').trim();
+  if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe) {
+    return buf.toString('utf16le').replace(/^﻿/, '').replace(/\0/g, '').trim();
+  }
+  // ASCII text in UTF-16LE is NUL-interleaved, but CJK text is not: its code
+  // units have no zero high byte, so the NUL heuristic alone silently turns
+  // localized (e.g. Chinese) wsl.exe messages into mojibake.  Fall back to
+  // "UTF-8 decoding produced replacement characters" as a second signal.
+  const nullRatio =
+    buf.reduce((acc, b, i) => (i % 2 === 1 && b === 0 ? acc + 1 : acc), 0) /
+    Math.max(1, Math.floor(buf.length / 2));
+  const asUtf8 = buf.toString('utf8');
+  const looksUtf16 = nullRatio > 0.3 || (buf.length % 2 === 0 && asUtf8.includes('�'));
+  if (looksUtf16) return buf.toString('utf16le').replace(/\0/g, '').trim();
+  return asUtf8.replace(/\0/g, '').trim();
+}
+
+/** One-line description of a failed elevated run, for the error card. */
+export function summarizeElevated(r: ElevatedRunResult, maxLen = 300): string {
+  if (r.kind === 'unknown' && r.error) return r.error;
+  const parts: string[] = [];
+  if (r.exitCode !== null) parts.push(`退出码 ${r.exitCode}`);
+  const out = r.output.replace(/\s+/g, ' ').trim();
+  if (out) parts.push(out.length > maxLen ? out.slice(-maxLen) : out);
+  return parts.join('——') || '无输出';
+}
+
+/**
+ * Run a command with administrator rights (UAC prompt) and recover its exit
+ * code and output.  Blocks until the elevated process exits.
+ */
+export function runElevated(payload: ElevatedPayload, timeoutMs = 300000): ElevatedRunResult {
+  let dir: string | null = null;
+  try {
+    dir = mkdtempSync(join(tmpdir(), 'miqi-elev-'));
+    const runPath = join(dir, 'run.cmd');
+    const errPath = join(dir, 'trampoline.txt');
+
+    // The elevated process starts with CWD=System32, so every path is
+    // anchored to %~dp0 (the directory of run.cmd).
+    const lines = ['@echo off'];
+    if (payload.powershell) {
+      // PowerShell 5.1 reads BOM-less .ps1 as ANSI — always write the BOM.
+      writeFileSync(join(dir, 'payload.ps1'), '﻿' + payload.powershell, 'utf8');
+      lines.push(
+        'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0payload.ps1" > "%~dp0out.txt" 2>&1'
+      );
+    } else {
+      lines.push(`${payload.command ?? ''} > "%~dp0out.txt" 2>&1`);
+    }
+    lines.push('set EC=%errorlevel%');
+    // Leading redirection: `echo %EC%> file` would be parsed as a handle.
+    lines.push('> "%~dp0exit.txt" echo %EC%');
+    writeFileSync(runPath, `${lines.join('\r\n')}\r\n`, 'utf8');
+
+    const outer =
+      "$ErrorActionPreference='Stop'; " +
+      `try { Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', '"${psEscape(runPath)}"' ` +
+      '-Verb RunAs -Wait -ErrorAction Stop } ' +
+      'catch { ' +
+      `if ($_.Exception.NativeErrorCode -eq ${ELEVATION_CANCELLED}) { exit ${ELEVATION_CANCELLED} } ` +
+      `Set-Content -LiteralPath '${psEscape(errPath)}' -Value $_.Exception.Message -Encoding UTF8; ` +
+      'exit 99 }';
+
+    const r = spawnSync('powershell.exe', ['-NoProfile', '-Command', outer], {
+      timeout: timeoutMs,
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+
+    if (r.error) return { kind: 'unknown', exitCode: null, output: '', error: r.error.message };
+    if (r.status === ELEVATION_CANCELLED) return { kind: 'cancelled', exitCode: null, output: '' };
+
+    const output = decodeWslOutput(readFileOrNull(join(dir, 'out.txt')));
+    const exitCode = readExitCode(join(dir, 'exit.txt'));
+    if (exitCode === null) {
+      // The elevated process never wrote its exit code: the trampoline failed
+      // (no UAC prompt was shown, or the batch file could not be launched).
+      const detail =
+        readTextOrNull(errPath) ||
+        (typeof r.stderr === 'string' ? r.stderr.trim() : '') ||
+        `提权进程未返回结果（powershell 退出码 ${r.status}）`;
+      return { kind: 'unknown', exitCode: null, output, error: detail };
+    }
+    return exitCode === 0 ? { kind: 'ok', exitCode, output } : { kind: 'failed', exitCode, output };
+  } catch (e: any) {
+    return { kind: 'unknown', exitCode: null, output: '', error: e?.message ?? String(e) };
+  } finally {
+    if (dir) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+}
+
+function psEscape(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function readFileOrNull(path: string): Buffer | null {
+  try {
+    return readFileSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function readTextOrNull(path: string): string | null {
+  const buf = readFileOrNull(path);
+  return buf ? decodeWslOutput(buf) : null;
+}
+
+function readExitCode(path: string): number | null {
+  const text = readTextOrNull(path);
+  if (text === null) return null;
+  const code = parseInt(text.trim(), 10);
+  return Number.isNaN(code) ? null : code;
+}
+
+export type KernelInstallOutcome =
+  { status: 'installed' } | { status: 'cancelled' } | { status: 'failed'; detail: string };
+
+/**
+ * Decide the kernel-install result from the elevated run plus the post-install
+ * system probe.  System state wins over the exit code: `wsl --install` can
+ * exit 0 while the Appx registration still lags behind the probe, and vice
+ * versa.  Only when both disagree does the exit code/output get surfaced.
+ */
+export function classifyKernelInstall(
+  r: ElevatedRunResult,
+  kernelPresent: boolean
+): KernelInstallOutcome {
+  if (kernelPresent) return { status: 'installed' };
+  if (r.kind === 'cancelled') return { status: 'cancelled' };
+  if (r.kind === 'ok') return { status: 'installed' };
+  return { status: 'failed', detail: summarizeElevated(r) };
 }
 
 export function classifyWslFeatureState(opts: {

--- a/apps/desktop/src/main/ipc/wsl-state.ts
+++ b/apps/desktop/src/main/ipc/wsl-state.ts
@@ -141,8 +141,12 @@ function sleepSync(ms: number): void {
 // ---------------------------------------------------------------------------
 // Elevation trampoline — recovers the exit code / output of a UAC-elevated
 // process.  Start-Process cannot return them (`ExitCode` throws after RunAs),
-// so the elevated child is launched through a generated batch file that
-// redirects its combined output and exit code to files next to it.
+// so the elevated child writes its exit code to a file instead.
+//
+// The elevated payload travels as an *encoded command line*, never as a script
+// file: %TEMP% is user-writable, so a same-user process could replace a script
+// between writing it and the UAC-elevated launch, turning the elevation prompt
+// into an admin code-execution primitive.  Only result files live in %TEMP%.
 // ---------------------------------------------------------------------------
 
 /** Exit code the trampoline reports when the user declines the UAC prompt. */
@@ -163,13 +167,13 @@ export interface ElevatedRunResult {
 }
 
 export interface ElevatedPayload {
-  /** Command line executed inside the elevated cmd.exe. */
-  command?: string;
-  /** PowerShell script executed elevated via a generated payload.ps1. */
+  /** Executable run elevated; its stdout/stderr and exit code are captured. */
+  command?: { file: string; args?: string[] };
+  /** PowerShell script run elevated; its output and exit code are captured. */
   powershell?: string;
 }
 
-/** Decode wsl.exe output, which is UTF-16LE even when redirected to a file. */
+/** Decode command output, which may be UTF-16LE even when redirected to a file. */
 export function decodeWslOutput(buf: Buffer | string | null | undefined): string {
   if (!buf || buf.length === 0) return '';
   if (typeof buf === 'string') return buf.replace(/\0/g, '').trim();
@@ -178,8 +182,8 @@ export function decodeWslOutput(buf: Buffer | string | null | undefined): string
   }
   // ASCII text in UTF-16LE is NUL-interleaved, but CJK text is not: its code
   // units have no zero high byte, so the NUL heuristic alone silently turns
-  // localized (e.g. Chinese) wsl.exe messages into mojibake.  Fall back to
-  // "UTF-8 decoding produced replacement characters" as a second signal.
+  // localized (e.g. Chinese) output into mojibake.  Fall back to "UTF-8
+  // decoding produced replacement characters" as a second signal.
   const nullRatio =
     buf.reduce((acc, b, i) => (i % 2 === 1 && b === 0 ? acc + 1 : acc), 0) /
     Math.max(1, Math.floor(buf.length / 2));
@@ -189,11 +193,15 @@ export function decodeWslOutput(buf: Buffer | string | null | undefined): string
   return asUtf8.replace(/\0/g, '').trim();
 }
 
-/** One-line description of a failed elevated run, for the error card. */
+/**
+ * One-line description of a failed elevated run, for the error card.  Exit
+ * code 0 is omitted: in a failure path it says "the process did not fail",
+ * and the captured output is the part that explains what went wrong.
+ */
 export function summarizeElevated(r: ElevatedRunResult, maxLen = 300): string {
   if (r.kind === 'unknown' && r.error) return r.error;
   const parts: string[] = [];
-  if (r.exitCode !== null) parts.push(`退出码 ${r.exitCode}`);
+  if (r.exitCode !== null && r.exitCode !== 0) parts.push(`退出码 ${r.exitCode}`);
   const out = r.output.replace(/\s+/g, ' ').trim();
   if (out) parts.push(out.length > maxLen ? out.slice(-maxLen) : out);
   return parts.join('——') || '无输出';
@@ -207,52 +215,43 @@ export function runElevated(payload: ElevatedPayload, timeoutMs = 300000): Eleva
   let dir: string | null = null;
   try {
     dir = mkdtempSync(join(tmpdir(), 'miqi-elev-'));
-    const runPath = join(dir, 'run.cmd');
-    const errPath = join(dir, 'trampoline.txt');
+    const outPath = join(dir, 'out.txt');
+    const errPath = join(dir, 'err.txt');
+    const codePath = join(dir, 'exit.txt');
+    const trampolinePath = join(dir, 'trampoline.txt');
 
-    // The elevated process starts with CWD=System32, so every path is
-    // anchored to %~dp0 (the directory of run.cmd).
-    const lines = ['@echo off'];
-    if (payload.powershell) {
-      // PowerShell 5.1 reads BOM-less .ps1 as ANSI — always write the BOM.
-      writeFileSync(join(dir, 'payload.ps1'), '﻿' + payload.powershell, 'utf8');
-      lines.push(
-        'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0payload.ps1" > "%~dp0out.txt" 2>&1'
-      );
-    } else {
-      lines.push(`${payload.command ?? ''} > "%~dp0out.txt" 2>&1`);
-    }
-    lines.push('set EC=%errorlevel%');
-    // Leading redirection: `echo %EC%> file` would be parsed as a handle.
-    lines.push('> "%~dp0exit.txt" echo %EC%');
-    writeFileSync(runPath, `${lines.join('\r\n')}\r\n`, 'utf8');
+    const elevated = payload.powershell
+      ? powershellCapture(payload.powershell, outPath, errPath, codePath)
+      : commandCapture(payload.command ?? { file: '' }, outPath, errPath, codePath);
 
-    const outer =
+    const trampoline =
       "$ErrorActionPreference='Stop'; " +
-      `try { Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', '"${psEscape(runPath)}"' ` +
+      `try { Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-EncodedCommand','${encodeCommand(elevated)}') ` +
       '-Verb RunAs -Wait -ErrorAction Stop } ' +
       'catch { ' +
       `if ($_.Exception.NativeErrorCode -eq ${ELEVATION_CANCELLED}) { exit ${ELEVATION_CANCELLED} } ` +
-      `Set-Content -LiteralPath '${psEscape(errPath)}' -Value $_.Exception.Message -Encoding UTF8; ` +
+      `Set-Content -LiteralPath '${psEscape(trampolinePath)}' -Value $_.Exception.Message -Encoding UTF8; ` +
       'exit 99 }';
 
-    const r = spawnSync('powershell.exe', ['-NoProfile', '-Command', outer], {
-      timeout: timeoutMs,
-      encoding: 'utf8',
-      windowsHide: true,
-    });
+    const r = spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-EncodedCommand', encodeCommand(trampoline)],
+      { timeout: timeoutMs, encoding: 'buffer', windowsHide: true }
+    );
 
     if (r.error) return { kind: 'unknown', exitCode: null, output: '', error: r.error.message };
     if (r.status === ELEVATION_CANCELLED) return { kind: 'cancelled', exitCode: null, output: '' };
 
-    const output = decodeWslOutput(readFileOrNull(join(dir, 'out.txt')));
-    const exitCode = readExitCode(join(dir, 'exit.txt'));
+    const stdout = decodeWslOutput(readFileOrNull(outPath));
+    const stderr = decodeWslOutput(readFileOrNull(errPath));
+    const output = [stdout, stderr].filter((s) => s.length > 0).join('\n');
+    const exitCode = readExitCode(codePath);
     if (exitCode === null) {
       // The elevated process never wrote its exit code: the trampoline failed
-      // (no UAC prompt was shown, or the batch file could not be launched).
+      // (no UAC prompt was shown, or the elevated process was killed early).
       const detail =
-        readTextOrNull(errPath) ||
-        (typeof r.stderr === 'string' ? r.stderr.trim() : '') ||
+        readTextOrNull(trampolinePath) ||
+        decodeWslOutput(r.stderr as Buffer | null) ||
         `提权进程未返回结果（powershell 退出码 ${r.status}）`;
       return { kind: 'unknown', exitCode: null, output, error: detail };
     }
@@ -268,6 +267,67 @@ export function runElevated(payload: ElevatedPayload, timeoutMs = 300000): Eleva
       }
     }
   }
+}
+
+/** Base64 UTF-16LE, the encoding PowerShell's -EncodedCommand expects. */
+function encodeCommand(script: string): string {
+  return Buffer.from(script, 'utf16le').toString('base64');
+}
+
+/** Elevated script: run an executable, capture both streams and the exit code. */
+function commandCapture(
+  cmd: { file: string; args?: string[] },
+  outPath: string,
+  errPath: string,
+  codePath: string
+): string {
+  const args = (cmd.args ?? []).map((a) => `'${psEscape(a)}'`).join(',');
+  // An empty @() is rejected by Start-Process ("argument collection contains a
+  // null value"), so the parameter is omitted entirely when there are no args.
+  const argList = args ? ` -ArgumentList @(${args})` : '';
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    'try {',
+    `  $p = Start-Process -FilePath '${psEscape(cmd.file)}'${argList} ` +
+      `-RedirectStandardOutput '${psEscape(outPath)}' ` +
+      `-RedirectStandardError '${psEscape(errPath)}' -NoNewWindow -Wait -PassThru -ErrorAction Stop`,
+    `  Set-Content -LiteralPath '${psEscape(codePath)}' -Value $p.ExitCode -Encoding ASCII`,
+    '  exit $p.ExitCode',
+    '} catch {',
+    `  $_ | Out-String | Set-Content -LiteralPath '${psEscape(errPath)}' -Encoding UTF8`,
+    `  Set-Content -LiteralPath '${psEscape(codePath)}' -Value 99 -Encoding ASCII`,
+    '  exit 99',
+    '}',
+  ].join('\r\n');
+}
+
+/**
+ * Elevated script: run a PowerShell body and capture everything it writes.
+ * `*>&1` merges the error stream into the captured text, so a cmdlet failure
+ * that PowerShell does not turn into a non-zero exit code still reaches the
+ * user instead of collapsing into a generic message.
+ */
+function powershellCapture(
+  body: string,
+  outPath: string,
+  errPath: string,
+  codePath: string
+): string {
+  return [
+    "$ErrorActionPreference = 'Continue'",
+    `$log = '${psEscape(outPath)}'`,
+    `$err = '${psEscape(errPath)}'`,
+    '$ec = 0',
+    'try {',
+    `  & {\n${body}\n  } *>&1 | Out-String | Set-Content -LiteralPath $log -Encoding UTF8`,
+    '} catch {',
+    '  $_ | Out-String | Set-Content -LiteralPath $err -Encoding UTF8',
+    '  $ec = 1',
+    '}',
+    'if ($LASTEXITCODE -is [int]) { $ec = $LASTEXITCODE }',
+    `Set-Content -LiteralPath '${psEscape(codePath)}' -Value $ec -Encoding ASCII`,
+    'exit $ec',
+  ].join('\r\n');
 }
 
 function psEscape(value: string): string {

--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -117,7 +117,10 @@ describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
 
       // 4. RUNNING 扣费提示（10 积分）——出现即截图，作为证据
       await expect(page.getByText(/已扣 10 积分/).first()).toBeVisible({ timeout: 300_000 });
-      await page.screenshot({ path: 'test-results/slurm-billing-hosted-charge.png', fullPage: true });
+      await page.screenshot({
+        path: 'test-results/slurm-billing-hosted-charge.png',
+        fullPage: true,
+      });
 
       // 5. 回合正常收尾
       await waitForResponseComplete(page, 300_000);


### PR DESCRIPTION
## 类型

<!-- 必选，勾一个 -->
- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档
- [ ] ♻️ 重构
- [ ] 🧪 测试
- [ ] 🔧 其他

## 变更概述

WSL2 一键安装回传 UAC 提权进程的退出码与真实输出，按「UAC 被取消 / 安装失败 / 待重启」分别给文案；提权载荷改为命令行编码下发，不在用户可写的 `%TEMP%` 留可执行脚本。

## 背景/问题

**现象**：一键安装 WSL2 卡在「安装 WSL」步骤，固定报 `WSL2 内核安装失败: 未检测到 WSL 包`（#1031）。

**根因**：`Start-Process -Verb RunAs` 提权后无法读回子进程退出码（`Select-Object ExitCode` 在 RunAs 下必抛），所以 `r.error?.message` 恒为空，落到兜底字符串。结果是三种完全不同的失败场景——

1. 用户在 UAC 弹窗点了「否」；
2. `wsl --install` 自身报错（商店不可用、老版本 Windows 不支持 inbox 安装等）；
3. 安装其实成功、只是包注册/状态核验时序没跟上——

全部显示同一条无信息量的文案，用户和我们都无法定位。其中第 3 种尤其糟：明明只差一次重启，却报成失败。

**影响**：WSL 是 Windows 上首次使用的必经步骤，用户在这个步骤失去所有可操作信息，只能照灰色提示手动执行命令。

## 关联 issue

- Closes #1031 WSL2 一键安装失败原因被兜底文案掩盖

## 变更内容

**`apps/desktop/src/main/ipc/wsl-state.ts`**

- `runElevated()`：提权跳板。提权子进程把**退出码写进文件**（绕开 RunAs 读不到退出码的限制），输出由 `Start-Process -RedirectStandardOutput/-RedirectStandardError -PassThru` 原样落盘后读回——`-PassThru` 在非 RunAs 子进程上可取 `.ExitCode`，且重定向保留 wsl.exe 的 UTF-16LE 原始字节。结果是四态判别：`ok` / `failed`（退出码 + 真实输出）/ `cancelled`（UAC 拒绝）/ `unknown`（跳板自身失败）。
- **安全**：提权载荷经 `-EncodedCommand`（base64 UTF-16LE）随命令行下发，**不再落成 `run.cmd` / `payload.ps1` 脚本文件**。`%TEMP%` 是用户可写的，写脚本再提权执行等于把 UAC 提示变成同用户→管理员的代码执行原语；现在 `%TEMP%` 只放结果文件。
- UAC 取消用 `ERROR_CANCELLED (1223)` 判定（`$_.Exception.NativeErrorCode`），**与系统语言无关**，不依赖匹配本地化的错误文本。
- `classifyKernelInstall()`：系统状态优先于退出码——`wsl --install` 可能退出 0 但 Appx 注册滞后，也可能退出非 0 而包已注册；只有两者都指向失败时才把退出码/输出抛给用户。
- `wslKernelPresent()`：核验加 3 次重试（Appx 注册滞后、重启前 `wsl --status` 必失败）。未用 `-AllUsers` 是因为它本身需要提权，非提权的桌面进程读不到。
- `decodeWslOutput()`：修正 CJK UTF-16 输出被解成乱码——中文码元没有 0 高位字节，已有的「NUL 占比」启发式只对 ASCII 有效，会把 WSL 的中文本地化报错变成 `�`，恰好毁掉本 PR 想给用户的「真实原因」。
- `summarizeElevated()`：失败文案里省略退出码 0（它只说明「进程没失败」，原因在输出里）。

**`apps/desktop/src/main/ipc/index.ts`**（三处提权调用统一改走跳板）

- 内核安装（Step 3）：`cancelled` → 提示重新点击并在 UAC 点「是」；`failed` → 文案带退出码与 wsl 真实输出；`ok` → 进入「需重启」而非报错。
- 启用 Windows 功能（Step 2）：提权脚本用 `*>&1` 合并错误流，DISM 的报错文本会随输出一起回传；此前 UAC 取消显示成「功能状态未变化」，现在单独给出取消文案。
- 安装 Ubuntu（Step 4）：命令成功（退出 0）但发行版尚未注册 → 按「待重启」返回成功，而不是报失败；只有非 0 退出才算安装失败。

**`apps/desktop/src/main/ipc.test.ts`**：新增 26 条用例——四态判别、输出解码（含 CJK 无 BOM）、退出码/输出回传、`*>&1` 合并、无参命令不生成空 `-ArgumentList`，以及**「不向 %TEMP% 写任何可执行文件」**这条安全断言。

**顺带修 `apps/desktop/tests/e2e/billing-hosted-live.spec.ts`**（与本 issue 无关）：该文件在 develop 上 prettier 检查失败（#1029 引入），会一直卡住 check-format，仅做 4 行换行格式化，无逻辑变更。

## 日志/验证证据

```
# 本机实测（Windows 11 + 真实 wsl.exe）。因无法在本机自动点击 UAC，
# 这里去掉 -Verb RunAs，其余跳板逻辑与生产逐字一致。

--- command 模式：wsl.exe --definitely-not-a-flag（真实 wsl.exe）
  outer status = 0
  out.txt = "无效的命令行参数： --definitely-not-a-flag\r\n请使用“wsl.exe --help' 获取受支持的参数列表。"
  err.txt = ""
  exit.txt = "-1"                       ← 退出码成功回传（旧实现完全读不到）

--- powershell 模式：body 内 cmdlet 失败
  out.txt = "first line\r\nGet-Item : Cannot find path 'C:\\...\\definitelymissing' because it does not exist.…"
  exit.txt = "0"                        ← cmdlet 失败不改退出码，所以错误文本必须靠 *>&1 捕获

--- 空 -ArgumentList（修复前的形态；本机实测恰好暴露了这个 bug）
  err.txt = "Start-Process : Cannot validate argument on parameter 'ArgumentList'…"
  exit.txt = "99"                       ← 跳板自身失败时不会误报成「安装失败」

--- 无参命令（whoami.exe，修复后）
  outer status = 0 | exit = 0           ← -ArgumentList @() 不再生成，问题修复
```

**修复前**（`ipc/index.ts`，三种场景同一条文案）：

```ts
message: `WSL2 内核安装失败: ${r.error?.message ?? '未检测到 WSL 包'}`,
error: r.error?.message ?? 'WSL package not found after install',
```

**修复后**：文案按场景分化——

```ts
// UAC 被拒
errorCode: 'ELEVATION_CANCELLED',
nextStep: '重新点击「一键安装 WSL2」，并在弹出的 UAC 窗口中点击「是」',

// 真实失败（退出码 + wsl 输出）
message: `WSL2 内核安装失败: 退出码 -1——无效的命令行参数： --definitely-not-a-flag 请使用“wsl.exe --help' 获取受支持的参数列表。`,

// 安装成功仅差重启 → 走 rebootRequired 分支，不再报错
```

## 测试情况

- `npx vitest run src/main/ipc.test.ts` → 48 passed（新增 26 条）
- `npx vitest run` 全量 → 38 files / 505 passed，5 skipped
- `npm run typecheck`（node + web）→ 无错误
- prettier `--check` 全量 → 通过
- 本机实测跳板四种路径（见上：命令模式 / powershell 模式 / 传输错误 / 无参命令）

**未覆盖的部分**：真实 UAC 弹窗交互（同意/取消）与「未装 WSL 内核的 Windows 机器」上的端到端流程，需要人工在目标机器点击验证——这依赖 issue 复现环境。建议由反馈 #1031 的用户用新构建复测一次。

## 截图

无需截图（主进程改动，无界面变更；用户可见变化是错误文案本身）。

## 后续计划

无。
