### PR TITLE
fix(desktop): 输入框击键不再重渲染整个聊天界面（ChatConsole 输入状态下沉 + MessageBubble memo 击穿修复）(#1021)

### DIFF
--- a/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
+++ b/apps/desktop/src/renderer/features/chat/ChatConsole.tsx
@@ -26,25 +26,19 @@ import { ErrorBoundary } from '../../components/ErrorBoundary';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Button } from '../../components/ui/Button';
-import { Textarea } from '../../components/ui/Textarea';
 import { Tooltip } from '../../components/ui/Tooltip';
 import { ContextMenu, type ContextMenuAction } from '../../components/ContextMenu';
 import { cn } from '../../lib/utils';
 import { Modal } from '../../components/shared';
 import { formatRelativeTime } from '../../lib/formatTime';
-import {
-  ExecutionPolicySelector,
-  type ExecutionPolicy,
-} from '../../components/ExecutionPolicySelector';
-import { ReasoningModeSwitch, type ReasoningMode } from './components/ReasoningModeSwitch';
+import { type ExecutionPolicy } from '../../components/ExecutionPolicySelector';
+import { type ReasoningMode } from './components/ReasoningModeSwitch';
 import {
   Send,
-  Square,
   Loader2,
   Copy,
   Check,
   CheckCircle,
-  Paperclip,
   X,
   FileText,
   Image,
@@ -74,8 +68,6 @@ import {
   ThumbsUp,
   ThumbsDown,
   RefreshCw,
-  Scissors,
-  ClipboardPaste,
   Star,
   Download,
 } from 'lucide-react';
@@ -98,6 +90,7 @@ import PaperSearchResult, {
   type PaperSearchPayload,
   type PaperItem,
 } from './PaperSearchResult';
+import { Composer, type ComposerHandle } from './Composer';
 
 interface Attachment {
   name: string;
@@ -287,6 +280,11 @@ interface MessageSource {
   tool: string;
   url: string;
 }
+
+// Stable empty array for messages without sources — keeps the `sources` prop
+// referentially equal so MessageBubble's memo isn't defeated by a fresh `[]`
+// on every keystroke (#1021).
+const EMPTY_SOURCES: MessageSource[] = [];
 
 const TOOL_LABELS: Record<string, string> = {
   web_fetch: '网页抓取',
@@ -2492,7 +2490,6 @@ export function ChatConsole({
   // #570: bump to force a manual reload of the current session's history
   // (used by the "重试" button on the load-failure error bubble).
   const [retryTick, setRetryTick] = useState(0);
-  const [input, setInput] = useState('');
   const [executionPolicy, setExecutionPolicy] = useState<ExecutionPolicy>('edit');
 
   // Reasoning mode (issue #680): ⚡极速回答 / 🧠深度研究. Default fast
@@ -2817,7 +2814,7 @@ export function ChatConsole({
   const userScrolledUp = useRef(false);
   const justOpened = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composerRef = useRef<ComposerHandle>(null);
   // 会话活动感知（restored from pre-#577, issue #677）：流式/消息变化时
   // 上报 App，让"+"能感知未落盘的活动
   useEffect(() => {
@@ -2844,7 +2841,7 @@ export function ChatConsole({
   }, [lastAdjustAt]);
   useEffect(() => {
     if (!adjustHint || streaming) return;
-    textareaRef.current?.focus();
+    composerRef.current?.focus();
   }, [adjustHint, streaming]);
   // 原生 window.confirm 模态框关闭后，Chromium 可能不把“真实的 OS 激活”交还
   // renderer：键盘事件被吞、点输入条无光标，刷新重建页面才恢复（手动复现）。
@@ -2862,7 +2859,7 @@ export function ChatConsole({
     if (messages.length === 0 && welcomeFocusedFor.current !== sessionKey) {
       welcomeFocusedFor.current = sessionKey ?? null;
       const prevHadMessages = (lastMsgCountRef.current ?? 0) > 0;
-      const focusInput = () => textareaRef.current?.focus();
+      const focusInput = () => composerRef.current?.focus();
       focusInput();
       void window.miqi.app?.focus?.();
       const t1 = window.setTimeout(focusInput, 120);
@@ -2898,10 +2895,10 @@ export function ChatConsole({
   const pendingRegrantRef = useRef(false);
   useEffect(() => {
     const runRegrant = () => {
-      textareaRef.current?.focus();
+      composerRef.current?.focus();
       window.setTimeout(() => {
         void window.miqi.app?.focus?.({ hard: true }).then(() => {
-          window.setTimeout(() => textareaRef.current?.focus(), 80);
+          window.setTimeout(() => composerRef.current?.focus(), 80);
         });
       }, 60);
     };
@@ -2924,10 +2921,10 @@ export function ChatConsole({
   useEffect(() => {
     if (historyLoaded && messages.length === 0 && pendingRegrantRef.current) {
       pendingRegrantRef.current = false;
-      textareaRef.current?.focus();
+      composerRef.current?.focus();
       window.setTimeout(() => {
         void window.miqi.app?.focus?.({ hard: true }).then(() => {
-          window.setTimeout(() => textareaRef.current?.focus(), 80);
+          window.setTimeout(() => composerRef.current?.focus(), 80);
         });
       }, 60);
     }
@@ -3273,7 +3270,7 @@ export function ChatConsole({
         setStreaming(false);
       }
       setCurrentReqId(null);
-      setInput('');
+      composerRef.current?.clear();
       setThreads([{ threadId: 'main', agentType: 'main', label: '主线程' }]);
       setActiveThreadId('main');
       setPlan(null);
@@ -4113,8 +4110,9 @@ export function ChatConsole({
     retry?: boolean;
   } | null>(null);
   const handleSendRef = useRef<() => void>(() => {});
-  /** 程序化发送（论文下载 fallback 等）经此 ref 显式传文本，handleSend
-   *  一次性消费。不依赖 setInput 后的渲染 flush（旧闭包读 input 是旧值）。 */
+  /** 发送文本经此 ref 显式传入 handleSend 并一次性消费：既承载程序化发送
+   *  （论文下载 fallback 等），也承载 Composer 的用户输入（#1021 下沉后
+   *  input 状态不再住在 ChatConsole）。不依赖 state 更新后的渲染 flush。 */
   const programmaticTextRef = useRef<string | null>(null);
   /** #740: pending resume-turn id — set by 继续执行, consumed by handleSend
    *  so the resume request flows through the full send pipeline (listeners,
@@ -4183,11 +4181,11 @@ export function ChatConsole({
     const _resumeId = resumeTurnIdRef.current;
     resumeTurnIdRef.current = null;
     const payload = retryPayloadRef.current;
-    // 程序化发送（论文下载 fallback 等）经 ref 显式传文本：不依赖
-    // setInput 后的渲染 flush（旧闭包读到的 input state 是旧值）。
+    // 发送文本经 ref 显式传入（程序化发送 + Composer 用户输入）：不依赖
+    // state 更新后的渲染 flush（旧闭包读到的 input state 是旧值）。
     const programmaticText = programmaticTextRef.current;
     programmaticTextRef.current = null;
-    const text = (payload?.text ?? programmaticText ?? input).trim();
+    const text = (payload?.text ?? programmaticText ?? '').trim();
     const atts = payload?.attachments ?? attachments;
     if (!text && atts.length === 0 && !_resumeId) {
       retryPayloadRef.current = null;
@@ -4268,13 +4266,7 @@ export function ChatConsole({
     // the streamed reply takes over rendering) — skip the optimistic push.
     if (!_resumeId) setMessages((prev) => [...prev, userMsg]);
     userScrolledUp.current = false;
-    setInput('');
-    // Reset textarea height after sending
-    setTimeout(() => {
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto';
-      }
-    }, 0);
+    composerRef.current?.clear();
     setAttachments([]);
     // Save a snapshot before clearing — chat.send needs it later.  Use the
     // resolved `atts` (which handles the retry-payload path), not the state,
@@ -4351,7 +4343,7 @@ export function ChatConsole({
           const resumeRemovedMsg = _resumeId ? resumeRemovedMsgRef.current : null;
           resumeRemovedMsgRef.current = null;
           setMessages((prev) => applyReloginIntercept(prev, userMsg, resumeRemovedMsg));
-          setInput(text);
+          composerRef.current?.setText(text);
           setAttachments(atts);
         }
         return;
@@ -4379,7 +4371,7 @@ export function ChatConsole({
             }
             return prev;
           });
-          setInput(text);
+          composerRef.current?.setText(text);
           setAttachments(atts);
         }
         return;
@@ -4399,7 +4391,7 @@ export function ChatConsole({
         // configure a provider before sending.  The draft is restored to the
         // input so they can re-send once configured.  Only touch the composer /
         // message list if THIS session is still displayed — the user may have
-        // switched away while providers.list was pending, and setInput /
+        // switched away while providers.list was pending, and the composer /
         // setAttachments / setMessages act on the currently displayed session.
         // #1000：未登录时没有 Provider 可配置（#835 合规收口后凭据配置已移除），
         // 拦截气泡直接给出一键登录按钮，登录后经网关自动获得平台内置模型。
@@ -4427,7 +4419,7 @@ export function ChatConsole({
             }
             return prev;
           });
-          setInput(text);
+          composerRef.current?.setText(text);
           setAttachments(atts);
         }
         return;
@@ -4441,7 +4433,7 @@ export function ChatConsole({
     // optimistic bubble and restore the composer (the send never started).
     // Only touch the composer / message list if THIS session is still
     // displayed — the user may have switched away while the check was pending,
-    // and setInput / setAttachments / setMessages act on the current session.
+    // and the composer / setAttachments / setMessages act on the current session.
     if (!isCurrentPendingSend(sendSessionKey, thisSendId)) {
       pendingSendIdsRef.current.delete(sendSessionKey);
       streamingBySession.delete(sendSessionKey);
@@ -4452,7 +4444,7 @@ export function ChatConsole({
           if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
           return prev;
         });
-        setInput(text);
+        composerRef.current?.setText(text);
         setAttachments(atts);
       }
       return;
@@ -4540,7 +4532,7 @@ export function ChatConsole({
       setSendingFor(sendSessionKey, null);
       // Only restore the composer / message list if THIS session is still
       // displayed — the user may have switched away while the aborts were
-      // awaited, and setInput / setAttachments / setMessages act on the
+      // awaited, and the composer / setAttachments / setMessages act on the
       // currently displayed session.
       if (currentSessionRef.current === sendSessionKey) {
         setStreaming(false);
@@ -4549,7 +4541,7 @@ export function ChatConsole({
           if (last?.timestamp === userMsg.timestamp) return prev.slice(0, -1);
           return prev;
         });
-        setInput(text);
+        composerRef.current?.setText(text);
         setAttachments(atts);
       }
       settleLifecycle();
@@ -5609,7 +5601,6 @@ export function ChatConsole({
       sendInvocationRegistryRef.current.delete(thisSendId);
     }
   }, [
-    input,
     attachments,
     streaming,
     cleanupListeners,
@@ -5709,7 +5700,7 @@ export function ChatConsole({
     const instruction = `请下载论文《${title}》的 PDF 文件。paperId: ${pid}`;
     setDownloadingPaperId(paper.id || null);
     // Set input and trigger send on next tick so React state propagates
-    setInput(instruction);
+    composerRef.current?.setText(instruction);
     setTimeout(() => {
       const text = instruction.trim();
       if (!text) {
@@ -5725,21 +5716,6 @@ export function ChatConsole({
       // 失败，指示都不悬挂；流式回复由 handleSend 的监听链负责渲染。
       setDownloadingPaperId(null);
     }, 0);
-  };
-
-  /** Auto-resize textarea to fit content */
-  const adjustTextareaHeight = useCallback(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
-  }, []);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
   };
 
   /** Normalise a sandbox-internal path to a host path that can be opened.
@@ -6064,75 +6040,6 @@ export function ChatConsole({
     [sessionKey]
   );
 
-  // Composer right-click edit menu (剪切/复制/粘贴/全选) — restored from
-  // #547 after the #577 rewrite dropped it.
-  const inputContextItems = useMemo<ContextMenuAction[]>(
-    () => [
-      {
-        label: '剪切',
-        icon: <Scissors size={14} />,
-        shortcut: 'Ctrl+X',
-        onSelect: () => {
-          const el = textareaRef.current;
-          if (!el) return;
-          const s = el.selectionStart,
-            e = el.selectionEnd;
-          if (s === e) return;
-          navigator.clipboard.writeText(el.value.slice(s, e)).catch(() => {});
-          el.setRangeText('', s, e, 'end');
-          // Let React's onChange pick up the new value — manual setInput can
-          // drift from the DOM (deleting then requires two passes).
-          el.dispatchEvent(new Event('input', { bubbles: true }));
-          el.focus();
-        },
-      },
-      {
-        label: '复制',
-        icon: <Copy size={14} />,
-        shortcut: 'Ctrl+C',
-        onSelect: () => {
-          const el = textareaRef.current;
-          if (!el) return;
-          const txt = el.value.slice(el.selectionStart, el.selectionEnd);
-          if (txt) navigator.clipboard.writeText(txt).catch(() => {});
-        },
-      },
-      {
-        label: '粘贴',
-        icon: <ClipboardPaste size={14} />,
-        shortcut: 'Ctrl+V',
-        onSelect: () => {
-          const el = textareaRef.current;
-          if (!el) return;
-          navigator.clipboard
-            .readText()
-            .then((text) => {
-              if (!text) return;
-              // Insert at the caret like native Ctrl+V — replace the current
-              // selection range instead of always appending at the end.
-              const s = el.selectionStart ?? el.value.length;
-              const e = el.selectionEnd ?? s;
-              el.setRangeText(text, s, e, 'end');
-              // Let React's onChange pick up the new value (single source of
-              // truth for state vs DOM — avoids double-delete drift).
-              el.dispatchEvent(new Event('input', { bubbles: true }));
-              el.focus();
-            })
-            .catch(() => {});
-        },
-      },
-      {
-        label: '全选',
-        icon: <CheckCircle size={14} />,
-        shortcut: 'Ctrl+A',
-        divider: true,
-        onSelect: () => textareaRef.current?.select(),
-      },
-    ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
   // Associate each assistant answer with the tool URLs that preceded it in
   // the same turn. Memoized — extractMessageSources scans full tool outputs,
   // which would otherwise re-run on every animation frame while streaming.
@@ -6142,11 +6049,15 @@ export function ChatConsole({
   // React.memo on MessageBubble below.  Tool rows update their content while
   // streaming, so their content length IS part of the signature; assistant
   // body length is NOT (extraction never depends on it).
-  const sourcesSig = messages
-    .map((m) =>
-      m.role === 'progress' ? `${m.toolCallId ?? ''}:${m.content?.length ?? 0}` : m.role
-    )
-    .join('|');
+  const sourcesSig = useMemo(
+    () =>
+      messages
+        .map((m) =>
+          m.role === 'progress' ? `${m.toolCallId ?? ''}:${m.content?.length ?? 0}` : m.role
+        )
+        .join('|'),
+    [messages]
+  );
   const sourcesByMsg = useMemo(() => {
     if (sourcesCacheRef.current?.sig === sourcesSig) return sourcesCacheRef.current.map;
     const map = new Map<Message, MessageSource[]>();
@@ -6222,7 +6133,7 @@ export function ChatConsole({
         // rewinding and dropping the "已停止" context.
         setMessages((prev) => (wasTurnStopped(prev, idx) ? prev : prev.slice(0, idx)));
       }
-      setInput(msg.content);
+      composerRef.current?.setText(msg.content);
       setAttachments(msg.attachments ?? []);
     },
     [streaming, cleanupListeners]
@@ -6252,7 +6163,7 @@ export function ChatConsole({
       // the interrupted round — keep it and let handleSend append the new
       // attempt after it.  Only a completed answer is replaced in place.
       setMessages((prev) => (wasTurnStopped(prev, userIdx) ? prev : prev.slice(0, userIdx)));
-      setInput(userMsg.content);
+      composerRef.current?.setText(userMsg.content);
       setAttachments(userMsg.attachments ?? []);
       requestAnimationFrame(() => handleSendRef.current());
     },
@@ -6911,7 +6822,7 @@ export function ChatConsole({
                         turnIndex={i}
                         execOutputs={execOutputs}
                         inlineExecOutput={inlineExecOutput}
-                        sources={sourcesByMsg.get(group.msg) ?? []}
+                        sources={sourcesByMsg.get(group.msg) ?? EMPTY_SOURCES}
                         toolStepIndex={toolStepByMsg.get(group.msg)}
                         isLast={i === chatGroups.length - 1}
                         onResume={
@@ -7173,143 +7084,25 @@ export function ChatConsole({
               {/* AI-initiated user confirmation cards (issue #646) */}
               <ConfirmCardArea />
 
-              <div
-                className="flex flex-col rounded-3xl px-7 py-3.5 transition-all"
-                data-testid="chat-input-container"
-                style={{
-                  background: 'color-mix(in srgb, var(--surface) 85%, transparent)',
-                  backdropFilter: 'blur(16px)',
-                  WebkitBackdropFilter: 'blur(16px)',
-                  border: '1px solid color-mix(in srgb, var(--border) 60%, transparent)',
-                  outline: 'none',
-                  boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
+              <Composer
+                ref={composerRef}
+                streaming={streaming}
+                hasAttachments={attachments.length > 0}
+                adjustHint={adjustHint}
+                executionPolicy={executionPolicy}
+                onExecutionPolicyChange={setExecutionPolicy}
+                onOpenApprovals={onOpenApprovals}
+                reasoningMode={reasoningMode}
+                onReasoningModeChange={changeReasoningMode}
+                complexHint={complexHint}
+                onComplexHintDismiss={() => setComplexHint(false)}
+                onAttachClick={handleAttachClick}
+                onSubmit={(text) => {
+                  programmaticTextRef.current = text;
+                  handleSend();
                 }}
-              >
-                {/* Textarea on top — grows up to 1/3 of viewport (DeepSeek style) */}
-                <ContextMenu items={inputContextItems} minWidth={160}>
-                  {({ onContextMenu }) => (
-                    <Textarea
-                      ref={textareaRef}
-                      value={input}
-                      onChange={(e) => {
-                        setInput(e.target.value);
-                      }}
-                      onKeyDown={handleKeyDown}
-                      onContextMenu={onContextMenu}
-                      placeholder={
-                        adjustHint
-                          ? '请输入调整要求（例如：市场改为海外、步骤精简到 3 步…）'
-                          : '请输入消息或拖入文件...'
-                      }
-                      rows={1}
-                      allowResize={true}
-                      className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
-                      style={{ color: 'var(--text)', fieldSizing: 'content' }}
-                    />
-                  )}
-                </ContextMenu>
-                {/* Icon row at the bottom — no text, like DeepSeek */}
-                <div className="flex items-center gap-3 pt-1.5 mt-0.5 border-t border-[var(--border-subtle)]">
-                  <ExecutionPolicySelector
-                    policy={executionPolicy}
-                    onChange={setExecutionPolicy}
-                    onOpenApprovals={onOpenApprovals}
-                  />
-                  {/* 复杂问题角标（#680 跟进）：轻量气泡挂在模式按钮上，
-                      3 秒自动消失，不占输入区。 */}
-                  <div className="relative">
-                    <ReasoningModeSwitch mode={reasoningMode} onChange={changeReasoningMode} />
-                    {complexHint && reasoningMode === 'fast' && (
-                      <div
-                        className="absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50 flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] whitespace-nowrap"
-                        style={{
-                          background: '#2f2f3a',
-                          border: '1px solid rgba(157,106,223,.45)',
-                          color: '#c9a5ef',
-                          boxShadow: '0 4px 14px rgba(0,0,0,.35)',
-                        }}
-                      >
-                        {/* 指向按钮的小箭头（左侧） */}
-                        <span
-                          className="absolute -left-[5px] top-1/2 -translate-y-1/2 w-2 h-2"
-                          style={{
-                            background: '#2f2f3a',
-                            borderLeft: '1px solid rgba(157,106,223,.45)',
-                            borderBottom: '1px solid rgba(157,106,223,.45)',
-                            transform: 'translateY(-50%) rotate(45deg)',
-                          }}
-                        />
-                        <span>💡 建议</span>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            changeReasoningMode('think');
-                            setComplexHint(false);
-                          }}
-                          className="font-semibold cursor-pointer"
-                          style={{ color: '#d9b8f5' }}
-                        >
-                          🧠 深度研究
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => setComplexHint(false)}
-                          className="opacity-60 hover:opacity-100 cursor-pointer"
-                          aria-label="关闭提示"
-                        >
-                          ✕
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  {/* AI disclaimer — centered in the mode row, fades when typing */}
-                  <div className="flex-1 flex items-center justify-center">
-                    <span
-                      className="text-size-2xs leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none transition-opacity duration-300"
-                      style={{ opacity: !input.trim() && attachments.length === 0 ? 1 : 0 }}
-                    >
-                      AI 也会犯错误，对于重要答案请谨慎验证
-                    </span>
-                  </div>
-                  <button
-                    onClick={handleAttachClick}
-                    className="shrink-0 p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
-                    title="附件或图片"
-                    aria-label="附件或图片"
-                  >
-                    <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
-                  </button>
-                  {streaming && !input.trim() && attachments.length === 0 ? (
-                    <button
-                      onClick={handleAbort}
-                      title="停止生成"
-                      aria-label="停止生成"
-                      className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:bg-[var(--surface-muted)] active:scale-95"
-                    >
-                      <Square
-                        size={12}
-                        style={{ color: 'var(--text-muted)' }}
-                        fill="currentColor"
-                      />
-                    </button>
-                  ) : (
-                    <button
-                      onClick={handleSend}
-                      disabled={!input.trim() && attachments.length === 0}
-                      title={streaming ? '中断当前生成并发送' : '发送'}
-                      aria-label={streaming ? '中断当前生成并发送' : '发送'}
-                      className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:brightness-110 hover:-translate-y-px active:scale-95 disabled:opacity-30 disabled:hover:brightness-100 disabled:hover:translate-y-0 disabled:shadow-none"
-                      style={{
-                        background:
-                          'linear-gradient(135deg, var(--accent), color-mix(in srgb, var(--accent) 65%, #000))',
-                        boxShadow: '0 2px 10px color-mix(in srgb, var(--accent) 35%, transparent)',
-                      }}
-                    >
-                      <Send size={14} style={{ color: '#fff' }} />
-                    </button>
-                  )}
-                </div>
-              </div>
+                onAbort={handleAbort}
+              />
             </div>
 
             {/* Inline workspace selector — only before the conversation starts */}
@@ -8194,7 +7987,7 @@ function ToolChainGroup({
               <MessageBubble
                 key={`${row.timestamp}-${i}`}
                 msg={row}
-                sources={sourcesByMsg.get(row) ?? []}
+                sources={sourcesByMsg.get(row) ?? EMPTY_SOURCES}
                 toolStepIndex={i + 1}
                 isLastToolRow={i === rows.length - 1}
                 isLast={false}

--- a/apps/desktop/src/renderer/features/chat/Composer.tsx
+++ b/apps/desktop/src/renderer/features/chat/Composer.tsx
@@ -1,0 +1,297 @@
+import {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+  type KeyboardEvent,
+} from 'react';
+import { Textarea } from '../../components/ui/Textarea';
+import { ContextMenu, type ContextMenuAction } from '../../components/ContextMenu';
+import {
+  ExecutionPolicySelector,
+  type ExecutionPolicy,
+} from '../../components/ExecutionPolicySelector';
+import { ReasoningModeSwitch, type ReasoningMode } from './components/ReasoningModeSwitch';
+import { Send, Square, Paperclip, Scissors, Copy, ClipboardPaste, CheckCircle } from 'lucide-react';
+
+/**
+ * Imperative handle so ChatConsole can drive the composer's text from
+ * programmatic paths (edit re-answer / retry prefill, send-failure draft
+ * restore, paper-download instruction, session-switch clear) without lifting
+ * `input` state back to the top — that lift is what made every keystroke
+ * re-render the whole chat tree (#1021).
+ */
+export interface ComposerHandle {
+  setText(text: string): void;
+  clear(): void;
+  focus(): void;
+}
+
+interface ComposerProps {
+  streaming: boolean;
+  /** `attachments.length > 0` — the composer only needs the boolean. */
+  hasAttachments: boolean;
+  adjustHint: boolean;
+  executionPolicy: ExecutionPolicy;
+  onExecutionPolicyChange: (policy: ExecutionPolicy) => void;
+  onOpenApprovals?: () => void;
+  reasoningMode: ReasoningMode;
+  onReasoningModeChange: (mode: ReasoningMode) => void;
+  complexHint: boolean;
+  onComplexHintDismiss: () => void;
+  onAttachClick: () => void;
+  onSubmit: (text: string) => void;
+  onAbort: () => void;
+}
+
+export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
+  {
+    streaming,
+    hasAttachments,
+    adjustHint,
+    executionPolicy,
+    onExecutionPolicyChange,
+    onOpenApprovals,
+    reasoningMode,
+    onReasoningModeChange,
+    complexHint,
+    onComplexHintDismiss,
+    onAttachClick,
+    onSubmit,
+    onAbort,
+  },
+  ref
+) {
+  const [input, setInput] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setText: (text: string) => setInput(text),
+      clear: () => {
+        setInput('');
+        // Reset textarea height after sending (mirrors the pre-#1021 reset).
+        setTimeout(() => {
+          if (textareaRef.current) textareaRef.current.style.height = 'auto';
+        }, 0);
+      },
+      focus: () => textareaRef.current?.focus(),
+    }),
+    []
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        onSubmit(input);
+      }
+    },
+    [onSubmit, input]
+  );
+
+  const inputContextItems = useMemo<ContextMenuAction[]>(
+    () => [
+      {
+        label: '剪切',
+        icon: <Scissors size={14} />,
+        shortcut: 'Ctrl+X',
+        onSelect: () => {
+          const el = textareaRef.current;
+          if (!el) return;
+          const s = el.selectionStart,
+            e = el.selectionEnd;
+          if (s === e) return;
+          navigator.clipboard.writeText(el.value.slice(s, e)).catch(() => {});
+          el.setRangeText('', s, e, 'end');
+          // Let React's onChange pick up the new value — manual setInput can
+          // drift from the DOM (deleting then requires two passes).
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.focus();
+        },
+      },
+      {
+        label: '复制',
+        icon: <Copy size={14} />,
+        shortcut: 'Ctrl+C',
+        onSelect: () => {
+          const el = textareaRef.current;
+          if (!el) return;
+          const txt = el.value.slice(el.selectionStart, el.selectionEnd);
+          if (txt) navigator.clipboard.writeText(txt).catch(() => {});
+        },
+      },
+      {
+        label: '粘贴',
+        icon: <ClipboardPaste size={14} />,
+        shortcut: 'Ctrl+V',
+        onSelect: () => {
+          const el = textareaRef.current;
+          if (!el) return;
+          navigator.clipboard
+            .readText()
+            .then((text) => {
+              if (!text) return;
+              // Insert at the caret like native Ctrl+V — replace the current
+              // selection range instead of always appending at the end.
+              const s = el.selectionStart ?? el.value.length;
+              const e = el.selectionEnd ?? s;
+              el.setRangeText(text, s, e, 'end');
+              // Let React's onChange pick up the new value (single source of
+              // truth for state vs DOM — avoids double-delete drift).
+              el.dispatchEvent(new Event('input', { bubbles: true }));
+              el.focus();
+            })
+            .catch(() => {});
+        },
+      },
+      {
+        label: '全选',
+        icon: <CheckCircle size={14} />,
+        shortcut: 'Ctrl+A',
+        divider: true,
+        onSelect: () => textareaRef.current?.select(),
+      },
+    ],
+    []
+  );
+
+  return (
+    <div
+      className="flex flex-col rounded-3xl px-7 py-3.5 transition-all"
+      data-testid="chat-input-container"
+      style={{
+        background: 'color-mix(in srgb, var(--surface) 85%, transparent)',
+        backdropFilter: 'blur(16px)',
+        WebkitBackdropFilter: 'blur(16px)',
+        border: '1px solid color-mix(in srgb, var(--border) 60%, transparent)',
+        outline: 'none',
+        boxShadow: '0 -4px 20px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)',
+      }}
+    >
+      {/* Textarea on top — grows up to 1/3 of viewport (DeepSeek style) */}
+      <ContextMenu items={inputContextItems} minWidth={160}>
+        {({ onContextMenu }) => (
+          <Textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+            }}
+            onKeyDown={handleKeyDown}
+            onContextMenu={onContextMenu}
+            placeholder={
+              adjustHint
+                ? '请输入调整要求（例如：市场改为海外、步骤精简到 3 步…）'
+                : '请输入消息或拖入文件...'
+            }
+            rows={1}
+            allowResize={true}
+            className="w-full border-0 bg-transparent p-0! leading-7! focus:ring-0 focus:border-0 min-h-[52px] max-h-[25vh] text-[15px]"
+            style={{ color: 'var(--text)', fieldSizing: 'content' }}
+          />
+        )}
+      </ContextMenu>
+      {/* Icon row at the bottom — no text, like DeepSeek */}
+      <div className="flex items-center gap-3 pt-1.5 mt-0.5 border-t border-[var(--border-subtle)]">
+        <ExecutionPolicySelector
+          policy={executionPolicy}
+          onChange={onExecutionPolicyChange}
+          onOpenApprovals={onOpenApprovals}
+        />
+        {/* 复杂问题角标（#680 跟进）：轻量气泡挂在模式按钮上，
+            3 秒自动消失，不占输入区。 */}
+        <div className="relative">
+          <ReasoningModeSwitch mode={reasoningMode} onChange={onReasoningModeChange} />
+          {complexHint && reasoningMode === 'fast' && (
+            <div
+              className="absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50 flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] whitespace-nowrap"
+              style={{
+                background: '#2f2f3a',
+                border: '1px solid rgba(157,106,223,.45)',
+                color: '#c9a5ef',
+                boxShadow: '0 4px 14px rgba(0,0,0,.35)',
+              }}
+            >
+              {/* 指向按钮的小箭头（左侧） */}
+              <span
+                className="absolute -left-[5px] top-1/2 -translate-y-1/2 w-2 h-2"
+                style={{
+                  background: '#2f2f3a',
+                  borderLeft: '1px solid rgba(157,106,223,.45)',
+                  borderBottom: '1px solid rgba(157,106,223,.45)',
+                  transform: 'translateY(-50%) rotate(45deg)',
+                }}
+              />
+              <span>💡 建议</span>
+              <button
+                type="button"
+                onClick={() => {
+                  onReasoningModeChange('think');
+                  onComplexHintDismiss();
+                }}
+                className="font-semibold cursor-pointer"
+                style={{ color: '#d9b8f5' }}
+              >
+                🧠 深度研究
+              </button>
+              <button
+                type="button"
+                onClick={onComplexHintDismiss}
+                className="opacity-60 hover:opacity-100 cursor-pointer"
+                aria-label="关闭提示"
+              >
+                ✕
+              </button>
+            </div>
+          )}
+        </div>
+        {/* AI disclaimer — centered in the mode row, fades when typing */}
+        <div className="flex-1 flex items-center justify-center">
+          <span
+            className="text-size-2xs leading-relaxed tracking-wide text-[var(--text-faint)] italic select-none transition-opacity duration-300"
+            style={{ opacity: !input.trim() && !hasAttachments ? 1 : 0 }}
+          >
+            AI 也会犯错误，对于重要答案请谨慎验证
+          </span>
+        </div>
+        <button
+          onClick={onAttachClick}
+          className="shrink-0 p-1.5 rounded hover:bg-[var(--surface-muted)] transition-colors"
+          title="附件或图片"
+          aria-label="附件或图片"
+        >
+          <Paperclip size={15} style={{ color: 'var(--text-faint)' }} />
+        </button>
+        {streaming && !input.trim() && !hasAttachments ? (
+          <button
+            onClick={onAbort}
+            title="停止生成"
+            aria-label="停止生成"
+            className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:bg-[var(--surface-muted)] active:scale-95"
+          >
+            <Square size={12} style={{ color: 'var(--text-muted)' }} fill="currentColor" />
+          </button>
+        ) : (
+          <button
+            onClick={() => onSubmit(input)}
+            disabled={!input.trim() && !hasAttachments}
+            title={streaming ? '中断当前生成并发送' : '发送'}
+            aria-label={streaming ? '中断当前生成并发送' : '发送'}
+            className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200 hover:brightness-110 hover:-translate-y-px active:scale-95 disabled:opacity-30 disabled:hover:brightness-100 disabled:hover:translate-y-0 disabled:shadow-none"
+            style={{
+              background:
+                'linear-gradient(135deg, var(--accent), color-mix(in srgb, var(--accent) 65%, #000))',
+              boxShadow: '0 2px 10px color-mix(in srgb, var(--accent) 35%, transparent)',
+            }}
+          >
+            <Send size={14} style={{ color: '#fff' }} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+});


### PR DESCRIPTION
## 类型

- [x] 🐛 Bug 修复

## 变更概述

把输入框状态从 9,313 行的 ChatConsole 顶层下沉到独立的 Composer 组件，并修复 MessageBubble 的 memo 击穿与 sourcesSig 的重复计算，消除长会话下打字/删除的卡顿。

## 背景/问题

**现象**：在底部输入框每敲一个键（或删一个字），整个聊天界面都会被重渲染一次 —— 输入/删除明显卡顿，会话越长越卡。

**根因**（issue #1021 定位，本次逐条复核确认）：

1. `input` 状态住在 ChatConsole 顶层（`const [input, setInput] = useState('')`），每次 `setInput` 都要重跑整个组件体并 reconcile 整棵聊天树；
2. `MessageBubble` 的 `memo` 被 `sources={sourcesByMsg.get(...) ?? []}` 击穿——取不到来源的 user 消息与无自身来源的工具行每次渲染都拿到一个新的 `[]`，导致数百个气泡每个键都真重渲染（气泡内含 `MarkdownContent` / `react-markdown`）；
3. `sourcesSig` 未包 `useMemo`，每次击键遍历全部消息拼一次字符串（O(消息数)）。

**影响**：issue 报告者本机长会话实测 378–399 条记录，即数百个气泡 × 每键全量重渲染。

## 关联 issue

- Closes #1021

## 变更内容

| 文件 | 改动 |
|---|---|
| `apps/desktop/src/renderer/features/chat/Composer.tsx`（新增） | 承载输入框 + 工具栏（审批策略 / 推理模式 / 附件 / 发送·停止）及其自身的 `input` 状态；暴露 `ComposerHandle.setText/clear/focus` |
| `apps/desktop/src/renderer/features/chat/ChatConsole.tsx` | 移除顶层 `input` state 与 `textareaRef`；10 个程序化写入点改经 `composerRef`；发送文本复用既有 `programmaticTextRef`；模块级 `EMPTY_SOURCES` 常量替换两处 `?? []`；`sourcesSig` 包 `useMemo([messages])`；顺带更正 3 处引用已删除符号的注释 |

**为什么复用 `programmaticTextRef` 而不改 `handleSend` 签名**：`handleSend` 是约 1,400 行的函数体，改签名会让 prettier 把整个函数体重新缩进（diff 从约 260 行涨到 2,900 行）。`programmaticTextRef` 本就是为「绕过 input state 传文本」而存在的机制（代码注释明确写着「旧闭包读到的 input state 是旧值」），直接复用，不引入第二套机制。

**关于 `sourcesSig` 的流式语义**（issue C 节标注的风险点）：已逐条核实流式期间所有 `setMessages` 都返回**新数组**（工具行更新 `const next = [...prev]`、typewriter、`appendReasoningDelta`），没有原地修改 message 对象，因此 `useMemo([messages])` 不会让流式来源提取停止刷新。

## 日志/验证证据

```
【性能前后对比】同一台机器、同一份 60 气泡会话、同一个临时渲染计数探针，唯一变量是是否应用本修复：

修复前（develop HEAD）：
  bubbles on screen     : 60
  renders before        : 360
  renders after 10 keys : 960
  DELTA (10 keystrokes) : 600      ← 60 气泡 × 10 次击键

修复后（本 PR）：
  bubbles on screen     : 60
  renders before        : 180
  renders after 10 keys : 180
  DELTA (10 keystrokes) : 0

【回归 E2E】本地 --project=electron，worktree 构建，16 passed / 0 failed：
  regression-delete-all-focus    2 passed   composerRef 聚焦重连
  execution-policy               passed     ExecutionPolicySelector 已搬入 Composer
  reasoning-mode                 3 passed   ReasoningModeSwitch 已搬入 Composer
  repro-364-send-latency         passed     乐观气泡 + 输入框立即清空
  issue-542-streaming-input      passed     流式期间输入框保持可用
  issue-797-turn-lock-resend     passed     中断后立即重发
  repro-570-silent-send          passed     发送/加载错误路径
```

结论：在输入框敲 10 个字符，`MessageBubble` 的渲染次数增量由 **600 → 0**，与 issue 验收标准 E2（「修复前 ≈ 气泡数 × 10，修复后应为 0」）完全一致。

测量方法：临时在 `MessageBubble` 函数体首行加 `window.__miqiBubbleRenders` 计数探针，用 Playwright Electron 启动构建后的应用，预置一份 60 气泡的会话，聚焦输入框 `type()` 敲 10 个字符后读取计数差值。探针与临时 spec 均已删除，不在本 PR 中。

（首轮 `reasoning-mode` 的 LLM 用例超时一次：失败快照显示用户消息已发出、输入框已清空回 placeholder、会话处于「进行中」——发送链路正常，只是 provider 未在 60s 内回复；单独重跑 3 passed，确认为 LLM 抖动。）

## 测试情况

```
npm run typecheck     ✅ 通过（tsconfig.node + tsconfig.web）
npm run format:check  ✅ 通过（全量）
npm test              ✅ 479 passed / 5 skipped
npm run build         ✅ electron-vite build 通过
```

## 截图

无需截图（本次为结构性重构 + 性能修复，composer 的界面与视觉无变化）。

## 后续计划

- #1021 的 D 节（聊天气泡长列表虚拟化）为结构性优化，按要求另开 PR，未包含在本次改动中。
- 排查中另发现两处**既有**问题（非本次引入、与击键重渲染无关），建议另开 issue 跟踪：
  - `App.tsx` 把 `onOpenProviderSettings` 以行内箭头传入，而该 prop 位于 `MessageBubble` 的 memo 比较器内 → 每次 App 重渲染（会话刷新、活动回调）仍会重渲染全部气泡；
  - memo 比较器未比较 `reasoningMode` → fast↔think 切换时，`msg.reasoningMode` 为 undefined 的气泡可能显示陈旧角标。

---

**需要评审者知悉的一处行为变化**：`继续执行`（resume 中断回合）此前会把输入框里的草稿折进 resume 请求的 content（因旧的 `?? input` 兜底），现在 content 为空。判断为修正而非回归——resume 不产生 user 气泡（`ChatConsole.tsx` 注释「resume has no user bubble」），旧行为等于「把草稿发给模型但永远不显示」；且 `handleSend` 的守卫本就显式允许 resume 空文本。正常 resume（输入框为空）不受影响。
