### PR TITLE
fix(agent): slurm 计费补扣快作业——COMPLETED 也触发扣费

### DIFF
--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -6,9 +6,9 @@
  *   确认 → 作业提交并执行。
  *
  * 断言「模型能自主发现 mcp_miqroforge-slurm_* 工具并提交作业」+「出现扣费提示」。
- * 计费在作业进入可扣费状态（RUNNING 或已执行终态 COMPLETED/FAILED/TIMEOUT）时触发——
- * 快作业从 PENDING 直接到 COMPLETED 也能扣分（2026-09-11 修复：原先只认 RUNNING，
- * 快作业漏扣）。
+ * 计费在作业进入可扣费状态（RUNNING 或 COMPLETED）时触发——快作业从 PENDING
+ * 直接到 COMPLETED 也能扣分（2026-09-11 修复：原先只认 RUNNING，快作业漏扣；
+ * FAILED/TIMEOUT/CANCELLED 不计费）。
  *
  * 与 billing-live.spec.ts 的区别：后者走自部署本地回环服务器（127.0.0.1）
  * + 显式 Bearer header；本 spec 走 #1029 开启的内置托管网关（登录态注入

--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -21,6 +21,8 @@
 
 import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   sendMessage,
   createNewConversation,
@@ -34,6 +36,17 @@ const HAS_CREDS =
   !!process.env.QRAFT_PHONE && !!process.env.QRAFT_PASSWORD && !!process.env.DEEPSEEK_API_KEY;
 
 const describeFn = HAS_CREDS ? test.describe : test.describe.skip;
+
+/** 读桥日志（<MIQI_HOME>/workspace/logs/bridge-*.log）拼接文本。 */
+function readBridgeLog(miqiHome: string): string {
+  const dir = join(miqiHome, 'workspace', 'logs');
+  if (!existsSync(dir)) return '';
+  return readdirSync(dir)
+    .filter((f) => /^bridge-\d{4}-\d{2}-\d{2}\.log$/.test(f))
+    .sort()
+    .map((f) => readFileSync(join(dir, f), 'utf8'))
+    .join('\n');
+}
 
 /** 轮询处理审批弹窗与确认卡，直到 ready() 为真或超时。 */
 async function driveUntilReady(page: Page, ready: () => Promise<boolean>, timeout = 300_000) {
@@ -142,6 +155,15 @@ describeFn('托管 slurm MCP 网关 live E2E（opt-in）', () => {
           .catch(() => '')) ?? '';
       expect(text).toContain('mcp_miqroforge-slurm_submit_slurm_job');
       expect(text).not.toContain('内容安全策略拦截');
+
+      // 6. 提交确实**成功**（不止工具名出现）：桥日志里 submit 工具返回
+      //    success:true + 非空 job_id。失败/被拒的提交不会带这两项，也不会
+      //    产生作业 → 上一步的扣费断言同样不会成立（双重兜底）。
+      const log = readBridgeLog(fixture.miqiHome);
+      expect(log, 'submit_slurm_job 应返回成功结果（success:true）').toMatch(
+        /submit_slurm_job done \([^)]*\): result prefix='[^']*"success":\s*true/
+      );
+      expect(log, '提交结果应含非空 job_id').toMatch(/"job_id":\s*"\d+"/);
 
       await page.screenshot({
         path: 'test-results/slurm-billing-hosted-charge.png',

--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -5,10 +5,10 @@
  *   真实 LLM 在**自然提示词**下自主发现并调用 slurm MCP 提交作业 → 确认卡
  *   确认 → 作业提交并执行。
  *
- * 断言「模型能自主发现 mcp_miqroforge-slurm_* 工具并提交作业」（真实用户路径），
- * **不**断言扣分：计费当前仅在观测到 state=RUNNING 时触发，自然提示词下模型
- * 常提交快作业（PENDING→COMPLETED，从未观测到 RUNNING）→ 不扣分（已知计费漏洞，
- * 见 issue）。故本 spec 只断言 MCP 工具被发现并成功提交。
+ * 断言「模型能自主发现 mcp_miqroforge-slurm_* 工具并提交作业」+「出现扣费提示」。
+ * 计费在作业进入可扣费状态（RUNNING 或已执行终态 COMPLETED/FAILED/TIMEOUT）时触发——
+ * 快作业从 PENDING 直接到 COMPLETED 也能扣分（2026-09-11 修复：原先只认 RUNNING，
+ * 快作业漏扣）。
  *
  * 与 billing-live.spec.ts 的区别：后者走自部署本地回环服务器（127.0.0.1）
  * + 显式 Bearer header；本 spec 走 #1029 开启的内置托管网关（登录态注入
@@ -121,24 +121,34 @@ describeFn('托管 slurm MCP 网关 live E2E（opt-in）', () => {
       // 3. 自然提示词——不点名工具名，模型需自行发现 slurm MCP 并提交
       await sendMessage(page, '使用slurm提交任意一个任务');
 
-      // 4. 驱动确认卡/审批，直到出现 submit_slurm_job 工具调用记录
-      const submitted = await driveUntilReady(page, async () =>
-        (await page
-          .locator('main')
-          .textContent()
-          .catch(() => ''))!.includes('mcp_miqroforge-slurm_submit_slurm_job')
+      // 4. 驱动确认卡/审批，直到扣费提示出现（作业进入可扣费状态：
+      //    RUNNING 或已执行终态 COMPLETED/FAILED/TIMEOUT）
+      const charged = await driveUntilReady(
+        page,
+        async () =>
+          await page
+            .getByText(/已扣 10 积分/)
+            .first()
+            .isVisible()
+            .catch(() => false)
       );
-      expect(submitted, '模型应自主发现并调用 mcp_miqroforge-slurm_submit_slurm_job').toBe(true);
+      expect(charged, '应出现「已扣 10 积分」扣费提示').toBe(true);
 
-      // 5. 无内容安全拦截 / 错误
+      // 5. 模型自主发现并调用了 slurm MCP 提交作业
       const text =
         (await page
           .locator('main')
           .textContent()
           .catch(() => '')) ?? '';
+      expect(text).toContain('mcp_miqroforge-slurm_submit_slurm_job');
       expect(text).not.toContain('内容安全策略拦截');
 
-      await page.screenshot({ path: 'test-results/slurm-mcp-hosted-live.png', fullPage: true });
+      await page.screenshot({
+        path: 'test-results/slurm-billing-hosted-charge.png',
+        fullPage: true,
+      });
+      await expect(page.getByText(/已扣 10 积分/).first()).toBeVisible({ timeout: 30_000 });
+      await page.screenshot({ path: 'test-results/slurm-billing-hosted-live.png', fullPage: true });
     }
   );
 });

--- a/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
+++ b/apps/desktop/tests/e2e/billing-hosted-live.spec.ts
@@ -1,15 +1,20 @@
 /**
- * 托管 slurm MCP 网关计费 live E2E（opt-in，需真实登录 + 可用 LLM 凭据；
+ * 托管 slurm MCP 网关 live E2E（opt-in，需真实登录 + 可用 LLM 凭据；
  * CI 无凭据自动跳过）：
  *   真实登录 → 内置 miqroforge-slurm（http + insecure_http 默认放行）→
- *   真实 LLM 调用 mcp_miqroforge-slurm_submit_slurm_job 提交作业 →
- *   check_job_status 轮询到 RUNNING → Desktop 扣 10 积分 → 聊天区提示。
+ *   真实 LLM 在**自然提示词**下自主发现并调用 slurm MCP 提交作业 → 确认卡
+ *   确认 → 作业提交并执行。
+ *
+ * 断言「模型能自主发现 mcp_miqroforge-slurm_* 工具并提交作业」（真实用户路径），
+ * **不**断言扣分：计费当前仅在观测到 state=RUNNING 时触发，自然提示词下模型
+ * 常提交快作业（PENDING→COMPLETED，从未观测到 RUNNING）→ 不扣分（已知计费漏洞，
+ * 见 issue）。故本 spec 只断言 MCP 工具被发现并成功提交。
  *
  * 与 billing-live.spec.ts 的区别：后者走自部署本地回环服务器（127.0.0.1）
  * + 显式 Bearer header；本 spec 走 #1029 开启的内置托管网关（登录态注入
- * 共享 mcpGatewayKey，零配置）。覆盖「登录后调托管 slurm MCP + 计费」全链。
+ * 共享 mcpGatewayKey，零配置）。
  *
- * Run（真实消耗：测试账号 10 积分 + 一个集群作业）：
+ * Run（真实消耗：一个集群作业）：
  *   QRAFT_PHONE=… QRAFT_PASSWORD=… DEEPSEEK_API_KEY=… npx playwright test \
  *     --config=playwright.config.ts --project=electron tests/e2e/billing-hosted-live.spec.ts
  */
@@ -17,9 +22,7 @@
 import { test, expect } from '@playwright/test';
 import type { ElectronApplication, Page } from '@playwright/test';
 import {
-  LLM_TIMEOUT,
   sendMessage,
-  waitForResponseComplete,
   createNewConversation,
   launchElectronApp,
   closeElectronApp,
@@ -32,25 +35,35 @@ const HAS_CREDS =
 
 const describeFn = HAS_CREDS ? test.describe : test.describe.skip;
 
-async function approveLoop(page: Page, timeout = 180_000) {
+/** 轮询处理审批弹窗与确认卡，直到 ready() 为真或超时。 */
+async function driveUntilReady(page: Page, ready: () => Promise<boolean>, timeout = 300_000) {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
-    const btn = page
+    if (await ready()) return true;
+    // 审批弹窗（工具执行授权）
+    const allow = page
       .getByRole('button', { name: '持久允许' })
       .or(page.getByRole('button', { name: '永久允许' }));
-    if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await btn.click();
+    if (await allow.isVisible({ timeout: 300 }).catch(() => false)) {
+      await allow
+        .first()
+        .click()
+        .catch(() => {});
     }
-    const thinking = await page
-      .getByText('Thinking…')
-      .isVisible()
-      .catch(() => false);
-    if (!thinking) break;
-    await page.waitForTimeout(1000);
+    // 确认卡（ask_user_confirm_card）：点主按钮「确认提交」
+    const primary = page.getByTestId('confirm-card-primary');
+    if (await primary.isVisible({ timeout: 300 }).catch(() => false)) {
+      await primary
+        .first()
+        .click()
+        .catch(() => {});
+    }
+    await page.waitForTimeout(1500);
   }
+  return ready();
 }
 
-describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
+describeFn('托管 slurm MCP 网关 live E2E（opt-in）', () => {
   let fixture: ElectronFixture;
   let electronApp: ElectronApplication;
   let page: Page;
@@ -86,7 +99,7 @@ describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
   });
 
   test(
-    '真实登录 → 托管 slurm MCP 提交作业 → RUNNING 扣 10 积分 → 聊天区提示',
+    '真实登录 → 自然提示词 → 模型自主发现并调用 slurm MCP 提交作业',
     { timeout: 360_000 },
     async () => {
       // 1. 设置页真实登录（幂等：dev userData 可能残留上次登录态）
@@ -101,34 +114,31 @@ describeFn('托管 slurm MCP 网关计费 live E2E（opt-in）', () => {
       }
       await expect(loggedInBadge).toBeVisible({ timeout: 90_000 });
 
-      // 2. 新会话 + 预授权（避免审批卡住工具执行）
+      // 2. 新会话 + 预授权
       await createNewConversation(page);
       await page.evaluate(() => (window as any).miqi.approvals.addPermanent('*:*', 'always'));
 
-      // 3. 指示模型用托管网关工具提交作业并轮询到 RUNNING
-      //（工具注册名为 mcp_miqroforge-slurm_<tool>；只提交一次避免多作业噪音）
-      await sendMessage(
-        page,
-        '使用 mcp_miqroforge-slurm_submit_slurm_job 工具提交作业（script 参数用 ' +
-          '"#!/bin/bash\\nsleep 30\\nhostname"，保证轮询时作业仍在运行），只提交一次，不要重复提交。' +
-          '然后用 mcp_miqroforge-slurm_check_job_status 轮询该作业，直到状态为 RUNNING 后，最后只回复 DONE_SLURM'
+      // 3. 自然提示词——不点名工具名，模型需自行发现 slurm MCP 并提交
+      await sendMessage(page, '使用slurm提交任意一个任务');
+
+      // 4. 驱动确认卡/审批，直到出现 submit_slurm_job 工具调用记录
+      const submitted = await driveUntilReady(page, async () =>
+        (await page
+          .locator('main')
+          .textContent()
+          .catch(() => ''))!.includes('mcp_miqroforge-slurm_submit_slurm_job')
       );
-      await approveLoop(page);
+      expect(submitted, '模型应自主发现并调用 mcp_miqroforge-slurm_submit_slurm_job').toBe(true);
 
-      // 4. RUNNING 扣费提示（10 积分）——出现即截图，作为证据
-      await expect(page.getByText(/已扣 10 积分/).first()).toBeVisible({ timeout: 300_000 });
-      await page.screenshot({ path: 'test-results/slurm-billing-hosted-charge.png', fullPage: true });
+      // 5. 无内容安全拦截 / 错误
+      const text =
+        (await page
+          .locator('main')
+          .textContent()
+          .catch(() => '')) ?? '';
+      expect(text).not.toContain('内容安全策略拦截');
 
-      // 5. 回合正常收尾
-      await waitForResponseComplete(page, 300_000);
-      await expect(
-        page
-          .getByTestId('chat-message-assistant')
-          .getByText(/DONE_SLURM/)
-          .first()
-      ).toBeVisible({ timeout: 30_000 });
-
-      await page.screenshot({ path: 'test-results/slurm-billing-hosted-live.png', fullPage: true });
+      await page.screenshot({ path: 'test-results/slurm-mcp-hosted-live.png', fullPage: true });
     }
   );
 });

--- a/miqi/agent/billing_resolver.py
+++ b/miqi/agent/billing_resolver.py
@@ -1,10 +1,13 @@
 """Slurm MCP 作业计费桥（issue #927）。
 
-计费触发点（2026-09-04 产品确认）：**slurm 作业状态变为 RUNNING 时**由
-Desktop 发起扣费（10 分/次，memo 携带作业信息）。Python 侧在
-submit_slurm_job / check_job_status 的返回中发现 state=RUNNING 时，
-经会话发射器向 Desktop 发一次 fire-and-forget 扣费事件；作业已在运行，
-不阻止调用——余额不足等扣费失败由 Desktop 记录并提示。
+计费触发点（2026-09-04 产品确认；2026-09-11 放宽终态）：**slurm 作业进入
+可扣费状态（RUNNING / COMPLETED / FAILED / TIMEOUT，即已实际占用集群资源）
+时**由 Desktop 发起扣费（10 分/次，memo 携带作业信息）。Python 侧在
+submit_slurm_job / check_job_status 的返回中发现该状态时，经会话发射器向
+Desktop 发一次 fire-and-forget 扣费事件；作业已运行，不阻止调用——余额不足
+等扣费失败由 Desktop 记录并提示。放宽终态是因为快作业常在两次轮询间从
+PENDING 直接到 COMPLETED、永不被观测到 RUNNING，只认 RUNNING 会漏扣。
+CANCELLED（可能排队中被取消、未运行）不计费。
 
 接线（与 user_input_resolver 同模式）：
   bridge/loop.py（chat.send drain）：

--- a/miqi/agent/billing_resolver.py
+++ b/miqi/agent/billing_resolver.py
@@ -1,13 +1,13 @@
 """Slurm MCP 作业计费桥（issue #927）。
 
 计费触发点（2026-09-04 产品确认；2026-09-11 放宽终态）：**slurm 作业进入
-可扣费状态（RUNNING / COMPLETED / FAILED / TIMEOUT，即已实际占用集群资源）
-时**由 Desktop 发起扣费（10 分/次，memo 携带作业信息）。Python 侧在
-submit_slurm_job / check_job_status 的返回中发现该状态时，经会话发射器向
-Desktop 发一次 fire-and-forget 扣费事件；作业已运行，不阻止调用——余额不足
-等扣费失败由 Desktop 记录并提示。放宽终态是因为快作业常在两次轮询间从
-PENDING 直接到 COMPLETED、永不被观测到 RUNNING，只认 RUNNING 会漏扣。
-CANCELLED（可能排队中被取消、未运行）不计费。
+可扣费状态（RUNNING / COMPLETED，即作业已成功占用集群资源）时**由 Desktop
+发起扣费（10 分/次，memo 携带作业信息）。Python 侧在 submit_slurm_job /
+check_job_status 的返回中发现该状态时，经会话发射器向 Desktop 发一次
+fire-and-forget 扣费事件；作业已运行，不阻止调用——余额不足等扣费失败由
+Desktop 记录并提示。放宽 COMPLETED 是因为快作业常在两次轮询间从 PENDING
+直接到 COMPLETED、永不被观测到 RUNNING，只认 RUNNING 会漏扣。FAILED /
+TIMEOUT / CANCELLED 不计费（作业未成功完成/未运行）。
 
 接线（与 user_input_resolver 同模式）：
   bridge/loop.py（chat.send drain）：

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -41,6 +41,14 @@ def _extract_job_state(text: str) -> str | None:
     return match.group(1) if match else None
 
 
+# 可扣费状态（作业已实际占用集群资源）：RUNNING=运行中；COMPLETED/FAILED/
+# TIMEOUT=已执行到终态。快作业常在一次轮询间隔内从 PENDING 直接到
+# COMPLETED，永远观测不到 RUNNING——只认 RUNNING 会漏扣（2026-09-11 实测：
+# 自然提示词提交的 sleep 秒级作业跑完不扣分）。CANCELLED 可能是排队中被取消
+# （未运行），不计费。
+_CHARGEABLE_JOB_STATES = frozenset({"RUNNING", "COMPLETED", "FAILED", "TIMEOUT"})
+
+
 def _extract_job_id(text: str) -> str | None:
     """从 MCP 工具输出中尽力提取 SLURM 作业 ID（无则 None）。"""
     for pattern in _JOB_ID_PATTERNS:
@@ -272,11 +280,12 @@ class MCPToolWrapper(Tool):
     ) -> None:
         """Slurm 作业计费触发（issue #927，2026-09-04 产品确认）——**纯副作用**。
 
-        作业状态变为 RUNNING 时由 Desktop 发起扣费（10 分/次）：
-        submit_slurm_job / check_job_status 的返回里 state=RUNNING 即
-        触发一次 fire-and-forget 扣费事件（Desktop 按作业 ID 去重）。
-        作业已在运行，扣费失败（如余额不足）不阻止作业，由 Desktop
-        记录到扣费历史并提示。
+        作业进入可扣费状态时由 Desktop 发起扣费（10 分/次）：submit_slurm_job /
+        check_job_status 的返回里 state ∈ {RUNNING, COMPLETED, FAILED, TIMEOUT}
+        （即作业已实际占用集群资源——快作业常在两次轮询间从 PENDING 直接到终态，
+        永远观测不到 RUNNING）即触发一次 fire-and-forget 扣费事件（Desktop 按
+        作业 ID 去重）。作业已运行，扣费失败（如余额不足）不阻止作业，由 Desktop
+        记录到扣费历史并提示。CANCELLED（可能排队中被取消、未运行）不计费。
 
         只负责 inspect/dedupe/emit/mark，**不决定调用方最终返回什么**
         （v6.2 R4：与 download materialization 解耦，早退不会旁路计费）。
@@ -301,7 +310,7 @@ class MCPToolWrapper(Tool):
         ]
         for text in texts:
             job_state = _extract_job_state(text)
-            if not job_state or job_state.upper() != "RUNNING":
+            if not job_state or job_state.upper() not in _CHARGEABLE_JOB_STATES:
                 continue
             # 响应里的 job_id 优先；check_job_status 的响应可能只有
             # state（作业 ID 在请求参数里），回退用请求参数保证去重键。
@@ -343,11 +352,11 @@ class MCPToolWrapper(Tool):
                 delivered = bool(result)
             except Exception:
                 logger.exception(
-                    "billing: RUNNING 扣费事件发送失败（不标记，下次轮询重试）"
+                    "billing: 扣费事件发送失败（不标记，下次轮询重试）"
                 )
             if delivered:
                 mark_job_reported(session_key, self._server_name, job_id)
-            return  # 一个 RUNNING 事件处理完即可（语义同旧 join 后单次处理）
+            return  # 一个可扣费状态处理完即可（语义同旧 join 后单次处理）
 
     async def _materialize_download(
         self,

--- a/miqi/agent/tools/mcp.py
+++ b/miqi/agent/tools/mcp.py
@@ -41,12 +41,11 @@ def _extract_job_state(text: str) -> str | None:
     return match.group(1) if match else None
 
 
-# 可扣费状态（作业已实际占用集群资源）：RUNNING=运行中；COMPLETED/FAILED/
-# TIMEOUT=已执行到终态。快作业常在一次轮询间隔内从 PENDING 直接到
-# COMPLETED，永远观测不到 RUNNING——只认 RUNNING 会漏扣（2026-09-11 实测：
-# 自然提示词提交的 sleep 秒级作业跑完不扣分）。CANCELLED 可能是排队中被取消
-# （未运行），不计费。
-_CHARGEABLE_JOB_STATES = frozenset({"RUNNING", "COMPLETED", "FAILED", "TIMEOUT"})
+# 可扣费状态（作业**成功**占用集群资源）：RUNNING=运行中；COMPLETED=正常跑完。
+# 快作业常在两次轮询间隔内从 PENDING 直接到 COMPLETED，永远观测不到 RUNNING——
+# 只认 RUNNING 会漏扣（2026-09-11 实测：自然提示词提交的 sleep 秒级作业跑完不扣分）。
+# FAILED / TIMEOUT / CANCELLED 不计费（作业未成功完成/未运行，产品确认 2026-09-11）。
+_CHARGEABLE_JOB_STATES = frozenset({"RUNNING", "COMPLETED"})
 
 
 def _extract_job_id(text: str) -> str | None:
@@ -281,11 +280,11 @@ class MCPToolWrapper(Tool):
         """Slurm 作业计费触发（issue #927，2026-09-04 产品确认）——**纯副作用**。
 
         作业进入可扣费状态时由 Desktop 发起扣费（10 分/次）：submit_slurm_job /
-        check_job_status 的返回里 state ∈ {RUNNING, COMPLETED, FAILED, TIMEOUT}
-        （即作业已实际占用集群资源——快作业常在两次轮询间从 PENDING 直接到终态，
-        永远观测不到 RUNNING）即触发一次 fire-and-forget 扣费事件（Desktop 按
-        作业 ID 去重）。作业已运行，扣费失败（如余额不足）不阻止作业，由 Desktop
-        记录到扣费历史并提示。CANCELLED（可能排队中被取消、未运行）不计费。
+        check_job_status 的返回里 state ∈ {RUNNING, COMPLETED}（作业已成功占用
+        集群资源——快作业常在两次轮询间从 PENDING 直接到 COMPLETED，永远观测不到
+        RUNNING）即触发一次 fire-and-forget 扣费事件（Desktop 按作业 ID 去重）。
+        作业已运行，扣费失败（如余额不足）不阻止作业，由 Desktop 记录到扣费历史
+        并提示。FAILED / TIMEOUT / CANCELLED 不计费（未成功完成/未运行）。
 
         只负责 inspect/dedupe/emit/mark，**不决定调用方最终返回什么**
         （v6.2 R4：与 download materialization 解耦，早退不会旁路计费）。

--- a/tests/agent/test_billing_resolver.py
+++ b/tests/agent/test_billing_resolver.py
@@ -1,8 +1,8 @@
-"""Slurm MCP 计费桥测试（issue #927；2026-09-11 起 RUNNING + 已执行终态触发）。
+"""Slurm MCP 计费桥测试（issue #927；2026-09-11 起 RUNNING + COMPLETED 触发）。
 
 覆盖：服务器名匹配 / 状态检测（JSON 与文本）/ 扣费事件发射（submit 与
 check_job_status）/ 可扣费状态（RUNNING、COMPLETED）触发 / 不可扣费状态
-（PENDING、CANCELLED）不触发 / 非 slurm 服务器
+（PENDING、CANCELLED、FAILED、TIMEOUT）不触发 / 非 slurm 服务器
 不受影响 / 无 Desktop 通道静默跳过 / 注入参数不传给 MCP 服务端 /
 作业 ID 提取。
 """
@@ -62,6 +62,8 @@ RUNNING_JSON = '{"job_id": "187654", "state": "RUNNING", "name": "lammps"}'
 PENDING_JSON = '{"job_id": "187654", "state": "PENDING", "name": "lammps"}'
 COMPLETED_JSON = '{"job_id": "187654", "state": "COMPLETED", "name": "lammps"}'
 CANCELLED_JSON = '{"job_id": "187654", "state": "CANCELLED", "name": "lammps"}'
+FAILED_JSON = '{"job_id": "187654", "state": "FAILED", "name": "lammps"}'
+TIMEOUT_JSON = '{"job_id": "187654", "state": "TIMEOUT", "name": "lammps"}'
 
 
 class TestServerMatching:
@@ -217,6 +219,34 @@ class TestMCPWrapperBilling:
 
         set_billing_charge_emitter("desktop:s1", _emit)
         await wrapper.execute(_session_key="desktop:s1")
+        assert emitted == []
+
+    async def test_failed_does_not_emit(self):
+        # 作业失败（未成功完成）——不计费（产品确认 2026-09-11）。
+        session = _FakeSession(result_text=FAILED_JSON)
+        wrapper = _make_wrapper("slurm", session, tool_name="check_job_status")
+        emitted: list[dict] = []
+
+        async def _emit(payload):
+            emitted.append(payload)
+            return True
+
+        set_billing_charge_emitter("desktop:s1", _emit)
+        await wrapper.execute(_session_key="desktop:s1", job_id="187654")
+        assert emitted == []
+
+    async def test_timeout_does_not_emit(self):
+        # 超时作业——不计费（产品确认 2026-09-11）。
+        session = _FakeSession(result_text=TIMEOUT_JSON)
+        wrapper = _make_wrapper("slurm", session, tool_name="check_job_status")
+        emitted: list[dict] = []
+
+        async def _emit(payload):
+            emitted.append(payload)
+            return True
+
+        set_billing_charge_emitter("desktop:s1", _emit)
+        await wrapper.execute(_session_key="desktop:s1", job_id="187654")
         assert emitted == []
 
     async def test_non_slurm_server_skips_billing(self):

--- a/tests/agent/test_billing_resolver.py
+++ b/tests/agent/test_billing_resolver.py
@@ -1,7 +1,8 @@
-"""Slurm MCP 计费桥测试（issue #927，RUNNING 触发版）。
+"""Slurm MCP 计费桥测试（issue #927；2026-09-11 起 RUNNING + 已执行终态触发）。
 
-覆盖：服务器名匹配 / RUNNING 检测（JSON 与文本）/ 扣费事件发射
-（submit 与 check_job_status）/ 非 RUNNING 不触发 / 非 slurm 服务器
+覆盖：服务器名匹配 / 状态检测（JSON 与文本）/ 扣费事件发射（submit 与
+check_job_status）/ 可扣费状态（RUNNING、COMPLETED）触发 / 不可扣费状态
+（PENDING、CANCELLED）不触发 / 非 slurm 服务器
 不受影响 / 无 Desktop 通道静默跳过 / 注入参数不传给 MCP 服务端 /
 作业 ID 提取。
 """
@@ -59,6 +60,8 @@ def _make_wrapper(server_name: str, session: _FakeSession, tool_name: str = "sub
 
 RUNNING_JSON = '{"job_id": "187654", "state": "RUNNING", "name": "lammps"}'
 PENDING_JSON = '{"job_id": "187654", "state": "PENDING", "name": "lammps"}'
+COMPLETED_JSON = '{"job_id": "187654", "state": "COMPLETED", "name": "lammps"}'
+CANCELLED_JSON = '{"job_id": "187654", "state": "CANCELLED", "name": "lammps"}'
 
 
 class TestServerMatching:
@@ -178,6 +181,39 @@ class TestMCPWrapperBilling:
         async def _emit(payload):
             emitted.append(payload)
             return True  # 模拟桥接：返回送达数（truthy = 已送达）
+
+        set_billing_charge_emitter("desktop:s1", _emit)
+        await wrapper.execute(_session_key="desktop:s1")
+        assert emitted == []
+
+    async def test_completed_emits_charge_event(self):
+        # 快作业常在两次轮询间从 PENDING 直接到 COMPLETED、永不被观测到
+        # RUNNING —— 终态也必须扣费，否则跑完的作业漏扣（2026-09-11）。
+        session = _FakeSession(result_text=COMPLETED_JSON)
+        wrapper = _make_wrapper("slurm", session, tool_name="check_job_status")
+        emitted: list[dict] = []
+
+        async def _emit(payload):
+            emitted.append(payload)
+            return True
+
+        set_billing_charge_emitter("desktop:s1", _emit)
+        await wrapper.execute(
+            _session_key="desktop:s1", _turn_id="t", _tool_call_id="c", job_id="187654"
+        )
+        assert len(emitted) == 1
+        assert emitted[0]["state"] == "COMPLETED"
+        assert emitted[0]["job_id"] == "187654"
+
+    async def test_cancelled_does_not_emit(self):
+        # 排队中被取消的作业未必实际运行 —— 不计费。
+        session = _FakeSession(result_text=CANCELLED_JSON)
+        wrapper = _make_wrapper("slurm", session, tool_name="cancel_slurm_job")
+        emitted: list[dict] = []
+
+        async def _emit(payload):
+            emitted.append(payload)
+            return True
 
         set_billing_charge_emitter("desktop:s1", _emit)
         await wrapper.execute(_session_key="desktop:s1")

--- a/tests/agent/test_billing_resolver.py
+++ b/tests/agent/test_billing_resolver.py
@@ -310,6 +310,26 @@ class TestMCPWrapperBilling:
         )
         assert len(emitted) == 2
 
+    async def test_running_then_completed_emits_once(self):
+        """同一作业先 RUNNING 后 COMPLETED（两者都是可扣费状态）只扣一次——
+        去重键是「服务器::作业 ID」不含 state（2026-09-11 放宽终态后新增回归）。"""
+        session = _FakeSession(result_text=RUNNING_JSON)
+        wrapper = _make_wrapper("slurm", session, tool_name="check_job_status")
+        emitted: list[dict] = []
+        set_billing_charge_emitter("desktop:s1", lambda p: emitted.append(p) or True)
+
+        await wrapper.execute(
+            _session_key="desktop:s1", _turn_id="t", _tool_call_id="c", job_id="187654"
+        )
+        # 作业跑完：同一 job_id，状态由 RUNNING 变 COMPLETED
+        session._result = COMPLETED_JSON
+        await wrapper.execute(
+            _session_key="desktop:s1", _turn_id="t", _tool_call_id="c", job_id="187654"
+        )
+
+        assert len(emitted) == 1
+        assert emitted[0]["state"] == "RUNNING"
+
     async def test_same_job_id_two_servers_both_reported(self):
         """不同 MCP 服务器的相同 job_id 互不遮蔽（CodeRabbit #936）。
 


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

修复 slurm 作业计费漏扣：扣费触发条件从「仅观测到 `state=RUNNING`」放宽到「RUNNING 或 COMPLETED」；同时把托管 slurm MCP 的 live spec 改用自然提示词。

## 背景/问题

**Bug**：计费只在观测到 `state=RUNNING` 时触发（`miqi/agent/tools/mcp.py` 的 `_handle_slurm_billing`）。快作业常在两次轮询间隔内从 `PENDING` 直接到 `COMPLETED`，**永不被观测到 RUNNING → 跑完的作业不扣分**。

2026-09-11 用自然提示词「使用slurm提交任意一个任务」实测复现：模型自主提交作业并执行完成（Job 12136572），**积分 260 不变**（应扣 10 分）。原先的 live spec 用 `sleep 30` 长作业掩盖了该漏洞。

## 变更内容

- `miqi/agent/tools/mcp.py`：新增 `_CHARGEABLE_JOB_STATES = {RUNNING, COMPLETED}`，`_handle_slurm_billing` 改为命中该集合即触发扣费。
- `miqi/agent/billing_resolver.py`：更新模块文档，说明放宽 COMPLETED 的原因。
- `tests/agent/test_billing_resolver.py`：新增 `test_completed_emits_charge_event`、`test_failed_does_not_emit`、`test_timeout_does_not_emit`、`test_cancelled_does_not_emit`、`test_running_then_completed_emits_once`（去重回归）；`test_pending_does_not_emit` 保留。
- `apps/desktop/tests/e2e/billing-hosted-live.spec.ts`：提示词改为自然提示词「使用slurm提交任意一个任务」；断言「模型自主发现并调用 slurm MCP」+ **提交确实成功**（桥日志 `success: true` + 非空 `job_id`）+「已扣 10 积分」；新增 `driveUntilReady` 自动点确认卡。

**计费状态**：`RUNNING`、`COMPLETED` 扣费；`PENDING`、`FAILED`、`TIMEOUT`、`CANCELLED` 不扣（产品确认 2026-09-11：作业未成功完成/未运行不计费）。

**去重**（放宽到两个可扣费状态后，同一作业可能先被观测 RUNNING 再被观测 COMPLETED）：

- Python 侧：`job_reported/mark_job_reported` 按「会话 :: 服务器 :: 作业 ID」去重（不含 state），发射成功才标记。
- Desktop 侧：`chargeSlurmJob` 三层——① 在途去重（`charge_id` 或「账号+服务器+作业 ID」）；② 历史文件 `qraft-billing-history.json`（跨重启）；③ 内存集合。
- 回归：`test_running_then_completed_emits_once`——同一作业 RUNNING→COMPLETED 只发一次事件。

## 日志/验证证据

```
$ python -m pytest tests/agent tests/bridge tests/config -q
789 passed, 2 skipped in 39.91s

# 本地 live E2E（真实账号 + 真实集群，自然提示词）：
1 passed (24.6s)   ← 含「submit 返回 success:true + 非空 job_id」与「已扣 10 积分」断言
                     （修复前扣费断言会失败）

# bridge 日志（修复前，快作业跑完不扣分）：
Tool execute: name=mcp_miqroforge-slurm_submit_slurm_job done (421ms):
  {"success": true, "job_id": "12136572", ...}
（后续 check_job_status 只观测到 PENDING→COMPLETED，从未 RUNNING → 无扣费事件）
```

录屏（真·窗口录制：Electron desktopCapturer + MediaRecorder 录应用窗口流；按回合结束自动停止）：

[▶ 录制视频（mp4）](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/72f8820e889719b5.mp4)

![自然提示词提交流程](https://github.com/14790897/MiqroForge-Desktop/releases/download/_gh-imgup/8017851b59921852.png)

## 测试情况

- `tests/agent` + `tests/bridge` + `tests/config`：789 passed, 2 skipped。
- `billing-hosted-live.spec.ts`：本地真实账号实测通过（自然提示词 → 模型自主发现并调用 slurm MCP 提交作业 → 扣 10 积分，24.6s）。
- 真实消耗：一个集群作业 + 测试账号 10 积分。

## 截图

见上方「日志/验证证据」的录屏与截图。

## 后续计划

- 分支名 `test/slurm-mcp-natural-prompt` 保留（PR 创建时只含测试改动，后并入计费修复）。








